### PR TITLE
Bradford parser and results, 2020 Primary

### DIFF
--- a/2020/20200602__pa__primary__bradford__precinct.csv
+++ b/2020/20200602__pa__primary__bradford__precinct.csv
@@ -1,304 +1,426 @@
 county,precinct,office,district,party,candidate,election_day,absentee,mail_in,provisional,votes
+Bradford,Alba Borough,Turnout,,,Registered Voters,,,,,95
+Bradford,Alba Borough,Turnout,,,Ballots Cast,36,0,5,0,41
 Bradford,Alba Borough,President Of The United States,,DEM,Bernie Sanders,0,0,0,0,0
 Bradford,Alba Borough,President Of The United States,,DEM,Joseph R. Biden,1,0,2,0,3
 Bradford,Alba Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Alba Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Alba Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Albany Township,Turnout,,,Registered Voters,,,,,545
+Bradford,Albany Township,Turnout,,,Ballots Cast,128,7,54,11,200
 Bradford,Albany Township,President Of The United States,,DEM,Bernie Sanders,3,0,3,1,7
 Bradford,Albany Township,President Of The United States,,DEM,Joseph R. Biden,13,3,16,4,36
 Bradford,Albany Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Albany Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,1,5
 Bradford,Albany Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Armenia Township,Turnout,,,Registered Voters,,,,,131
+Bradford,Armenia Township,Turnout,,,Ballots Cast,42,0,4,2,48
 Bradford,Armenia Township,President Of The United States,,DEM,Bernie Sanders,1,0,0,0,1
 Bradford,Armenia Township,President Of The United States,,DEM,Joseph R. Biden,0,0,2,2,4
 Bradford,Armenia Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
 Bradford,Armenia Township,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
 Bradford,Armenia Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Turnout,,,Registered Voters,,,,,627
+Bradford,Asylum Township,Turnout,,,Ballots Cast,138,8,67,4,217
 Bradford,Asylum Township,President Of The United States,,DEM,Bernie Sanders,0,1,4,0,5
 Bradford,Asylum Township,President Of The United States,,DEM,Joseph R. Biden,20,0,22,0,42
 Bradford,Asylum Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,Asylum Township,President Of The United States,,DEM,Donald J. Trump,0,0,1,0,1
 Bradford,Asylum Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Turnout,,,Registered Voters,,,,,344
+Bradford,Athens Borough 1St Ward,Turnout,,,Ballots Cast,69,5,35,3,112
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,4,0,2,1,7
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,19,1,20,0,40
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Turnout,,,Registered Voters,,,,,365
+Bradford,Athens Borough 2Nd Ward,Turnout,,,Ballots Cast,64,4,20,1,89
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,6,1,3,0,10
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,18,0,10,1,29
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Athens Borough 3Rd Ward,Turnout,,,Registered Voters,,,,,522
+Bradford,Athens Borough 3Rd Ward,Turnout,,,Ballots Cast,84,3,36,3,126
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,7,0,1,1,9
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,24,3,21,0,48
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Turnout,,,Registered Voters,,,,,568
+Bradford,Athens Borough 4Th Ward,Turnout,,,Ballots Cast,102,7,46,9,164
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Bernie Sanders,6,3,6,1,16
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Joseph R. Biden,30,1,11,5,47
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Turnout,,,Registered Voters,,,,,1286
+Bradford,Athens Township 1St District,Turnout,,,Ballots Cast,209,16,93,9,327
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Bernie Sanders,13,1,7,1,22
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Joseph R. Biden,32,8,38,3,81
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Turnout,,,Registered Voters,,,,,1871
+Bradford,Athens Township 2Nd District,Turnout,,,Ballots Cast,261,50,185,19,515
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Bernie Sanders,11,2,12,4,29
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Joseph R. Biden,47,25,87,4,163
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Tulsi Gabbard,4,1,1,0,6
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Write-In,2,0,1,0,3
+Bradford,Burlington Borough,Turnout,,,Registered Voters,,,,,83
+Bradford,Burlington Borough,Turnout,,,Ballots Cast,24,0,3,0,27
 Bradford,Burlington Borough,President Of The United States,,DEM,Bernie Sanders,1,0,2,0,3
 Bradford,Burlington Borough,President Of The United States,,DEM,Joseph R. Biden,3,0,0,0,3
 Bradford,Burlington Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Burlington Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Burlington Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Turnout,,,Registered Voters,,,,,449
+Bradford,Burlington Township,Turnout,,,Ballots Cast,110,3,57,3,173
 Bradford,Burlington Township,President Of The United States,,DEM,Bernie Sanders,4,0,2,0,6
 Bradford,Burlington Township,President Of The United States,,DEM,Joseph R. Biden,7,1,16,0,24
 Bradford,Burlington Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Burlington Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Burlington Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Turnout,,,Registered Voters,,,,,310
+Bradford,West Burlington Township,Turnout,,,Ballots Cast,107,3,16,4,130
 Bradford,West Burlington Township,President Of The United States,,DEM,Bernie Sanders,3,1,0,0,4
 Bradford,West Burlington Township,President Of The United States,,DEM,Joseph R. Biden,16,1,1,2,20
 Bradford,West Burlington Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,West Burlington Township,President Of The United States,,DEM,Donald J. Trump,5,0,1,0,6
 Bradford,West Burlington Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Turnout,,,Registered Voters,,,,,907
+Bradford,Canton Borough,Turnout,,,Ballots Cast,209,14,58,10,291
 Bradford,Canton Borough,President Of The United States,,DEM,Bernie Sanders,11,3,4,3,21
 Bradford,Canton Borough,President Of The United States,,DEM,Joseph R. Biden,18,4,17,0,39
 Bradford,Canton Borough,President Of The United States,,DEM,Tulsi Gabbard,3,1,0,0,4
 Bradford,Canton Borough,President Of The United States,,DEM,Donald J. Trump,8,0,0,0,8
 Bradford,Canton Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Township,Turnout,,,Registered Voters,,,,,1098
+Bradford,Canton Township,Turnout,,,Ballots Cast,296,9,65,15,385
 Bradford,Canton Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
 Bradford,Canton Township,President Of The United States,,DEM,Joseph R. Biden,23,1,14,2,40
 Bradford,Canton Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,2,0,5
 Bradford,Canton Township,President Of The United States,,DEM,Donald J. Trump,4,0,2,0,6
 Bradford,Canton Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Columbia Township,Turnout,,,Registered Voters,,,,,668
+Bradford,Columbia Township,Turnout,,,Ballots Cast,173,8,44,8,233
 Bradford,Columbia Township,President Of The United States,,DEM,Bernie Sanders,11,5,5,1,22
 Bradford,Columbia Township,President Of The United States,,DEM,Joseph R. Biden,16,2,9,3,30
 Bradford,Columbia Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Columbia Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,0,4
 Bradford,Columbia Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Turnout,,,Registered Voters,,,,,372
+Bradford,Franklin Township,Turnout,,,Ballots Cast,82,4,19,1,106
 Bradford,Franklin Township,President Of The United States,,DEM,Bernie Sanders,1,0,0,0,1
 Bradford,Franklin Township,President Of The United States,,DEM,Joseph R. Biden,7,0,4,0,11
 Bradford,Franklin Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,Franklin Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Franklin Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Granville Township,Turnout,,,Registered Voters,,,,,521
+Bradford,Granville Township,Turnout,,,Ballots Cast,118,5,32,3,158
 Bradford,Granville Township,President Of The United States,,DEM,Bernie Sanders,3,1,1,0,5
 Bradford,Granville Township,President Of The United States,,DEM,Joseph R. Biden,9,1,8,2,20
 Bradford,Granville Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
 Bradford,Granville Township,President Of The United States,,DEM,Donald J. Trump,3,1,2,0,6
 Bradford,Granville Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Turnout,,,Registered Voters,,,,,472
+Bradford,Herrick Township,Turnout,,,Ballots Cast,149,6,28,5,188
 Bradford,Herrick Township,President Of The United States,,DEM,Bernie Sanders,3,1,1,2,7
 Bradford,Herrick Township,President Of The United States,,DEM,Joseph R. Biden,13,2,4,1,20
 Bradford,Herrick Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
 Bradford,Herrick Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,0,4
 Bradford,Herrick Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Turnout,,,Registered Voters,,,,,150
+Bradford,Leraysville Borough,Turnout,,,Ballots Cast,44,2,14,0,60
 Bradford,Leraysville Borough,President Of The United States,,DEM,Bernie Sanders,0,0,1,0,1
 Bradford,Leraysville Borough,President Of The United States,,DEM,Joseph R. Biden,3,0,4,0,7
 Bradford,Leraysville Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Leraysville Borough,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Leraysville Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Turnout,,,Registered Voters,,,,,392
+Bradford,Leroy Township,Turnout,,,Ballots Cast,132,3,37,2,174
 Bradford,Leroy Township,President Of The United States,,DEM,Bernie Sanders,2,0,1,0,3
 Bradford,Leroy Township,President Of The United States,,DEM,Joseph R. Biden,18,1,11,2,32
 Bradford,Leroy Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,0,0,2
 Bradford,Leroy Township,President Of The United States,,DEM,Donald J. Trump,4,1,0,0,5
 Bradford,Leroy Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Turnout,,,Registered Voters,,,,,839
+Bradford,Litchfield Township,Turnout,,,Ballots Cast,171,9,57,5,242
 Bradford,Litchfield Township,President Of The United States,,DEM,Bernie Sanders,4,2,4,1,11
 Bradford,Litchfield Township,President Of The United States,,DEM,Joseph R. Biden,22,3,14,0,39
 Bradford,Litchfield Township,President Of The United States,,DEM,Tulsi Gabbard,5,0,1,0,6
 Bradford,Litchfield Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Litchfield Township,President Of The United States,,DEM,Write-In,2,0,0,0,2
+Bradford,Monroe Borough,Turnout,,,Registered Voters,,,,,281
+Bradford,Monroe Borough,Turnout,,,Ballots Cast,79,3,30,0,112
 Bradford,Monroe Borough,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
 Bradford,Monroe Borough,President Of The United States,,DEM,Joseph R. Biden,6,2,12,0,20
 Bradford,Monroe Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Monroe Borough,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Monroe Borough,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Monroe Township,Turnout,,,Registered Voters,,,,,654
+Bradford,Monroe Township,Turnout,,,Ballots Cast,159,11,49,8,227
 Bradford,Monroe Township,President Of The United States,,DEM,Bernie Sanders,4,2,0,0,6
 Bradford,Monroe Township,President Of The United States,,DEM,Joseph R. Biden,14,5,13,1,33
 Bradford,Monroe Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Monroe Township,President Of The United States,,DEM,Donald J. Trump,6,0,0,0,6
 Bradford,Monroe Township,President Of The United States,,DEM,Write-In,2,0,0,0,2
+Bradford,New Albany Borough,Turnout,,,Registered Voters,,,,,134
+Bradford,New Albany Borough,Turnout,,,Ballots Cast,38,1,4,0,43
 Bradford,New Albany Borough,President Of The United States,,DEM,Bernie Sanders,0,0,1,0,1
 Bradford,New Albany Borough,President Of The United States,,DEM,Joseph R. Biden,6,0,2,0,8
 Bradford,New Albany Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,New Albany Borough,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,New Albany Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Orwell Township,Turnout,,,Registered Voters,,,,,740
+Bradford,Orwell Township,Turnout,,,Ballots Cast,185,11,77,4,277
 Bradford,Orwell Township,President Of The United States,,DEM,Bernie Sanders,6,3,0,0,9
 Bradford,Orwell Township,President Of The United States,,DEM,Joseph R. Biden,18,0,21,1,40
 Bradford,Orwell Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,0,3
 Bradford,Orwell Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Orwell Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Overton Township,Turnout,,,Registered Voters,,,,,149
+Bradford,Overton Township,Turnout,,,Ballots Cast,51,1,13,3,68
 Bradford,Overton Township,President Of The United States,,DEM,Bernie Sanders,8,0,0,1,9
 Bradford,Overton Township,President Of The United States,,DEM,Joseph R. Biden,6,0,7,0,13
 Bradford,Overton Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,0,3
 Bradford,Overton Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Overton Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Pike Township,Turnout,,,Registered Voters,,,,,358
+Bradford,Pike Township,Turnout,,,Ballots Cast,105,7,22,4,138
 Bradford,Pike Township,President Of The United States,,DEM,Bernie Sanders,3,1,0,0,4
 Bradford,Pike Township,President Of The United States,,DEM,Joseph R. Biden,10,3,5,0,18
 Bradford,Pike Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Pike Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Pike Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Turnout,,,Registered Voters,,,,,1219
+Bradford,Ridgebury Township,Turnout,,,Ballots Cast,225,17,48,9,299
 Bradford,Ridgebury Township,President Of The United States,,DEM,Bernie Sanders,9,0,2,0,11
 Bradford,Ridgebury Township,President Of The United States,,DEM,Joseph R. Biden,17,7,17,2,43
 Bradford,Ridgebury Township,President Of The United States,,DEM,Tulsi Gabbard,5,0,3,1,9
 Bradford,Ridgebury Township,President Of The United States,,DEM,Donald J. Trump,2,0,1,1,4
 Bradford,Ridgebury Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Rome Borough,Turnout,,,Registered Voters,,,,,192
+Bradford,Rome Borough,Turnout,,,Ballots Cast,36,4,15,0,55
 Bradford,Rome Borough,President Of The United States,,DEM,Bernie Sanders,3,0,1,0,4
 Bradford,Rome Borough,President Of The United States,,DEM,Joseph R. Biden,1,0,1,0,2
 Bradford,Rome Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,Rome Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Rome Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Rome Township,Turnout,,,Registered Voters,,,,,675
+Bradford,Rome Township,Turnout,,,Ballots Cast,174,12,53,4,243
 Bradford,Rome Township,President Of The United States,,DEM,Bernie Sanders,0,0,3,0,3
 Bradford,Rome Township,President Of The United States,,DEM,Joseph R. Biden,12,1,7,0,20
 Bradford,Rome Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Rome Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Rome Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 1St Ward,Turnout,,,Registered Voters,,,,,472
+Bradford,Sayre Borough 1St Ward,Turnout,,,Ballots Cast,79,8,53,5,145
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,6,2,5,3,16
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,21,5,27,2,55
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,2,0,2
+Bradford,Sayre Borough 2Nd Ward,Turnout,,,Registered Voters,,,,,1426
+Bradford,Sayre Borough 2Nd Ward,Turnout,,,Ballots Cast,230,20,143,11,404
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,10,4,13,3,30
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,68,12,77,4,161
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,4,0,0,0,4
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Write-In,3,1,2,0,6
+Bradford,Sayre Borough 3Rd Ward,Turnout,,,Registered Voters,,,,,313
+Bradford,Sayre Borough 3Rd Ward,Turnout,,,Ballots Cast,60,3,10,0,73
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,9,0,1,0,10
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,13,1,3,0,17
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Turnout,,,Registered Voters,,,,,842
+Bradford,Sayre Borough 4Th Ward,Turnout,,,Ballots Cast,150,15,59,9,233
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Bernie Sanders,11,2,2,2,17
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Joseph R. Biden,48,8,31,3,90
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Tulsi Gabbard,5,0,2,0,7
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 5Th Ward,Turnout,,,Registered Voters,,,,,182
+Bradford,Sayre Borough 5Th Ward,Turnout,,,Ballots Cast,31,3,14,0,48
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Bernie Sanders,2,1,2,0,5
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Joseph R. Biden,6,1,7,0,14
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Donald J. Trump,2,0,1,0,3
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Turnout,,,Registered Voters,,,,,784
+Bradford,Sheshequin Township,Turnout,,,Ballots Cast,149,15,62,8,234
 Bradford,Sheshequin Township,President Of The United States,,DEM,Bernie Sanders,2,0,4,0,6
 Bradford,Sheshequin Township,President Of The United States,,DEM,Joseph R. Biden,10,2,21,5,38
 Bradford,Sheshequin Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,0,0,2
 Bradford,Sheshequin Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Sheshequin Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Turnout,,,Registered Voters,,,,,968
+Bradford,Smithfield Township,Turnout,,,Ballots Cast,228,10,79,9,326
 Bradford,Smithfield Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
 Bradford,Smithfield Township,President Of The United States,,DEM,Joseph R. Biden,24,1,24,2,51
 Bradford,Smithfield Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,1,4
 Bradford,Smithfield Township,President Of The United States,,DEM,Donald J. Trump,2,0,2,0,4
 Bradford,Smithfield Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Turnout,,,Registered Voters,,,,,740
+Bradford,South Creek Township,Turnout,,,Ballots Cast,178,4,45,4,231
 Bradford,South Creek Township,President Of The United States,,DEM,Bernie Sanders,3,0,0,0,3
 Bradford,South Creek Township,President Of The United States,,DEM,Joseph R. Biden,14,1,10,1,26
 Bradford,South Creek Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,South Creek Township,President Of The United States,,DEM,Donald J. Trump,7,0,1,0,8
 Bradford,South Creek Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Turnout,,,Registered Voters,,,,,710
+Bradford,South Waverly Borough,Turnout,,,Ballots Cast,146,9,68,5,228
 Bradford,South Waverly Borough,President Of The United States,,DEM,Bernie Sanders,12,0,6,0,18
 Bradford,South Waverly Borough,President Of The United States,,DEM,Joseph R. Biden,39,6,31,4,80
 Bradford,South Waverly Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,South Waverly Borough,President Of The United States,,DEM,Donald J. Trump,5,1,1,0,7
 Bradford,South Waverly Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Turnout,,,Registered Voters,,,,,734
+Bradford,Springfield Township,Turnout,,,Ballots Cast,171,9,66,16,262
 Bradford,Springfield Township,President Of The United States,,DEM,Bernie Sanders,4,1,2,0,7
 Bradford,Springfield Township,President Of The United States,,DEM,Joseph R. Biden,17,3,30,2,52
 Bradford,Springfield Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Springfield Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Springfield Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Standing Stone Township,Turnout,,,Registered Voters,,,,,391
+Bradford,Standing Stone Township,Turnout,,,Ballots Cast,76,8,33,4,121
 Bradford,Standing Stone Township,President Of The United States,,DEM,Bernie Sanders,1,1,2,0,4
 Bradford,Standing Stone Township,President Of The United States,,DEM,Joseph R. Biden,7,1,8,1,17
 Bradford,Standing Stone Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,2,0,3
 Bradford,Standing Stone Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Standing Stone Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Stevens Township,Turnout,,,Registered Voters,,,,,285
+Bradford,Stevens Township,Turnout,,,Ballots Cast,90,6,23,2,121
 Bradford,Stevens Township,President Of The United States,,DEM,Bernie Sanders,5,2,0,0,7
 Bradford,Stevens Township,President Of The United States,,DEM,Joseph R. Biden,8,1,7,1,17
 Bradford,Stevens Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Stevens Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Stevens Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Sylvania Borough,Turnout,,,Registered Voters,,,,,119
+Bradford,Sylvania Borough,Turnout,,,Ballots Cast,39,1,12,0,52
 Bradford,Sylvania Borough,President Of The United States,,DEM,Bernie Sanders,2,1,0,0,3
 Bradford,Sylvania Borough,President Of The United States,,DEM,Joseph R. Biden,7,0,2,0,9
 Bradford,Sylvania Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Sylvania Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Sylvania Borough,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Terry Township,Turnout,,,Registered Voters,,,,,543
+Bradford,Terry Township,Turnout,,,Ballots Cast,158,5,43,1,207
 Bradford,Terry Township,President Of The United States,,DEM,Bernie Sanders,7,2,2,0,11
 Bradford,Terry Township,President Of The United States,,DEM,Joseph R. Biden,12,1,17,0,30
 Bradford,Terry Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
 Bradford,Terry Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Terry Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Turnout,,,Registered Voters,,,,,356
+Bradford,Towanda Borough 1St Ward,Turnout,,,Ballots Cast,78,0,21,1,100
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,5,0,0,0,5
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,5,0,7,0,12
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Turnout,,,Registered Voters,,,,,488
+Bradford,Towanda Borough 2Nd Ward,Turnout,,,Ballots Cast,94,7,46,7,154
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,4,1,3,0,8
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,21,0,18,2,41
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,1,0,2
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Turnout,,,Registered Voters,,,,,695
+Bradford,Towanda Borough 3Rd Ward,Turnout,,,Ballots Cast,144,17,91,5,257
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,6,0,4,0,10
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,19,8,33,3,63
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,1,1,0,3
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,1,1,0,2
+Bradford,Towanda Township,Turnout,,,Registered Voters,,,,,591
+Bradford,Towanda Township,Turnout,,,Ballots Cast,99,16,35,2,152
 Bradford,Towanda Township,President Of The United States,,DEM,Bernie Sanders,5,0,3,0,8
 Bradford,Towanda Township,President Of The United States,,DEM,Joseph R. Biden,14,6,10,2,32
 Bradford,Towanda Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Towanda Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Towanda Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Turnout,,,Registered Voters,,,,,617
+Bradford,North Towanda Township,Turnout,,,Ballots Cast,107,16,75,0,198
 Bradford,North Towanda Township,President Of The United States,,DEM,Bernie Sanders,3,3,2,0,8
 Bradford,North Towanda Township,President Of The United States,,DEM,Joseph R. Biden,14,5,28,0,47
 Bradford,North Towanda Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,North Towanda Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,North Towanda Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Turnout,,,Registered Voters,,,,,710
+Bradford,Troy Borough,Turnout,,,Ballots Cast,170,6,56,13,245
 Bradford,Troy Borough,President Of The United States,,DEM,Bernie Sanders,2,0,6,1,9
 Bradford,Troy Borough,President Of The United States,,DEM,Joseph R. Biden,32,2,24,2,60
 Bradford,Troy Borough,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
 Bradford,Troy Borough,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Troy Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Township,Turnout,,,Registered Voters,,,,,1094
+Bradford,Troy Township,Turnout,,,Ballots Cast,255,16,111,13,395
 Bradford,Troy Township,President Of The United States,,DEM,Bernie Sanders,3,0,5,1,9
 Bradford,Troy Township,President Of The United States,,DEM,Joseph R. Biden,23,7,25,1,56
 Bradford,Troy Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
 Bradford,Troy Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Troy Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Turnout,,,Registered Voters,,,,,652
+Bradford,Tuscarora Township,Turnout,,,Ballots Cast,194,12,55,3,264
 Bradford,Tuscarora Township,President Of The United States,,DEM,Bernie Sanders,8,1,4,0,13
 Bradford,Tuscarora Township,President Of The United States,,DEM,Joseph R. Biden,12,0,17,0,29
 Bradford,Tuscarora Township,President Of The United States,,DEM,Tulsi Gabbard,3,1,1,0,5
 Bradford,Tuscarora Township,President Of The United States,,DEM,Donald J. Trump,5,1,0,0,6
 Bradford,Tuscarora Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Ulster Township,Turnout,,,Registered Voters,,,,,793
+Bradford,Ulster Township,Turnout,,,Ballots Cast,141,13,43,0,197
 Bradford,Ulster Township,President Of The United States,,DEM,Bernie Sanders,1,0,3,0,4
 Bradford,Ulster Township,President Of The United States,,DEM,Joseph R. Biden,16,3,18,0,37
 Bradford,Ulster Township,President Of The United States,,DEM,Tulsi Gabbard,4,0,2,0,6
 Bradford,Ulster Township,President Of The United States,,DEM,Donald J. Trump,6,0,0,0,6
 Bradford,Ulster Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Warren Township,Turnout,,,Registered Voters,,,,,671
+Bradford,Warren Township,Turnout,,,Ballots Cast,169,7,44,7,227
 Bradford,Warren Township,President Of The United States,,DEM,Bernie Sanders,4,0,1,0,5
 Bradford,Warren Township,President Of The United States,,DEM,Joseph R. Biden,12,1,17,2,32
 Bradford,Warren Township,President Of The United States,,DEM,Tulsi Gabbard,0,1,0,0,1
 Bradford,Warren Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Warren Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Wells Township,Turnout,,,Registered Voters,,,,,716
+Bradford,Wells Township,Turnout,,,Ballots Cast,186,5,34,2,227
 Bradford,Wells Township,President Of The United States,,DEM,Bernie Sanders,4,0,2,0,6
 Bradford,Wells Township,President Of The United States,,DEM,Joseph R. Biden,15,3,14,0,32
 Bradford,Wells Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Wells Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Wells Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Turnout,,,Registered Voters,,,,,745
+Bradford,Wilmot Township,Turnout,,,Ballots Cast,180,18,70,15,283
 Bradford,Wilmot Township,President Of The United States,,DEM,Bernie Sanders,5,4,3,0,12
 Bradford,Wilmot Township,President Of The United States,,DEM,Joseph R. Biden,15,5,18,3,41
 Bradford,Wilmot Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,1,0,2
 Bradford,Wilmot Township,President Of The United States,,DEM,Donald J. Trump,3,0,1,0,4
 Bradford,Wilmot Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Windham Township,Turnout,,,Registered Voters,,,,,546
+Bradford,Windham Township,Turnout,,,Ballots Cast,115,9,50,11,185
 Bradford,Windham Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
 Bradford,Windham Township,President Of The United States,,DEM,Joseph R. Biden,7,5,10,2,24
 Bradford,Windham Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Windham Township,President Of The United States,,DEM,Donald J. Trump,0,0,2,0,2
 Bradford,Windham Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Wyalusing Borough,Turnout,,,Registered Voters,,,,,335
+Bradford,Wyalusing Borough,Turnout,,,Ballots Cast,99,5,26,8,138
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Bernie Sanders,4,0,0,0,4
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Joseph R. Biden,26,4,13,1,44
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,1,2
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Turnout,,,Registered Voters,,,,,810
+Bradford,Wyalusing Township,Turnout,,,Ballots Cast,220,20,68,5,313
 Bradford,Wyalusing Township,President Of The United States,,DEM,Bernie Sanders,4,1,8,0,13
 Bradford,Wyalusing Township,President Of The United States,,DEM,Joseph R. Biden,14,5,17,0,36
 Bradford,Wyalusing Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,1,0,3
 Bradford,Wyalusing Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Wyalusing Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Turnout,,,Registered Voters,,,,,979
+Bradford,Wysox Township,Turnout,,,Ballots Cast,225,19,91,2,337
 Bradford,Wysox Township,President Of The United States,,DEM,Bernie Sanders,7,1,4,0,12
 Bradford,Wysox Township,President Of The United States,,DEM,Joseph R. Biden,22,6,26,1,55
 Bradford,Wysox Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,4,0,4

--- a/2020/20200602__pa__primary__bradford__precinct.csv
+++ b/2020/20200602__pa__primary__bradford__precinct.csv
@@ -978,674 +978,674 @@ Bradford,Wysox Township,Auditor General,,DEM,Write-In,0,0,0,0,0
 Bradford,Alba Borough,State Treasurer,,DEM,Joseph Torsella,3,0,2,0,5
 Bradford,Alba Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Alba Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Alba Borough,Representative In Congress,12,,Lee Griffin,3,0,2,0,5
-Bradford,Alba Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Alba Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Representative In Congress,12,DEM,Lee Griffin,3,0,2,0,5
+Bradford,Alba Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Alba Borough,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Albany Township,State Treasurer,,DEM,Joseph Torsella,15,3,20,5,43
 Bradford,Albany Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Albany Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Albany Township,Representative In Congress,12,,Lee Griffin,17,3,18,5,43
-Bradford,Albany Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
-Bradford,Albany Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In Congress,12,DEM,Lee Griffin,17,3,18,5,43
+Bradford,Albany Township,Representative In Congress,12,DEM,Fred Keller,1,0,0,0,1
+Bradford,Albany Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Armenia Township,State Treasurer,,DEM,Joseph Torsella,3,0,1,2,6
 Bradford,Armenia Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Armenia Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Armenia Township,Representative In Congress,12,,Lee Griffin,2,0,2,1,5
-Bradford,Armenia Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Armenia Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Representative In Congress,12,DEM,Lee Griffin,2,0,2,1,5
+Bradford,Armenia Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Armenia Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Asylum Township,State Treasurer,,DEM,Joseph Torsella,16,1,24,0,41
 Bradford,Asylum Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,2,0,2
 Bradford,Asylum Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Asylum Township,Representative In Congress,12,,Lee Griffin,16,1,25,0,42
-Bradford,Asylum Township,Representative In Congress,12,,Fred Keller,0,0,1,0,1
-Bradford,Asylum Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Representative In Congress,12,DEM,Lee Griffin,16,1,25,0,42
+Bradford,Asylum Township,Representative In Congress,12,DEM,Fred Keller,0,0,1,0,1
+Bradford,Asylum Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Borough 1St Ward,State Treasurer,,DEM,Joseph Torsella,21,1,20,1,43
 Bradford,Athens Borough 1St Ward,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Athens Borough 1St Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 1St Ward,Representative In Congress,12,,Lee Griffin,22,1,19,1,43
-Bradford,Athens Borough 1St Ward,Representative In Congress,12,,Fred Keller,0,0,1,0,1
-Bradford,Athens Borough 1St Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,DEM,Lee Griffin,22,1,19,1,43
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,DEM,Fred Keller,0,0,1,0,1
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,State Treasurer,,DEM,Joseph Torsella,19,1,11,1,32
 Bradford,Athens Borough 2Nd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,,Lee Griffin,20,0,9,1,30
-Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,DEM,Lee Griffin,20,0,9,1,30
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Borough 3Rd Ward,State Treasurer,,DEM,Joseph Torsella,28,1,20,1,50
 Bradford,Athens Borough 3Rd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Athens Borough 3Rd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,,Lee Griffin,26,1,20,1,48
-Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,DEM,Lee Griffin,26,1,20,1,48
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Borough 4Th Ward,State Treasurer,,DEM,Joseph Torsella,36,3,17,6,62
 Bradford,Athens Borough 4Th Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Athens Borough 4Th Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 4Th Ward,Representative In Congress,12,,Lee Griffin,35,3,17,5,60
-Bradford,Athens Borough 4Th Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Athens Borough 4Th Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,DEM,Lee Griffin,35,3,17,5,60
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Township 1St District,State Treasurer,,DEM,Joseph Torsella,38,8,40,4,90
 Bradford,Athens Township 1St District,State Treasurer,,DEM,Stacy L. Garrity,1,0,1,0,2
 Bradford,Athens Township 1St District,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Township 1St District,Representative In Congress,12,,Lee Griffin,38,9,42,4,93
-Bradford,Athens Township 1St District,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Athens Township 1St District,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Athens Township 1St District,Representative In Congress,12,DEM,Lee Griffin,38,9,42,4,93
+Bradford,Athens Township 1St District,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Athens Township 2Nd District,State Treasurer,,DEM,Joseph Torsella,49,23,86,8,166
 Bradford,Athens Township 2Nd District,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
 Bradford,Athens Township 2Nd District,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Township 2Nd District,Representative In Congress,12,,Lee Griffin,49,23,89,8,169
-Bradford,Athens Township 2Nd District,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Athens Township 2Nd District,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Athens Township 2Nd District,Representative In Congress,12,DEM,Lee Griffin,49,23,89,8,169
+Bradford,Athens Township 2Nd District,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Burlington Borough,State Treasurer,,DEM,Joseph Torsella,3,0,2,0,5
 Bradford,Burlington Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Burlington Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Burlington Borough,Representative In Congress,12,,Lee Griffin,4,0,2,0,6
-Bradford,Burlington Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Burlington Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Representative In Congress,12,DEM,Lee Griffin,4,0,2,0,6
+Bradford,Burlington Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Burlington Borough,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Burlington Township,State Treasurer,,DEM,Joseph Torsella,12,0,18,0,30
 Bradford,Burlington Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Burlington Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Burlington Township,Representative In Congress,12,,Lee Griffin,11,0,18,0,29
-Bradford,Burlington Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
-Bradford,Burlington Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Representative In Congress,12,DEM,Lee Griffin,11,0,18,0,29
+Bradford,Burlington Township,Representative In Congress,12,DEM,Fred Keller,1,0,0,0,1
+Bradford,Burlington Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,West Burlington Township,State Treasurer,,DEM,Joseph Torsella,13,2,2,2,19
 Bradford,West Burlington Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
 Bradford,West Burlington Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,West Burlington Township,Representative In Congress,12,,Lee Griffin,13,2,2,2,19
-Bradford,West Burlington Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
-Bradford,West Burlington Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Representative In Congress,12,DEM,Lee Griffin,13,2,2,2,19
+Bradford,West Burlington Township,Representative In Congress,12,DEM,Fred Keller,1,0,0,0,1
+Bradford,West Burlington Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Canton Borough,State Treasurer,,DEM,Joseph Torsella,31,8,18,3,60
 Bradford,Canton Borough,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
 Bradford,Canton Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Canton Borough,Representative In Congress,12,,Lee Griffin,34,8,19,3,64
-Bradford,Canton Borough,Representative In Congress,12,,Fred Keller,2,0,0,0,2
-Bradford,Canton Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Representative In Congress,12,DEM,Lee Griffin,34,8,19,3,64
+Bradford,Canton Borough,Representative In Congress,12,DEM,Fred Keller,2,0,0,0,2
+Bradford,Canton Borough,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Canton Township,State Treasurer,,DEM,Joseph Torsella,28,1,17,3,49
 Bradford,Canton Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,1,0,2
 Bradford,Canton Township,State Treasurer,,DEM,Write-In,0,0,1,0,1
-Bradford,Canton Township,Representative In Congress,12,,Lee Griffin,27,1,17,2,47
-Bradford,Canton Township,Representative In Congress,12,,Fred Keller,1,0,1,0,2
-Bradford,Canton Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Canton Township,Representative In Congress,12,DEM,Lee Griffin,27,1,17,2,47
+Bradford,Canton Township,Representative In Congress,12,DEM,Fred Keller,1,0,1,0,2
+Bradford,Canton Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Columbia Township,State Treasurer,,DEM,Joseph Torsella,30,6,10,4,50
 Bradford,Columbia Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Columbia Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Columbia Township,Representative In Congress,12,,Lee Griffin,25,7,10,4,46
-Bradford,Columbia Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Columbia Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Representative In Congress,12,DEM,Lee Griffin,25,7,10,4,46
+Bradford,Columbia Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Columbia Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Franklin Township,State Treasurer,,DEM,Joseph Torsella,7,0,3,0,10
 Bradford,Franklin Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Franklin Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Franklin Township,Representative In Congress,12,,Lee Griffin,7,0,3,0,10
-Bradford,Franklin Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Franklin Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In Congress,12,DEM,Lee Griffin,7,0,3,0,10
+Bradford,Franklin Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Franklin Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Granville Township,State Treasurer,,DEM,Joseph Torsella,16,2,8,2,28
 Bradford,Granville Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,2,0,2
 Bradford,Granville Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Granville Township,Representative In Congress,12,,Lee Griffin,16,3,8,2,29
-Bradford,Granville Township,Representative In Congress,12,,Fred Keller,0,0,2,0,2
-Bradford,Granville Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Granville Township,Representative In Congress,12,DEM,Lee Griffin,16,3,8,2,29
+Bradford,Granville Township,Representative In Congress,12,DEM,Fred Keller,0,0,2,0,2
+Bradford,Granville Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Herrick Township,State Treasurer,,DEM,Joseph Torsella,20,3,4,3,30
 Bradford,Herrick Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Herrick Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Herrick Township,Representative In Congress,12,,Lee Griffin,19,3,4,3,29
-Bradford,Herrick Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Herrick Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Representative In Congress,12,DEM,Lee Griffin,19,3,4,3,29
+Bradford,Herrick Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Herrick Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Leraysville Borough,State Treasurer,,DEM,Joseph Torsella,2,0,4,0,6
 Bradford,Leraysville Borough,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Leraysville Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Leraysville Borough,Representative In Congress,12,,Lee Griffin,3,0,4,0,7
-Bradford,Leraysville Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Leraysville Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In Congress,12,DEM,Lee Griffin,3,0,4,0,7
+Bradford,Leraysville Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Leroy Township,State Treasurer,,DEM,Joseph Torsella,19,2,8,2,31
 Bradford,Leroy Township,State Treasurer,,DEM,Stacy L. Garrity,0,1,0,0,1
 Bradford,Leroy Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Leroy Township,Representative In Congress,12,,Lee Griffin,19,2,8,2,31
-Bradford,Leroy Township,Representative In Congress,12,,Fred Keller,0,1,0,0,1
-Bradford,Leroy Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Representative In Congress,12,DEM,Lee Griffin,19,2,8,2,31
+Bradford,Leroy Township,Representative In Congress,12,DEM,Fred Keller,0,1,0,0,1
+Bradford,Leroy Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Litchfield Township,State Treasurer,,DEM,Joseph Torsella,27,4,18,1,50
 Bradford,Litchfield Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
 Bradford,Litchfield Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Litchfield Township,Representative In Congress,12,,Lee Griffin,26,5,19,1,51
-Bradford,Litchfield Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Litchfield Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Representative In Congress,12,DEM,Lee Griffin,26,5,19,1,51
+Bradford,Litchfield Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Litchfield Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Monroe Borough,State Treasurer,,DEM,Joseph Torsella,8,2,11,0,21
 Bradford,Monroe Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Monroe Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Monroe Borough,Representative In Congress,12,,Lee Griffin,7,2,12,0,21
-Bradford,Monroe Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Monroe Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Representative In Congress,12,DEM,Lee Griffin,7,2,12,0,21
+Bradford,Monroe Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Monroe Borough,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Monroe Township,State Treasurer,,DEM,Joseph Torsella,19,6,12,1,38
 Bradford,Monroe Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
 Bradford,Monroe Township,State Treasurer,,DEM,Write-In,0,1,0,0,1
-Bradford,Monroe Township,Representative In Congress,12,,Lee Griffin,19,6,12,1,38
-Bradford,Monroe Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Monroe Township,Representative In Congress,12,,Write-In,2,0,0,0,2
+Bradford,Monroe Township,Representative In Congress,12,DEM,Lee Griffin,19,6,12,1,38
+Bradford,Monroe Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Monroe Township,Representative In Congress,12,DEM,Write-In,2,0,0,0,2
 Bradford,New Albany Borough,State Treasurer,,DEM,Joseph Torsella,7,0,3,0,10
 Bradford,New Albany Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,New Albany Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,New Albany Borough,Representative In Congress,12,,Lee Griffin,7,0,3,0,10
-Bradford,New Albany Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,New Albany Borough,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,New Albany Borough,Representative In Congress,12,DEM,Lee Griffin,7,0,3,0,10
+Bradford,New Albany Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,New Albany Borough,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Orwell Township,State Treasurer,,DEM,Joseph Torsella,25,3,21,0,49
 Bradford,Orwell Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Orwell Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Orwell Township,Representative In Congress,12,,Lee Griffin,27,3,18,1,49
-Bradford,Orwell Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
-Bradford,Orwell Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Representative In Congress,12,DEM,Lee Griffin,27,3,18,1,49
+Bradford,Orwell Township,Representative In Congress,12,DEM,Fred Keller,1,0,0,0,1
+Bradford,Orwell Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Overton Township,State Treasurer,,DEM,Joseph Torsella,17,0,7,1,25
 Bradford,Overton Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Overton Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Overton Township,Representative In Congress,12,,Lee Griffin,17,0,6,1,24
-Bradford,Overton Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Overton Township,Representative In Congress,12,,Write-In,0,0,1,0,1
+Bradford,Overton Township,Representative In Congress,12,DEM,Lee Griffin,17,0,6,1,24
+Bradford,Overton Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Overton Township,Representative In Congress,12,DEM,Write-In,0,0,1,0,1
 Bradford,Pike Township,State Treasurer,,DEM,Joseph Torsella,13,3,6,0,22
 Bradford,Pike Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Pike Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Pike Township,Representative In Congress,12,,Lee Griffin,14,4,6,0,24
-Bradford,Pike Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Pike Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Pike Township,Representative In Congress,12,DEM,Lee Griffin,14,4,6,0,24
+Bradford,Pike Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Pike Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Ridgebury Township,State Treasurer,,DEM,Joseph Torsella,26,6,21,2,55
 Bradford,Ridgebury Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,1,1
 Bradford,Ridgebury Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Ridgebury Township,Representative In Congress,12,,Lee Griffin,25,6,21,4,56
-Bradford,Ridgebury Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Ridgebury Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Ridgebury Township,Representative In Congress,12,DEM,Lee Griffin,25,6,21,4,56
+Bradford,Ridgebury Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Rome Borough,State Treasurer,,DEM,Joseph Torsella,4,0,2,0,6
 Bradford,Rome Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Rome Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Rome Borough,Representative In Congress,12,,Lee Griffin,4,0,3,0,7
-Bradford,Rome Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Rome Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In Congress,12,DEM,Lee Griffin,4,0,3,0,7
+Bradford,Rome Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Rome Borough,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Rome Township,State Treasurer,,DEM,Joseph Torsella,13,1,8,0,22
 Bradford,Rome Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Rome Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Rome Township,Representative In Congress,12,,Lee Griffin,13,1,7,0,21
-Bradford,Rome Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Rome Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Rome Township,Representative In Congress,12,DEM,Lee Griffin,13,1,7,0,21
+Bradford,Rome Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Rome Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 1St Ward,State Treasurer,,DEM,Joseph Torsella,24,5,30,4,63
 Bradford,Sayre Borough 1St Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
 Bradford,Sayre Borough 1St Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 1St Ward,Representative In Congress,12,,Lee Griffin,22,5,29,4,60
-Bradford,Sayre Borough 1St Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Sayre Borough 1St Ward,Representative In Congress,12,,Write-In,2,0,0,0,2
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,DEM,Lee Griffin,22,5,29,4,60
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,DEM,Write-In,2,0,0,0,2
 Bradford,Sayre Borough 2Nd Ward,State Treasurer,,DEM,Joseph Torsella,78,17,82,7,184
 Bradford,Sayre Borough 2Nd Ward,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Sayre Borough 2Nd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,,Lee Griffin,79,17,75,6,177
-Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,,Write-In,1,0,1,0,2
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,DEM,Lee Griffin,79,17,75,6,177
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,DEM,Write-In,1,0,1,0,2
 Bradford,Sayre Borough 3Rd Ward,State Treasurer,,DEM,Joseph Torsella,19,1,4,0,24
 Bradford,Sayre Borough 3Rd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Sayre Borough 3Rd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,,Lee Griffin,20,1,4,0,25
-Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,DEM,Lee Griffin,20,1,4,0,25
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Sayre Borough 4Th Ward,State Treasurer,,DEM,Joseph Torsella,52,9,31,3,95
 Bradford,Sayre Borough 4Th Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Sayre Borough 4Th Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,,Lee Griffin,51,8,32,2,93
-Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,,Write-In,0,0,2,1,3
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,DEM,Lee Griffin,51,8,32,2,93
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,DEM,Write-In,0,0,2,1,3
 Bradford,Sayre Borough 5Th Ward,State Treasurer,,DEM,Joseph Torsella,10,1,10,0,21
 Bradford,Sayre Borough 5Th Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Sayre Borough 5Th Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,,Lee Griffin,12,1,10,0,23
-Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,DEM,Lee Griffin,12,1,10,0,23
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Sheshequin Township,State Treasurer,,DEM,Joseph Torsella,13,3,19,5,40
 Bradford,Sheshequin Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Sheshequin Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Sheshequin Township,Representative In Congress,12,,Lee Griffin,13,3,18,2,36
-Bradford,Sheshequin Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Sheshequin Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In Congress,12,DEM,Lee Griffin,13,3,18,2,36
+Bradford,Sheshequin Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Smithfield Township,State Treasurer,,DEM,Joseph Torsella,30,2,21,2,55
 Bradford,Smithfield Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,2,0,2
 Bradford,Smithfield Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Smithfield Township,Representative In Congress,12,,Lee Griffin,32,2,19,2,55
-Bradford,Smithfield Township,Representative In Congress,12,,Fred Keller,0,0,1,0,1
-Bradford,Smithfield Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Representative In Congress,12,DEM,Lee Griffin,32,2,19,2,55
+Bradford,Smithfield Township,Representative In Congress,12,DEM,Fred Keller,0,0,1,0,1
+Bradford,Smithfield Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,South Creek Township,State Treasurer,,DEM,Joseph Torsella,22,1,5,1,29
 Bradford,South Creek Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
 Bradford,South Creek Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,South Creek Township,Representative In Congress,12,,Lee Griffin,19,1,5,1,26
-Bradford,South Creek Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,South Creek Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Representative In Congress,12,DEM,Lee Griffin,19,1,5,1,26
+Bradford,South Creek Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,South Creek Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,South Waverly Borough,State Treasurer,,DEM,Joseph Torsella,39,5,35,3,82
 Bradford,South Waverly Borough,State Treasurer,,DEM,Stacy L. Garrity,2,1,0,0,3
 Bradford,South Waverly Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,South Waverly Borough,Representative In Congress,12,,Lee Griffin,40,5,36,4,85
-Bradford,South Waverly Borough,Representative In Congress,12,,Fred Keller,0,1,0,0,1
-Bradford,South Waverly Borough,Representative In Congress,12,,Write-In,2,0,0,0,2
+Bradford,South Waverly Borough,Representative In Congress,12,DEM,Lee Griffin,40,5,36,4,85
+Bradford,South Waverly Borough,Representative In Congress,12,DEM,Fred Keller,0,1,0,0,1
+Bradford,South Waverly Borough,Representative In Congress,12,DEM,Write-In,2,0,0,0,2
 Bradford,Springfield Township,State Treasurer,,DEM,Joseph Torsella,20,4,31,2,57
 Bradford,Springfield Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
 Bradford,Springfield Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Springfield Township,Representative In Congress,12,,Lee Griffin,20,4,30,2,56
-Bradford,Springfield Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Springfield Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Representative In Congress,12,DEM,Lee Griffin,20,4,30,2,56
+Bradford,Springfield Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Springfield Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Standing Stone Township,State Treasurer,,DEM,Joseph Torsella,10,2,12,0,24
 Bradford,Standing Stone Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Standing Stone Township,State Treasurer,,DEM,Write-In,1,0,0,0,1
-Bradford,Standing Stone Township,Representative In Congress,12,,Lee Griffin,9,2,12,0,23
-Bradford,Standing Stone Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Standing Stone Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Standing Stone Township,Representative In Congress,12,DEM,Lee Griffin,9,2,12,0,23
+Bradford,Standing Stone Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Stevens Township,State Treasurer,,DEM,Joseph Torsella,7,2,8,1,18
 Bradford,Stevens Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Stevens Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Stevens Township,Representative In Congress,12,,Lee Griffin,8,1,7,1,17
-Bradford,Stevens Township,Representative In Congress,12,,Fred Keller,2,0,0,0,2
-Bradford,Stevens Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Representative In Congress,12,DEM,Lee Griffin,8,1,7,1,17
+Bradford,Stevens Township,Representative In Congress,12,DEM,Fred Keller,2,0,0,0,2
+Bradford,Stevens Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Sylvania Borough,State Treasurer,,DEM,Joseph Torsella,7,1,2,0,10
 Bradford,Sylvania Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Sylvania Borough,State Treasurer,,DEM,Write-In,0,0,1,0,1
-Bradford,Sylvania Borough,Representative In Congress,12,,Lee Griffin,7,1,2,0,10
-Bradford,Sylvania Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Sylvania Borough,Representative In Congress,12,,Write-In,0,0,1,0,1
+Bradford,Sylvania Borough,Representative In Congress,12,DEM,Lee Griffin,7,1,2,0,10
+Bradford,Sylvania Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In Congress,12,DEM,Write-In,0,0,1,0,1
 Bradford,Terry Township,State Treasurer,,DEM,Joseph Torsella,22,1,18,0,41
 Bradford,Terry Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Terry Township,State Treasurer,,DEM,Write-In,0,1,0,0,1
-Bradford,Terry Township,Representative In Congress,12,,Lee Griffin,23,1,18,0,42
-Bradford,Terry Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
-Bradford,Terry Township,Representative In Congress,12,,Write-In,0,1,0,0,1
+Bradford,Terry Township,Representative In Congress,12,DEM,Lee Griffin,23,1,18,0,42
+Bradford,Terry Township,Representative In Congress,12,DEM,Fred Keller,1,0,0,0,1
+Bradford,Terry Township,Representative In Congress,12,DEM,Write-In,0,1,0,0,1
 Bradford,Towanda Borough 1St Ward,State Treasurer,,DEM,Joseph Torsella,12,0,7,0,19
 Bradford,Towanda Borough 1St Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Towanda Borough 1St Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 1St Ward,Representative In Congress,12,,Lee Griffin,10,0,7,0,17
-Bradford,Towanda Borough 1St Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Towanda Borough 1St Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,DEM,Lee Griffin,10,0,7,0,17
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Towanda Borough 2Nd Ward,State Treasurer,,DEM,Joseph Torsella,24,1,20,2,47
 Bradford,Towanda Borough 2Nd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Towanda Borough 2Nd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,,Lee Griffin,24,1,19,3,47
-Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,DEM,Lee Griffin,24,1,19,3,47
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Towanda Borough 3Rd Ward,State Treasurer,,DEM,Joseph Torsella,24,9,33,3,69
 Bradford,Towanda Borough 3Rd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
 Bradford,Towanda Borough 3Rd Ward,State Treasurer,,DEM,Write-In,1,0,0,0,1
-Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,,Lee Griffin,25,9,30,3,67
-Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,,Fred Keller,1,0,0,0,1
-Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,DEM,Lee Griffin,25,9,30,3,67
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,DEM,Fred Keller,1,0,0,0,1
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Towanda Township,State Treasurer,,DEM,Joseph Torsella,16,6,12,2,36
 Bradford,Towanda Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
 Bradford,Towanda Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Township,Representative In Congress,12,,Lee Griffin,17,6,12,2,37
-Bradford,Towanda Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Towanda Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Representative In Congress,12,DEM,Lee Griffin,17,6,12,2,37
+Bradford,Towanda Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Towanda Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,North Towanda Township,State Treasurer,,DEM,Joseph Torsella,14,3,29,0,46
 Bradford,North Towanda Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,North Towanda Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,North Towanda Township,Representative In Congress,12,,Lee Griffin,14,3,29,0,46
-Bradford,North Towanda Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,North Towanda Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,North Towanda Township,Representative In Congress,12,DEM,Lee Griffin,14,3,29,0,46
+Bradford,North Towanda Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,North Towanda Township,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Troy Borough,State Treasurer,,DEM,Joseph Torsella,30,2,26,3,61
 Bradford,Troy Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Troy Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Troy Borough,Representative In Congress,12,,Lee Griffin,31,2,24,3,60
-Bradford,Troy Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Troy Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Representative In Congress,12,DEM,Lee Griffin,31,2,24,3,60
+Bradford,Troy Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Troy Borough,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Troy Township,State Treasurer,,DEM,Joseph Torsella,27,5,27,2,61
 Bradford,Troy Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Troy Township,State Treasurer,,DEM,Write-In,1,0,0,0,1
-Bradford,Troy Township,Representative In Congress,12,,Lee Griffin,27,5,24,2,58
-Bradford,Troy Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Troy Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Troy Township,Representative In Congress,12,DEM,Lee Griffin,27,5,24,2,58
+Bradford,Troy Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Troy Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Tuscarora Township,State Treasurer,,DEM,Joseph Torsella,21,2,22,0,45
 Bradford,Tuscarora Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Tuscarora Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Tuscarora Township,Representative In Congress,12,,Lee Griffin,24,3,22,0,49
-Bradford,Tuscarora Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Tuscarora Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In Congress,12,DEM,Lee Griffin,24,3,22,0,49
+Bradford,Tuscarora Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Ulster Township,State Treasurer,,DEM,Joseph Torsella,20,3,21,0,44
 Bradford,Ulster Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
 Bradford,Ulster Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Ulster Township,Representative In Congress,12,,Lee Griffin,23,3,21,0,47
-Bradford,Ulster Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Ulster Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Representative In Congress,12,DEM,Lee Griffin,23,3,21,0,47
+Bradford,Ulster Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Ulster Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Warren Township,State Treasurer,,DEM,Joseph Torsella,19,2,17,2,40
 Bradford,Warren Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Warren Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Warren Township,Representative In Congress,12,,Lee Griffin,19,2,17,2,40
-Bradford,Warren Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Warren Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Warren Township,Representative In Congress,12,DEM,Lee Griffin,19,2,17,2,40
+Bradford,Warren Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Warren Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Wells Township,State Treasurer,,DEM,Joseph Torsella,20,3,16,0,39
 Bradford,Wells Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Wells Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Wells Township,Representative In Congress,12,,Lee Griffin,20,3,15,0,38
-Bradford,Wells Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Wells Township,Representative In Congress,12,,Write-In,0,0,1,0,1
+Bradford,Wells Township,Representative In Congress,12,DEM,Lee Griffin,20,3,15,0,38
+Bradford,Wells Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Wells Township,Representative In Congress,12,DEM,Write-In,0,0,1,0,1
 Bradford,Wilmot Township,State Treasurer,,DEM,Joseph Torsella,17,6,21,2,46
 Bradford,Wilmot Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Wilmot Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Wilmot Township,Representative In Congress,12,,Lee Griffin,17,6,21,3,47
-Bradford,Wilmot Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Wilmot Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Wilmot Township,Representative In Congress,12,DEM,Lee Griffin,17,6,21,3,47
+Bradford,Wilmot Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Wilmot Township,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Windham Township,State Treasurer,,DEM,Joseph Torsella,11,6,13,2,32
 Bradford,Windham Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Windham Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Windham Township,Representative In Congress,12,,Lee Griffin,10,5,12,2,29
-Bradford,Windham Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Windham Township,Representative In Congress,12,,Write-In,0,0,1,0,1
+Bradford,Windham Township,Representative In Congress,12,DEM,Lee Griffin,10,5,12,2,29
+Bradford,Windham Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Windham Township,Representative In Congress,12,DEM,Write-In,0,0,1,0,1
 Bradford,Wyalusing Borough,State Treasurer,,DEM,Joseph Torsella,25,1,13,2,41
 Bradford,Wyalusing Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Wyalusing Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Wyalusing Borough,Representative In Congress,12,,Lee Griffin,24,2,12,2,40
-Bradford,Wyalusing Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Wyalusing Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In Congress,12,DEM,Lee Griffin,24,2,12,2,40
+Bradford,Wyalusing Borough,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Wyalusing Township,State Treasurer,,DEM,Joseph Torsella,21,6,21,0,48
 Bradford,Wyalusing Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
 Bradford,Wyalusing Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Wyalusing Township,Representative In Congress,12,,Lee Griffin,18,5,21,0,44
-Bradford,Wyalusing Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
-Bradford,Wyalusing Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In Congress,12,DEM,Lee Griffin,18,5,21,0,44
+Bradford,Wyalusing Township,Representative In Congress,12,DEM,Fred Keller,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In Congress,12,DEM,Write-In,0,0,0,0,0
 Bradford,Wysox Township,State Treasurer,,DEM,Joseph Torsella,24,6,33,0,63
 Bradford,Wysox Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
 Bradford,Wysox Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
-Bradford,Wysox Township,Representative In Congress,12,,Lee Griffin,25,6,31,0,62
-Bradford,Wysox Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
-Bradford,Wysox Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Wysox Township,Representative In Congress,12,DEM,Lee Griffin,25,6,31,0,62
+Bradford,Wysox Township,Representative In Congress,12,DEM,Fred Keller,1,0,0,0,1
+Bradford,Wysox Township,Representative In Congress,12,DEM,Write-In,1,0,0,0,1
 Bradford,Alba Borough,Senator In The General Assembly,23,DEM,Jackie Baker,3,0,2,0,5
 Bradford,Alba Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Alba Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Alba Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Alba Borough,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Alba Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,68,DEM,Write-In,1,0,0,0,1
 Bradford,Albany Township,Senator In The General Assembly,23,DEM,Jackie Baker,17,3,18,5,43
 Bradford,Albany Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
 Bradford,Albany Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Albany Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Albany Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Armenia Township,Senator In The General Assembly,23,DEM,Jackie Baker,2,0,1,1,4
 Bradford,Armenia Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Armenia Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Armenia Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Armenia Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Asylum Township,Senator In The General Assembly,23,DEM,Jackie Baker,15,1,24,1,41
 Bradford,Asylum Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
 Bradford,Asylum Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
-Bradford,Asylum Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Asylum Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,DEM,Jackie Baker,23,1,19,1,44
 Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
 Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,21,0,9,1,31
 Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,26,1,21,1,49
 Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,DEM,Jackie Baker,36,3,16,5,60
 Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Township 1St District,Senator In The General Assembly,23,DEM,Jackie Baker,41,9,43,4,97
 Bradford,Athens Township 1St District,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Athens Township 1St District,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Township 1St District,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Township 1St District,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,DEM,Jackie Baker,51,23,88,7,169
 Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Burlington Borough,Senator In The General Assembly,23,DEM,Jackie Baker,4,0,2,0,6
 Bradford,Burlington Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Burlington Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Burlington Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Burlington Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Burlington Township,Senator In The General Assembly,23,DEM,Jackie Baker,12,1,18,0,31
 Bradford,Burlington Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Burlington Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Burlington Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Burlington Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,West Burlington Township,Senator In The General Assembly,23,DEM,Jackie Baker,16,2,2,2,22
 Bradford,West Burlington Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
 Bradford,West Burlington Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,West Burlington Township,Representative In The General Assembly,68,,Clint Owlett,3,0,0,0,3
-Bradford,West Burlington Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,68,DEM,Clint Owlett,3,0,0,0,3
+Bradford,West Burlington Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Canton Borough,Senator In The General Assembly,23,DEM,Jackie Baker,34,8,18,3,63
 Bradford,Canton Borough,Senator In The General Assembly,23,DEM,Gene Yaw,2,0,0,0,2
 Bradford,Canton Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Canton Borough,Representative In The General Assembly,68,,Clint Owlett,1,1,3,0,5
-Bradford,Canton Borough,Representative In The General Assembly,68,,Write-In,1,1,3,2,7
+Bradford,Canton Borough,Representative In The General Assembly,68,DEM,Clint Owlett,1,1,3,0,5
+Bradford,Canton Borough,Representative In The General Assembly,68,DEM,Write-In,1,1,3,2,7
 Bradford,Canton Township,Senator In The General Assembly,23,DEM,Jackie Baker,29,1,16,2,48
 Bradford,Canton Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
 Bradford,Canton Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Canton Township,Representative In The General Assembly,68,,Clint Owlett,3,0,3,1,7
-Bradford,Canton Township,Representative In The General Assembly,68,,Write-In,2,0,3,0,5
+Bradford,Canton Township,Representative In The General Assembly,68,DEM,Clint Owlett,3,0,3,1,7
+Bradford,Canton Township,Representative In The General Assembly,68,DEM,Write-In,2,0,3,0,5
 Bradford,Columbia Township,Senator In The General Assembly,23,DEM,Jackie Baker,29,7,10,4,50
 Bradford,Columbia Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Columbia Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Columbia Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Columbia Township,Representative In The General Assembly,68,,Write-In,1,0,2,0,3
+Bradford,Columbia Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,68,DEM,Write-In,1,0,2,0,3
 Bradford,Franklin Township,Senator In The General Assembly,23,DEM,Jackie Baker,9,0,3,0,12
 Bradford,Franklin Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Franklin Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Franklin Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Franklin Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Granville Township,Senator In The General Assembly,23,DEM,Jackie Baker,17,3,8,2,30
 Bradford,Granville Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,2,0,2
 Bradford,Granville Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Granville Township,Representative In The General Assembly,68,,Clint Owlett,0,0,2,0,2
-Bradford,Granville Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,2,0,2
+Bradford,Granville Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Herrick Township,Senator In The General Assembly,23,DEM,Jackie Baker,19,3,5,3,30
 Bradford,Herrick Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Herrick Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Herrick Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Herrick Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Leraysville Borough,Senator In The General Assembly,23,DEM,Jackie Baker,4,0,4,0,8
 Bradford,Leraysville Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Leraysville Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Leraysville Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Leraysville Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Leroy Township,Senator In The General Assembly,23,DEM,Jackie Baker,21,2,8,2,33
 Bradford,Leroy Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,1,0,0,1
 Bradford,Leroy Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Leroy Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Leroy Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Litchfield Township,Senator In The General Assembly,23,DEM,Jackie Baker,27,5,19,1,52
 Bradford,Litchfield Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Litchfield Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
-Bradford,Litchfield Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Litchfield Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Monroe Borough,Senator In The General Assembly,23,DEM,Jackie Baker,8,1,12,0,21
 Bradford,Monroe Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Monroe Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Monroe Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Monroe Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Monroe Township,Senator In The General Assembly,23,DEM,Jackie Baker,20,7,12,1,40
 Bradford,Monroe Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Monroe Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
-Bradford,Monroe Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Monroe Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,New Albany Borough,Senator In The General Assembly,23,DEM,Jackie Baker,8,0,3,0,11
 Bradford,New Albany Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,New Albany Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,New Albany Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,New Albany Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Orwell Township,Senator In The General Assembly,23,DEM,Jackie Baker,26,3,18,1,48
 Bradford,Orwell Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
 Bradford,Orwell Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Orwell Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Orwell Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Overton Township,Senator In The General Assembly,23,DEM,Jackie Baker,16,0,6,1,23
 Bradford,Overton Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
 Bradford,Overton Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Overton Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Overton Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Pike Township,Senator In The General Assembly,23,DEM,Jackie Baker,13,4,6,0,23
 Bradford,Pike Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
 Bradford,Pike Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Pike Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Pike Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Ridgebury Township,Senator In The General Assembly,23,DEM,Jackie Baker,28,5,21,3,57
 Bradford,Ridgebury Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,1,1
 Bradford,Ridgebury Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Ridgebury Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,1,1
-Bradford,Ridgebury Township,Representative In The General Assembly,68,,Write-In,5,0,2,1,8
+Bradford,Ridgebury Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,1,1
+Bradford,Ridgebury Township,Representative In The General Assembly,68,DEM,Write-In,5,0,2,1,8
 Bradford,Rome Borough,Senator In The General Assembly,23,DEM,Jackie Baker,5,0,3,0,8
 Bradford,Rome Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Rome Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Rome Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Rome Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Rome Township,Senator In The General Assembly,23,DEM,Jackie Baker,13,1,9,0,23
 Bradford,Rome Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Rome Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Rome Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Rome Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,DEM,Jackie Baker,24,5,30,3,62
 Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,1,1
-Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,81,17,78,6,182
 Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
-Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,21,1,3,0,25
 Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
-Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,DEM,Jackie Baker,54,8,31,3,96
 Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
 Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,DEM,Jackie Baker,12,1,9,0,22
 Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Sheshequin Township,Senator In The General Assembly,23,DEM,Jackie Baker,13,3,16,1,33
 Bradford,Sheshequin Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Sheshequin Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Sheshequin Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sheshequin Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Smithfield Township,Senator In The General Assembly,23,DEM,Jackie Baker,31,2,21,3,57
 Bradford,Smithfield Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Smithfield Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
-Bradford,Smithfield Township,Representative In The General Assembly,68,,Clint Owlett,0,0,1,0,1
-Bradford,Smithfield Township,Representative In The General Assembly,68,,Write-In,2,0,2,0,4
+Bradford,Smithfield Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,1,0,1
+Bradford,Smithfield Township,Representative In The General Assembly,68,DEM,Write-In,2,0,2,0,4
 Bradford,South Creek Township,Senator In The General Assembly,23,DEM,Jackie Baker,22,1,5,1,29
 Bradford,South Creek Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
 Bradford,South Creek Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,South Creek Township,Representative In The General Assembly,68,,Clint Owlett,0,0,2,0,2
-Bradford,South Creek Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,2,0,2
+Bradford,South Creek Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,South Waverly Borough,Senator In The General Assembly,23,DEM,Jackie Baker,45,5,36,4,90
 Bradford,South Waverly Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,1,0,0,1
 Bradford,South Waverly Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,South Waverly Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,South Waverly Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Springfield Township,Senator In The General Assembly,23,DEM,Jackie Baker,20,4,29,2,55
 Bradford,Springfield Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Springfield Township,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
-Bradford,Springfield Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Springfield Township,Representative In The General Assembly,68,,Write-In,0,3,2,0,5
+Bradford,Springfield Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,68,DEM,Write-In,0,3,2,0,5
 Bradford,Standing Stone Township,Senator In The General Assembly,23,DEM,Jackie Baker,10,2,12,1,25
 Bradford,Standing Stone Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
 Bradford,Standing Stone Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
-Bradford,Standing Stone Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Standing Stone Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Stevens Township,Senator In The General Assembly,23,DEM,Jackie Baker,10,2,7,1,20
 Bradford,Stevens Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
 Bradford,Stevens Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
-Bradford,Stevens Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Stevens Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Sylvania Borough,Senator In The General Assembly,23,DEM,Jackie Baker,9,1,2,0,12
 Bradford,Sylvania Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Sylvania Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
-Bradford,Sylvania Borough,Representative In The General Assembly,68,,Clint Owlett,1,0,0,0,1
-Bradford,Sylvania Borough,Representative In The General Assembly,68,,Write-In,0,0,1,0,1
+Bradford,Sylvania Borough,Representative In The General Assembly,68,DEM,Clint Owlett,1,0,0,0,1
+Bradford,Sylvania Borough,Representative In The General Assembly,68,DEM,Write-In,0,0,1,0,1
 Bradford,Terry Township,Senator In The General Assembly,23,DEM,Jackie Baker,23,1,17,0,41
 Bradford,Terry Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
 Bradford,Terry Township,Senator In The General Assembly,23,DEM,Write-In,0,1,0,0,1
-Bradford,Terry Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Terry Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,DEM,Jackie Baker,11,0,7,0,18
 Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,26,1,18,1,46
 Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,26,9,30,3,68
 Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,2,0,3
 Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Towanda Township,Senator In The General Assembly,23,DEM,Jackie Baker,18,5,12,2,37
 Bradford,Towanda Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Towanda Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Towanda Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,North Towanda Township,Senator In The General Assembly,23,DEM,Jackie Baker,15,3,28,0,46
 Bradford,North Towanda Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,North Towanda Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,North Towanda Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,North Towanda Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Troy Borough,Senator In The General Assembly,23,DEM,Jackie Baker,32,2,25,3,62
 Bradford,Troy Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Troy Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Troy Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,1,0,1
-Bradford,Troy Borough,Representative In The General Assembly,68,,Write-In,2,0,1,0,3
+Bradford,Troy Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,1,0,1
+Bradford,Troy Borough,Representative In The General Assembly,68,DEM,Write-In,2,0,1,0,3
 Bradford,Troy Township,Senator In The General Assembly,23,DEM,Jackie Baker,27,5,26,2,60
 Bradford,Troy Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Troy Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
-Bradford,Troy Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Troy Township,Representative In The General Assembly,68,,Write-In,1,0,1,0,2
+Bradford,Troy Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,68,DEM,Write-In,1,0,1,0,2
 Bradford,Tuscarora Township,Senator In The General Assembly,23,DEM,Jackie Baker,26,3,22,0,51
 Bradford,Tuscarora Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Tuscarora Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Tuscarora Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Tuscarora Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Ulster Township,Senator In The General Assembly,23,DEM,Jackie Baker,22,3,21,0,46
 Bradford,Ulster Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Ulster Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Ulster Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Ulster Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Warren Township,Senator In The General Assembly,23,DEM,Jackie Baker,18,2,17,2,39
 Bradford,Warren Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Warren Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Warren Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Warren Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Wells Township,Senator In The General Assembly,23,DEM,Jackie Baker,19,3,15,0,37
 Bradford,Wells Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Wells Township,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
-Bradford,Wells Township,Representative In The General Assembly,68,,Clint Owlett,0,0,1,0,1
-Bradford,Wells Township,Representative In The General Assembly,68,,Write-In,2,0,2,0,4
+Bradford,Wells Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,1,0,1
+Bradford,Wells Township,Representative In The General Assembly,68,DEM,Write-In,2,0,2,0,4
 Bradford,Wilmot Township,Senator In The General Assembly,23,DEM,Jackie Baker,17,6,21,3,47
 Bradford,Wilmot Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Wilmot Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Wilmot Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Wilmot Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Windham Township,Senator In The General Assembly,23,DEM,Jackie Baker,11,5,12,2,30
 Bradford,Windham Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Windham Township,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
-Bradford,Windham Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Windham Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Wyalusing Borough,Senator In The General Assembly,23,DEM,Jackie Baker,30,2,13,2,47
 Bradford,Wyalusing Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Wyalusing Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Wyalusing Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Wyalusing Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Wyalusing Township,Senator In The General Assembly,23,DEM,Jackie Baker,20,5,21,0,46
 Bradford,Wyalusing Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
 Bradford,Wyalusing Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Wyalusing Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Wyalusing Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Wysox Township,Senator In The General Assembly,23,DEM,Jackie Baker,26,6,33,0,65
 Bradford,Wysox Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
 Bradford,Wysox Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
-Bradford,Wysox Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Wysox Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,68,DEM,Clint Owlett,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,68,DEM,Write-In,0,0,0,0,0
 Bradford,Alba Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
 Bradford,Alba Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
 Bradford,Alba Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
@@ -3113,308 +3113,308 @@ Bradford,Wysox Township,Representative In Congress,12,REP,Write-In,1,0,1,0,2
 Bradford,Alba Borough,Senator In The General Assembly,23,REP,Gene Yaw,32,0,3,0,35
 Bradford,Alba Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Alba Borough,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Alba Borough,Representative In The General Assembly,68,,Clint Owlett,32,0,3,0,35
-Bradford,Alba Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,68,REP,Clint Owlett,32,0,3,0,35
+Bradford,Alba Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Albany Township,Senator In The General Assembly,23,REP,Gene Yaw,101,4,30,5,140
 Bradford,Albany Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Albany Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Albany Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Albany Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Armenia Township,Senator In The General Assembly,23,REP,Gene Yaw,30,0,0,0,30
 Bradford,Armenia Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Armenia Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Armenia Township,Representative In The General Assembly,68,,Clint Owlett,32,0,1,0,33
-Bradford,Armenia Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,68,REP,Clint Owlett,32,0,1,0,33
+Bradford,Armenia Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Asylum Township,Senator In The General Assembly,23,REP,Gene Yaw,103,6,33,2,144
 Bradford,Asylum Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Asylum Township,Senator In The General Assembly,23,REP,Write-In,0,1,0,0,1
-Bradford,Asylum Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Asylum Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,REP,Gene Yaw,40,3,12,1,56
 Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,REP,Gene Yaw,33,3,7,0,43
 Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,REP,Gene Yaw,47,0,14,2,63
 Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,REP,Gene Yaw,61,3,26,3,93
 Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Athens Township 1St District,Senator In The General Assembly,23,REP,Gene Yaw,140,6,41,5,192
 Bradford,Athens Township 1St District,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
 Bradford,Athens Township 1St District,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Athens Township 1St District,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Township 1St District,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,REP,Gene Yaw,173,17,77,10,277
 Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Burlington Borough,Senator In The General Assembly,23,REP,Gene Yaw,19,0,1,0,20
 Bradford,Burlington Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Burlington Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Burlington Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Burlington Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Burlington Township,Senator In The General Assembly,23,REP,Gene Yaw,83,2,31,3,119
 Bradford,Burlington Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
 Bradford,Burlington Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Burlington Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Burlington Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,West Burlington Township,Senator In The General Assembly,23,REP,Gene Yaw,73,1,10,2,86
 Bradford,West Burlington Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,West Burlington Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,West Burlington Township,Representative In The General Assembly,68,,Clint Owlett,79,1,13,2,95
-Bradford,West Burlington Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,68,REP,Clint Owlett,79,1,13,2,95
+Bradford,West Burlington Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Canton Borough,Senator In The General Assembly,23,REP,Gene Yaw,150,6,33,7,196
 Bradford,Canton Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Canton Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Canton Borough,Representative In The General Assembly,68,,Clint Owlett,152,6,35,7,200
-Bradford,Canton Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,68,REP,Clint Owlett,152,6,35,7,200
+Bradford,Canton Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Canton Township,Senator In The General Assembly,23,REP,Gene Yaw,243,8,42,11,304
 Bradford,Canton Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Canton Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Canton Township,Representative In The General Assembly,68,,Clint Owlett,252,8,42,12,314
-Bradford,Canton Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,68,REP,Clint Owlett,252,8,42,12,314
+Bradford,Canton Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Columbia Township,Senator In The General Assembly,23,REP,Gene Yaw,124,1,28,4,157
 Bradford,Columbia Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Columbia Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Columbia Township,Representative In The General Assembly,68,,Clint Owlett,131,1,29,4,165
-Bradford,Columbia Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,68,REP,Clint Owlett,131,1,29,4,165
+Bradford,Columbia Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Franklin Township,Senator In The General Assembly,23,REP,Gene Yaw,65,4,14,1,84
 Bradford,Franklin Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Franklin Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Franklin Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Franklin Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Granville Township,Senator In The General Assembly,23,REP,Gene Yaw,89,1,20,1,111
 Bradford,Granville Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Granville Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Granville Township,Representative In The General Assembly,68,,Clint Owlett,92,1,20,1,114
-Bradford,Granville Township,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Granville Township,Representative In The General Assembly,68,REP,Clint Owlett,92,1,20,1,114
+Bradford,Granville Township,Representative In The General Assembly,68,REP,Write-In,1,0,0,0,1
 Bradford,Herrick Township,Senator In The General Assembly,23,REP,Gene Yaw,115,3,19,2,139
 Bradford,Herrick Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
 Bradford,Herrick Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Herrick Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Herrick Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Leraysville Borough,Senator In The General Assembly,23,REP,Gene Yaw,37,2,8,0,47
 Bradford,Leraysville Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Leraysville Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Leraysville Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Leraysville Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Leroy Township,Senator In The General Assembly,23,REP,Gene Yaw,100,0,24,0,124
 Bradford,Leroy Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Leroy Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Leroy Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Leroy Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Litchfield Township,Senator In The General Assembly,23,REP,Gene Yaw,125,3,29,3,160
 Bradford,Litchfield Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Litchfield Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Litchfield Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Litchfield Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Monroe Borough,Senator In The General Assembly,23,REP,Gene Yaw,59,1,11,0,71
 Bradford,Monroe Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Monroe Borough,Senator In The General Assembly,23,REP,Write-In,1,0,1,0,2
-Bradford,Monroe Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Monroe Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Monroe Township,Senator In The General Assembly,23,REP,Gene Yaw,115,4,28,6,153
 Bradford,Monroe Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Monroe Township,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
-Bradford,Monroe Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Monroe Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,New Albany Borough,Senator In The General Assembly,23,REP,Gene Yaw,26,1,1,0,28
 Bradford,New Albany Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,New Albany Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,New Albany Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,New Albany Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Orwell Township,Senator In The General Assembly,23,REP,Gene Yaw,133,8,52,2,195
 Bradford,Orwell Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Orwell Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Orwell Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Orwell Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Overton Township,Senator In The General Assembly,23,REP,Gene Yaw,31,1,5,1,38
 Bradford,Overton Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Overton Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Overton Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Overton Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Pike Township,Senator In The General Assembly,23,REP,Gene Yaw,75,3,16,4,98
 Bradford,Pike Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Pike Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Pike Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Pike Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Ridgebury Township,Senator In The General Assembly,23,REP,Gene Yaw,173,9,20,5,207
 Bradford,Ridgebury Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Ridgebury Township,Senator In The General Assembly,23,REP,Write-In,1,1,0,0,2
-Bradford,Ridgebury Township,Representative In The General Assembly,68,,Clint Owlett,175,10,22,5,212
-Bradford,Ridgebury Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,68,REP,Clint Owlett,175,10,22,5,212
+Bradford,Ridgebury Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Rome Borough,Senator In The General Assembly,23,REP,Gene Yaw,23,2,11,0,36
 Bradford,Rome Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Rome Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Rome Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Rome Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Rome Township,Senator In The General Assembly,23,REP,Gene Yaw,144,11,39,4,198
 Bradford,Rome Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Rome Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Rome Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Rome Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,REP,Gene Yaw,46,1,16,0,63
 Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,3,0,3
 Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,REP,Gene Yaw,127,3,45,2,177
 Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
 Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,1,1
-Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,REP,Gene Yaw,33,2,5,0,40
 Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,REP,Gene Yaw,75,4,18,3,100
 Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
 Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,REP,Write-In,0,0,1,0,1
-Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,REP,Gene Yaw,16,1,2,0,19
 Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Sheshequin Township,Senator In The General Assembly,23,REP,Gene Yaw,114,12,33,3,162
 Bradford,Sheshequin Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,3,0,3
 Bradford,Sheshequin Township,Senator In The General Assembly,23,REP,Write-In,3,0,0,0,3
-Bradford,Sheshequin Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Sheshequin Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Smithfield Township,Senator In The General Assembly,23,REP,Gene Yaw,171,6,44,6,227
 Bradford,Smithfield Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
 Bradford,Smithfield Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Smithfield Township,Representative In The General Assembly,68,,Clint Owlett,173,6,49,5,233
-Bradford,Smithfield Township,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Smithfield Township,Representative In The General Assembly,68,REP,Clint Owlett,173,6,49,5,233
+Bradford,Smithfield Township,Representative In The General Assembly,68,REP,Write-In,1,0,0,0,1
 Bradford,South Creek Township,Senator In The General Assembly,23,REP,Gene Yaw,136,3,29,3,171
 Bradford,South Creek Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,2,0,2
 Bradford,South Creek Township,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
-Bradford,South Creek Township,Representative In The General Assembly,68,,Clint Owlett,142,3,29,3,177
-Bradford,South Creek Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,68,REP,Clint Owlett,142,3,29,3,177
+Bradford,South Creek Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,South Waverly Borough,Senator In The General Assembly,23,REP,Gene Yaw,78,2,28,1,109
 Bradford,South Waverly Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,South Waverly Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,South Waverly Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,South Waverly Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Springfield Township,Senator In The General Assembly,23,REP,Gene Yaw,131,5,32,12,180
 Bradford,Springfield Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Springfield Township,Senator In The General Assembly,23,REP,Write-In,4,0,1,1,6
-Bradford,Springfield Township,Representative In The General Assembly,68,,Clint Owlett,145,4,34,13,196
-Bradford,Springfield Township,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Springfield Township,Representative In The General Assembly,68,REP,Clint Owlett,145,4,34,13,196
+Bradford,Springfield Township,Representative In The General Assembly,68,REP,Write-In,1,0,0,0,1
 Bradford,Standing Stone Township,Senator In The General Assembly,23,REP,Gene Yaw,54,6,19,2,81
 Bradford,Standing Stone Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Standing Stone Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Standing Stone Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Standing Stone Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Stevens Township,Senator In The General Assembly,23,REP,Gene Yaw,66,3,12,1,82
 Bradford,Stevens Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Stevens Township,Senator In The General Assembly,23,REP,Write-In,1,0,1,0,2
-Bradford,Stevens Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Stevens Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Sylvania Borough,Senator In The General Assembly,23,REP,Gene Yaw,28,0,9,0,37
 Bradford,Sylvania Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Sylvania Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Sylvania Borough,Representative In The General Assembly,68,,Clint Owlett,29,0,8,0,37
-Bradford,Sylvania Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,68,REP,Clint Owlett,29,0,8,0,37
+Bradford,Sylvania Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Terry Township,Senator In The General Assembly,23,REP,Gene Yaw,118,1,23,1,143
 Bradford,Terry Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Terry Township,Senator In The General Assembly,23,REP,Write-In,2,0,1,0,3
-Bradford,Terry Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Terry Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,REP,Gene Yaw,60,0,14,1,75
 Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
-Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,REP,Gene Yaw,61,5,21,4,91
 Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,REP,Write-In,0,1,0,0,1
-Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,REP,Gene Yaw,102,3,42,2,149
 Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
 Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Towanda Township,Senator In The General Assembly,23,REP,Gene Yaw,73,10,19,0,102
 Bradford,Towanda Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Towanda Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Towanda Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Towanda Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,North Towanda Township,Senator In The General Assembly,23,REP,Gene Yaw,81,6,42,0,129
 Bradford,North Towanda Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,North Towanda Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,North Towanda Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,North Towanda Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Troy Borough,Senator In The General Assembly,23,REP,Gene Yaw,116,4,21,10,151
 Bradford,Troy Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Troy Borough,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Troy Borough,Representative In The General Assembly,68,,Clint Owlett,123,4,23,10,160
-Bradford,Troy Borough,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Troy Borough,Representative In The General Assembly,68,REP,Clint Owlett,123,4,23,10,160
+Bradford,Troy Borough,Representative In The General Assembly,68,REP,Write-In,1,0,0,0,1
 Bradford,Troy Township,Senator In The General Assembly,23,REP,Gene Yaw,209,9,73,8,299
 Bradford,Troy Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Troy Township,Senator In The General Assembly,23,REP,Write-In,1,0,1,0,2
-Bradford,Troy Township,Representative In The General Assembly,68,,Clint Owlett,218,9,78,9,314
-Bradford,Troy Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,68,REP,Clint Owlett,218,9,78,9,314
+Bradford,Troy Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Tuscarora Township,Senator In The General Assembly,23,REP,Gene Yaw,144,9,30,3,186
 Bradford,Tuscarora Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Tuscarora Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Tuscarora Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Tuscarora Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Ulster Township,Senator In The General Assembly,23,REP,Gene Yaw,103,10,17,0,130
 Bradford,Ulster Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Ulster Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Ulster Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Ulster Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Warren Township,Senator In The General Assembly,23,REP,Gene Yaw,137,5,24,5,171
 Bradford,Warren Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Warren Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Warren Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Warren Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Wells Township,Senator In The General Assembly,23,REP,Gene Yaw,154,2,11,2,169
 Bradford,Wells Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,2,0,2
 Bradford,Wells Township,Senator In The General Assembly,23,REP,Write-In,1,0,1,0,2
-Bradford,Wells Township,Representative In The General Assembly,68,,Clint Owlett,156,2,14,2,174
-Bradford,Wells Township,Representative In The General Assembly,68,,Write-In,0,0,1,0,1
+Bradford,Wells Township,Representative In The General Assembly,68,REP,Clint Owlett,156,2,14,2,174
+Bradford,Wells Township,Representative In The General Assembly,68,REP,Write-In,0,0,1,0,1
 Bradford,Wilmot Township,Senator In The General Assembly,23,REP,Gene Yaw,130,9,40,11,190
 Bradford,Wilmot Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
 Bradford,Wilmot Township,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
-Bradford,Wilmot Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Wilmot Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Windham Township,Senator In The General Assembly,23,REP,Gene Yaw,82,3,29,9,123
 Bradford,Windham Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Windham Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Windham Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Windham Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Wyalusing Borough,Senator In The General Assembly,23,REP,Gene Yaw,61,1,10,6,78
 Bradford,Wyalusing Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Wyalusing Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
-Bradford,Wyalusing Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Wyalusing Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Wyalusing Township,Senator In The General Assembly,23,REP,Gene Yaw,167,13,40,4,224
 Bradford,Wyalusing Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Wyalusing Township,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
-Bradford,Wyalusing Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Wyalusing Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Wysox Township,Senator In The General Assembly,23,REP,Gene Yaw,166,11,49,1,227
 Bradford,Wysox Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
 Bradford,Wysox Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
-Bradford,Wysox Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
-Bradford,Wysox Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,68,REP,Clint Owlett,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,68,REP,Write-In,0,0,0,0,0
 Bradford,Alba Borough,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
 Bradford,Alba Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
 Bradford,Alba Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0

--- a/2020/20200602__pa__primary__bradford__precinct.csv
+++ b/2020/20200602__pa__primary__bradford__precinct.csv
@@ -1,426 +1,426 @@
 county,precinct,office,district,party,candidate,election_day,absentee,mail_in,provisional,votes
-Bradford,Alba Borough,Turnout,,,Registered Voters,,,,,95
-Bradford,Alba Borough,Turnout,,,Ballots Cast,36,0,5,0,41
+Bradford,Alba Borough,Registered Voters,,,,,,,,95
+Bradford,Alba Borough,Ballots Cast,,,,36,0,5,0,41
 Bradford,Alba Borough,President Of The United States,,DEM,Bernie Sanders,0,0,0,0,0
 Bradford,Alba Borough,President Of The United States,,DEM,Joseph R. Biden,1,0,2,0,3
 Bradford,Alba Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Alba Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Alba Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Albany Township,Turnout,,,Registered Voters,,,,,545
-Bradford,Albany Township,Turnout,,,Ballots Cast,128,7,54,11,200
+Bradford,Albany Township,Registered Voters,,,,,,,,545
+Bradford,Albany Township,Ballots Cast,,,,128,7,54,11,200
 Bradford,Albany Township,President Of The United States,,DEM,Bernie Sanders,3,0,3,1,7
 Bradford,Albany Township,President Of The United States,,DEM,Joseph R. Biden,13,3,16,4,36
 Bradford,Albany Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Albany Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,1,5
 Bradford,Albany Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
-Bradford,Armenia Township,Turnout,,,Registered Voters,,,,,131
-Bradford,Armenia Township,Turnout,,,Ballots Cast,42,0,4,2,48
+Bradford,Armenia Township,Registered Voters,,,,,,,,131
+Bradford,Armenia Township,Ballots Cast,,,,42,0,4,2,48
 Bradford,Armenia Township,President Of The United States,,DEM,Bernie Sanders,1,0,0,0,1
 Bradford,Armenia Township,President Of The United States,,DEM,Joseph R. Biden,0,0,2,2,4
 Bradford,Armenia Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
 Bradford,Armenia Township,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
 Bradford,Armenia Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Asylum Township,Turnout,,,Registered Voters,,,,,627
-Bradford,Asylum Township,Turnout,,,Ballots Cast,138,8,67,4,217
+Bradford,Asylum Township,Registered Voters,,,,,,,,627
+Bradford,Asylum Township,Ballots Cast,,,,138,8,67,4,217
 Bradford,Asylum Township,President Of The United States,,DEM,Bernie Sanders,0,1,4,0,5
 Bradford,Asylum Township,President Of The United States,,DEM,Joseph R. Biden,20,0,22,0,42
 Bradford,Asylum Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,Asylum Township,President Of The United States,,DEM,Donald J. Trump,0,0,1,0,1
 Bradford,Asylum Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 1St Ward,Turnout,,,Registered Voters,,,,,344
-Bradford,Athens Borough 1St Ward,Turnout,,,Ballots Cast,69,5,35,3,112
+Bradford,Athens Borough 1St Ward,Registered Voters,,,,,,,,344
+Bradford,Athens Borough 1St Ward,Ballots Cast,,,,69,5,35,3,112
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,4,0,2,1,7
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,19,1,20,0,40
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
 Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 2Nd Ward,Turnout,,,Registered Voters,,,,,365
-Bradford,Athens Borough 2Nd Ward,Turnout,,,Ballots Cast,64,4,20,1,89
+Bradford,Athens Borough 2Nd Ward,Registered Voters,,,,,,,,365
+Bradford,Athens Borough 2Nd Ward,Ballots Cast,,,,64,4,20,1,89
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,6,1,3,0,10
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,18,0,10,1,29
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Athens Borough 3Rd Ward,Turnout,,,Registered Voters,,,,,522
-Bradford,Athens Borough 3Rd Ward,Turnout,,,Ballots Cast,84,3,36,3,126
+Bradford,Athens Borough 3Rd Ward,Registered Voters,,,,,,,,522
+Bradford,Athens Borough 3Rd Ward,Ballots Cast,,,,84,3,36,3,126
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,7,0,1,1,9
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,24,3,21,0,48
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Borough 4Th Ward,Turnout,,,Registered Voters,,,,,568
-Bradford,Athens Borough 4Th Ward,Turnout,,,Ballots Cast,102,7,46,9,164
+Bradford,Athens Borough 4Th Ward,Registered Voters,,,,,,,,568
+Bradford,Athens Borough 4Th Ward,Ballots Cast,,,,102,7,46,9,164
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Bernie Sanders,6,3,6,1,16
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Joseph R. Biden,30,1,11,5,47
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
 Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Township 1St District,Turnout,,,Registered Voters,,,,,1286
-Bradford,Athens Township 1St District,Turnout,,,Ballots Cast,209,16,93,9,327
+Bradford,Athens Township 1St District,Registered Voters,,,,,,,,1286
+Bradford,Athens Township 1St District,Ballots Cast,,,,209,16,93,9,327
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Bernie Sanders,13,1,7,1,22
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Joseph R. Biden,32,8,38,3,81
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
 Bradford,Athens Township 1St District,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Athens Township 2Nd District,Turnout,,,Registered Voters,,,,,1871
-Bradford,Athens Township 2Nd District,Turnout,,,Ballots Cast,261,50,185,19,515
+Bradford,Athens Township 2Nd District,Registered Voters,,,,,,,,1871
+Bradford,Athens Township 2Nd District,Ballots Cast,,,,261,50,185,19,515
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Bernie Sanders,11,2,12,4,29
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Joseph R. Biden,47,25,87,4,163
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Tulsi Gabbard,4,1,1,0,6
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Write-In,2,0,1,0,3
-Bradford,Burlington Borough,Turnout,,,Registered Voters,,,,,83
-Bradford,Burlington Borough,Turnout,,,Ballots Cast,24,0,3,0,27
+Bradford,Burlington Borough,Registered Voters,,,,,,,,83
+Bradford,Burlington Borough,Ballots Cast,,,,24,0,3,0,27
 Bradford,Burlington Borough,President Of The United States,,DEM,Bernie Sanders,1,0,2,0,3
 Bradford,Burlington Borough,President Of The United States,,DEM,Joseph R. Biden,3,0,0,0,3
 Bradford,Burlington Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Burlington Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Burlington Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Burlington Township,Turnout,,,Registered Voters,,,,,449
-Bradford,Burlington Township,Turnout,,,Ballots Cast,110,3,57,3,173
+Bradford,Burlington Township,Registered Voters,,,,,,,,449
+Bradford,Burlington Township,Ballots Cast,,,,110,3,57,3,173
 Bradford,Burlington Township,President Of The United States,,DEM,Bernie Sanders,4,0,2,0,6
 Bradford,Burlington Township,President Of The United States,,DEM,Joseph R. Biden,7,1,16,0,24
 Bradford,Burlington Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Burlington Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Burlington Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,West Burlington Township,Turnout,,,Registered Voters,,,,,310
-Bradford,West Burlington Township,Turnout,,,Ballots Cast,107,3,16,4,130
+Bradford,West Burlington Township,Registered Voters,,,,,,,,310
+Bradford,West Burlington Township,Ballots Cast,,,,107,3,16,4,130
 Bradford,West Burlington Township,President Of The United States,,DEM,Bernie Sanders,3,1,0,0,4
 Bradford,West Burlington Township,President Of The United States,,DEM,Joseph R. Biden,16,1,1,2,20
 Bradford,West Burlington Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,West Burlington Township,President Of The United States,,DEM,Donald J. Trump,5,0,1,0,6
 Bradford,West Burlington Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Canton Borough,Turnout,,,Registered Voters,,,,,907
-Bradford,Canton Borough,Turnout,,,Ballots Cast,209,14,58,10,291
+Bradford,Canton Borough,Registered Voters,,,,,,,,907
+Bradford,Canton Borough,Ballots Cast,,,,209,14,58,10,291
 Bradford,Canton Borough,President Of The United States,,DEM,Bernie Sanders,11,3,4,3,21
 Bradford,Canton Borough,President Of The United States,,DEM,Joseph R. Biden,18,4,17,0,39
 Bradford,Canton Borough,President Of The United States,,DEM,Tulsi Gabbard,3,1,0,0,4
 Bradford,Canton Borough,President Of The United States,,DEM,Donald J. Trump,8,0,0,0,8
 Bradford,Canton Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Canton Township,Turnout,,,Registered Voters,,,,,1098
-Bradford,Canton Township,Turnout,,,Ballots Cast,296,9,65,15,385
+Bradford,Canton Township,Registered Voters,,,,,,,,1098
+Bradford,Canton Township,Ballots Cast,,,,296,9,65,15,385
 Bradford,Canton Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
 Bradford,Canton Township,President Of The United States,,DEM,Joseph R. Biden,23,1,14,2,40
 Bradford,Canton Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,2,0,5
 Bradford,Canton Township,President Of The United States,,DEM,Donald J. Trump,4,0,2,0,6
 Bradford,Canton Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Columbia Township,Turnout,,,Registered Voters,,,,,668
-Bradford,Columbia Township,Turnout,,,Ballots Cast,173,8,44,8,233
+Bradford,Columbia Township,Registered Voters,,,,,,,,668
+Bradford,Columbia Township,Ballots Cast,,,,173,8,44,8,233
 Bradford,Columbia Township,President Of The United States,,DEM,Bernie Sanders,11,5,5,1,22
 Bradford,Columbia Township,President Of The United States,,DEM,Joseph R. Biden,16,2,9,3,30
 Bradford,Columbia Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Columbia Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,0,4
 Bradford,Columbia Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Franklin Township,Turnout,,,Registered Voters,,,,,372
-Bradford,Franklin Township,Turnout,,,Ballots Cast,82,4,19,1,106
+Bradford,Franklin Township,Registered Voters,,,,,,,,372
+Bradford,Franklin Township,Ballots Cast,,,,82,4,19,1,106
 Bradford,Franklin Township,President Of The United States,,DEM,Bernie Sanders,1,0,0,0,1
 Bradford,Franklin Township,President Of The United States,,DEM,Joseph R. Biden,7,0,4,0,11
 Bradford,Franklin Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,Franklin Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Franklin Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Granville Township,Turnout,,,Registered Voters,,,,,521
-Bradford,Granville Township,Turnout,,,Ballots Cast,118,5,32,3,158
+Bradford,Granville Township,Registered Voters,,,,,,,,521
+Bradford,Granville Township,Ballots Cast,,,,118,5,32,3,158
 Bradford,Granville Township,President Of The United States,,DEM,Bernie Sanders,3,1,1,0,5
 Bradford,Granville Township,President Of The United States,,DEM,Joseph R. Biden,9,1,8,2,20
 Bradford,Granville Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
 Bradford,Granville Township,President Of The United States,,DEM,Donald J. Trump,3,1,2,0,6
 Bradford,Granville Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Herrick Township,Turnout,,,Registered Voters,,,,,472
-Bradford,Herrick Township,Turnout,,,Ballots Cast,149,6,28,5,188
+Bradford,Herrick Township,Registered Voters,,,,,,,,472
+Bradford,Herrick Township,Ballots Cast,,,,149,6,28,5,188
 Bradford,Herrick Township,President Of The United States,,DEM,Bernie Sanders,3,1,1,2,7
 Bradford,Herrick Township,President Of The United States,,DEM,Joseph R. Biden,13,2,4,1,20
 Bradford,Herrick Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
 Bradford,Herrick Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,0,4
 Bradford,Herrick Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Leraysville Borough,Turnout,,,Registered Voters,,,,,150
-Bradford,Leraysville Borough,Turnout,,,Ballots Cast,44,2,14,0,60
+Bradford,Leraysville Borough,Registered Voters,,,,,,,,150
+Bradford,Leraysville Borough,Ballots Cast,,,,44,2,14,0,60
 Bradford,Leraysville Borough,President Of The United States,,DEM,Bernie Sanders,0,0,1,0,1
 Bradford,Leraysville Borough,President Of The United States,,DEM,Joseph R. Biden,3,0,4,0,7
 Bradford,Leraysville Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Leraysville Borough,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Leraysville Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Leroy Township,Turnout,,,Registered Voters,,,,,392
-Bradford,Leroy Township,Turnout,,,Ballots Cast,132,3,37,2,174
+Bradford,Leroy Township,Registered Voters,,,,,,,,392
+Bradford,Leroy Township,Ballots Cast,,,,132,3,37,2,174
 Bradford,Leroy Township,President Of The United States,,DEM,Bernie Sanders,2,0,1,0,3
 Bradford,Leroy Township,President Of The United States,,DEM,Joseph R. Biden,18,1,11,2,32
 Bradford,Leroy Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,0,0,2
 Bradford,Leroy Township,President Of The United States,,DEM,Donald J. Trump,4,1,0,0,5
 Bradford,Leroy Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Litchfield Township,Turnout,,,Registered Voters,,,,,839
-Bradford,Litchfield Township,Turnout,,,Ballots Cast,171,9,57,5,242
+Bradford,Litchfield Township,Registered Voters,,,,,,,,839
+Bradford,Litchfield Township,Ballots Cast,,,,171,9,57,5,242
 Bradford,Litchfield Township,President Of The United States,,DEM,Bernie Sanders,4,2,4,1,11
 Bradford,Litchfield Township,President Of The United States,,DEM,Joseph R. Biden,22,3,14,0,39
 Bradford,Litchfield Township,President Of The United States,,DEM,Tulsi Gabbard,5,0,1,0,6
 Bradford,Litchfield Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Litchfield Township,President Of The United States,,DEM,Write-In,2,0,0,0,2
-Bradford,Monroe Borough,Turnout,,,Registered Voters,,,,,281
-Bradford,Monroe Borough,Turnout,,,Ballots Cast,79,3,30,0,112
+Bradford,Monroe Borough,Registered Voters,,,,,,,,281
+Bradford,Monroe Borough,Ballots Cast,,,,79,3,30,0,112
 Bradford,Monroe Borough,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
 Bradford,Monroe Borough,President Of The United States,,DEM,Joseph R. Biden,6,2,12,0,20
 Bradford,Monroe Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Monroe Borough,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Monroe Borough,President Of The United States,,DEM,Write-In,0,0,1,0,1
-Bradford,Monroe Township,Turnout,,,Registered Voters,,,,,654
-Bradford,Monroe Township,Turnout,,,Ballots Cast,159,11,49,8,227
+Bradford,Monroe Township,Registered Voters,,,,,,,,654
+Bradford,Monroe Township,Ballots Cast,,,,159,11,49,8,227
 Bradford,Monroe Township,President Of The United States,,DEM,Bernie Sanders,4,2,0,0,6
 Bradford,Monroe Township,President Of The United States,,DEM,Joseph R. Biden,14,5,13,1,33
 Bradford,Monroe Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Monroe Township,President Of The United States,,DEM,Donald J. Trump,6,0,0,0,6
 Bradford,Monroe Township,President Of The United States,,DEM,Write-In,2,0,0,0,2
-Bradford,New Albany Borough,Turnout,,,Registered Voters,,,,,134
-Bradford,New Albany Borough,Turnout,,,Ballots Cast,38,1,4,0,43
+Bradford,New Albany Borough,Registered Voters,,,,,,,,134
+Bradford,New Albany Borough,Ballots Cast,,,,38,1,4,0,43
 Bradford,New Albany Borough,President Of The United States,,DEM,Bernie Sanders,0,0,1,0,1
 Bradford,New Albany Borough,President Of The United States,,DEM,Joseph R. Biden,6,0,2,0,8
 Bradford,New Albany Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,New Albany Borough,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,New Albany Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Orwell Township,Turnout,,,Registered Voters,,,,,740
-Bradford,Orwell Township,Turnout,,,Ballots Cast,185,11,77,4,277
+Bradford,Orwell Township,Registered Voters,,,,,,,,740
+Bradford,Orwell Township,Ballots Cast,,,,185,11,77,4,277
 Bradford,Orwell Township,President Of The United States,,DEM,Bernie Sanders,6,3,0,0,9
 Bradford,Orwell Township,President Of The United States,,DEM,Joseph R. Biden,18,0,21,1,40
 Bradford,Orwell Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,0,3
 Bradford,Orwell Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Orwell Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Overton Township,Turnout,,,Registered Voters,,,,,149
-Bradford,Overton Township,Turnout,,,Ballots Cast,51,1,13,3,68
+Bradford,Overton Township,Registered Voters,,,,,,,,149
+Bradford,Overton Township,Ballots Cast,,,,51,1,13,3,68
 Bradford,Overton Township,President Of The United States,,DEM,Bernie Sanders,8,0,0,1,9
 Bradford,Overton Township,President Of The United States,,DEM,Joseph R. Biden,6,0,7,0,13
 Bradford,Overton Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,0,3
 Bradford,Overton Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Overton Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Pike Township,Turnout,,,Registered Voters,,,,,358
-Bradford,Pike Township,Turnout,,,Ballots Cast,105,7,22,4,138
+Bradford,Pike Township,Registered Voters,,,,,,,,358
+Bradford,Pike Township,Ballots Cast,,,,105,7,22,4,138
 Bradford,Pike Township,President Of The United States,,DEM,Bernie Sanders,3,1,0,0,4
 Bradford,Pike Township,President Of The United States,,DEM,Joseph R. Biden,10,3,5,0,18
 Bradford,Pike Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Pike Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Pike Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Ridgebury Township,Turnout,,,Registered Voters,,,,,1219
-Bradford,Ridgebury Township,Turnout,,,Ballots Cast,225,17,48,9,299
+Bradford,Ridgebury Township,Registered Voters,,,,,,,,1219
+Bradford,Ridgebury Township,Ballots Cast,,,,225,17,48,9,299
 Bradford,Ridgebury Township,President Of The United States,,DEM,Bernie Sanders,9,0,2,0,11
 Bradford,Ridgebury Township,President Of The United States,,DEM,Joseph R. Biden,17,7,17,2,43
 Bradford,Ridgebury Township,President Of The United States,,DEM,Tulsi Gabbard,5,0,3,1,9
 Bradford,Ridgebury Township,President Of The United States,,DEM,Donald J. Trump,2,0,1,1,4
 Bradford,Ridgebury Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
-Bradford,Rome Borough,Turnout,,,Registered Voters,,,,,192
-Bradford,Rome Borough,Turnout,,,Ballots Cast,36,4,15,0,55
+Bradford,Rome Borough,Registered Voters,,,,,,,,192
+Bradford,Rome Borough,Ballots Cast,,,,36,4,15,0,55
 Bradford,Rome Borough,President Of The United States,,DEM,Bernie Sanders,3,0,1,0,4
 Bradford,Rome Borough,President Of The United States,,DEM,Joseph R. Biden,1,0,1,0,2
 Bradford,Rome Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,Rome Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Rome Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Rome Township,Turnout,,,Registered Voters,,,,,675
-Bradford,Rome Township,Turnout,,,Ballots Cast,174,12,53,4,243
+Bradford,Rome Township,Registered Voters,,,,,,,,675
+Bradford,Rome Township,Ballots Cast,,,,174,12,53,4,243
 Bradford,Rome Township,President Of The United States,,DEM,Bernie Sanders,0,0,3,0,3
 Bradford,Rome Township,President Of The United States,,DEM,Joseph R. Biden,12,1,7,0,20
 Bradford,Rome Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Rome Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Rome Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Sayre Borough 1St Ward,Turnout,,,Registered Voters,,,,,472
-Bradford,Sayre Borough 1St Ward,Turnout,,,Ballots Cast,79,8,53,5,145
+Bradford,Sayre Borough 1St Ward,Registered Voters,,,,,,,,472
+Bradford,Sayre Borough 1St Ward,Ballots Cast,,,,79,8,53,5,145
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,6,2,5,3,16
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,21,5,27,2,55
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,2,0,2
-Bradford,Sayre Borough 2Nd Ward,Turnout,,,Registered Voters,,,,,1426
-Bradford,Sayre Borough 2Nd Ward,Turnout,,,Ballots Cast,230,20,143,11,404
+Bradford,Sayre Borough 2Nd Ward,Registered Voters,,,,,,,,1426
+Bradford,Sayre Borough 2Nd Ward,Ballots Cast,,,,230,20,143,11,404
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,10,4,13,3,30
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,68,12,77,4,161
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,4,0,0,0,4
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
 Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Write-In,3,1,2,0,6
-Bradford,Sayre Borough 3Rd Ward,Turnout,,,Registered Voters,,,,,313
-Bradford,Sayre Borough 3Rd Ward,Turnout,,,Ballots Cast,60,3,10,0,73
+Bradford,Sayre Borough 3Rd Ward,Registered Voters,,,,,,,,313
+Bradford,Sayre Borough 3Rd Ward,Ballots Cast,,,,60,3,10,0,73
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,9,0,1,0,10
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,13,1,3,0,17
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
 Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Sayre Borough 4Th Ward,Turnout,,,Registered Voters,,,,,842
-Bradford,Sayre Borough 4Th Ward,Turnout,,,Ballots Cast,150,15,59,9,233
+Bradford,Sayre Borough 4Th Ward,Registered Voters,,,,,,,,842
+Bradford,Sayre Borough 4Th Ward,Ballots Cast,,,,150,15,59,9,233
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Bernie Sanders,11,2,2,2,17
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Joseph R. Biden,48,8,31,3,90
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Tulsi Gabbard,5,0,2,0,7
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
 Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Sayre Borough 5Th Ward,Turnout,,,Registered Voters,,,,,182
-Bradford,Sayre Borough 5Th Ward,Turnout,,,Ballots Cast,31,3,14,0,48
+Bradford,Sayre Borough 5Th Ward,Registered Voters,,,,,,,,182
+Bradford,Sayre Borough 5Th Ward,Ballots Cast,,,,31,3,14,0,48
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Bernie Sanders,2,1,2,0,5
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Joseph R. Biden,6,1,7,0,14
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Donald J. Trump,2,0,1,0,3
 Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Sheshequin Township,Turnout,,,Registered Voters,,,,,784
-Bradford,Sheshequin Township,Turnout,,,Ballots Cast,149,15,62,8,234
+Bradford,Sheshequin Township,Registered Voters,,,,,,,,784
+Bradford,Sheshequin Township,Ballots Cast,,,,149,15,62,8,234
 Bradford,Sheshequin Township,President Of The United States,,DEM,Bernie Sanders,2,0,4,0,6
 Bradford,Sheshequin Township,President Of The United States,,DEM,Joseph R. Biden,10,2,21,5,38
 Bradford,Sheshequin Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,0,0,2
 Bradford,Sheshequin Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Sheshequin Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Smithfield Township,Turnout,,,Registered Voters,,,,,968
-Bradford,Smithfield Township,Turnout,,,Ballots Cast,228,10,79,9,326
+Bradford,Smithfield Township,Registered Voters,,,,,,,,968
+Bradford,Smithfield Township,Ballots Cast,,,,228,10,79,9,326
 Bradford,Smithfield Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
 Bradford,Smithfield Township,President Of The United States,,DEM,Joseph R. Biden,24,1,24,2,51
 Bradford,Smithfield Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,1,4
 Bradford,Smithfield Township,President Of The United States,,DEM,Donald J. Trump,2,0,2,0,4
 Bradford,Smithfield Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,South Creek Township,Turnout,,,Registered Voters,,,,,740
-Bradford,South Creek Township,Turnout,,,Ballots Cast,178,4,45,4,231
+Bradford,South Creek Township,Registered Voters,,,,,,,,740
+Bradford,South Creek Township,Ballots Cast,,,,178,4,45,4,231
 Bradford,South Creek Township,President Of The United States,,DEM,Bernie Sanders,3,0,0,0,3
 Bradford,South Creek Township,President Of The United States,,DEM,Joseph R. Biden,14,1,10,1,26
 Bradford,South Creek Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,South Creek Township,President Of The United States,,DEM,Donald J. Trump,7,0,1,0,8
 Bradford,South Creek Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,South Waverly Borough,Turnout,,,Registered Voters,,,,,710
-Bradford,South Waverly Borough,Turnout,,,Ballots Cast,146,9,68,5,228
+Bradford,South Waverly Borough,Registered Voters,,,,,,,,710
+Bradford,South Waverly Borough,Ballots Cast,,,,146,9,68,5,228
 Bradford,South Waverly Borough,President Of The United States,,DEM,Bernie Sanders,12,0,6,0,18
 Bradford,South Waverly Borough,President Of The United States,,DEM,Joseph R. Biden,39,6,31,4,80
 Bradford,South Waverly Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,South Waverly Borough,President Of The United States,,DEM,Donald J. Trump,5,1,1,0,7
 Bradford,South Waverly Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Springfield Township,Turnout,,,Registered Voters,,,,,734
-Bradford,Springfield Township,Turnout,,,Ballots Cast,171,9,66,16,262
+Bradford,Springfield Township,Registered Voters,,,,,,,,734
+Bradford,Springfield Township,Ballots Cast,,,,171,9,66,16,262
 Bradford,Springfield Township,President Of The United States,,DEM,Bernie Sanders,4,1,2,0,7
 Bradford,Springfield Township,President Of The United States,,DEM,Joseph R. Biden,17,3,30,2,52
 Bradford,Springfield Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Springfield Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Springfield Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Standing Stone Township,Turnout,,,Registered Voters,,,,,391
-Bradford,Standing Stone Township,Turnout,,,Ballots Cast,76,8,33,4,121
+Bradford,Standing Stone Township,Registered Voters,,,,,,,,391
+Bradford,Standing Stone Township,Ballots Cast,,,,76,8,33,4,121
 Bradford,Standing Stone Township,President Of The United States,,DEM,Bernie Sanders,1,1,2,0,4
 Bradford,Standing Stone Township,President Of The United States,,DEM,Joseph R. Biden,7,1,8,1,17
 Bradford,Standing Stone Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,2,0,3
 Bradford,Standing Stone Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Standing Stone Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Stevens Township,Turnout,,,Registered Voters,,,,,285
-Bradford,Stevens Township,Turnout,,,Ballots Cast,90,6,23,2,121
+Bradford,Stevens Township,Registered Voters,,,,,,,,285
+Bradford,Stevens Township,Ballots Cast,,,,90,6,23,2,121
 Bradford,Stevens Township,President Of The United States,,DEM,Bernie Sanders,5,2,0,0,7
 Bradford,Stevens Township,President Of The United States,,DEM,Joseph R. Biden,8,1,7,1,17
 Bradford,Stevens Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Stevens Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Stevens Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
-Bradford,Sylvania Borough,Turnout,,,Registered Voters,,,,,119
-Bradford,Sylvania Borough,Turnout,,,Ballots Cast,39,1,12,0,52
+Bradford,Sylvania Borough,Registered Voters,,,,,,,,119
+Bradford,Sylvania Borough,Ballots Cast,,,,39,1,12,0,52
 Bradford,Sylvania Borough,President Of The United States,,DEM,Bernie Sanders,2,1,0,0,3
 Bradford,Sylvania Borough,President Of The United States,,DEM,Joseph R. Biden,7,0,2,0,9
 Bradford,Sylvania Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Sylvania Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Sylvania Borough,President Of The United States,,DEM,Write-In,0,0,1,0,1
-Bradford,Terry Township,Turnout,,,Registered Voters,,,,,543
-Bradford,Terry Township,Turnout,,,Ballots Cast,158,5,43,1,207
+Bradford,Terry Township,Registered Voters,,,,,,,,543
+Bradford,Terry Township,Ballots Cast,,,,158,5,43,1,207
 Bradford,Terry Township,President Of The United States,,DEM,Bernie Sanders,7,2,2,0,11
 Bradford,Terry Township,President Of The United States,,DEM,Joseph R. Biden,12,1,17,0,30
 Bradford,Terry Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
 Bradford,Terry Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Terry Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 1St Ward,Turnout,,,Registered Voters,,,,,356
-Bradford,Towanda Borough 1St Ward,Turnout,,,Ballots Cast,78,0,21,1,100
+Bradford,Towanda Borough 1St Ward,Registered Voters,,,,,,,,356
+Bradford,Towanda Borough 1St Ward,Ballots Cast,,,,78,0,21,1,100
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,5,0,0,0,5
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,5,0,7,0,12
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 2Nd Ward,Turnout,,,Registered Voters,,,,,488
-Bradford,Towanda Borough 2Nd Ward,Turnout,,,Ballots Cast,94,7,46,7,154
+Bradford,Towanda Borough 2Nd Ward,Registered Voters,,,,,,,,488
+Bradford,Towanda Borough 2Nd Ward,Ballots Cast,,,,94,7,46,7,154
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,4,1,3,0,8
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,21,0,18,2,41
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,1,0,2
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Towanda Borough 3Rd Ward,Turnout,,,Registered Voters,,,,,695
-Bradford,Towanda Borough 3Rd Ward,Turnout,,,Ballots Cast,144,17,91,5,257
+Bradford,Towanda Borough 3Rd Ward,Registered Voters,,,,,,,,695
+Bradford,Towanda Borough 3Rd Ward,Ballots Cast,,,,144,17,91,5,257
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,6,0,4,0,10
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,19,8,33,3,63
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,1,1,0,3
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
 Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,1,1,0,2
-Bradford,Towanda Township,Turnout,,,Registered Voters,,,,,591
-Bradford,Towanda Township,Turnout,,,Ballots Cast,99,16,35,2,152
+Bradford,Towanda Township,Registered Voters,,,,,,,,591
+Bradford,Towanda Township,Ballots Cast,,,,99,16,35,2,152
 Bradford,Towanda Township,President Of The United States,,DEM,Bernie Sanders,5,0,3,0,8
 Bradford,Towanda Township,President Of The United States,,DEM,Joseph R. Biden,14,6,10,2,32
 Bradford,Towanda Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Towanda Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,Towanda Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,North Towanda Township,Turnout,,,Registered Voters,,,,,617
-Bradford,North Towanda Township,Turnout,,,Ballots Cast,107,16,75,0,198
+Bradford,North Towanda Township,Registered Voters,,,,,,,,617
+Bradford,North Towanda Township,Ballots Cast,,,,107,16,75,0,198
 Bradford,North Towanda Township,President Of The United States,,DEM,Bernie Sanders,3,3,2,0,8
 Bradford,North Towanda Township,President Of The United States,,DEM,Joseph R. Biden,14,5,28,0,47
 Bradford,North Towanda Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
 Bradford,North Towanda Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
 Bradford,North Towanda Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Troy Borough,Turnout,,,Registered Voters,,,,,710
-Bradford,Troy Borough,Turnout,,,Ballots Cast,170,6,56,13,245
+Bradford,Troy Borough,Registered Voters,,,,,,,,710
+Bradford,Troy Borough,Ballots Cast,,,,170,6,56,13,245
 Bradford,Troy Borough,President Of The United States,,DEM,Bernie Sanders,2,0,6,1,9
 Bradford,Troy Borough,President Of The United States,,DEM,Joseph R. Biden,32,2,24,2,60
 Bradford,Troy Borough,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
 Bradford,Troy Borough,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Troy Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Troy Township,Turnout,,,Registered Voters,,,,,1094
-Bradford,Troy Township,Turnout,,,Ballots Cast,255,16,111,13,395
+Bradford,Troy Township,Registered Voters,,,,,,,,1094
+Bradford,Troy Township,Ballots Cast,,,,255,16,111,13,395
 Bradford,Troy Township,President Of The United States,,DEM,Bernie Sanders,3,0,5,1,9
 Bradford,Troy Township,President Of The United States,,DEM,Joseph R. Biden,23,7,25,1,56
 Bradford,Troy Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
 Bradford,Troy Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Troy Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Tuscarora Township,Turnout,,,Registered Voters,,,,,652
-Bradford,Tuscarora Township,Turnout,,,Ballots Cast,194,12,55,3,264
+Bradford,Tuscarora Township,Registered Voters,,,,,,,,652
+Bradford,Tuscarora Township,Ballots Cast,,,,194,12,55,3,264
 Bradford,Tuscarora Township,President Of The United States,,DEM,Bernie Sanders,8,1,4,0,13
 Bradford,Tuscarora Township,President Of The United States,,DEM,Joseph R. Biden,12,0,17,0,29
 Bradford,Tuscarora Township,President Of The United States,,DEM,Tulsi Gabbard,3,1,1,0,5
 Bradford,Tuscarora Township,President Of The United States,,DEM,Donald J. Trump,5,1,0,0,6
 Bradford,Tuscarora Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
-Bradford,Ulster Township,Turnout,,,Registered Voters,,,,,793
-Bradford,Ulster Township,Turnout,,,Ballots Cast,141,13,43,0,197
+Bradford,Ulster Township,Registered Voters,,,,,,,,793
+Bradford,Ulster Township,Ballots Cast,,,,141,13,43,0,197
 Bradford,Ulster Township,President Of The United States,,DEM,Bernie Sanders,1,0,3,0,4
 Bradford,Ulster Township,President Of The United States,,DEM,Joseph R. Biden,16,3,18,0,37
 Bradford,Ulster Township,President Of The United States,,DEM,Tulsi Gabbard,4,0,2,0,6
 Bradford,Ulster Township,President Of The United States,,DEM,Donald J. Trump,6,0,0,0,6
 Bradford,Ulster Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
-Bradford,Warren Township,Turnout,,,Registered Voters,,,,,671
-Bradford,Warren Township,Turnout,,,Ballots Cast,169,7,44,7,227
+Bradford,Warren Township,Registered Voters,,,,,,,,671
+Bradford,Warren Township,Ballots Cast,,,,169,7,44,7,227
 Bradford,Warren Township,President Of The United States,,DEM,Bernie Sanders,4,0,1,0,5
 Bradford,Warren Township,President Of The United States,,DEM,Joseph R. Biden,12,1,17,2,32
 Bradford,Warren Township,President Of The United States,,DEM,Tulsi Gabbard,0,1,0,0,1
 Bradford,Warren Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Warren Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Wells Township,Turnout,,,Registered Voters,,,,,716
-Bradford,Wells Township,Turnout,,,Ballots Cast,186,5,34,2,227
+Bradford,Wells Township,Registered Voters,,,,,,,,716
+Bradford,Wells Township,Ballots Cast,,,,186,5,34,2,227
 Bradford,Wells Township,President Of The United States,,DEM,Bernie Sanders,4,0,2,0,6
 Bradford,Wells Township,President Of The United States,,DEM,Joseph R. Biden,15,3,14,0,32
 Bradford,Wells Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Wells Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Wells Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Wilmot Township,Turnout,,,Registered Voters,,,,,745
-Bradford,Wilmot Township,Turnout,,,Ballots Cast,180,18,70,15,283
+Bradford,Wilmot Township,Registered Voters,,,,,,,,745
+Bradford,Wilmot Township,Ballots Cast,,,,180,18,70,15,283
 Bradford,Wilmot Township,President Of The United States,,DEM,Bernie Sanders,5,4,3,0,12
 Bradford,Wilmot Township,President Of The United States,,DEM,Joseph R. Biden,15,5,18,3,41
 Bradford,Wilmot Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,1,0,2
 Bradford,Wilmot Township,President Of The United States,,DEM,Donald J. Trump,3,0,1,0,4
 Bradford,Wilmot Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Windham Township,Turnout,,,Registered Voters,,,,,546
-Bradford,Windham Township,Turnout,,,Ballots Cast,115,9,50,11,185
+Bradford,Windham Township,Registered Voters,,,,,,,,546
+Bradford,Windham Township,Ballots Cast,,,,115,9,50,11,185
 Bradford,Windham Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
 Bradford,Windham Township,President Of The United States,,DEM,Joseph R. Biden,7,5,10,2,24
 Bradford,Windham Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
 Bradford,Windham Township,President Of The United States,,DEM,Donald J. Trump,0,0,2,0,2
 Bradford,Windham Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
-Bradford,Wyalusing Borough,Turnout,,,Registered Voters,,,,,335
-Bradford,Wyalusing Borough,Turnout,,,Ballots Cast,99,5,26,8,138
+Bradford,Wyalusing Borough,Registered Voters,,,,,,,,335
+Bradford,Wyalusing Borough,Ballots Cast,,,,99,5,26,8,138
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Bernie Sanders,4,0,0,0,4
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Joseph R. Biden,26,4,13,1,44
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,1,2
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
 Bradford,Wyalusing Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Wyalusing Township,Turnout,,,Registered Voters,,,,,810
-Bradford,Wyalusing Township,Turnout,,,Ballots Cast,220,20,68,5,313
+Bradford,Wyalusing Township,Registered Voters,,,,,,,,810
+Bradford,Wyalusing Township,Ballots Cast,,,,220,20,68,5,313
 Bradford,Wyalusing Township,President Of The United States,,DEM,Bernie Sanders,4,1,8,0,13
 Bradford,Wyalusing Township,President Of The United States,,DEM,Joseph R. Biden,14,5,17,0,36
 Bradford,Wyalusing Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,1,0,3
 Bradford,Wyalusing Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
 Bradford,Wyalusing Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
-Bradford,Wysox Township,Turnout,,,Registered Voters,,,,,979
-Bradford,Wysox Township,Turnout,,,Ballots Cast,225,19,91,2,337
+Bradford,Wysox Township,Registered Voters,,,,,,,,979
+Bradford,Wysox Township,Ballots Cast,,,,225,19,91,2,337
 Bradford,Wysox Township,President Of The United States,,DEM,Bernie Sanders,7,1,4,0,12
 Bradford,Wysox Township,President Of The United States,,DEM,Joseph R. Biden,22,6,26,1,55
 Bradford,Wysox Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,4,0,4

--- a/2020/20200602__pa__primary__bradford__precinct.csv
+++ b/2020/20200602__pa__primary__bradford__precinct.csv
@@ -1,0 +1,3722 @@
+county,precinct,office,district,party,candidate,election_day,absentee,mail_in,provisional,votes
+Bradford,Alba Borough,President Of The United States,,DEM,Bernie Sanders,0,0,0,0,0
+Bradford,Alba Borough,President Of The United States,,DEM,Joseph R. Biden,1,0,2,0,3
+Bradford,Alba Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
+Bradford,Alba Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Alba Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Albany Township,President Of The United States,,DEM,Bernie Sanders,3,0,3,1,7
+Bradford,Albany Township,President Of The United States,,DEM,Joseph R. Biden,13,3,16,4,36
+Bradford,Albany Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
+Bradford,Albany Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,1,5
+Bradford,Albany Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Armenia Township,President Of The United States,,DEM,Bernie Sanders,1,0,0,0,1
+Bradford,Armenia Township,President Of The United States,,DEM,Joseph R. Biden,0,0,2,2,4
+Bradford,Armenia Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
+Bradford,Armenia Township,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
+Bradford,Armenia Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Asylum Township,President Of The United States,,DEM,Bernie Sanders,0,1,4,0,5
+Bradford,Asylum Township,President Of The United States,,DEM,Joseph R. Biden,20,0,22,0,42
+Bradford,Asylum Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
+Bradford,Asylum Township,President Of The United States,,DEM,Donald J. Trump,0,0,1,0,1
+Bradford,Asylum Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,4,0,2,1,7
+Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,19,1,20,0,40
+Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
+Bradford,Athens Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,6,1,3,0,10
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,18,0,10,1,29
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,7,0,1,1,9
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,24,3,21,0,48
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Bernie Sanders,6,3,6,1,16
+Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Joseph R. Biden,30,1,11,5,47
+Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
+Bradford,Athens Borough 4Th Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,President Of The United States,,DEM,Bernie Sanders,13,1,7,1,22
+Bradford,Athens Township 1St District,President Of The United States,,DEM,Joseph R. Biden,32,8,38,3,81
+Bradford,Athens Township 1St District,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
+Bradford,Athens Township 1St District,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
+Bradford,Athens Township 1St District,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Bernie Sanders,11,2,12,4,29
+Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Joseph R. Biden,47,25,87,4,163
+Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Tulsi Gabbard,4,1,1,0,6
+Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,Athens Township 2Nd District,President Of The United States,,DEM,Write-In,2,0,1,0,3
+Bradford,Burlington Borough,President Of The United States,,DEM,Bernie Sanders,1,0,2,0,3
+Bradford,Burlington Borough,President Of The United States,,DEM,Joseph R. Biden,3,0,0,0,3
+Bradford,Burlington Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Burlington Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Burlington Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Township,President Of The United States,,DEM,Bernie Sanders,4,0,2,0,6
+Bradford,Burlington Township,President Of The United States,,DEM,Joseph R. Biden,7,1,16,0,24
+Bradford,Burlington Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Burlington Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
+Bradford,Burlington Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,President Of The United States,,DEM,Bernie Sanders,3,1,0,0,4
+Bradford,West Burlington Township,President Of The United States,,DEM,Joseph R. Biden,16,1,1,2,20
+Bradford,West Burlington Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
+Bradford,West Burlington Township,President Of The United States,,DEM,Donald J. Trump,5,0,1,0,6
+Bradford,West Burlington Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Borough,President Of The United States,,DEM,Bernie Sanders,11,3,4,3,21
+Bradford,Canton Borough,President Of The United States,,DEM,Joseph R. Biden,18,4,17,0,39
+Bradford,Canton Borough,President Of The United States,,DEM,Tulsi Gabbard,3,1,0,0,4
+Bradford,Canton Borough,President Of The United States,,DEM,Donald J. Trump,8,0,0,0,8
+Bradford,Canton Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
+Bradford,Canton Township,President Of The United States,,DEM,Joseph R. Biden,23,1,14,2,40
+Bradford,Canton Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,2,0,5
+Bradford,Canton Township,President Of The United States,,DEM,Donald J. Trump,4,0,2,0,6
+Bradford,Canton Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Columbia Township,President Of The United States,,DEM,Bernie Sanders,11,5,5,1,22
+Bradford,Columbia Township,President Of The United States,,DEM,Joseph R. Biden,16,2,9,3,30
+Bradford,Columbia Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
+Bradford,Columbia Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,0,4
+Bradford,Columbia Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Franklin Township,President Of The United States,,DEM,Bernie Sanders,1,0,0,0,1
+Bradford,Franklin Township,President Of The United States,,DEM,Joseph R. Biden,7,0,4,0,11
+Bradford,Franklin Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
+Bradford,Franklin Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,Franklin Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Granville Township,President Of The United States,,DEM,Bernie Sanders,3,1,1,0,5
+Bradford,Granville Township,President Of The United States,,DEM,Joseph R. Biden,9,1,8,2,20
+Bradford,Granville Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
+Bradford,Granville Township,President Of The United States,,DEM,Donald J. Trump,3,1,2,0,6
+Bradford,Granville Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Herrick Township,President Of The United States,,DEM,Bernie Sanders,3,1,1,2,7
+Bradford,Herrick Township,President Of The United States,,DEM,Joseph R. Biden,13,2,4,1,20
+Bradford,Herrick Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
+Bradford,Herrick Township,President Of The United States,,DEM,Donald J. Trump,4,0,0,0,4
+Bradford,Herrick Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,President Of The United States,,DEM,Bernie Sanders,0,0,1,0,1
+Bradford,Leraysville Borough,President Of The United States,,DEM,Joseph R. Biden,3,0,4,0,7
+Bradford,Leraysville Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
+Bradford,Leraysville Borough,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,Leraysville Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Leroy Township,President Of The United States,,DEM,Bernie Sanders,2,0,1,0,3
+Bradford,Leroy Township,President Of The United States,,DEM,Joseph R. Biden,18,1,11,2,32
+Bradford,Leroy Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,0,0,2
+Bradford,Leroy Township,President Of The United States,,DEM,Donald J. Trump,4,1,0,0,5
+Bradford,Leroy Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,President Of The United States,,DEM,Bernie Sanders,4,2,4,1,11
+Bradford,Litchfield Township,President Of The United States,,DEM,Joseph R. Biden,22,3,14,0,39
+Bradford,Litchfield Township,President Of The United States,,DEM,Tulsi Gabbard,5,0,1,0,6
+Bradford,Litchfield Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
+Bradford,Litchfield Township,President Of The United States,,DEM,Write-In,2,0,0,0,2
+Bradford,Monroe Borough,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
+Bradford,Monroe Borough,President Of The United States,,DEM,Joseph R. Biden,6,2,12,0,20
+Bradford,Monroe Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Monroe Borough,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,Monroe Borough,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Monroe Township,President Of The United States,,DEM,Bernie Sanders,4,2,0,0,6
+Bradford,Monroe Township,President Of The United States,,DEM,Joseph R. Biden,14,5,13,1,33
+Bradford,Monroe Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Monroe Township,President Of The United States,,DEM,Donald J. Trump,6,0,0,0,6
+Bradford,Monroe Township,President Of The United States,,DEM,Write-In,2,0,0,0,2
+Bradford,New Albany Borough,President Of The United States,,DEM,Bernie Sanders,0,0,1,0,1
+Bradford,New Albany Borough,President Of The United States,,DEM,Joseph R. Biden,6,0,2,0,8
+Bradford,New Albany Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,New Albany Borough,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
+Bradford,New Albany Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Orwell Township,President Of The United States,,DEM,Bernie Sanders,6,3,0,0,9
+Bradford,Orwell Township,President Of The United States,,DEM,Joseph R. Biden,18,0,21,1,40
+Bradford,Orwell Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,0,3
+Bradford,Orwell Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
+Bradford,Orwell Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Overton Township,President Of The United States,,DEM,Bernie Sanders,8,0,0,1,9
+Bradford,Overton Township,President Of The United States,,DEM,Joseph R. Biden,6,0,7,0,13
+Bradford,Overton Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,0,3
+Bradford,Overton Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,Overton Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Pike Township,President Of The United States,,DEM,Bernie Sanders,3,1,0,0,4
+Bradford,Pike Township,President Of The United States,,DEM,Joseph R. Biden,10,3,5,0,18
+Bradford,Pike Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Pike Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,Pike Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,President Of The United States,,DEM,Bernie Sanders,9,0,2,0,11
+Bradford,Ridgebury Township,President Of The United States,,DEM,Joseph R. Biden,17,7,17,2,43
+Bradford,Ridgebury Township,President Of The United States,,DEM,Tulsi Gabbard,5,0,3,1,9
+Bradford,Ridgebury Township,President Of The United States,,DEM,Donald J. Trump,2,0,1,1,4
+Bradford,Ridgebury Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Rome Borough,President Of The United States,,DEM,Bernie Sanders,3,0,1,0,4
+Bradford,Rome Borough,President Of The United States,,DEM,Joseph R. Biden,1,0,1,0,2
+Bradford,Rome Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
+Bradford,Rome Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Rome Borough,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Rome Township,President Of The United States,,DEM,Bernie Sanders,0,0,3,0,3
+Bradford,Rome Township,President Of The United States,,DEM,Joseph R. Biden,12,1,7,0,20
+Bradford,Rome Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Rome Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Rome Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,6,2,5,3,16
+Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,21,5,27,2,55
+Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
+Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,Sayre Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,2,0,2
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,10,4,13,3,30
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,68,12,77,4,161
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,4,0,0,0,4
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,DEM,Write-In,3,1,2,0,6
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,9,0,1,0,10
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,13,1,3,0,17
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,1,0,1,0,2
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Bernie Sanders,11,2,2,2,17
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Joseph R. Biden,48,8,31,3,90
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Tulsi Gabbard,5,0,2,0,7
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Donald J. Trump,5,0,0,0,5
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Bernie Sanders,2,1,2,0,5
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Joseph R. Biden,6,1,7,0,14
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Donald J. Trump,2,0,1,0,3
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,President Of The United States,,DEM,Bernie Sanders,2,0,4,0,6
+Bradford,Sheshequin Township,President Of The United States,,DEM,Joseph R. Biden,10,2,21,5,38
+Bradford,Sheshequin Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,0,0,2
+Bradford,Sheshequin Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
+Bradford,Sheshequin Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
+Bradford,Smithfield Township,President Of The United States,,DEM,Joseph R. Biden,24,1,24,2,51
+Bradford,Smithfield Township,President Of The United States,,DEM,Tulsi Gabbard,3,0,0,1,4
+Bradford,Smithfield Township,President Of The United States,,DEM,Donald J. Trump,2,0,2,0,4
+Bradford,Smithfield Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,South Creek Township,President Of The United States,,DEM,Bernie Sanders,3,0,0,0,3
+Bradford,South Creek Township,President Of The United States,,DEM,Joseph R. Biden,14,1,10,1,26
+Bradford,South Creek Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,South Creek Township,President Of The United States,,DEM,Donald J. Trump,7,0,1,0,8
+Bradford,South Creek Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,President Of The United States,,DEM,Bernie Sanders,12,0,6,0,18
+Bradford,South Waverly Borough,President Of The United States,,DEM,Joseph R. Biden,39,6,31,4,80
+Bradford,South Waverly Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
+Bradford,South Waverly Borough,President Of The United States,,DEM,Donald J. Trump,5,1,1,0,7
+Bradford,South Waverly Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Springfield Township,President Of The United States,,DEM,Bernie Sanders,4,1,2,0,7
+Bradford,Springfield Township,President Of The United States,,DEM,Joseph R. Biden,17,3,30,2,52
+Bradford,Springfield Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Springfield Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Springfield Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Standing Stone Township,President Of The United States,,DEM,Bernie Sanders,1,1,2,0,4
+Bradford,Standing Stone Township,President Of The United States,,DEM,Joseph R. Biden,7,1,8,1,17
+Bradford,Standing Stone Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,2,0,3
+Bradford,Standing Stone Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
+Bradford,Standing Stone Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Stevens Township,President Of The United States,,DEM,Bernie Sanders,5,2,0,0,7
+Bradford,Stevens Township,President Of The United States,,DEM,Joseph R. Biden,8,1,7,1,17
+Bradford,Stevens Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Stevens Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
+Bradford,Stevens Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Sylvania Borough,President Of The United States,,DEM,Bernie Sanders,2,1,0,0,3
+Bradford,Sylvania Borough,President Of The United States,,DEM,Joseph R. Biden,7,0,2,0,9
+Bradford,Sylvania Borough,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Sylvania Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Sylvania Borough,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Terry Township,President Of The United States,,DEM,Bernie Sanders,7,2,2,0,11
+Bradford,Terry Township,President Of The United States,,DEM,Joseph R. Biden,12,1,17,0,30
+Bradford,Terry Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,0,0,2
+Bradford,Terry Township,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
+Bradford,Terry Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Bernie Sanders,5,0,0,0,5
+Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Joseph R. Biden,5,0,7,0,12
+Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,0,1
+Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,4,1,3,0,8
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Joseph R. Biden,21,0,18,2,41
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,0,1,0,2
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,6,0,4,0,10
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Joseph R. Biden,19,8,33,3,63
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,1,1,1,0,3
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Donald J. Trump,2,0,0,0,2
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,DEM,Write-In,0,1,1,0,2
+Bradford,Towanda Township,President Of The United States,,DEM,Bernie Sanders,5,0,3,0,8
+Bradford,Towanda Township,President Of The United States,,DEM,Joseph R. Biden,14,6,10,2,32
+Bradford,Towanda Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Towanda Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,Towanda Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,President Of The United States,,DEM,Bernie Sanders,3,3,2,0,8
+Bradford,North Towanda Township,President Of The United States,,DEM,Joseph R. Biden,14,5,28,0,47
+Bradford,North Towanda Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,1,0,1
+Bradford,North Towanda Township,President Of The United States,,DEM,Donald J. Trump,1,0,0,0,1
+Bradford,North Towanda Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Borough,President Of The United States,,DEM,Bernie Sanders,2,0,6,1,9
+Bradford,Troy Borough,President Of The United States,,DEM,Joseph R. Biden,32,2,24,2,60
+Bradford,Troy Borough,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
+Bradford,Troy Borough,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
+Bradford,Troy Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Township,President Of The United States,,DEM,Bernie Sanders,3,0,5,1,9
+Bradford,Troy Township,President Of The United States,,DEM,Joseph R. Biden,23,7,25,1,56
+Bradford,Troy Township,President Of The United States,,DEM,Tulsi Gabbard,2,0,1,0,3
+Bradford,Troy Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
+Bradford,Troy Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,President Of The United States,,DEM,Bernie Sanders,8,1,4,0,13
+Bradford,Tuscarora Township,President Of The United States,,DEM,Joseph R. Biden,12,0,17,0,29
+Bradford,Tuscarora Township,President Of The United States,,DEM,Tulsi Gabbard,3,1,1,0,5
+Bradford,Tuscarora Township,President Of The United States,,DEM,Donald J. Trump,5,1,0,0,6
+Bradford,Tuscarora Township,President Of The United States,,DEM,Write-In,1,0,0,0,1
+Bradford,Ulster Township,President Of The United States,,DEM,Bernie Sanders,1,0,3,0,4
+Bradford,Ulster Township,President Of The United States,,DEM,Joseph R. Biden,16,3,18,0,37
+Bradford,Ulster Township,President Of The United States,,DEM,Tulsi Gabbard,4,0,2,0,6
+Bradford,Ulster Township,President Of The United States,,DEM,Donald J. Trump,6,0,0,0,6
+Bradford,Ulster Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Warren Township,President Of The United States,,DEM,Bernie Sanders,4,0,1,0,5
+Bradford,Warren Township,President Of The United States,,DEM,Joseph R. Biden,12,1,17,2,32
+Bradford,Warren Township,President Of The United States,,DEM,Tulsi Gabbard,0,1,0,0,1
+Bradford,Warren Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
+Bradford,Warren Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Wells Township,President Of The United States,,DEM,Bernie Sanders,4,0,2,0,6
+Bradford,Wells Township,President Of The United States,,DEM,Joseph R. Biden,15,3,14,0,32
+Bradford,Wells Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Wells Township,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Wells Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,President Of The United States,,DEM,Bernie Sanders,5,4,3,0,12
+Bradford,Wilmot Township,President Of The United States,,DEM,Joseph R. Biden,15,5,18,3,41
+Bradford,Wilmot Township,President Of The United States,,DEM,Tulsi Gabbard,1,0,1,0,2
+Bradford,Wilmot Township,President Of The United States,,DEM,Donald J. Trump,3,0,1,0,4
+Bradford,Wilmot Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Windham Township,President Of The United States,,DEM,Bernie Sanders,3,0,2,0,5
+Bradford,Windham Township,President Of The United States,,DEM,Joseph R. Biden,7,5,10,2,24
+Bradford,Windham Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,0,0,0
+Bradford,Windham Township,President Of The United States,,DEM,Donald J. Trump,0,0,2,0,2
+Bradford,Windham Township,President Of The United States,,DEM,Write-In,0,0,1,0,1
+Bradford,Wyalusing Borough,President Of The United States,,DEM,Bernie Sanders,4,0,0,0,4
+Bradford,Wyalusing Borough,President Of The United States,,DEM,Joseph R. Biden,26,4,13,1,44
+Bradford,Wyalusing Borough,President Of The United States,,DEM,Tulsi Gabbard,1,0,0,1,2
+Bradford,Wyalusing Borough,President Of The United States,,DEM,Donald J. Trump,0,0,0,0,0
+Bradford,Wyalusing Borough,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,President Of The United States,,DEM,Bernie Sanders,4,1,8,0,13
+Bradford,Wyalusing Township,President Of The United States,,DEM,Joseph R. Biden,14,5,17,0,36
+Bradford,Wyalusing Township,President Of The United States,,DEM,Tulsi Gabbard,1,1,1,0,3
+Bradford,Wyalusing Township,President Of The United States,,DEM,Donald J. Trump,3,0,0,0,3
+Bradford,Wyalusing Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Wysox Township,President Of The United States,,DEM,Bernie Sanders,7,1,4,0,12
+Bradford,Wysox Township,President Of The United States,,DEM,Joseph R. Biden,22,6,26,1,55
+Bradford,Wysox Township,President Of The United States,,DEM,Tulsi Gabbard,0,0,4,0,4
+Bradford,Wysox Township,President Of The United States,,DEM,Donald J. Trump,6,0,1,0,7
+Bradford,Wysox Township,President Of The United States,,DEM,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Attorney General,,DEM,Josh Shapiro,3,0,2,0,5
+Bradford,Alba Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Alba Borough,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Albany Township,Attorney General,,DEM,Josh Shapiro,18,2,19,5,44
+Bradford,Albany Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Albany Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Attorney General,,DEM,Josh Shapiro,3,0,3,1,7
+Bradford,Armenia Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Armenia Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Attorney General,,DEM,Josh Shapiro,16,1,27,1,45
+Bradford,Asylum Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,1,0,1
+Bradford,Asylum Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Attorney General,,DEM,Josh Shapiro,23,1,18,1,43
+Bradford,Athens Borough 1St Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Attorney General,,DEM,Write-In,0,0,1,0,1
+Bradford,Athens Borough 2Nd Ward,Attorney General,,DEM,Josh Shapiro,19,1,11,1,32
+Bradford,Athens Borough 2Nd Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Attorney General,,DEM,Josh Shapiro,27,1,21,1,50
+Bradford,Athens Borough 3Rd Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Attorney General,,DEM,Josh Shapiro,32,3,17,6,58
+Bradford,Athens Borough 4Th Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Attorney General,,DEM,Josh Shapiro,45,9,40,4,98
+Bradford,Athens Township 1St District,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Athens Township 1St District,Attorney General,,DEM,Write-In,1,0,2,0,3
+Bradford,Athens Township 2Nd District,Attorney General,,DEM,Josh Shapiro,54,24,91,7,176
+Bradford,Athens Township 2Nd District,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Attorney General,,DEM,Write-In,0,0,1,0,1
+Bradford,Burlington Borough,Attorney General,,DEM,Josh Shapiro,3,0,2,0,5
+Bradford,Burlington Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Burlington Borough,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Attorney General,,DEM,Josh Shapiro,12,0,18,0,30
+Bradford,Burlington Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Burlington Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Attorney General,,DEM,Josh Shapiro,18,2,2,1,23
+Bradford,West Burlington Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,West Burlington Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Attorney General,,DEM,Josh Shapiro,36,6,18,3,63
+Bradford,Canton Borough,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Canton Borough,Attorney General,,DEM,Write-In,1,0,0,0,1
+Bradford,Canton Township,Attorney General,,DEM,Josh Shapiro,32,1,17,2,52
+Bradford,Canton Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Canton Township,Attorney General,,DEM,Write-In,0,0,1,0,1
+Bradford,Columbia Township,Attorney General,,DEM,Josh Shapiro,27,7,11,4,49
+Bradford,Columbia Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Columbia Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Attorney General,,DEM,Josh Shapiro,8,0,3,0,11
+Bradford,Franklin Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Franklin Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Granville Township,Attorney General,,DEM,Josh Shapiro,15,2,8,2,27
+Bradford,Granville Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,2,0,2
+Bradford,Granville Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Attorney General,,DEM,Josh Shapiro,18,3,5,3,29
+Bradford,Herrick Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Herrick Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Attorney General,,DEM,Josh Shapiro,4,0,4,0,8
+Bradford,Leraysville Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Leraysville Borough,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Attorney General,,DEM,Josh Shapiro,22,2,12,2,38
+Bradford,Leroy Township,Attorney General,,DEM,Heather Heidelbaugh,0,1,0,0,1
+Bradford,Leroy Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Attorney General,,DEM,Josh Shapiro,30,5,19,1,55
+Bradford,Litchfield Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Litchfield Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Attorney General,,DEM,Josh Shapiro,8,2,13,0,23
+Bradford,Monroe Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Monroe Borough,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Monroe Township,Attorney General,,DEM,Josh Shapiro,24,7,11,1,43
+Bradford,Monroe Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Monroe Township,Attorney General,,DEM,Write-In,0,0,1,0,1
+Bradford,New Albany Borough,Attorney General,,DEM,Josh Shapiro,9,0,3,0,12
+Bradford,New Albany Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,New Albany Borough,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Attorney General,,DEM,Josh Shapiro,26,3,21,1,51
+Bradford,Orwell Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Orwell Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Overton Township,Attorney General,,DEM,Josh Shapiro,18,0,7,1,26
+Bradford,Overton Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Overton Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Pike Township,Attorney General,,DEM,Josh Shapiro,14,4,6,0,24
+Bradford,Pike Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Pike Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Attorney General,,DEM,Josh Shapiro,28,6,21,4,59
+Bradford,Ridgebury Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Ridgebury Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Attorney General,,DEM,Josh Shapiro,5,0,2,0,7
+Bradford,Rome Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Rome Borough,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Rome Township,Attorney General,,DEM,Josh Shapiro,12,1,7,0,20
+Bradford,Rome Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Rome Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Attorney General,,DEM,Josh Shapiro,26,5,30,4,65
+Bradford,Sayre Borough 1St Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Attorney General,,DEM,Josh Shapiro,82,16,81,7,186
+Bradford,Sayre Borough 2Nd Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Attorney General,,DEM,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 3Rd Ward,Attorney General,,DEM,Josh Shapiro,21,1,4,0,26
+Bradford,Sayre Borough 3Rd Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Attorney General,,DEM,Josh Shapiro,59,9,29,3,100
+Bradford,Sayre Borough 4Th Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,1,0,1
+Bradford,Sayre Borough 4Th Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Attorney General,,DEM,Josh Shapiro,9,1,10,0,20
+Bradford,Sayre Borough 5Th Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Attorney General,,DEM,Josh Shapiro,13,3,20,5,41
+Bradford,Sheshequin Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Sheshequin Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Attorney General,,DEM,Josh Shapiro,30,1,21,3,55
+Bradford,Smithfield Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Smithfield Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Attorney General,,DEM,Josh Shapiro,22,1,5,1,29
+Bradford,South Creek Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,South Creek Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Attorney General,,DEM,Josh Shapiro,45,5,36,4,90
+Bradford,South Waverly Borough,Attorney General,,DEM,Heather Heidelbaugh,0,1,0,0,1
+Bradford,South Waverly Borough,Attorney General,,DEM,Write-In,1,0,0,0,1
+Bradford,Springfield Township,Attorney General,,DEM,Josh Shapiro,20,4,31,1,56
+Bradford,Springfield Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Springfield Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,Attorney General,,DEM,Josh Shapiro,9,2,11,1,23
+Bradford,Standing Stone Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Standing Stone Township,Attorney General,,DEM,Write-In,1,0,0,0,1
+Bradford,Stevens Township,Attorney General,,DEM,Josh Shapiro,8,3,7,1,19
+Bradford,Stevens Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Stevens Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,Attorney General,,DEM,Josh Shapiro,7,1,2,0,10
+Bradford,Sylvania Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Sylvania Borough,Attorney General,,DEM,Write-In,0,0,1,0,1
+Bradford,Terry Township,Attorney General,,DEM,Josh Shapiro,20,1,17,0,38
+Bradford,Terry Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Terry Township,Attorney General,,DEM,Write-In,0,1,0,0,1
+Bradford,Towanda Borough 1St Ward,Attorney General,,DEM,Josh Shapiro,11,0,7,0,18
+Bradford,Towanda Borough 1St Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Attorney General,,DEM,Josh Shapiro,24,1,21,2,48
+Bradford,Towanda Borough 2Nd Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Attorney General,,DEM,Josh Shapiro,27,9,31,3,70
+Bradford,Towanda Borough 3Rd Ward,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Attorney General,,DEM,Josh Shapiro,18,6,12,2,38
+Bradford,Towanda Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Towanda Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Attorney General,,DEM,Josh Shapiro,14,5,29,0,48
+Bradford,North Towanda Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,North Towanda Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Attorney General,,DEM,Josh Shapiro,31,2,24,3,60
+Bradford,Troy Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Troy Borough,Attorney General,,DEM,Write-In,0,0,1,0,1
+Bradford,Troy Township,Attorney General,,DEM,Josh Shapiro,26,6,26,2,60
+Bradford,Troy Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Troy Township,Attorney General,,DEM,Write-In,1,0,0,0,1
+Bradford,Tuscarora Township,Attorney General,,DEM,Josh Shapiro,24,3,22,0,49
+Bradford,Tuscarora Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Tuscarora Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Attorney General,,DEM,Josh Shapiro,25,3,21,0,49
+Bradford,Ulster Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Ulster Township,Attorney General,,DEM,Write-In,0,0,1,0,1
+Bradford,Warren Township,Attorney General,,DEM,Josh Shapiro,17,2,16,2,37
+Bradford,Warren Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Warren Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wells Township,Attorney General,,DEM,Josh Shapiro,20,3,16,0,39
+Bradford,Wells Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Wells Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Attorney General,,DEM,Josh Shapiro,17,7,20,2,46
+Bradford,Wilmot Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Wilmot Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Windham Township,Attorney General,,DEM,Josh Shapiro,11,5,14,2,32
+Bradford,Windham Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Windham Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Attorney General,,DEM,Josh Shapiro,24,2,13,2,41
+Bradford,Wyalusing Borough,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Wyalusing Borough,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Attorney General,,DEM,Josh Shapiro,17,7,19,0,43
+Bradford,Wyalusing Township,Attorney General,,DEM,Heather Heidelbaugh,0,0,0,0,0
+Bradford,Wyalusing Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Attorney General,,DEM,Josh Shapiro,27,6,33,0,66
+Bradford,Wysox Township,Attorney General,,DEM,Heather Heidelbaugh,1,0,0,0,1
+Bradford,Wysox Township,Attorney General,,DEM,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Auditor General,,DEM,H. Scott Conklin,2,0,0,0,2
+Bradford,Alba Borough,Auditor General,,DEM,Michael Lamb,0,0,2,0,2
+Bradford,Alba Borough,Auditor General,,DEM,Tracie Fountain,0,0,0,0,0
+Bradford,Alba Borough,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,0,1
+Bradford,Alba Borough,Auditor General,,DEM,Nina Ahmad,0,0,0,0,0
+Bradford,Alba Borough,Auditor General,,DEM,Christina M. Hartman,0,0,0,0,0
+Bradford,Alba Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Alba Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Albany Township,Auditor General,,DEM,H. Scott Conklin,2,1,4,0,7
+Bradford,Albany Township,Auditor General,,DEM,Michael Lamb,9,0,0,1,10
+Bradford,Albany Township,Auditor General,,DEM,Tracie Fountain,2,1,3,1,7
+Bradford,Albany Township,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,5,0,7
+Bradford,Albany Township,Auditor General,,DEM,Nina Ahmad,3,0,0,2,5
+Bradford,Albany Township,Auditor General,,DEM,Christina M. Hartman,3,0,7,2,12
+Bradford,Albany Township,Auditor General,,DEM,Timothy Defoor,1,0,0,0,1
+Bradford,Albany Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Auditor General,,DEM,H. Scott Conklin,0,0,0,0,0
+Bradford,Armenia Township,Auditor General,,DEM,Michael Lamb,0,0,0,1,1
+Bradford,Armenia Township,Auditor General,,DEM,Tracie Fountain,1,0,0,0,1
+Bradford,Armenia Township,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0,0
+Bradford,Armenia Township,Auditor General,,DEM,Nina Ahmad,0,0,0,0,0
+Bradford,Armenia Township,Auditor General,,DEM,Christina M. Hartman,1,0,2,0,3
+Bradford,Armenia Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Armenia Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Auditor General,,DEM,H. Scott Conklin,3,0,8,0,11
+Bradford,Asylum Township,Auditor General,,DEM,Michael Lamb,3,0,7,0,10
+Bradford,Asylum Township,Auditor General,,DEM,Tracie Fountain,0,0,4,0,4
+Bradford,Asylum Township,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2,0,4
+Bradford,Asylum Township,Auditor General,,DEM,Nina Ahmad,6,0,0,0,6
+Bradford,Asylum Township,Auditor General,,DEM,Christina M. Hartman,5,0,5,0,10
+Bradford,Asylum Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Asylum Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Auditor General,,DEM,H. Scott Conklin,3,0,3,0,6
+Bradford,Athens Borough 1St Ward,Auditor General,,DEM,Michael Lamb,0,0,1,1,2
+Bradford,Athens Borough 1St Ward,Auditor General,,DEM,Tracie Fountain,3,0,4,0,7
+Bradford,Athens Borough 1St Ward,Auditor General,,DEM,Rose Rosie Marie Davis,7,0,0,0,7
+Bradford,Athens Borough 1St Ward,Auditor General,,DEM,Nina Ahmad,6,1,7,0,14
+Bradford,Athens Borough 1St Ward,Auditor General,,DEM,Christina M. Hartman,4,0,4,0,8
+Bradford,Athens Borough 1St Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Auditor General,,DEM,Write-In,0,0,1,0,1
+Bradford,Athens Borough 2Nd Ward,Auditor General,,DEM,H. Scott Conklin,6,0,4,0,10
+Bradford,Athens Borough 2Nd Ward,Auditor General,,DEM,Michael Lamb,5,0,1,0,6
+Bradford,Athens Borough 2Nd Ward,Auditor General,,DEM,Tracie Fountain,1,1,2,0,4
+Bradford,Athens Borough 2Nd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2,0,4
+Bradford,Athens Borough 2Nd Ward,Auditor General,,DEM,Nina Ahmad,3,0,3,0,6
+Bradford,Athens Borough 2Nd Ward,Auditor General,,DEM,Christina M. Hartman,2,0,0,1,3
+Bradford,Athens Borough 2Nd Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Auditor General,,DEM,H. Scott Conklin,7,0,5,0,12
+Bradford,Athens Borough 3Rd Ward,Auditor General,,DEM,Michael Lamb,3,0,5,0,8
+Bradford,Athens Borough 3Rd Ward,Auditor General,,DEM,Tracie Fountain,2,1,6,0,9
+Bradford,Athens Borough 3Rd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1,0,2
+Bradford,Athens Borough 3Rd Ward,Auditor General,,DEM,Nina Ahmad,7,0,2,1,10
+Bradford,Athens Borough 3Rd Ward,Auditor General,,DEM,Christina M. Hartman,7,0,2,0,9
+Bradford,Athens Borough 3Rd Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Auditor General,,DEM,H. Scott Conklin,5,2,1,2,10
+Bradford,Athens Borough 4Th Ward,Auditor General,,DEM,Michael Lamb,1,0,1,0,2
+Bradford,Athens Borough 4Th Ward,Auditor General,,DEM,Tracie Fountain,1,1,3,1,6
+Bradford,Athens Borough 4Th Ward,Auditor General,,DEM,Rose Rosie Marie Davis,6,0,3,1,10
+Bradford,Athens Borough 4Th Ward,Auditor General,,DEM,Nina Ahmad,7,1,4,0,12
+Bradford,Athens Borough 4Th Ward,Auditor General,,DEM,Christina M. Hartman,17,0,5,2,24
+Bradford,Athens Borough 4Th Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Auditor General,,DEM,H. Scott Conklin,6,0,3,0,9
+Bradford,Athens Township 1St District,Auditor General,,DEM,Michael Lamb,4,1,9,1,15
+Bradford,Athens Township 1St District,Auditor General,,DEM,Tracie Fountain,2,2,6,0,10
+Bradford,Athens Township 1St District,Auditor General,,DEM,Rose Rosie Marie Davis,7,3,5,1,16
+Bradford,Athens Township 1St District,Auditor General,,DEM,Nina Ahmad,13,0,10,2,25
+Bradford,Athens Township 1St District,Auditor General,,DEM,Christina M. Hartman,6,2,9,0,17
+Bradford,Athens Township 1St District,Auditor General,,DEM,Timothy Defoor,1,0,0,0,1
+Bradford,Athens Township 1St District,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Auditor General,,DEM,H. Scott Conklin,10,7,14,0,31
+Bradford,Athens Township 2Nd District,Auditor General,,DEM,Michael Lamb,12,2,8,3,25
+Bradford,Athens Township 2Nd District,Auditor General,,DEM,Tracie Fountain,5,4,16,1,26
+Bradford,Athens Township 2Nd District,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,12,3,21
+Bradford,Athens Township 2Nd District,Auditor General,,DEM,Nina Ahmad,7,3,14,1,25
+Bradford,Athens Township 2Nd District,Auditor General,,DEM,Christina M. Hartman,14,3,19,0,36
+Bradford,Athens Township 2Nd District,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Auditor General,,DEM,H. Scott Conklin,1,0,0,0,1
+Bradford,Burlington Borough,Auditor General,,DEM,Michael Lamb,0,0,0,0,0
+Bradford,Burlington Borough,Auditor General,,DEM,Tracie Fountain,0,0,0,0,0
+Bradford,Burlington Borough,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2,0,4
+Bradford,Burlington Borough,Auditor General,,DEM,Nina Ahmad,0,0,0,0,0
+Bradford,Burlington Borough,Auditor General,,DEM,Christina M. Hartman,1,0,0,0,1
+Bradford,Burlington Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Burlington Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Auditor General,,DEM,H. Scott Conklin,2,1,4,0,7
+Bradford,Burlington Township,Auditor General,,DEM,Michael Lamb,3,0,1,0,4
+Bradford,Burlington Township,Auditor General,,DEM,Tracie Fountain,1,0,0,0,1
+Bradford,Burlington Township,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2,0,4
+Bradford,Burlington Township,Auditor General,,DEM,Nina Ahmad,1,0,7,0,8
+Bradford,Burlington Township,Auditor General,,DEM,Christina M. Hartman,1,0,4,0,5
+Bradford,Burlington Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Burlington Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Auditor General,,DEM,H. Scott Conklin,4,0,0,0,4
+Bradford,West Burlington Township,Auditor General,,DEM,Michael Lamb,5,1,0,0,6
+Bradford,West Burlington Township,Auditor General,,DEM,Tracie Fountain,0,0,1,0,1
+Bradford,West Burlington Township,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,1,3
+Bradford,West Burlington Township,Auditor General,,DEM,Nina Ahmad,2,0,0,1,3
+Bradford,West Burlington Township,Auditor General,,DEM,Christina M. Hartman,7,0,1,0,8
+Bradford,West Burlington Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,West Burlington Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Auditor General,,DEM,H. Scott Conklin,8,0,7,0,15
+Bradford,Canton Borough,Auditor General,,DEM,Michael Lamb,9,1,1,1,12
+Bradford,Canton Borough,Auditor General,,DEM,Tracie Fountain,4,3,3,0,10
+Bradford,Canton Borough,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,6,0,10
+Bradford,Canton Borough,Auditor General,,DEM,Nina Ahmad,7,1,1,0,9
+Bradford,Canton Borough,Auditor General,,DEM,Christina M. Hartman,8,1,2,2,13
+Bradford,Canton Borough,Auditor General,,DEM,Timothy Defoor,2,0,0,0,2
+Bradford,Canton Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Township,Auditor General,,DEM,H. Scott Conklin,6,0,4,0,10
+Bradford,Canton Township,Auditor General,,DEM,Michael Lamb,5,0,4,0,9
+Bradford,Canton Township,Auditor General,,DEM,Tracie Fountain,5,0,2,0,7
+Bradford,Canton Township,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,2,1,4
+Bradford,Canton Township,Auditor General,,DEM,Nina Ahmad,2,1,3,1,7
+Bradford,Canton Township,Auditor General,,DEM,Christina M. Hartman,9,0,3,0,12
+Bradford,Canton Township,Auditor General,,DEM,Timothy Defoor,1,0,0,0,1
+Bradford,Canton Township,Auditor General,,DEM,Write-In,0,0,2,0,2
+Bradford,Columbia Township,Auditor General,,DEM,H. Scott Conklin,7,0,1,0,8
+Bradford,Columbia Township,Auditor General,,DEM,Michael Lamb,2,1,3,0,6
+Bradford,Columbia Township,Auditor General,,DEM,Tracie Fountain,4,0,1,3,8
+Bradford,Columbia Township,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,1,0,5
+Bradford,Columbia Township,Auditor General,,DEM,Nina Ahmad,5,1,5,1,12
+Bradford,Columbia Township,Auditor General,,DEM,Christina M. Hartman,7,2,1,0,10
+Bradford,Columbia Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Columbia Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Auditor General,,DEM,H. Scott Conklin,2,0,0,0,2
+Bradford,Franklin Township,Auditor General,,DEM,Michael Lamb,0,0,0,0,0
+Bradford,Franklin Township,Auditor General,,DEM,Tracie Fountain,0,0,0,0,0
+Bradford,Franklin Township,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2,0,4
+Bradford,Franklin Township,Auditor General,,DEM,Nina Ahmad,3,0,1,0,4
+Bradford,Franklin Township,Auditor General,,DEM,Christina M. Hartman,1,0,1,0,2
+Bradford,Franklin Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Franklin Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Granville Township,Auditor General,,DEM,H. Scott Conklin,4,1,4,0,9
+Bradford,Granville Township,Auditor General,,DEM,Michael Lamb,5,0,0,0,5
+Bradford,Granville Township,Auditor General,,DEM,Tracie Fountain,1,0,0,0,1
+Bradford,Granville Township,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2,1,5
+Bradford,Granville Township,Auditor General,,DEM,Nina Ahmad,1,0,1,1,3
+Bradford,Granville Township,Auditor General,,DEM,Christina M. Hartman,5,0,2,0,7
+Bradford,Granville Township,Auditor General,,DEM,Timothy Defoor,0,0,2,0,2
+Bradford,Granville Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Auditor General,,DEM,H. Scott Conklin,4,0,1,0,5
+Bradford,Herrick Township,Auditor General,,DEM,Michael Lamb,3,0,0,0,3
+Bradford,Herrick Township,Auditor General,,DEM,Tracie Fountain,1,0,1,0,2
+Bradford,Herrick Township,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,2,0,6
+Bradford,Herrick Township,Auditor General,,DEM,Nina Ahmad,2,2,0,2,6
+Bradford,Herrick Township,Auditor General,,DEM,Christina M. Hartman,6,0,0,1,7
+Bradford,Herrick Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Herrick Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Auditor General,,DEM,H. Scott Conklin,0,0,0,0,0
+Bradford,Leraysville Borough,Auditor General,,DEM,Michael Lamb,0,0,2,0,2
+Bradford,Leraysville Borough,Auditor General,,DEM,Tracie Fountain,0,0,0,0,0
+Bradford,Leraysville Borough,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1,0,2
+Bradford,Leraysville Borough,Auditor General,,DEM,Nina Ahmad,1,0,1,0,2
+Bradford,Leraysville Borough,Auditor General,,DEM,Christina M. Hartman,2,0,1,0,3
+Bradford,Leraysville Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Leraysville Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Auditor General,,DEM,H. Scott Conklin,3,0,4,0,7
+Bradford,Leroy Township,Auditor General,,DEM,Michael Lamb,7,0,0,0,7
+Bradford,Leroy Township,Auditor General,,DEM,Tracie Fountain,0,2,2,0,4
+Bradford,Leroy Township,Auditor General,,DEM,Rose Rosie Marie Davis,4,1,1,2,8
+Bradford,Leroy Township,Auditor General,,DEM,Nina Ahmad,2,0,0,0,2
+Bradford,Leroy Township,Auditor General,,DEM,Christina M. Hartman,4,0,2,0,6
+Bradford,Leroy Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Leroy Township,Auditor General,,DEM,Write-In,1,0,0,0,1
+Bradford,Litchfield Township,Auditor General,,DEM,H. Scott Conklin,6,1,1,1,9
+Bradford,Litchfield Township,Auditor General,,DEM,Michael Lamb,6,1,2,0,9
+Bradford,Litchfield Township,Auditor General,,DEM,Tracie Fountain,1,0,5,0,6
+Bradford,Litchfield Township,Auditor General,,DEM,Rose Rosie Marie Davis,5,0,3,0,8
+Bradford,Litchfield Township,Auditor General,,DEM,Nina Ahmad,8,3,6,0,17
+Bradford,Litchfield Township,Auditor General,,DEM,Christina M. Hartman,9,0,2,0,11
+Bradford,Litchfield Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Litchfield Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Auditor General,,DEM,H. Scott Conklin,1,1,1,0,3
+Bradford,Monroe Borough,Auditor General,,DEM,Michael Lamb,3,0,2,0,5
+Bradford,Monroe Borough,Auditor General,,DEM,Tracie Fountain,0,0,3,0,3
+Bradford,Monroe Borough,Auditor General,,DEM,Rose Rosie Marie Davis,4,1,3,0,8
+Bradford,Monroe Borough,Auditor General,,DEM,Nina Ahmad,0,0,5,0,5
+Bradford,Monroe Borough,Auditor General,,DEM,Christina M. Hartman,2,0,1,0,3
+Bradford,Monroe Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Monroe Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Monroe Township,Auditor General,,DEM,H. Scott Conklin,2,0,1,0,3
+Bradford,Monroe Township,Auditor General,,DEM,Michael Lamb,4,1,4,0,9
+Bradford,Monroe Township,Auditor General,,DEM,Tracie Fountain,0,2,0,0,2
+Bradford,Monroe Township,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,2,0,8
+Bradford,Monroe Township,Auditor General,,DEM,Nina Ahmad,8,1,1,1,11
+Bradford,Monroe Township,Auditor General,,DEM,Christina M. Hartman,3,0,3,0,6
+Bradford,Monroe Township,Auditor General,,DEM,Timothy Defoor,2,0,0,0,2
+Bradford,Monroe Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Auditor General,,DEM,H. Scott Conklin,1,0,2,0,3
+Bradford,New Albany Borough,Auditor General,,DEM,Michael Lamb,2,0,0,0,2
+Bradford,New Albany Borough,Auditor General,,DEM,Tracie Fountain,1,0,0,0,1
+Bradford,New Albany Borough,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,0,1
+Bradford,New Albany Borough,Auditor General,,DEM,Nina Ahmad,1,0,1,0,2
+Bradford,New Albany Borough,Auditor General,,DEM,Christina M. Hartman,3,0,0,0,3
+Bradford,New Albany Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,New Albany Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Auditor General,,DEM,H. Scott Conklin,2,1,2,0,5
+Bradford,Orwell Township,Auditor General,,DEM,Michael Lamb,1,0,3,0,4
+Bradford,Orwell Township,Auditor General,,DEM,Tracie Fountain,1,0,1,0,2
+Bradford,Orwell Township,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,4,1,9
+Bradford,Orwell Township,Auditor General,,DEM,Nina Ahmad,9,2,2,0,13
+Bradford,Orwell Township,Auditor General,,DEM,Christina M. Hartman,9,0,7,0,16
+Bradford,Orwell Township,Auditor General,,DEM,Timothy Defoor,1,0,0,0,1
+Bradford,Orwell Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Overton Township,Auditor General,,DEM,H. Scott Conklin,6,0,0,0,6
+Bradford,Overton Township,Auditor General,,DEM,Michael Lamb,0,0,1,0,1
+Bradford,Overton Township,Auditor General,,DEM,Tracie Fountain,2,0,0,1,3
+Bradford,Overton Township,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,2,0,6
+Bradford,Overton Township,Auditor General,,DEM,Nina Ahmad,1,0,0,0,1
+Bradford,Overton Township,Auditor General,,DEM,Christina M. Hartman,4,0,2,0,6
+Bradford,Overton Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Overton Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Pike Township,Auditor General,,DEM,H. Scott Conklin,3,0,2,0,5
+Bradford,Pike Township,Auditor General,,DEM,Michael Lamb,1,0,1,0,2
+Bradford,Pike Township,Auditor General,,DEM,Tracie Fountain,0,0,0,0,0
+Bradford,Pike Township,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,0,3
+Bradford,Pike Township,Auditor General,,DEM,Nina Ahmad,5,1,2,0,8
+Bradford,Pike Township,Auditor General,,DEM,Christina M. Hartman,2,2,1,0,5
+Bradford,Pike Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Pike Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Auditor General,,DEM,H. Scott Conklin,8,0,7,0,15
+Bradford,Ridgebury Township,Auditor General,,DEM,Michael Lamb,2,1,4,2,9
+Bradford,Ridgebury Township,Auditor General,,DEM,Tracie Fountain,1,2,4,1,8
+Bradford,Ridgebury Township,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,1,0,5
+Bradford,Ridgebury Township,Auditor General,,DEM,Nina Ahmad,5,1,2,1,9
+Bradford,Ridgebury Township,Auditor General,,DEM,Christina M. Hartman,7,2,3,0,12
+Bradford,Ridgebury Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Ridgebury Township,Auditor General,,DEM,Write-In,1,0,0,0,1
+Bradford,Rome Borough,Auditor General,,DEM,H. Scott Conklin,1,0,0,0,1
+Bradford,Rome Borough,Auditor General,,DEM,Michael Lamb,0,0,0,0,0
+Bradford,Rome Borough,Auditor General,,DEM,Tracie Fountain,1,0,0,0,1
+Bradford,Rome Borough,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0,0
+Bradford,Rome Borough,Auditor General,,DEM,Nina Ahmad,0,0,1,0,1
+Bradford,Rome Borough,Auditor General,,DEM,Christina M. Hartman,3,0,1,0,4
+Bradford,Rome Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Rome Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Rome Township,Auditor General,,DEM,H. Scott Conklin,1,1,2,0,4
+Bradford,Rome Township,Auditor General,,DEM,Michael Lamb,3,0,3,0,6
+Bradford,Rome Township,Auditor General,,DEM,Tracie Fountain,2,0,0,0,2
+Bradford,Rome Township,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,0,3
+Bradford,Rome Township,Auditor General,,DEM,Nina Ahmad,2,0,0,0,2
+Bradford,Rome Township,Auditor General,,DEM,Christina M. Hartman,2,0,3,0,5
+Bradford,Rome Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Rome Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Auditor General,,DEM,H. Scott Conklin,1,0,7,0,8
+Bradford,Sayre Borough 1St Ward,Auditor General,,DEM,Michael Lamb,4,1,2,1,8
+Bradford,Sayre Borough 1St Ward,Auditor General,,DEM,Tracie Fountain,2,1,8,1,12
+Bradford,Sayre Borough 1St Ward,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,4,2,10
+Bradford,Sayre Borough 1St Ward,Auditor General,,DEM,Nina Ahmad,6,2,5,1,14
+Bradford,Sayre Borough 1St Ward,Auditor General,,DEM,Christina M. Hartman,8,2,2,0,12
+Bradford,Sayre Borough 1St Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,DEM,H. Scott Conklin,15,5,11,2,33
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,DEM,Michael Lamb,8,3,13,0,24
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,DEM,Tracie Fountain,7,2,15,0,24
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,15,3,8,2,28
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,DEM,Nina Ahmad,12,3,19,3,37
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,DEM,Christina M. Hartman,23,1,17,0,41
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,DEM,H. Scott Conklin,4,0,0,0,4
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,DEM,Michael Lamb,0,0,1,0,1
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,DEM,Tracie Fountain,6,0,0,0,6
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,0,3
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,DEM,Nina Ahmad,3,1,1,0,5
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,DEM,Christina M. Hartman,5,0,2,0,7
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Auditor General,,DEM,H. Scott Conklin,19,2,7,1,29
+Bradford,Sayre Borough 4Th Ward,Auditor General,,DEM,Michael Lamb,12,0,3,0,15
+Bradford,Sayre Borough 4Th Ward,Auditor General,,DEM,Tracie Fountain,5,2,5,0,12
+Bradford,Sayre Borough 4Th Ward,Auditor General,,DEM,Rose Rosie Marie Davis,6,1,4,0,11
+Bradford,Sayre Borough 4Th Ward,Auditor General,,DEM,Nina Ahmad,10,1,6,2,19
+Bradford,Sayre Borough 4Th Ward,Auditor General,,DEM,Christina M. Hartman,7,2,5,2,16
+Bradford,Sayre Borough 4Th Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Auditor General,,DEM,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 5Th Ward,Auditor General,,DEM,H. Scott Conklin,1,0,1,0,2
+Bradford,Sayre Borough 5Th Ward,Auditor General,,DEM,Michael Lamb,1,0,3,0,4
+Bradford,Sayre Borough 5Th Ward,Auditor General,,DEM,Tracie Fountain,4,0,0,0,4
+Bradford,Sayre Borough 5Th Ward,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,3,0,5
+Bradford,Sayre Borough 5Th Ward,Auditor General,,DEM,Nina Ahmad,2,1,2,0,5
+Bradford,Sayre Borough 5Th Ward,Auditor General,,DEM,Christina M. Hartman,2,0,1,0,3
+Bradford,Sayre Borough 5Th Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Auditor General,,DEM,H. Scott Conklin,0,0,1,0,1
+Bradford,Sheshequin Township,Auditor General,,DEM,Michael Lamb,4,1,4,0,9
+Bradford,Sheshequin Township,Auditor General,,DEM,Tracie Fountain,0,0,3,0,3
+Bradford,Sheshequin Township,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,6,1,10
+Bradford,Sheshequin Township,Auditor General,,DEM,Nina Ahmad,2,0,5,2,9
+Bradford,Sheshequin Township,Auditor General,,DEM,Christina M. Hartman,2,2,2,2,8
+Bradford,Sheshequin Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Sheshequin Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Auditor General,,DEM,H. Scott Conklin,5,0,3,2,10
+Bradford,Smithfield Township,Auditor General,,DEM,Michael Lamb,11,0,4,1,16
+Bradford,Smithfield Township,Auditor General,,DEM,Tracie Fountain,2,0,4,0,6
+Bradford,Smithfield Township,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,8,0,11
+Bradford,Smithfield Township,Auditor General,,DEM,Nina Ahmad,3,1,1,0,5
+Bradford,Smithfield Township,Auditor General,,DEM,Christina M. Hartman,7,0,4,0,11
+Bradford,Smithfield Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Smithfield Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Auditor General,,DEM,H. Scott Conklin,6,1,0,0,7
+Bradford,South Creek Township,Auditor General,,DEM,Michael Lamb,4,0,1,0,5
+Bradford,South Creek Township,Auditor General,,DEM,Tracie Fountain,0,0,1,0,1
+Bradford,South Creek Township,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,0,2
+Bradford,South Creek Township,Auditor General,,DEM,Nina Ahmad,3,0,1,0,4
+Bradford,South Creek Township,Auditor General,,DEM,Christina M. Hartman,3,0,3,1,7
+Bradford,South Creek Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,South Creek Township,Auditor General,,DEM,Write-In,1,0,0,0,1
+Bradford,South Waverly Borough,Auditor General,,DEM,H. Scott Conklin,1,1,2,0,4
+Bradford,South Waverly Borough,Auditor General,,DEM,Michael Lamb,4,1,6,0,11
+Bradford,South Waverly Borough,Auditor General,,DEM,Tracie Fountain,3,1,8,0,12
+Bradford,South Waverly Borough,Auditor General,,DEM,Rose Rosie Marie Davis,6,1,1,0,8
+Bradford,South Waverly Borough,Auditor General,,DEM,Nina Ahmad,11,0,2,4,17
+Bradford,South Waverly Borough,Auditor General,,DEM,Christina M. Hartman,15,1,12,0,28
+Bradford,South Waverly Borough,Auditor General,,DEM,Timothy Defoor,0,1,0,0,1
+Bradford,South Waverly Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Auditor General,,DEM,H. Scott Conklin,4,0,8,1,13
+Bradford,Springfield Township,Auditor General,,DEM,Michael Lamb,3,1,11,0,15
+Bradford,Springfield Township,Auditor General,,DEM,Tracie Fountain,1,0,1,0,2
+Bradford,Springfield Township,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,4,0,7
+Bradford,Springfield Township,Auditor General,,DEM,Nina Ahmad,7,3,7,0,17
+Bradford,Springfield Township,Auditor General,,DEM,Christina M. Hartman,3,0,1,1,5
+Bradford,Springfield Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Springfield Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,Auditor General,,DEM,H. Scott Conklin,1,0,2,1,4
+Bradford,Standing Stone Township,Auditor General,,DEM,Michael Lamb,4,0,1,0,5
+Bradford,Standing Stone Township,Auditor General,,DEM,Tracie Fountain,0,0,3,0,3
+Bradford,Standing Stone Township,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2,0,4
+Bradford,Standing Stone Township,Auditor General,,DEM,Nina Ahmad,0,2,2,0,4
+Bradford,Standing Stone Township,Auditor General,,DEM,Christina M. Hartman,6,0,2,0,8
+Bradford,Standing Stone Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Standing Stone Township,Auditor General,,DEM,Write-In,1,0,0,0,1
+Bradford,Stevens Township,Auditor General,,DEM,H. Scott Conklin,2,0,1,0,3
+Bradford,Stevens Township,Auditor General,,DEM,Michael Lamb,1,0,2,0,3
+Bradford,Stevens Township,Auditor General,,DEM,Tracie Fountain,0,0,0,0,0
+Bradford,Stevens Township,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,2,0,8
+Bradford,Stevens Township,Auditor General,,DEM,Nina Ahmad,1,1,0,0,2
+Bradford,Stevens Township,Auditor General,,DEM,Christina M. Hartman,1,0,2,1,4
+Bradford,Stevens Township,Auditor General,,DEM,Timothy Defoor,1,0,0,0,1
+Bradford,Stevens Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,Auditor General,,DEM,H. Scott Conklin,1,0,0,0,1
+Bradford,Sylvania Borough,Auditor General,,DEM,Michael Lamb,2,0,2,0,4
+Bradford,Sylvania Borough,Auditor General,,DEM,Tracie Fountain,0,0,0,0,0
+Bradford,Sylvania Borough,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,0,2
+Bradford,Sylvania Borough,Auditor General,,DEM,Nina Ahmad,1,1,0,0,2
+Bradford,Sylvania Borough,Auditor General,,DEM,Christina M. Hartman,1,0,1,0,2
+Bradford,Sylvania Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Sylvania Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Terry Township,Auditor General,,DEM,H. Scott Conklin,7,1,5,0,13
+Bradford,Terry Township,Auditor General,,DEM,Michael Lamb,2,1,1,0,4
+Bradford,Terry Township,Auditor General,,DEM,Tracie Fountain,2,0,2,0,4
+Bradford,Terry Township,Auditor General,,DEM,Rose Rosie Marie Davis,6,0,4,0,10
+Bradford,Terry Township,Auditor General,,DEM,Nina Ahmad,4,0,3,0,7
+Bradford,Terry Township,Auditor General,,DEM,Christina M. Hartman,2,0,3,0,5
+Bradford,Terry Township,Auditor General,,DEM,Timothy Defoor,1,0,0,0,1
+Bradford,Terry Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Auditor General,,DEM,H. Scott Conklin,2,0,3,0,5
+Bradford,Towanda Borough 1St Ward,Auditor General,,DEM,Michael Lamb,1,0,0,0,1
+Bradford,Towanda Borough 1St Ward,Auditor General,,DEM,Tracie Fountain,1,0,2,0,3
+Bradford,Towanda Borough 1St Ward,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Auditor General,,DEM,Nina Ahmad,2,0,1,0,3
+Bradford,Towanda Borough 1St Ward,Auditor General,,DEM,Christina M. Hartman,4,0,1,0,5
+Bradford,Towanda Borough 1St Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,DEM,H. Scott Conklin,5,0,3,0,8
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,DEM,Michael Lamb,4,0,1,0,5
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,DEM,Tracie Fountain,5,0,2,0,7
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,6,0,8
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,DEM,Nina Ahmad,1,0,6,1,8
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,DEM,Christina M. Hartman,6,1,3,0,10
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,DEM,H. Scott Conklin,3,1,7,1,12
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,DEM,Michael Lamb,6,0,6,1,13
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,DEM,Tracie Fountain,4,0,1,0,5
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,3,4,7,0,14
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,DEM,Nina Ahmad,6,0,6,0,12
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,DEM,Christina M. Hartman,4,4,8,1,17
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,DEM,Write-In,0,0,1,0,1
+Bradford,Towanda Township,Auditor General,,DEM,H. Scott Conklin,4,1,3,0,8
+Bradford,Towanda Township,Auditor General,,DEM,Michael Lamb,3,3,1,1,8
+Bradford,Towanda Township,Auditor General,,DEM,Tracie Fountain,0,2,2,0,4
+Bradford,Towanda Township,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2,1,5
+Bradford,Towanda Township,Auditor General,,DEM,Nina Ahmad,7,0,1,0,8
+Bradford,Towanda Township,Auditor General,,DEM,Christina M. Hartman,3,0,4,0,7
+Bradford,Towanda Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Towanda Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Auditor General,,DEM,H. Scott Conklin,2,1,5,0,8
+Bradford,North Towanda Township,Auditor General,,DEM,Michael Lamb,3,1,4,0,8
+Bradford,North Towanda Township,Auditor General,,DEM,Tracie Fountain,1,1,2,0,4
+Bradford,North Towanda Township,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,3,0,7
+Bradford,North Towanda Township,Auditor General,,DEM,Nina Ahmad,4,0,6,0,10
+Bradford,North Towanda Township,Auditor General,,DEM,Christina M. Hartman,2,0,8,0,10
+Bradford,North Towanda Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,North Towanda Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Auditor General,,DEM,H. Scott Conklin,9,1,3,3,16
+Bradford,Troy Borough,Auditor General,,DEM,Michael Lamb,3,1,5,0,9
+Bradford,Troy Borough,Auditor General,,DEM,Tracie Fountain,0,0,1,0,1
+Bradford,Troy Borough,Auditor General,,DEM,Rose Rosie Marie Davis,7,0,2,0,9
+Bradford,Troy Borough,Auditor General,,DEM,Nina Ahmad,4,0,7,0,11
+Bradford,Troy Borough,Auditor General,,DEM,Christina M. Hartman,10,0,6,0,16
+Bradford,Troy Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Troy Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Township,Auditor General,,DEM,H. Scott Conklin,5,3,4,1,13
+Bradford,Troy Township,Auditor General,,DEM,Michael Lamb,9,0,5,0,14
+Bradford,Troy Township,Auditor General,,DEM,Tracie Fountain,1,1,4,0,6
+Bradford,Troy Township,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,3,0,3
+Bradford,Troy Township,Auditor General,,DEM,Nina Ahmad,7,0,5,1,13
+Bradford,Troy Township,Auditor General,,DEM,Christina M. Hartman,4,1,5,0,10
+Bradford,Troy Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Troy Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Auditor General,,DEM,H. Scott Conklin,2,1,0,0,3
+Bradford,Tuscarora Township,Auditor General,,DEM,Michael Lamb,7,0,4,0,11
+Bradford,Tuscarora Township,Auditor General,,DEM,Tracie Fountain,4,1,3,0,8
+Bradford,Tuscarora Township,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,1,0,7
+Bradford,Tuscarora Township,Auditor General,,DEM,Nina Ahmad,2,0,4,0,6
+Bradford,Tuscarora Township,Auditor General,,DEM,Christina M. Hartman,3,0,10,0,13
+Bradford,Tuscarora Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Tuscarora Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Auditor General,,DEM,H. Scott Conklin,1,0,5,0,6
+Bradford,Ulster Township,Auditor General,,DEM,Michael Lamb,7,0,3,0,10
+Bradford,Ulster Township,Auditor General,,DEM,Tracie Fountain,1,1,2,0,4
+Bradford,Ulster Township,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,1,0,1
+Bradford,Ulster Township,Auditor General,,DEM,Nina Ahmad,3,2,3,0,8
+Bradford,Ulster Township,Auditor General,,DEM,Christina M. Hartman,10,0,7,0,17
+Bradford,Ulster Township,Auditor General,,DEM,Timothy Defoor,1,0,0,0,1
+Bradford,Ulster Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Warren Township,Auditor General,,DEM,H. Scott Conklin,4,1,3,0,8
+Bradford,Warren Township,Auditor General,,DEM,Michael Lamb,5,0,0,0,5
+Bradford,Warren Township,Auditor General,,DEM,Tracie Fountain,1,0,1,0,2
+Bradford,Warren Township,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,4,1,6
+Bradford,Warren Township,Auditor General,,DEM,Nina Ahmad,5,0,4,1,10
+Bradford,Warren Township,Auditor General,,DEM,Christina M. Hartman,3,1,5,0,9
+Bradford,Warren Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Warren Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wells Township,Auditor General,,DEM,H. Scott Conklin,3,0,1,0,4
+Bradford,Wells Township,Auditor General,,DEM,Michael Lamb,4,0,3,0,7
+Bradford,Wells Township,Auditor General,,DEM,Tracie Fountain,2,0,5,0,7
+Bradford,Wells Township,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,1,0,1
+Bradford,Wells Township,Auditor General,,DEM,Nina Ahmad,3,1,1,0,5
+Bradford,Wells Township,Auditor General,,DEM,Christina M. Hartman,5,2,4,0,11
+Bradford,Wells Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Wells Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Auditor General,,DEM,H. Scott Conklin,4,0,4,0,8
+Bradford,Wilmot Township,Auditor General,,DEM,Michael Lamb,2,3,2,1,8
+Bradford,Wilmot Township,Auditor General,,DEM,Tracie Fountain,0,3,2,1,6
+Bradford,Wilmot Township,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,3,0,5
+Bradford,Wilmot Township,Auditor General,,DEM,Nina Ahmad,7,2,8,1,18
+Bradford,Wilmot Township,Auditor General,,DEM,Christina M. Hartman,4,0,2,0,6
+Bradford,Wilmot Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Wilmot Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Windham Township,Auditor General,,DEM,H. Scott Conklin,0,1,1,0,2
+Bradford,Windham Township,Auditor General,,DEM,Michael Lamb,2,0,2,1,5
+Bradford,Windham Township,Auditor General,,DEM,Tracie Fountain,0,2,1,0,3
+Bradford,Windham Township,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,3,0,4
+Bradford,Windham Township,Auditor General,,DEM,Nina Ahmad,3,1,3,0,7
+Bradford,Windham Township,Auditor General,,DEM,Christina M. Hartman,5,0,4,1,10
+Bradford,Windham Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Windham Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Auditor General,,DEM,H. Scott Conklin,5,0,4,0,9
+Bradford,Wyalusing Borough,Auditor General,,DEM,Michael Lamb,5,0,2,0,7
+Bradford,Wyalusing Borough,Auditor General,,DEM,Tracie Fountain,1,0,1,0,2
+Bradford,Wyalusing Borough,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,1,0,5
+Bradford,Wyalusing Borough,Auditor General,,DEM,Nina Ahmad,5,1,3,1,10
+Bradford,Wyalusing Borough,Auditor General,,DEM,Christina M. Hartman,7,0,2,1,10
+Bradford,Wyalusing Borough,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Wyalusing Borough,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Auditor General,,DEM,H. Scott Conklin,5,0,4,0,9
+Bradford,Wyalusing Township,Auditor General,,DEM,Michael Lamb,3,1,4,0,8
+Bradford,Wyalusing Township,Auditor General,,DEM,Tracie Fountain,1,1,1,0,3
+Bradford,Wyalusing Township,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,0,3
+Bradford,Wyalusing Township,Auditor General,,DEM,Nina Ahmad,6,1,4,0,11
+Bradford,Wyalusing Township,Auditor General,,DEM,Christina M. Hartman,4,3,9,0,16
+Bradford,Wyalusing Township,Auditor General,,DEM,Timothy Defoor,0,0,0,0,0
+Bradford,Wyalusing Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Auditor General,,DEM,H. Scott Conklin,6,0,2,0,8
+Bradford,Wysox Township,Auditor General,,DEM,Michael Lamb,5,3,9,0,17
+Bradford,Wysox Township,Auditor General,,DEM,Tracie Fountain,2,0,4,0,6
+Bradford,Wysox Township,Auditor General,,DEM,Rose Rosie Marie Davis,5,0,4,0,9
+Bradford,Wysox Township,Auditor General,,DEM,Nina Ahmad,4,0,2,1,7
+Bradford,Wysox Township,Auditor General,,DEM,Christina M. Hartman,2,3,13,0,18
+Bradford,Wysox Township,Auditor General,,DEM,Timothy Defoor,1,0,0,0,1
+Bradford,Wysox Township,Auditor General,,DEM,Write-In,0,0,0,0,0
+Bradford,Alba Borough,State Treasurer,,DEM,Joseph Torsella,3,0,2,0,5
+Bradford,Alba Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Alba Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Representative In Congress,12,,Lee Griffin,3,0,2,0,5
+Bradford,Alba Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Alba Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Albany Township,State Treasurer,,DEM,Joseph Torsella,15,3,20,5,43
+Bradford,Albany Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Albany Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In Congress,12,,Lee Griffin,17,3,18,5,43
+Bradford,Albany Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
+Bradford,Albany Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Armenia Township,State Treasurer,,DEM,Joseph Torsella,3,0,1,2,6
+Bradford,Armenia Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Armenia Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Representative In Congress,12,,Lee Griffin,2,0,2,1,5
+Bradford,Armenia Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Armenia Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Asylum Township,State Treasurer,,DEM,Joseph Torsella,16,1,24,0,41
+Bradford,Asylum Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,2,0,2
+Bradford,Asylum Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Representative In Congress,12,,Lee Griffin,16,1,25,0,42
+Bradford,Asylum Township,Representative In Congress,12,,Fred Keller,0,0,1,0,1
+Bradford,Asylum Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,State Treasurer,,DEM,Joseph Torsella,21,1,20,1,43
+Bradford,Athens Borough 1St Ward,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Athens Borough 1St Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,,Lee Griffin,22,1,19,1,43
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,,Fred Keller,0,0,1,0,1
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,State Treasurer,,DEM,Joseph Torsella,19,1,11,1,32
+Bradford,Athens Borough 2Nd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,,Lee Griffin,20,0,9,1,30
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,State Treasurer,,DEM,Joseph Torsella,28,1,20,1,50
+Bradford,Athens Borough 3Rd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,,Lee Griffin,26,1,20,1,48
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,State Treasurer,,DEM,Joseph Torsella,36,3,17,6,62
+Bradford,Athens Borough 4Th Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,,Lee Griffin,35,3,17,5,60
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,State Treasurer,,DEM,Joseph Torsella,38,8,40,4,90
+Bradford,Athens Township 1St District,State Treasurer,,DEM,Stacy L. Garrity,1,0,1,0,2
+Bradford,Athens Township 1St District,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In Congress,12,,Lee Griffin,38,9,42,4,93
+Bradford,Athens Township 1St District,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Athens Township 2Nd District,State Treasurer,,DEM,Joseph Torsella,49,23,86,8,166
+Bradford,Athens Township 2Nd District,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
+Bradford,Athens Township 2Nd District,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In Congress,12,,Lee Griffin,49,23,89,8,169
+Bradford,Athens Township 2Nd District,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Burlington Borough,State Treasurer,,DEM,Joseph Torsella,3,0,2,0,5
+Bradford,Burlington Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Burlington Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Representative In Congress,12,,Lee Griffin,4,0,2,0,6
+Bradford,Burlington Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Burlington Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Burlington Township,State Treasurer,,DEM,Joseph Torsella,12,0,18,0,30
+Bradford,Burlington Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Burlington Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Representative In Congress,12,,Lee Griffin,11,0,18,0,29
+Bradford,Burlington Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
+Bradford,Burlington Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,State Treasurer,,DEM,Joseph Torsella,13,2,2,2,19
+Bradford,West Burlington Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
+Bradford,West Burlington Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Representative In Congress,12,,Lee Griffin,13,2,2,2,19
+Bradford,West Burlington Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
+Bradford,West Burlington Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Canton Borough,State Treasurer,,DEM,Joseph Torsella,31,8,18,3,60
+Bradford,Canton Borough,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
+Bradford,Canton Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Representative In Congress,12,,Lee Griffin,34,8,19,3,64
+Bradford,Canton Borough,Representative In Congress,12,,Fred Keller,2,0,0,0,2
+Bradford,Canton Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Canton Township,State Treasurer,,DEM,Joseph Torsella,28,1,17,3,49
+Bradford,Canton Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,1,0,2
+Bradford,Canton Township,State Treasurer,,DEM,Write-In,0,0,1,0,1
+Bradford,Canton Township,Representative In Congress,12,,Lee Griffin,27,1,17,2,47
+Bradford,Canton Township,Representative In Congress,12,,Fred Keller,1,0,1,0,2
+Bradford,Canton Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Columbia Township,State Treasurer,,DEM,Joseph Torsella,30,6,10,4,50
+Bradford,Columbia Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Columbia Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Representative In Congress,12,,Lee Griffin,25,7,10,4,46
+Bradford,Columbia Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Columbia Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Franklin Township,State Treasurer,,DEM,Joseph Torsella,7,0,3,0,10
+Bradford,Franklin Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Franklin Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In Congress,12,,Lee Griffin,7,0,3,0,10
+Bradford,Franklin Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Franklin Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Granville Township,State Treasurer,,DEM,Joseph Torsella,16,2,8,2,28
+Bradford,Granville Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,2,0,2
+Bradford,Granville Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Granville Township,Representative In Congress,12,,Lee Griffin,16,3,8,2,29
+Bradford,Granville Township,Representative In Congress,12,,Fred Keller,0,0,2,0,2
+Bradford,Granville Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Herrick Township,State Treasurer,,DEM,Joseph Torsella,20,3,4,3,30
+Bradford,Herrick Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Herrick Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Representative In Congress,12,,Lee Griffin,19,3,4,3,29
+Bradford,Herrick Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Herrick Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,State Treasurer,,DEM,Joseph Torsella,2,0,4,0,6
+Bradford,Leraysville Borough,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Leraysville Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In Congress,12,,Lee Griffin,3,0,4,0,7
+Bradford,Leraysville Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Leroy Township,State Treasurer,,DEM,Joseph Torsella,19,2,8,2,31
+Bradford,Leroy Township,State Treasurer,,DEM,Stacy L. Garrity,0,1,0,0,1
+Bradford,Leroy Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Representative In Congress,12,,Lee Griffin,19,2,8,2,31
+Bradford,Leroy Township,Representative In Congress,12,,Fred Keller,0,1,0,0,1
+Bradford,Leroy Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,State Treasurer,,DEM,Joseph Torsella,27,4,18,1,50
+Bradford,Litchfield Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
+Bradford,Litchfield Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Representative In Congress,12,,Lee Griffin,26,5,19,1,51
+Bradford,Litchfield Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Litchfield Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,State Treasurer,,DEM,Joseph Torsella,8,2,11,0,21
+Bradford,Monroe Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Monroe Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Representative In Congress,12,,Lee Griffin,7,2,12,0,21
+Bradford,Monroe Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Monroe Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Monroe Township,State Treasurer,,DEM,Joseph Torsella,19,6,12,1,38
+Bradford,Monroe Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
+Bradford,Monroe Township,State Treasurer,,DEM,Write-In,0,1,0,0,1
+Bradford,Monroe Township,Representative In Congress,12,,Lee Griffin,19,6,12,1,38
+Bradford,Monroe Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Monroe Township,Representative In Congress,12,,Write-In,2,0,0,0,2
+Bradford,New Albany Borough,State Treasurer,,DEM,Joseph Torsella,7,0,3,0,10
+Bradford,New Albany Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,New Albany Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Representative In Congress,12,,Lee Griffin,7,0,3,0,10
+Bradford,New Albany Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,New Albany Borough,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Orwell Township,State Treasurer,,DEM,Joseph Torsella,25,3,21,0,49
+Bradford,Orwell Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Orwell Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Representative In Congress,12,,Lee Griffin,27,3,18,1,49
+Bradford,Orwell Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
+Bradford,Orwell Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Overton Township,State Treasurer,,DEM,Joseph Torsella,17,0,7,1,25
+Bradford,Overton Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Overton Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Overton Township,Representative In Congress,12,,Lee Griffin,17,0,6,1,24
+Bradford,Overton Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Overton Township,Representative In Congress,12,,Write-In,0,0,1,0,1
+Bradford,Pike Township,State Treasurer,,DEM,Joseph Torsella,13,3,6,0,22
+Bradford,Pike Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Pike Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Pike Township,Representative In Congress,12,,Lee Griffin,14,4,6,0,24
+Bradford,Pike Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Pike Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,State Treasurer,,DEM,Joseph Torsella,26,6,21,2,55
+Bradford,Ridgebury Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,1,1
+Bradford,Ridgebury Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In Congress,12,,Lee Griffin,25,6,21,4,56
+Bradford,Ridgebury Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Rome Borough,State Treasurer,,DEM,Joseph Torsella,4,0,2,0,6
+Bradford,Rome Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Rome Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In Congress,12,,Lee Griffin,4,0,3,0,7
+Bradford,Rome Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Rome Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Rome Township,State Treasurer,,DEM,Joseph Torsella,13,1,8,0,22
+Bradford,Rome Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Rome Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Rome Township,Representative In Congress,12,,Lee Griffin,13,1,7,0,21
+Bradford,Rome Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Rome Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,State Treasurer,,DEM,Joseph Torsella,24,5,30,4,63
+Bradford,Sayre Borough 1St Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
+Bradford,Sayre Borough 1St Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,,Lee Griffin,22,5,29,4,60
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,,Write-In,2,0,0,0,2
+Bradford,Sayre Borough 2Nd Ward,State Treasurer,,DEM,Joseph Torsella,78,17,82,7,184
+Bradford,Sayre Borough 2Nd Ward,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Sayre Borough 2Nd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,,Lee Griffin,79,17,75,6,177
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,,Write-In,1,0,1,0,2
+Bradford,Sayre Borough 3Rd Ward,State Treasurer,,DEM,Joseph Torsella,19,1,4,0,24
+Bradford,Sayre Borough 3Rd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,,Lee Griffin,20,1,4,0,25
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 4Th Ward,State Treasurer,,DEM,Joseph Torsella,52,9,31,3,95
+Bradford,Sayre Borough 4Th Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,,Lee Griffin,51,8,32,2,93
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,,Write-In,0,0,2,1,3
+Bradford,Sayre Borough 5Th Ward,State Treasurer,,DEM,Joseph Torsella,10,1,10,0,21
+Bradford,Sayre Borough 5Th Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,,Lee Griffin,12,1,10,0,23
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,State Treasurer,,DEM,Joseph Torsella,13,3,19,5,40
+Bradford,Sheshequin Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Sheshequin Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In Congress,12,,Lee Griffin,13,3,18,2,36
+Bradford,Sheshequin Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,State Treasurer,,DEM,Joseph Torsella,30,2,21,2,55
+Bradford,Smithfield Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,2,0,2
+Bradford,Smithfield Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Representative In Congress,12,,Lee Griffin,32,2,19,2,55
+Bradford,Smithfield Township,Representative In Congress,12,,Fred Keller,0,0,1,0,1
+Bradford,Smithfield Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,South Creek Township,State Treasurer,,DEM,Joseph Torsella,22,1,5,1,29
+Bradford,South Creek Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
+Bradford,South Creek Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Representative In Congress,12,,Lee Griffin,19,1,5,1,26
+Bradford,South Creek Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,South Creek Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,State Treasurer,,DEM,Joseph Torsella,39,5,35,3,82
+Bradford,South Waverly Borough,State Treasurer,,DEM,Stacy L. Garrity,2,1,0,0,3
+Bradford,South Waverly Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In Congress,12,,Lee Griffin,40,5,36,4,85
+Bradford,South Waverly Borough,Representative In Congress,12,,Fred Keller,0,1,0,0,1
+Bradford,South Waverly Borough,Representative In Congress,12,,Write-In,2,0,0,0,2
+Bradford,Springfield Township,State Treasurer,,DEM,Joseph Torsella,20,4,31,2,57
+Bradford,Springfield Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
+Bradford,Springfield Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Representative In Congress,12,,Lee Griffin,20,4,30,2,56
+Bradford,Springfield Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Springfield Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,State Treasurer,,DEM,Joseph Torsella,10,2,12,0,24
+Bradford,Standing Stone Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Standing Stone Township,State Treasurer,,DEM,Write-In,1,0,0,0,1
+Bradford,Standing Stone Township,Representative In Congress,12,,Lee Griffin,9,2,12,0,23
+Bradford,Standing Stone Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Stevens Township,State Treasurer,,DEM,Joseph Torsella,7,2,8,1,18
+Bradford,Stevens Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Stevens Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Representative In Congress,12,,Lee Griffin,8,1,7,1,17
+Bradford,Stevens Township,Representative In Congress,12,,Fred Keller,2,0,0,0,2
+Bradford,Stevens Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,State Treasurer,,DEM,Joseph Torsella,7,1,2,0,10
+Bradford,Sylvania Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Sylvania Borough,State Treasurer,,DEM,Write-In,0,0,1,0,1
+Bradford,Sylvania Borough,Representative In Congress,12,,Lee Griffin,7,1,2,0,10
+Bradford,Sylvania Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In Congress,12,,Write-In,0,0,1,0,1
+Bradford,Terry Township,State Treasurer,,DEM,Joseph Torsella,22,1,18,0,41
+Bradford,Terry Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Terry Township,State Treasurer,,DEM,Write-In,0,1,0,0,1
+Bradford,Terry Township,Representative In Congress,12,,Lee Griffin,23,1,18,0,42
+Bradford,Terry Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
+Bradford,Terry Township,Representative In Congress,12,,Write-In,0,1,0,0,1
+Bradford,Towanda Borough 1St Ward,State Treasurer,,DEM,Joseph Torsella,12,0,7,0,19
+Bradford,Towanda Borough 1St Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,,Lee Griffin,10,0,7,0,17
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,State Treasurer,,DEM,Joseph Torsella,24,1,20,2,47
+Bradford,Towanda Borough 2Nd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,,Lee Griffin,24,1,19,3,47
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,State Treasurer,,DEM,Joseph Torsella,24,9,33,3,69
+Bradford,Towanda Borough 3Rd Ward,State Treasurer,,DEM,Stacy L. Garrity,0,0,1,0,1
+Bradford,Towanda Borough 3Rd Ward,State Treasurer,,DEM,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,,Lee Griffin,25,9,30,3,67
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,,Fred Keller,1,0,0,0,1
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Towanda Township,State Treasurer,,DEM,Joseph Torsella,16,6,12,2,36
+Bradford,Towanda Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
+Bradford,Towanda Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Representative In Congress,12,,Lee Griffin,17,6,12,2,37
+Bradford,Towanda Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Towanda Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,State Treasurer,,DEM,Joseph Torsella,14,3,29,0,46
+Bradford,North Towanda Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,North Towanda Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Representative In Congress,12,,Lee Griffin,14,3,29,0,46
+Bradford,North Towanda Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,North Towanda Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Troy Borough,State Treasurer,,DEM,Joseph Torsella,30,2,26,3,61
+Bradford,Troy Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Troy Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Representative In Congress,12,,Lee Griffin,31,2,24,3,60
+Bradford,Troy Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Troy Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Troy Township,State Treasurer,,DEM,Joseph Torsella,27,5,27,2,61
+Bradford,Troy Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Troy Township,State Treasurer,,DEM,Write-In,1,0,0,0,1
+Bradford,Troy Township,Representative In Congress,12,,Lee Griffin,27,5,24,2,58
+Bradford,Troy Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Troy Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,State Treasurer,,DEM,Joseph Torsella,21,2,22,0,45
+Bradford,Tuscarora Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Tuscarora Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In Congress,12,,Lee Griffin,24,3,22,0,49
+Bradford,Tuscarora Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Ulster Township,State Treasurer,,DEM,Joseph Torsella,20,3,21,0,44
+Bradford,Ulster Township,State Treasurer,,DEM,Stacy L. Garrity,2,0,0,0,2
+Bradford,Ulster Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Representative In Congress,12,,Lee Griffin,23,3,21,0,47
+Bradford,Ulster Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Ulster Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Warren Township,State Treasurer,,DEM,Joseph Torsella,19,2,17,2,40
+Bradford,Warren Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Warren Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Warren Township,Representative In Congress,12,,Lee Griffin,19,2,17,2,40
+Bradford,Warren Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Warren Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Wells Township,State Treasurer,,DEM,Joseph Torsella,20,3,16,0,39
+Bradford,Wells Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Wells Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Wells Township,Representative In Congress,12,,Lee Griffin,20,3,15,0,38
+Bradford,Wells Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Wells Township,Representative In Congress,12,,Write-In,0,0,1,0,1
+Bradford,Wilmot Township,State Treasurer,,DEM,Joseph Torsella,17,6,21,2,46
+Bradford,Wilmot Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Wilmot Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Representative In Congress,12,,Lee Griffin,17,6,21,3,47
+Bradford,Wilmot Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Wilmot Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Windham Township,State Treasurer,,DEM,Joseph Torsella,11,6,13,2,32
+Bradford,Windham Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Windham Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Windham Township,Representative In Congress,12,,Lee Griffin,10,5,12,2,29
+Bradford,Windham Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Windham Township,Representative In Congress,12,,Write-In,0,0,1,0,1
+Bradford,Wyalusing Borough,State Treasurer,,DEM,Joseph Torsella,25,1,13,2,41
+Bradford,Wyalusing Borough,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Wyalusing Borough,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In Congress,12,,Lee Griffin,24,2,12,2,40
+Bradford,Wyalusing Borough,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,State Treasurer,,DEM,Joseph Torsella,21,6,21,0,48
+Bradford,Wyalusing Township,State Treasurer,,DEM,Stacy L. Garrity,0,0,0,0,0
+Bradford,Wyalusing Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In Congress,12,,Lee Griffin,18,5,21,0,44
+Bradford,Wyalusing Township,Representative In Congress,12,,Fred Keller,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In Congress,12,,Write-In,0,0,0,0,0
+Bradford,Wysox Township,State Treasurer,,DEM,Joseph Torsella,24,6,33,0,63
+Bradford,Wysox Township,State Treasurer,,DEM,Stacy L. Garrity,1,0,0,0,1
+Bradford,Wysox Township,State Treasurer,,DEM,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Representative In Congress,12,,Lee Griffin,25,6,31,0,62
+Bradford,Wysox Township,Representative In Congress,12,,Fred Keller,1,0,0,0,1
+Bradford,Wysox Township,Representative In Congress,12,,Write-In,1,0,0,0,1
+Bradford,Alba Borough,Senator In The General Assembly,23,DEM,Jackie Baker,3,0,2,0,5
+Bradford,Alba Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Alba Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Albany Township,Senator In The General Assembly,23,DEM,Jackie Baker,17,3,18,5,43
+Bradford,Albany Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
+Bradford,Albany Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Senator In The General Assembly,23,DEM,Jackie Baker,2,0,1,1,4
+Bradford,Armenia Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Armenia Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Senator In The General Assembly,23,DEM,Jackie Baker,15,1,24,1,41
+Bradford,Asylum Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
+Bradford,Asylum Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
+Bradford,Asylum Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,DEM,Jackie Baker,23,1,19,1,44
+Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
+Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,21,0,9,1,31
+Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,26,1,21,1,49
+Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,DEM,Jackie Baker,36,3,16,5,60
+Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Senator In The General Assembly,23,DEM,Jackie Baker,41,9,43,4,97
+Bradford,Athens Township 1St District,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Athens Township 1St District,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,DEM,Jackie Baker,51,23,88,7,169
+Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Senator In The General Assembly,23,DEM,Jackie Baker,4,0,2,0,6
+Bradford,Burlington Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Burlington Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Senator In The General Assembly,23,DEM,Jackie Baker,12,1,18,0,31
+Bradford,Burlington Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Burlington Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Senator In The General Assembly,23,DEM,Jackie Baker,16,2,2,2,22
+Bradford,West Burlington Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
+Bradford,West Burlington Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,68,,Clint Owlett,3,0,0,0,3
+Bradford,West Burlington Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Senator In The General Assembly,23,DEM,Jackie Baker,34,8,18,3,63
+Bradford,Canton Borough,Senator In The General Assembly,23,DEM,Gene Yaw,2,0,0,0,2
+Bradford,Canton Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,68,,Clint Owlett,1,1,3,0,5
+Bradford,Canton Borough,Representative In The General Assembly,68,,Write-In,1,1,3,2,7
+Bradford,Canton Township,Senator In The General Assembly,23,DEM,Jackie Baker,29,1,16,2,48
+Bradford,Canton Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
+Bradford,Canton Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,68,,Clint Owlett,3,0,3,1,7
+Bradford,Canton Township,Representative In The General Assembly,68,,Write-In,2,0,3,0,5
+Bradford,Columbia Township,Senator In The General Assembly,23,DEM,Jackie Baker,29,7,10,4,50
+Bradford,Columbia Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Columbia Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,68,,Write-In,1,0,2,0,3
+Bradford,Franklin Township,Senator In The General Assembly,23,DEM,Jackie Baker,9,0,3,0,12
+Bradford,Franklin Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Franklin Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Granville Township,Senator In The General Assembly,23,DEM,Jackie Baker,17,3,8,2,30
+Bradford,Granville Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,2,0,2
+Bradford,Granville Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,68,,Clint Owlett,0,0,2,0,2
+Bradford,Granville Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Senator In The General Assembly,23,DEM,Jackie Baker,19,3,5,3,30
+Bradford,Herrick Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Herrick Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Senator In The General Assembly,23,DEM,Jackie Baker,4,0,4,0,8
+Bradford,Leraysville Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Leraysville Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Senator In The General Assembly,23,DEM,Jackie Baker,21,2,8,2,33
+Bradford,Leroy Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,1,0,0,1
+Bradford,Leroy Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Senator In The General Assembly,23,DEM,Jackie Baker,27,5,19,1,52
+Bradford,Litchfield Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Litchfield Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
+Bradford,Litchfield Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Senator In The General Assembly,23,DEM,Jackie Baker,8,1,12,0,21
+Bradford,Monroe Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Monroe Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Monroe Township,Senator In The General Assembly,23,DEM,Jackie Baker,20,7,12,1,40
+Bradford,Monroe Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Monroe Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
+Bradford,Monroe Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Senator In The General Assembly,23,DEM,Jackie Baker,8,0,3,0,11
+Bradford,New Albany Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,New Albany Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Senator In The General Assembly,23,DEM,Jackie Baker,26,3,18,1,48
+Bradford,Orwell Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
+Bradford,Orwell Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Overton Township,Senator In The General Assembly,23,DEM,Jackie Baker,16,0,6,1,23
+Bradford,Overton Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
+Bradford,Overton Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Pike Township,Senator In The General Assembly,23,DEM,Jackie Baker,13,4,6,0,23
+Bradford,Pike Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
+Bradford,Pike Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Senator In The General Assembly,23,DEM,Jackie Baker,28,5,21,3,57
+Bradford,Ridgebury Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,1,1
+Bradford,Ridgebury Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,1,1
+Bradford,Ridgebury Township,Representative In The General Assembly,68,,Write-In,5,0,2,1,8
+Bradford,Rome Borough,Senator In The General Assembly,23,DEM,Jackie Baker,5,0,3,0,8
+Bradford,Rome Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Rome Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Rome Township,Senator In The General Assembly,23,DEM,Jackie Baker,13,1,9,0,23
+Bradford,Rome Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Rome Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,DEM,Jackie Baker,24,5,30,3,62
+Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,1,1
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,81,17,78,6,182
+Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,21,1,3,0,25
+Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,DEM,Jackie Baker,54,8,31,3,96
+Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
+Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,DEM,Jackie Baker,12,1,9,0,22
+Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Senator In The General Assembly,23,DEM,Jackie Baker,13,3,16,1,33
+Bradford,Sheshequin Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Sheshequin Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Senator In The General Assembly,23,DEM,Jackie Baker,31,2,21,3,57
+Bradford,Smithfield Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Smithfield Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
+Bradford,Smithfield Township,Representative In The General Assembly,68,,Clint Owlett,0,0,1,0,1
+Bradford,Smithfield Township,Representative In The General Assembly,68,,Write-In,2,0,2,0,4
+Bradford,South Creek Township,Senator In The General Assembly,23,DEM,Jackie Baker,22,1,5,1,29
+Bradford,South Creek Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,1,0,1
+Bradford,South Creek Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,68,,Clint Owlett,0,0,2,0,2
+Bradford,South Creek Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Senator In The General Assembly,23,DEM,Jackie Baker,45,5,36,4,90
+Bradford,South Waverly Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,1,0,0,1
+Bradford,South Waverly Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Senator In The General Assembly,23,DEM,Jackie Baker,20,4,29,2,55
+Bradford,Springfield Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Springfield Township,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
+Bradford,Springfield Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,68,,Write-In,0,3,2,0,5
+Bradford,Standing Stone Township,Senator In The General Assembly,23,DEM,Jackie Baker,10,2,12,1,25
+Bradford,Standing Stone Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
+Bradford,Standing Stone Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
+Bradford,Standing Stone Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Senator In The General Assembly,23,DEM,Jackie Baker,10,2,7,1,20
+Bradford,Stevens Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
+Bradford,Stevens Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
+Bradford,Stevens Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,Senator In The General Assembly,23,DEM,Jackie Baker,9,1,2,0,12
+Bradford,Sylvania Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Sylvania Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
+Bradford,Sylvania Borough,Representative In The General Assembly,68,,Clint Owlett,1,0,0,0,1
+Bradford,Sylvania Borough,Representative In The General Assembly,68,,Write-In,0,0,1,0,1
+Bradford,Terry Township,Senator In The General Assembly,23,DEM,Jackie Baker,23,1,17,0,41
+Bradford,Terry Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
+Bradford,Terry Township,Senator In The General Assembly,23,DEM,Write-In,0,1,0,0,1
+Bradford,Terry Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,DEM,Jackie Baker,11,0,7,0,18
+Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,26,1,18,1,46
+Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Jackie Baker,26,9,30,3,68
+Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,2,0,3
+Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Senator In The General Assembly,23,DEM,Jackie Baker,18,5,12,2,37
+Bradford,Towanda Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Towanda Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Senator In The General Assembly,23,DEM,Jackie Baker,15,3,28,0,46
+Bradford,North Towanda Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,North Towanda Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Senator In The General Assembly,23,DEM,Jackie Baker,32,2,25,3,62
+Bradford,Troy Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Troy Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,1,0,1
+Bradford,Troy Borough,Representative In The General Assembly,68,,Write-In,2,0,1,0,3
+Bradford,Troy Township,Senator In The General Assembly,23,DEM,Jackie Baker,27,5,26,2,60
+Bradford,Troy Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Troy Township,Senator In The General Assembly,23,DEM,Write-In,1,0,0,0,1
+Bradford,Troy Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,68,,Write-In,1,0,1,0,2
+Bradford,Tuscarora Township,Senator In The General Assembly,23,DEM,Jackie Baker,26,3,22,0,51
+Bradford,Tuscarora Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Tuscarora Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Senator In The General Assembly,23,DEM,Jackie Baker,22,3,21,0,46
+Bradford,Ulster Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Ulster Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Warren Township,Senator In The General Assembly,23,DEM,Jackie Baker,18,2,17,2,39
+Bradford,Warren Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Warren Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wells Township,Senator In The General Assembly,23,DEM,Jackie Baker,19,3,15,0,37
+Bradford,Wells Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Wells Township,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
+Bradford,Wells Township,Representative In The General Assembly,68,,Clint Owlett,0,0,1,0,1
+Bradford,Wells Township,Representative In The General Assembly,68,,Write-In,2,0,2,0,4
+Bradford,Wilmot Township,Senator In The General Assembly,23,DEM,Jackie Baker,17,6,21,3,47
+Bradford,Wilmot Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Wilmot Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Windham Township,Senator In The General Assembly,23,DEM,Jackie Baker,11,5,12,2,30
+Bradford,Windham Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Windham Township,Senator In The General Assembly,23,DEM,Write-In,0,0,1,0,1
+Bradford,Windham Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Senator In The General Assembly,23,DEM,Jackie Baker,30,2,13,2,47
+Bradford,Wyalusing Borough,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Wyalusing Borough,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Senator In The General Assembly,23,DEM,Jackie Baker,20,5,21,0,46
+Bradford,Wyalusing Township,Senator In The General Assembly,23,DEM,Gene Yaw,0,0,0,0,0
+Bradford,Wyalusing Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Senator In The General Assembly,23,DEM,Jackie Baker,26,6,33,0,65
+Bradford,Wysox Township,Senator In The General Assembly,23,DEM,Gene Yaw,1,0,0,0,1
+Bradford,Wysox Township,Senator In The General Assembly,23,DEM,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,110,DEM,Tina Pickett,1,0,0,0,1
+Bradford,Albany Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,1,0,1
+Bradford,Albany Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,110,DEM,Write-In,2,0,0,0,2
+Bradford,Armenia Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,1,0,1
+Bradford,Asylum Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,1,0,0,1
+Bradford,Asylum Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,110,DEM,Write-In,1,0,1,0,2
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,2,0,2
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,DEM,James Shaw,2,0,0,0,2
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,DEM,Write-In,3,0,1,0,4
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Tina Pickett,1,0,0,0,1
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Write-In,1,0,2,0,3
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,1,0,1
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Write-In,3,0,1,1,5
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,2,0,2
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,DEM,Write-In,1,1,1,0,3
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,1,0,1
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,DEM,James Shaw,1,0,0,0,1
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,DEM,Write-In,3,1,5,0,9
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,1,0,1
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,DEM,James Shaw,5,0,0,0,5
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,DEM,Write-In,5,1,1,1,8
+Bradford,Burlington Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,1,0,1
+Bradford,Burlington Township,Representative In The General Assembly,110,DEM,Tina Pickett,1,0,0,0,1
+Bradford,Burlington Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,2,2
+Bradford,Herrick Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,110,DEM,Write-In,0,0,1,0,1
+Bradford,Leraysville Borough,Representative In The General Assembly,110,DEM,Tina Pickett,2,0,0,0,2
+Bradford,Leraysville Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,1,0,1
+Bradford,Leroy Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,110,DEM,Write-In,1,0,0,0,1
+Bradford,Litchfield Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,1,0,1
+Bradford,Litchfield Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,110,DEM,Write-In,2,0,1,0,3
+Bradford,Monroe Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,2,0,2
+Bradford,Monroe Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,1,0,1
+Bradford,Monroe Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,110,DEM,Write-In,4,0,2,0,6
+Bradford,New Albany Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,1,0,1
+Bradford,Orwell Township,Representative In The General Assembly,110,DEM,Tina Pickett,1,0,0,0,1
+Bradford,Orwell Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,1,0,1
+Bradford,Overton Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,110,DEM,Write-In,1,0,0,0,1
+Bradford,Rome Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,110,DEM,Write-In,0,0,1,0,1
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,1,0,1
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,DEM,James Shaw,2,0,0,1,3
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,DEM,Write-In,0,1,2,0,3
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Tina Pickett,3,1,6,0,10
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,DEM,James Shaw,5,0,1,0,6
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Write-In,6,1,8,1,16
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,1,0,1
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Write-In,2,0,0,0,2
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,DEM,James Shaw,6,0,0,0,6
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,DEM,Write-In,5,1,3,0,9
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,DEM,Write-In,2,0,5,0,7
+Bradford,Sheshequin Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,2,0,2
+Bradford,Sheshequin Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Smithfield Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Smithfield Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Smithfield Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,110,DEM,Tina Pickett,1,1,1,0,3
+Bradford,South Waverly Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,110,DEM,James Shaw,6,0,0,4,10
+Bradford,South Waverly Borough,Representative In The General Assembly,110,DEM,Write-In,4,1,4,0,9
+Bradford,Springfield Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,2,0,2
+Bradford,Standing Stone Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,110,DEM,Write-In,1,0,2,0,3
+Bradford,Stevens Township,Representative In The General Assembly,110,DEM,Tina Pickett,2,0,0,0,2
+Bradford,Stevens Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,1,0,1
+Bradford,Stevens Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,110,DEM,Write-In,1,1,1,0,3
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,DEM,Write-In,1,0,2,0,3
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Tina Pickett,1,0,0,0,1
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,DEM,Write-In,1,0,2,0,3
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,2,0,2
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Donna Iannone,1,0,1,0,2
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,DEM,Write-In,5,1,4,1,11
+Bradford,Towanda Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,2,0,2
+Bradford,Towanda Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,110,DEM,Write-In,3,2,1,0,6
+Bradford,North Towanda Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,2,0,2
+Bradford,North Towanda Township,Representative In The General Assembly,110,DEM,James Shaw,4,0,0,0,4
+Bradford,North Towanda Township,Representative In The General Assembly,110,DEM,Write-In,0,1,2,0,3
+Bradford,Troy Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Troy Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Troy Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Troy Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,110,DEM,Tina Pickett,1,0,1,0,2
+Bradford,Tuscarora Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,110,DEM,Write-In,3,0,2,0,5
+Bradford,Ulster Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,110,DEM,Write-In,1,1,1,0,3
+Bradford,Warren Township,Representative In The General Assembly,110,DEM,Tina Pickett,1,0,0,0,1
+Bradford,Warren Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,110,DEM,James Shaw,1,0,0,0,1
+Bradford,Warren Township,Representative In The General Assembly,110,DEM,Write-In,0,0,1,0,1
+Bradford,Wells Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Wells Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Wells Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Wells Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,110,DEM,Tina Pickett,1,0,0,0,1
+Bradford,Windham Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,110,DEM,Write-In,1,1,1,0,3
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,DEM,Tina Pickett,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,DEM,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,110,DEM,Tina Pickett,0,1,0,0,1
+Bradford,Wyalusing Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,1,0,1
+Bradford,Wyalusing Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,110,DEM,Write-In,1,0,1,0,2
+Bradford,Wysox Township,Representative In The General Assembly,110,DEM,Tina Pickett,1,1,2,0,4
+Bradford,Wysox Township,Representative In The General Assembly,110,DEM,Donna Iannone,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,110,DEM,James Shaw,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,110,DEM,Write-In,2,0,4,0,6
+Bradford,Alba Borough,President Of The United States,,REP,Donald J. Trump,30,0,2,0,32
+Bradford,Alba Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Alba Borough,President Of The United States,,REP,Bill Weld,2,0,1,0,3
+Bradford,Alba Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Alba Borough,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Alba Borough,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Albany Township,President Of The United States,,REP,Donald J. Trump,100,4,29,5,138
+Bradford,Albany Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,1,0,2
+Bradford,Albany Township,President Of The United States,,REP,Bill Weld,4,0,0,0,4
+Bradford,Albany Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Albany Township,President Of The United States,,REP,Joseph R. Biden,0,0,2,0,2
+Bradford,Albany Township,President Of The United States,,REP,Write-In,1,0,0,0,1
+Bradford,Armenia Township,President Of The United States,,REP,Donald J. Trump,37,0,0,0,37
+Bradford,Armenia Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Bradford,Armenia Township,President Of The United States,,REP,Bill Weld,0,0,0,0,0
+Bradford,Armenia Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Armenia Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Armenia Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Asylum Township,President Of The United States,,REP,Donald J. Trump,107,5,31,3,146
+Bradford,Asylum Township,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Bradford,Asylum Township,President Of The United States,,REP,Bill Weld,4,1,4,0,9
+Bradford,Asylum Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Asylum Township,President Of The United States,,REP,Joseph R. Biden,1,0,2,0,3
+Bradford,Asylum Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,President Of The United States,,REP,Donald J. Trump,35,4,6,2,47
+Bradford,Athens Borough 1St Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,President Of The United States,,REP,Bill Weld,5,0,2,0,7
+Bradford,Athens Borough 1St Ward,President Of The United States,,REP,Bernie Sanders,0,0,1,0,1
+Bradford,Athens Borough 1St Ward,President Of The United States,,REP,Joseph R. Biden,1,0,1,0,2
+Bradford,Athens Borough 1St Ward,President Of The United States,,REP,Write-In,1,0,0,0,1
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,REP,Donald J. Trump,31,3,6,0,40
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,REP,Bill Weld,3,0,0,0,3
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Athens Borough 2Nd Ward,President Of The United States,,REP,Write-In,1,0,0,0,1
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,REP,Donald J. Trump,50,0,11,1,62
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,REP,Bill Weld,1,0,1,0,2
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,REP,Joseph R. Biden,0,0,1,1,2
+Bradford,Athens Borough 3Rd Ward,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,President Of The United States,,REP,Donald J. Trump,57,2,15,2,76
+Bradford,Athens Borough 4Th Ward,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,2,0,4
+Bradford,Athens Borough 4Th Ward,President Of The United States,,REP,Bill Weld,2,0,8,0,10
+Bradford,Athens Borough 4Th Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,President Of The United States,,REP,Joseph R. Biden,1,0,1,1,3
+Bradford,Athens Borough 4Th Ward,President Of The United States,,REP,Write-In,0,1,0,0,1
+Bradford,Athens Township 1St District,President Of The United States,,REP,Donald J. Trump,144,5,31,4,184
+Bradford,Athens Township 1St District,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Bradford,Athens Township 1St District,President Of The United States,,REP,Bill Weld,7,1,4,1,13
+Bradford,Athens Township 1St District,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Athens Township 1St District,President Of The United States,,REP,Joseph R. Biden,2,1,7,0,10
+Bradford,Athens Township 1St District,President Of The United States,,REP,Write-In,1,0,1,0,2
+Bradford,Athens Township 2Nd District,President Of The United States,,REP,Donald J. Trump,176,16,64,8,264
+Bradford,Athens Township 2Nd District,President Of The United States,,REP,Roque Rocky De La Fuente,1,1,4,0,6
+Bradford,Athens Township 2Nd District,President Of The United States,,REP,Bill Weld,10,5,5,0,20
+Bradford,Athens Township 2Nd District,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Athens Township 2Nd District,President Of The United States,,REP,Joseph R. Biden,1,0,1,2,4
+Bradford,Athens Township 2Nd District,President Of The United States,,REP,Write-In,4,0,2,1,7
+Bradford,Burlington Borough,President Of The United States,,REP,Donald J. Trump,19,0,1,0,20
+Bradford,Burlington Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Burlington Borough,President Of The United States,,REP,Bill Weld,1,0,0,0,1
+Bradford,Burlington Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Burlington Borough,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Burlington Borough,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Burlington Township,President Of The United States,,REP,Donald J. Trump,91,1,27,3,122
+Bradford,Burlington Township,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,1,0,3
+Bradford,Burlington Township,President Of The United States,,REP,Bill Weld,0,0,4,0,4
+Bradford,Burlington Township,President Of The United States,,REP,Bernie Sanders,1,0,0,0,1
+Bradford,Burlington Township,President Of The United States,,REP,Joseph R. Biden,1,0,1,0,2
+Bradford,Burlington Township,President Of The United States,,REP,Write-In,0,0,3,0,3
+Bradford,West Burlington Township,President Of The United States,,REP,Donald J. Trump,71,0,9,1,81
+Bradford,West Burlington Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,2,0,3
+Bradford,West Burlington Township,President Of The United States,,REP,Bill Weld,4,0,2,0,6
+Bradford,West Burlington Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,West Burlington Township,President Of The United States,,REP,Joseph R. Biden,2,1,0,0,3
+Bradford,West Burlington Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Canton Borough,President Of The United States,,REP,Donald J. Trump,155,6,22,7,190
+Bradford,Canton Borough,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Bradford,Canton Borough,President Of The United States,,REP,Bill Weld,2,0,7,0,9
+Bradford,Canton Borough,President Of The United States,,REP,Bernie Sanders,1,0,0,0,1
+Bradford,Canton Borough,President Of The United States,,REP,Joseph R. Biden,3,0,4,0,7
+Bradford,Canton Borough,President Of The United States,,REP,Write-In,1,0,2,0,3
+Bradford,Canton Township,President Of The United States,,REP,Donald J. Trump,245,7,38,12,302
+Bradford,Canton Township,President Of The United States,,REP,Roque Rocky De La Fuente,4,0,0,0,4
+Bradford,Canton Township,President Of The United States,,REP,Bill Weld,7,1,5,0,13
+Bradford,Canton Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Canton Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Canton Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Columbia Township,President Of The United States,,REP,Donald J. Trump,130,1,25,3,159
+Bradford,Columbia Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Columbia Township,President Of The United States,,REP,Bill Weld,7,0,2,1,10
+Bradford,Columbia Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Columbia Township,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Columbia Township,President Of The United States,,REP,Write-In,1,0,0,0,1
+Bradford,Franklin Township,President Of The United States,,REP,Donald J. Trump,64,4,12,1,81
+Bradford,Franklin Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Franklin Township,President Of The United States,,REP,Bill Weld,6,0,1,0,7
+Bradford,Franklin Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Franklin Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Franklin Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Granville Township,President Of The United States,,REP,Donald J. Trump,98,0,18,1,117
+Bradford,Granville Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Granville Township,President Of The United States,,REP,Bill Weld,2,0,2,0,4
+Bradford,Granville Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Granville Township,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Granville Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Herrick Township,President Of The United States,,REP,Donald J. Trump,121,3,17,2,143
+Bradford,Herrick Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Herrick Township,President Of The United States,,REP,Bill Weld,2,0,0,0,2
+Bradford,Herrick Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Herrick Township,President Of The United States,,REP,Joseph R. Biden,0,0,1,0,1
+Bradford,Herrick Township,President Of The United States,,REP,Write-In,1,0,3,0,4
+Bradford,Leraysville Borough,President Of The United States,,REP,Donald J. Trump,35,1,6,0,42
+Bradford,Leraysville Borough,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Leraysville Borough,President Of The United States,,REP,Bill Weld,0,1,1,0,2
+Bradford,Leraysville Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Leraysville Borough,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Leraysville Borough,President Of The United States,,REP,Write-In,0,0,1,0,1
+Bradford,Leroy Township,President Of The United States,,REP,Donald J. Trump,96,0,17,0,113
+Bradford,Leroy Township,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,2,0,4
+Bradford,Leroy Township,President Of The United States,,REP,Bill Weld,5,0,3,0,8
+Bradford,Leroy Township,President Of The United States,,REP,Bernie Sanders,0,0,1,0,1
+Bradford,Leroy Township,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Leroy Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,President Of The United States,,REP,Donald J. Trump,128,4,26,4,162
+Bradford,Litchfield Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,2,0,2
+Bradford,Litchfield Township,President Of The United States,,REP,Bill Weld,4,0,6,0,10
+Bradford,Litchfield Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Litchfield Township,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Litchfield Township,President Of The United States,,REP,Write-In,0,0,1,0,1
+Bradford,Monroe Borough,President Of The United States,,REP,Donald J. Trump,64,0,6,0,70
+Bradford,Monroe Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Monroe Borough,President Of The United States,,REP,Bill Weld,0,1,3,0,4
+Bradford,Monroe Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Monroe Borough,President Of The United States,,REP,Joseph R. Biden,0,0,1,0,1
+Bradford,Monroe Borough,President Of The United States,,REP,Write-In,0,0,1,0,1
+Bradford,Monroe Township,President Of The United States,,REP,Donald J. Trump,121,4,27,4,156
+Bradford,Monroe Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,1,1,3
+Bradford,Monroe Township,President Of The United States,,REP,Bill Weld,4,0,5,0,9
+Bradford,Monroe Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Monroe Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,1,2
+Bradford,Monroe Township,President Of The United States,,REP,Write-In,1,0,2,0,3
+Bradford,New Albany Borough,President Of The United States,,REP,Donald J. Trump,25,0,1,0,26
+Bradford,New Albany Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,New Albany Borough,President Of The United States,,REP,Bill Weld,2,0,0,0,2
+Bradford,New Albany Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,New Albany Borough,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,New Albany Borough,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Orwell Township,President Of The United States,,REP,Donald J. Trump,143,8,48,2,201
+Bradford,Orwell Township,President Of The United States,,REP,Roque Rocky De La Fuente,3,0,1,1,5
+Bradford,Orwell Township,President Of The United States,,REP,Bill Weld,2,0,4,0,6
+Bradford,Orwell Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Orwell Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Orwell Township,President Of The United States,,REP,Write-In,0,0,2,0,2
+Bradford,Overton Township,President Of The United States,,REP,Donald J. Trump,32,1,4,2,39
+Bradford,Overton Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Overton Township,President Of The United States,,REP,Bill Weld,0,0,0,0,0
+Bradford,Overton Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Overton Township,President Of The United States,,REP,Joseph R. Biden,0,0,1,0,1
+Bradford,Overton Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Pike Township,President Of The United States,,REP,Donald J. Trump,85,2,12,4,103
+Bradford,Pike Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Pike Township,President Of The United States,,REP,Bill Weld,3,1,1,0,5
+Bradford,Pike Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Pike Township,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Pike Township,President Of The United States,,REP,Write-In,0,0,1,0,1
+Bradford,Ridgebury Township,President Of The United States,,REP,Donald J. Trump,177,6,16,5,204
+Bradford,Ridgebury Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,1,1,0,3
+Bradford,Ridgebury Township,President Of The United States,,REP,Bill Weld,6,1,2,0,9
+Bradford,Ridgebury Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Ridgebury Township,President Of The United States,,REP,Joseph R. Biden,3,1,0,0,4
+Bradford,Ridgebury Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Rome Borough,President Of The United States,,REP,Donald J. Trump,27,4,11,0,42
+Bradford,Rome Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Rome Borough,President Of The United States,,REP,Bill Weld,0,0,1,0,1
+Bradford,Rome Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Rome Borough,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Rome Borough,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Rome Township,President Of The United States,,REP,Donald J. Trump,152,10,32,3,197
+Bradford,Rome Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,2,0,3
+Bradford,Rome Township,President Of The United States,,REP,Bill Weld,5,0,2,1,8
+Bradford,Rome Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Rome Township,President Of The United States,,REP,Joseph R. Biden,0,1,0,0,1
+Bradford,Rome Township,President Of The United States,,REP,Write-In,0,0,2,0,2
+Bradford,Sayre Borough 1St Ward,President Of The United States,,REP,Donald J. Trump,44,1,9,0,54
+Bradford,Sayre Borough 1St Ward,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Sayre Borough 1St Ward,President Of The United States,,REP,Bill Weld,0,0,3,0,3
+Bradford,Sayre Borough 1St Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,President Of The United States,,REP,Joseph R. Biden,2,0,6,0,8
+Bradford,Sayre Borough 1St Ward,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,REP,Donald J. Trump,126,2,39,2,169
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,REP,Bill Weld,5,0,4,0,9
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,REP,Bernie Sanders,1,0,0,0,1
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,REP,Joseph R. Biden,1,0,3,0,4
+Bradford,Sayre Borough 2Nd Ward,President Of The United States,,REP,Write-In,1,0,1,1,3
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,REP,Donald J. Trump,28,2,5,0,35
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,REP,Bill Weld,3,0,0,0,3
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Sayre Borough 3Rd Ward,President Of The United States,,REP,Write-In,2,0,0,0,2
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,REP,Donald J. Trump,64,4,11,3,82
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,REP,Roque Rocky De La Fuente,4,0,0,0,4
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,REP,Bill Weld,4,0,5,1,10
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,REP,Joseph R. Biden,3,0,2,0,5
+Bradford,Sayre Borough 4Th Ward,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,REP,Donald J. Trump,16,0,2,0,18
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,REP,Bill Weld,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,REP,Joseph R. Biden,0,1,0,0,1
+Bradford,Sayre Borough 5Th Ward,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,President Of The United States,,REP,Donald J. Trump,121,9,30,3,163
+Bradford,Sheshequin Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Sheshequin Township,President Of The United States,,REP,Bill Weld,6,2,1,0,9
+Bradford,Sheshequin Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Sheshequin Township,President Of The United States,,REP,Joseph R. Biden,1,0,5,0,6
+Bradford,Sheshequin Township,President Of The United States,,REP,Write-In,1,0,0,0,1
+Bradford,Smithfield Township,President Of The United States,,REP,Donald J. Trump,174,7,43,6,230
+Bradford,Smithfield Township,President Of The United States,,REP,Roque Rocky De La Fuente,3,0,1,0,4
+Bradford,Smithfield Township,President Of The United States,,REP,Bill Weld,7,0,2,0,9
+Bradford,Smithfield Township,President Of The United States,,REP,Bernie Sanders,0,0,1,0,1
+Bradford,Smithfield Township,President Of The United States,,REP,Joseph R. Biden,2,0,1,0,3
+Bradford,Smithfield Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,South Creek Township,President Of The United States,,REP,Donald J. Trump,142,3,21,3,169
+Bradford,South Creek Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,4,0,5
+Bradford,South Creek Township,President Of The United States,,REP,Bill Weld,3,0,7,0,10
+Bradford,South Creek Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,South Creek Township,President Of The United States,,REP,Joseph R. Biden,1,0,2,0,3
+Bradford,South Creek Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,President Of The United States,,REP,Donald J. Trump,74,2,23,1,100
+Bradford,South Waverly Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,South Waverly Borough,President Of The United States,,REP,Bill Weld,6,0,3,0,9
+Bradford,South Waverly Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,South Waverly Borough,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,South Waverly Borough,President Of The United States,,REP,Write-In,1,0,1,0,2
+Bradford,Springfield Township,President Of The United States,,REP,Donald J. Trump,137,4,21,11,173
+Bradford,Springfield Township,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,1,0,3
+Bradford,Springfield Township,President Of The United States,,REP,Bill Weld,2,0,3,1,6
+Bradford,Springfield Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Springfield Township,President Of The United States,,REP,Joseph R. Biden,3,0,2,0,5
+Bradford,Springfield Township,President Of The United States,,REP,Write-In,1,0,2,2,5
+Bradford,Standing Stone Township,President Of The United States,,REP,Donald J. Trump,56,1,15,3,75
+Bradford,Standing Stone Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,3,0,4
+Bradford,Standing Stone Township,President Of The United States,,REP,Bill Weld,3,2,2,0,7
+Bradford,Standing Stone Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Standing Stone Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Standing Stone Township,President Of The United States,,REP,Write-In,0,2,1,0,3
+Bradford,Stevens Township,President Of The United States,,REP,Donald J. Trump,71,3,10,1,85
+Bradford,Stevens Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Stevens Township,President Of The United States,,REP,Bill Weld,3,0,4,0,7
+Bradford,Stevens Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Stevens Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Stevens Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,President Of The United States,,REP,Donald J. Trump,26,0,5,0,31
+Bradford,Sylvania Borough,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Sylvania Borough,President Of The United States,,REP,Bill Weld,1,0,2,0,3
+Bradford,Sylvania Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Sylvania Borough,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Sylvania Borough,President Of The United States,,REP,Write-In,0,0,2,0,2
+Bradford,Terry Township,President Of The United States,,REP,Donald J. Trump,123,2,22,1,148
+Bradford,Terry Township,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,1,0,3
+Bradford,Terry Township,President Of The United States,,REP,Bill Weld,3,0,1,0,4
+Bradford,Terry Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Terry Township,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Terry Township,President Of The United States,,REP,Write-In,2,0,0,0,2
+Bradford,Towanda Borough 1St Ward,President Of The United States,,REP,Donald J. Trump,61,0,10,0,71
+Bradford,Towanda Borough 1St Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,President Of The United States,,REP,Bill Weld,3,0,0,0,3
+Bradford,Towanda Borough 1St Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,President Of The United States,,REP,Write-In,1,0,1,0,2
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,REP,Donald J. Trump,57,3,13,4,77
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,2,1,0,0,3
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,REP,Bill Weld,1,0,9,0,10
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,REP,Joseph R. Biden,3,2,2,0,7
+Bradford,Towanda Borough 2Nd Ward,President Of The United States,,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,REP,Donald J. Trump,104,4,37,1,146
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,REP,Bill Weld,4,1,5,1,11
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,REP,Bernie Sanders,1,0,0,0,1
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,REP,Joseph R. Biden,3,1,3,0,7
+Bradford,Towanda Borough 3Rd Ward,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Township,President Of The United States,,REP,Donald J. Trump,75,8,18,0,101
+Bradford,Towanda Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Bradford,Towanda Township,President Of The United States,,REP,Bill Weld,1,1,1,0,3
+Bradford,Towanda Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Towanda Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Towanda Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,President Of The United States,,REP,Donald J. Trump,84,4,29,0,117
+Bradford,North Towanda Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,North Towanda Township,President Of The United States,,REP,Bill Weld,2,1,4,0,7
+Bradford,North Towanda Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,North Towanda Township,President Of The United States,,REP,Joseph R. Biden,2,2,4,0,8
+Bradford,North Towanda Township,President Of The United States,,REP,Write-In,0,0,0,0,0
+Bradford,Troy Borough,President Of The United States,,REP,Donald J. Trump,107,2,14,9,132
+Bradford,Troy Borough,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,1,0,2
+Bradford,Troy Borough,President Of The United States,,REP,Bill Weld,9,2,2,1,14
+Bradford,Troy Borough,President Of The United States,,REP,Bernie Sanders,1,0,0,0,1
+Bradford,Troy Borough,President Of The United States,,REP,Joseph R. Biden,4,0,3,0,7
+Bradford,Troy Borough,President Of The United States,,REP,Write-In,1,0,1,0,2
+Bradford,Troy Township,President Of The United States,,REP,Donald J. Trump,216,5,52,10,283
+Bradford,Troy Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,1,3,0,5
+Bradford,Troy Township,President Of The United States,,REP,Bill Weld,2,0,14,0,16
+Bradford,Troy Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Troy Township,President Of The United States,,REP,Joseph R. Biden,0,1,2,0,3
+Bradford,Troy Township,President Of The United States,,REP,Write-In,1,0,2,0,3
+Bradford,Tuscarora Township,President Of The United States,,REP,Donald J. Trump,154,9,27,2,192
+Bradford,Tuscarora Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Bradford,Tuscarora Township,President Of The United States,,REP,Bill Weld,4,0,1,0,5
+Bradford,Tuscarora Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Tuscarora Township,President Of The United States,,REP,Joseph R. Biden,1,0,4,0,5
+Bradford,Tuscarora Township,President Of The United States,,REP,Write-In,0,0,0,1,1
+Bradford,Ulster Township,President Of The United States,,REP,Donald J. Trump,105,8,18,0,131
+Bradford,Ulster Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Ulster Township,President Of The United States,,REP,Bill Weld,2,0,1,0,3
+Bradford,Ulster Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Ulster Township,President Of The United States,,REP,Joseph R. Biden,1,1,0,0,2
+Bradford,Ulster Township,President Of The United States,,REP,Write-In,2,0,0,0,2
+Bradford,Warren Township,President Of The United States,,REP,Donald J. Trump,138,5,24,5,172
+Bradford,Warren Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,1,0,2
+Bradford,Warren Township,President Of The United States,,REP,Bill Weld,4,0,0,0,4
+Bradford,Warren Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Warren Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Warren Township,President Of The United States,,REP,Write-In,2,0,0,0,2
+Bradford,Wells Township,President Of The United States,,REP,Donald J. Trump,159,1,14,1,175
+Bradford,Wells Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Wells Township,President Of The United States,,REP,Bill Weld,1,1,2,1,5
+Bradford,Wells Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Wells Township,President Of The United States,,REP,Joseph R. Biden,2,0,2,0,4
+Bradford,Wells Township,President Of The United States,,REP,Write-In,1,0,0,0,1
+Bradford,Wilmot Township,President Of The United States,,REP,Donald J. Trump,143,5,40,12,200
+Bradford,Wilmot Township,President Of The United States,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Bradford,Wilmot Township,President Of The United States,,REP,Bill Weld,9,3,2,0,14
+Bradford,Wilmot Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Wilmot Township,President Of The United States,,REP,Joseph R. Biden,0,0,2,0,2
+Bradford,Wilmot Township,President Of The United States,,REP,Write-In,0,1,1,0,2
+Bradford,Windham Township,President Of The United States,,REP,Donald J. Trump,96,3,29,8,136
+Bradford,Windham Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Bradford,Windham Township,President Of The United States,,REP,Bill Weld,2,0,2,0,4
+Bradford,Windham Township,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Windham Township,President Of The United States,,REP,Joseph R. Biden,0,0,0,0,0
+Bradford,Windham Township,President Of The United States,,REP,Write-In,0,0,1,0,1
+Bradford,Wyalusing Borough,President Of The United States,,REP,Donald J. Trump,54,1,10,6,71
+Bradford,Wyalusing Borough,President Of The United States,,REP,Roque Rocky De La Fuente,2,0,1,0,3
+Bradford,Wyalusing Borough,President Of The United States,,REP,Bill Weld,6,0,1,0,7
+Bradford,Wyalusing Borough,President Of The United States,,REP,Bernie Sanders,0,0,0,0,0
+Bradford,Wyalusing Borough,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Wyalusing Borough,President Of The United States,,REP,Write-In,1,0,1,0,2
+Bradford,Wyalusing Township,President Of The United States,,REP,Donald J. Trump,183,13,33,5,234
+Bradford,Wyalusing Township,President Of The United States,,REP,Roque Rocky De La Fuente,1,0,4,0,5
+Bradford,Wyalusing Township,President Of The United States,,REP,Bill Weld,7,0,2,0,9
+Bradford,Wyalusing Township,President Of The United States,,REP,Bernie Sanders,1,0,0,0,1
+Bradford,Wyalusing Township,President Of The United States,,REP,Joseph R. Biden,0,0,1,0,1
+Bradford,Wyalusing Township,President Of The United States,,REP,Write-In,2,0,1,0,3
+Bradford,Wysox Township,President Of The United States,,REP,Donald J. Trump,171,9,41,1,222
+Bradford,Wysox Township,President Of The United States,,REP,Roque Rocky De La Fuente,2,1,0,0,3
+Bradford,Wysox Township,President Of The United States,,REP,Bill Weld,9,2,9,0,20
+Bradford,Wysox Township,President Of The United States,,REP,Bernie Sanders,0,0,1,0,1
+Bradford,Wysox Township,President Of The United States,,REP,Joseph R. Biden,1,0,0,0,1
+Bradford,Wysox Township,President Of The United States,,REP,Write-In,3,0,0,0,3
+Bradford,Alba Borough,Attorney General,,REP,Heather Heidelbaugh,29,0,3,0,32
+Bradford,Alba Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Alba Borough,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Albany Township,Attorney General,,REP,Heather Heidelbaugh,93,3,27,5,128
+Bradford,Albany Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Albany Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Attorney General,,REP,Heather Heidelbaugh,31,0,1,0,32
+Bradford,Armenia Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Armenia Township,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Asylum Township,Attorney General,,REP,Heather Heidelbaugh,97,7,31,2,137
+Bradford,Asylum Township,Attorney General,,REP,Josh Shapiro,0,0,1,0,1
+Bradford,Asylum Township,Attorney General,,REP,Write-In,2,0,0,0,2
+Bradford,Athens Borough 1St Ward,Attorney General,,REP,Heather Heidelbaugh,41,3,11,1,56
+Bradford,Athens Borough 1St Ward,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Attorney General,,REP,Heather Heidelbaugh,30,1,7,0,38
+Bradford,Athens Borough 2Nd Ward,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Athens Borough 3Rd Ward,Attorney General,,REP,Heather Heidelbaugh,45,0,14,2,61
+Bradford,Athens Borough 3Rd Ward,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Attorney General,,REP,Heather Heidelbaugh,60,3,26,3,92
+Bradford,Athens Borough 4Th Ward,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Attorney General,,REP,Heather Heidelbaugh,131,6,34,5,176
+Bradford,Athens Township 1St District,Attorney General,,REP,Josh Shapiro,0,0,1,0,1
+Bradford,Athens Township 1St District,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Attorney General,,REP,Heather Heidelbaugh,163,17,77,10,267
+Bradford,Athens Township 2Nd District,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Burlington Borough,Attorney General,,REP,Heather Heidelbaugh,17,0,1,0,18
+Bradford,Burlington Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Burlington Borough,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Attorney General,,REP,Heather Heidelbaugh,81,2,29,3,115
+Bradford,Burlington Township,Attorney General,,REP,Josh Shapiro,0,0,1,0,1
+Bradford,Burlington Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Attorney General,,REP,Heather Heidelbaugh,69,1,10,1,81
+Bradford,West Burlington Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,West Burlington Township,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Canton Borough,Attorney General,,REP,Heather Heidelbaugh,146,6,33,7,192
+Bradford,Canton Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Canton Borough,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Canton Township,Attorney General,,REP,Heather Heidelbaugh,229,8,36,11,284
+Bradford,Canton Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Canton Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Attorney General,,REP,Heather Heidelbaugh,112,1,25,3,141
+Bradford,Columbia Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Columbia Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Attorney General,,REP,Heather Heidelbaugh,60,4,13,1,78
+Bradford,Franklin Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Franklin Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Granville Township,Attorney General,,REP,Heather Heidelbaugh,84,0,18,0,102
+Bradford,Granville Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Granville Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Attorney General,,REP,Heather Heidelbaugh,112,3,17,2,134
+Bradford,Herrick Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Herrick Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Attorney General,,REP,Heather Heidelbaugh,37,2,8,0,47
+Bradford,Leraysville Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Leraysville Borough,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Attorney General,,REP,Heather Heidelbaugh,90,0,20,0,110
+Bradford,Leroy Township,Attorney General,,REP,Josh Shapiro,0,0,1,0,1
+Bradford,Leroy Township,Attorney General,,REP,Write-In,0,0,1,0,1
+Bradford,Litchfield Township,Attorney General,,REP,Heather Heidelbaugh,121,3,27,3,154
+Bradford,Litchfield Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Litchfield Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Attorney General,,REP,Heather Heidelbaugh,56,1,8,0,65
+Bradford,Monroe Borough,Attorney General,,REP,Josh Shapiro,0,0,1,0,1
+Bradford,Monroe Borough,Attorney General,,REP,Write-In,0,0,2,0,2
+Bradford,Monroe Township,Attorney General,,REP,Heather Heidelbaugh,109,4,30,5,148
+Bradford,Monroe Township,Attorney General,,REP,Josh Shapiro,0,0,0,1,1
+Bradford,Monroe Township,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,New Albany Borough,Attorney General,,REP,Heather Heidelbaugh,25,0,1,0,26
+Bradford,New Albany Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,New Albany Borough,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Attorney General,,REP,Heather Heidelbaugh,129,8,49,2,188
+Bradford,Orwell Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Orwell Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Overton Township,Attorney General,,REP,Heather Heidelbaugh,28,1,4,1,34
+Bradford,Overton Township,Attorney General,,REP,Josh Shapiro,0,0,1,0,1
+Bradford,Overton Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Pike Township,Attorney General,,REP,Heather Heidelbaugh,77,3,13,4,97
+Bradford,Pike Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Pike Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Attorney General,,REP,Heather Heidelbaugh,161,8,17,5,191
+Bradford,Ridgebury Township,Attorney General,,REP,Josh Shapiro,0,1,0,0,1
+Bradford,Ridgebury Township,Attorney General,,REP,Write-In,0,0,2,0,2
+Bradford,Rome Borough,Attorney General,,REP,Heather Heidelbaugh,22,3,8,0,33
+Bradford,Rome Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Rome Borough,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Rome Township,Attorney General,,REP,Heather Heidelbaugh,131,7,28,4,170
+Bradford,Rome Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Rome Township,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 1St Ward,Attorney General,,REP,Heather Heidelbaugh,42,1,13,0,56
+Bradford,Sayre Borough 1St Ward,Attorney General,,REP,Josh Shapiro,0,0,3,0,3
+Bradford,Sayre Borough 1St Ward,Attorney General,,REP,Write-In,2,0,0,0,2
+Bradford,Sayre Borough 2Nd Ward,Attorney General,,REP,Heather Heidelbaugh,123,2,43,4,172
+Bradford,Sayre Borough 2Nd Ward,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 3Rd Ward,Attorney General,,REP,Heather Heidelbaugh,33,2,4,0,39
+Bradford,Sayre Borough 3Rd Ward,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Attorney General,,REP,Heather Heidelbaugh,61,4,16,3,84
+Bradford,Sayre Borough 4Th Ward,Attorney General,,REP,Josh Shapiro,0,0,1,0,1
+Bradford,Sayre Borough 4Th Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Attorney General,,REP,Heather Heidelbaugh,14,1,2,0,17
+Bradford,Sayre Borough 5Th Ward,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Attorney General,,REP,Heather Heidelbaugh,110,11,32,2,155
+Bradford,Sheshequin Township,Attorney General,,REP,Josh Shapiro,0,0,3,0,3
+Bradford,Sheshequin Township,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Smithfield Township,Attorney General,,REP,Heather Heidelbaugh,154,6,41,5,206
+Bradford,Smithfield Township,Attorney General,,REP,Josh Shapiro,0,0,1,0,1
+Bradford,Smithfield Township,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,South Creek Township,Attorney General,,REP,Heather Heidelbaugh,129,3,29,3,164
+Bradford,South Creek Township,Attorney General,,REP,Josh Shapiro,0,0,3,0,3
+Bradford,South Creek Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Attorney General,,REP,Heather Heidelbaugh,71,2,27,1,101
+Bradford,South Waverly Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,South Waverly Borough,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Attorney General,,REP,Heather Heidelbaugh,129,3,28,12,172
+Bradford,Springfield Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Springfield Township,Attorney General,,REP,Write-In,2,0,0,0,2
+Bradford,Standing Stone Township,Attorney General,,REP,Heather Heidelbaugh,46,4,18,3,71
+Bradford,Standing Stone Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Standing Stone Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Attorney General,,REP,Heather Heidelbaugh,62,2,12,1,77
+Bradford,Stevens Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Stevens Township,Attorney General,,REP,Write-In,1,1,1,0,3
+Bradford,Sylvania Borough,Attorney General,,REP,Heather Heidelbaugh,25,0,8,0,33
+Bradford,Sylvania Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Sylvania Borough,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Terry Township,Attorney General,,REP,Heather Heidelbaugh,117,1,24,1,143
+Bradford,Terry Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Terry Township,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 1St Ward,Attorney General,,REP,Heather Heidelbaugh,57,0,14,1,72
+Bradford,Towanda Borough 1St Ward,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Attorney General,,REP,Heather Heidelbaugh,59,4,19,4,86
+Bradford,Towanda Borough 2Nd Ward,Attorney General,,REP,Josh Shapiro,0,1,0,0,1
+Bradford,Towanda Borough 2Nd Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Attorney General,,REP,Heather Heidelbaugh,93,4,38,2,137
+Bradford,Towanda Borough 3Rd Ward,Attorney General,,REP,Josh Shapiro,1,0,1,0,2
+Bradford,Towanda Borough 3Rd Ward,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Attorney General,,REP,Heather Heidelbaugh,73,6,20,0,99
+Bradford,Towanda Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Towanda Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Attorney General,,REP,Heather Heidelbaugh,75,7,41,0,123
+Bradford,North Towanda Township,Attorney General,,REP,Josh Shapiro,1,0,0,0,1
+Bradford,North Towanda Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Attorney General,,REP,Heather Heidelbaugh,109,3,19,10,141
+Bradford,Troy Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Troy Borough,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Troy Township,Attorney General,,REP,Heather Heidelbaugh,194,8,66,8,276
+Bradford,Troy Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Troy Township,Attorney General,,REP,Write-In,0,0,1,0,1
+Bradford,Tuscarora Township,Attorney General,,REP,Heather Heidelbaugh,139,9,27,3,178
+Bradford,Tuscarora Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Tuscarora Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Attorney General,,REP,Heather Heidelbaugh,101,9,16,0,126
+Bradford,Ulster Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Ulster Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Warren Township,Attorney General,,REP,Heather Heidelbaugh,132,5,25,4,166
+Bradford,Warren Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Warren Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Wells Township,Attorney General,,REP,Heather Heidelbaugh,143,2,12,2,159
+Bradford,Wells Township,Attorney General,,REP,Josh Shapiro,0,0,2,0,2
+Bradford,Wells Township,Attorney General,,REP,Write-In,1,0,0,0,1
+Bradford,Wilmot Township,Attorney General,,REP,Heather Heidelbaugh,135,6,38,11,190
+Bradford,Wilmot Township,Attorney General,,REP,Josh Shapiro,0,0,2,0,2
+Bradford,Wilmot Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Windham Township,Attorney General,,REP,Heather Heidelbaugh,78,3,25,8,114
+Bradford,Windham Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Windham Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Attorney General,,REP,Heather Heidelbaugh,60,1,12,6,79
+Bradford,Wyalusing Borough,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Wyalusing Borough,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Attorney General,,REP,Heather Heidelbaugh,169,13,40,3,225
+Bradford,Wyalusing Township,Attorney General,,REP,Josh Shapiro,0,0,0,0,0
+Bradford,Wyalusing Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Attorney General,,REP,Heather Heidelbaugh,152,10,49,1,212
+Bradford,Wysox Township,Attorney General,,REP,Josh Shapiro,1,0,0,0,1
+Bradford,Wysox Township,Attorney General,,REP,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Auditor General,,REP,Timothy Defoor,29,0,3,0,32
+Bradford,Alba Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Alba Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Alba Borough,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Albany Township,Auditor General,,REP,Timothy Defoor,89,3,24,5,121
+Bradford,Albany Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Albany Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Albany Township,Auditor General,,REP,Write-In,0,0,1,0,1
+Bradford,Armenia Township,Auditor General,,REP,Timothy Defoor,30,0,0,0,30
+Bradford,Armenia Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Armenia Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Armenia Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Auditor General,,REP,Timothy Defoor,93,7,32,2,134
+Bradford,Asylum Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Asylum Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Asylum Township,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Athens Borough 1St Ward,Auditor General,,REP,Timothy Defoor,41,3,11,1,56
+Bradford,Athens Borough 1St Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Auditor General,,REP,Timothy Defoor,29,1,7,0,37
+Bradford,Athens Borough 2Nd Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Auditor General,,REP,Timothy Defoor,43,0,14,2,59
+Bradford,Athens Borough 3Rd Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Auditor General,,REP,Timothy Defoor,59,3,26,3,91
+Bradford,Athens Borough 4Th Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Auditor General,,REP,Timothy Defoor,128,6,36,5,175
+Bradford,Athens Township 1St District,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Athens Township 1St District,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Athens Township 1St District,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Auditor General,,REP,Timothy Defoor,158,15,76,10,259
+Bradford,Athens Township 2Nd District,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Burlington Borough,Auditor General,,REP,Timothy Defoor,16,0,1,0,17
+Bradford,Burlington Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Burlington Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Burlington Borough,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Auditor General,,REP,Timothy Defoor,81,2,27,3,113
+Bradford,Burlington Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Burlington Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Burlington Township,Auditor General,,REP,Write-In,0,0,1,0,1
+Bradford,West Burlington Township,Auditor General,,REP,Timothy Defoor,68,1,10,1,80
+Bradford,West Burlington Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,West Burlington Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,West Burlington Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Auditor General,,REP,Timothy Defoor,139,6,31,6,182
+Bradford,Canton Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Canton Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Canton Borough,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Canton Township,Auditor General,,REP,Timothy Defoor,221,8,36,10,275
+Bradford,Canton Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Canton Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Canton Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Auditor General,,REP,Timothy Defoor,112,1,23,4,140
+Bradford,Columbia Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Columbia Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Columbia Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Auditor General,,REP,Timothy Defoor,59,4,13,1,77
+Bradford,Franklin Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Franklin Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Franklin Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Granville Township,Auditor General,,REP,Timothy Defoor,82,0,18,0,100
+Bradford,Granville Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Granville Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Granville Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Auditor General,,REP,Timothy Defoor,109,3,16,2,130
+Bradford,Herrick Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Herrick Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Herrick Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Auditor General,,REP,Timothy Defoor,36,2,7,0,45
+Bradford,Leraysville Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Leraysville Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Leraysville Borough,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Auditor General,,REP,Timothy Defoor,83,0,18,0,101
+Bradford,Leroy Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Leroy Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Leroy Township,Auditor General,,REP,Write-In,0,0,1,0,1
+Bradford,Litchfield Township,Auditor General,,REP,Timothy Defoor,115,3,27,2,147
+Bradford,Litchfield Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Litchfield Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Litchfield Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Auditor General,,REP,Timothy Defoor,55,1,9,0,65
+Bradford,Monroe Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Monroe Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Monroe Borough,Auditor General,,REP,Write-In,0,0,2,0,2
+Bradford,Monroe Township,Auditor General,,REP,Timothy Defoor,104,4,29,6,143
+Bradford,Monroe Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Monroe Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Monroe Township,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,New Albany Borough,Auditor General,,REP,Timothy Defoor,24,0,1,0,25
+Bradford,New Albany Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,New Albany Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,New Albany Borough,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Auditor General,,REP,Timothy Defoor,126,8,44,2,180
+Bradford,Orwell Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Orwell Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Orwell Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Overton Township,Auditor General,,REP,Timothy Defoor,30,1,5,1,37
+Bradford,Overton Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Overton Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Overton Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Pike Township,Auditor General,,REP,Timothy Defoor,79,3,13,4,99
+Bradford,Pike Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Pike Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Pike Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Auditor General,,REP,Timothy Defoor,160,10,17,5,192
+Bradford,Ridgebury Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Ridgebury Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Ridgebury Township,Auditor General,,REP,Write-In,0,0,2,0,2
+Bradford,Rome Borough,Auditor General,,REP,Timothy Defoor,22,3,10,0,35
+Bradford,Rome Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Rome Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Rome Borough,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Rome Township,Auditor General,,REP,Timothy Defoor,127,7,26,4,164
+Bradford,Rome Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Rome Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Rome Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Auditor General,,REP,Timothy Defoor,44,1,13,0,58
+Bradford,Sayre Borough 1St Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Auditor General,,REP,Write-In,0,0,3,0,3
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,REP,Timothy Defoor,123,2,40,4,169
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Auditor General,,REP,Write-In,1,0,1,0,2
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,REP,Timothy Defoor,32,2,4,0,38
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Auditor General,,REP,Timothy Defoor,62,4,16,3,85
+Bradford,Sayre Borough 4Th Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Auditor General,,REP,Write-In,0,0,1,0,1
+Bradford,Sayre Borough 5Th Ward,Auditor General,,REP,Timothy Defoor,15,1,2,0,18
+Bradford,Sayre Borough 5Th Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Auditor General,,REP,Timothy Defoor,106,11,31,2,150
+Bradford,Sheshequin Township,Auditor General,,REP,Christina M. Hartman,0,0,3,0,3
+Bradford,Sheshequin Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Sheshequin Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Auditor General,,REP,Timothy Defoor,152,6,41,5,204
+Bradford,Smithfield Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Smithfield Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Smithfield Township,Auditor General,,REP,Write-In,1,0,1,0,2
+Bradford,South Creek Township,Auditor General,,REP,Timothy Defoor,126,3,26,3,158
+Bradford,South Creek Township,Auditor General,,REP,Christina M. Hartman,0,0,1,0,1
+Bradford,South Creek Township,Auditor General,,REP,Tracie Fountain,0,0,2,0,2
+Bradford,South Creek Township,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,South Waverly Borough,Auditor General,,REP,Timothy Defoor,71,2,27,1,101
+Bradford,South Waverly Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,South Waverly Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,South Waverly Borough,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Auditor General,,REP,Timothy Defoor,122,3,27,12,164
+Bradford,Springfield Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Springfield Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Springfield Township,Auditor General,,REP,Write-In,2,0,0,0,2
+Bradford,Standing Stone Township,Auditor General,,REP,Timothy Defoor,45,5,18,2,70
+Bradford,Standing Stone Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Standing Stone Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Standing Stone Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Auditor General,,REP,Timothy Defoor,60,3,12,1,76
+Bradford,Stevens Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Stevens Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Stevens Township,Auditor General,,REP,Write-In,1,0,1,0,2
+Bradford,Sylvania Borough,Auditor General,,REP,Timothy Defoor,24,0,8,0,32
+Bradford,Sylvania Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Sylvania Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Sylvania Borough,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Terry Township,Auditor General,,REP,Timothy Defoor,113,2,24,1,140
+Bradford,Terry Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Terry Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Terry Township,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 1St Ward,Auditor General,,REP,Timothy Defoor,53,0,14,1,68
+Bradford,Towanda Borough 1St Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,REP,Timothy Defoor,58,4,19,4,85
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Auditor General,,REP,Write-In,0,1,0,0,1
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,REP,Timothy Defoor,93,4,38,1,136
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,REP,Christina M. Hartman,0,0,1,0,1
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Auditor General,,REP,Timothy Defoor,72,6,18,0,96
+Bradford,Towanda Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Towanda Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Towanda Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Auditor General,,REP,Timothy Defoor,71,5,40,0,116
+Bradford,North Towanda Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,North Towanda Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,North Towanda Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Auditor General,,REP,Timothy Defoor,108,3,20,10,141
+Bradford,Troy Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Troy Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Troy Borough,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Troy Township,Auditor General,,REP,Timothy Defoor,193,7,68,7,275
+Bradford,Troy Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Troy Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Troy Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Auditor General,,REP,Timothy Defoor,138,9,23,3,173
+Bradford,Tuscarora Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Tuscarora Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Tuscarora Township,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Ulster Township,Auditor General,,REP,Timothy Defoor,102,9,16,0,127
+Bradford,Ulster Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Ulster Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Ulster Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Warren Township,Auditor General,,REP,Timothy Defoor,128,5,25,4,162
+Bradford,Warren Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Warren Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Warren Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Wells Township,Auditor General,,REP,Timothy Defoor,143,2,12,2,159
+Bradford,Wells Township,Auditor General,,REP,Christina M. Hartman,0,0,2,0,2
+Bradford,Wells Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Wells Township,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Wilmot Township,Auditor General,,REP,Timothy Defoor,127,6,37,11,181
+Bradford,Wilmot Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Wilmot Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Wilmot Township,Auditor General,,REP,Write-In,0,0,1,0,1
+Bradford,Windham Township,Auditor General,,REP,Timothy Defoor,71,3,22,8,104
+Bradford,Windham Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Windham Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Windham Township,Auditor General,,REP,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Auditor General,,REP,Timothy Defoor,59,1,12,6,78
+Bradford,Wyalusing Borough,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Wyalusing Borough,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Wyalusing Borough,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Wyalusing Township,Auditor General,,REP,Timothy Defoor,164,13,39,4,220
+Bradford,Wyalusing Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Wyalusing Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Wyalusing Township,Auditor General,,REP,Write-In,0,0,1,0,1
+Bradford,Wysox Township,Auditor General,,REP,Timothy Defoor,147,10,48,1,206
+Bradford,Wysox Township,Auditor General,,REP,Christina M. Hartman,0,0,0,0,0
+Bradford,Wysox Township,Auditor General,,REP,Tracie Fountain,0,0,0,0,0
+Bradford,Wysox Township,Auditor General,,REP,Write-In,1,0,0,0,1
+Bradford,Alba Borough,State Treasurer,,REP,Stacy L. Garrity,33,0,3,0,36
+Bradford,Alba Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Alba Borough,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Albany Township,State Treasurer,,REP,Stacy L. Garrity,103,3,26,5,137
+Bradford,Albany Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Albany Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Armenia Township,State Treasurer,,REP,Stacy L. Garrity,32,0,0,0,32
+Bradford,Armenia Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Armenia Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Asylum Township,State Treasurer,,REP,Stacy L. Garrity,107,7,35,3,152
+Bradford,Asylum Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Asylum Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,State Treasurer,,REP,Stacy L. Garrity,43,4,11,1,59
+Bradford,Athens Borough 1St Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,State Treasurer,,REP,Stacy L. Garrity,33,3,7,0,43
+Bradford,Athens Borough 2Nd Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,State Treasurer,,REP,Write-In,1,0,0,0,1
+Bradford,Athens Borough 3Rd Ward,State Treasurer,,REP,Stacy L. Garrity,49,0,14,2,65
+Bradford,Athens Borough 3Rd Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,State Treasurer,,REP,Stacy L. Garrity,61,3,28,3,95
+Bradford,Athens Borough 4Th Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,State Treasurer,,REP,Stacy L. Garrity,147,7,40,5,199
+Bradford,Athens Township 1St District,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Athens Township 1St District,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,State Treasurer,,REP,Stacy L. Garrity,175,21,79,10,285
+Bradford,Athens Township 2Nd District,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Athens Township 2Nd District,State Treasurer,,REP,Write-In,2,0,0,0,2
+Bradford,Burlington Borough,State Treasurer,,REP,Stacy L. Garrity,19,0,1,0,20
+Bradford,Burlington Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Burlington Borough,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Burlington Township,State Treasurer,,REP,Stacy L. Garrity,87,2,31,3,123
+Bradford,Burlington Township,State Treasurer,,REP,Joseph Torsella,0,0,1,0,1
+Bradford,Burlington Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,State Treasurer,,REP,Stacy L. Garrity,75,1,13,2,91
+Bradford,West Burlington Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,West Burlington Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Canton Borough,State Treasurer,,REP,Stacy L. Garrity,155,6,35,7,203
+Bradford,Canton Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Canton Borough,State Treasurer,,REP,Write-In,1,0,0,0,1
+Bradford,Canton Township,State Treasurer,,REP,Stacy L. Garrity,245,8,43,12,308
+Bradford,Canton Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Canton Township,State Treasurer,,REP,Write-In,1,0,0,0,1
+Bradford,Columbia Township,State Treasurer,,REP,Stacy L. Garrity,124,1,29,4,158
+Bradford,Columbia Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Columbia Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Franklin Township,State Treasurer,,REP,Stacy L. Garrity,64,4,14,1,83
+Bradford,Franklin Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Franklin Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Granville Township,State Treasurer,,REP,Stacy L. Garrity,94,1,20,0,115
+Bradford,Granville Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Granville Township,State Treasurer,,REP,Write-In,1,0,0,0,1
+Bradford,Herrick Township,State Treasurer,,REP,Stacy L. Garrity,120,3,18,2,143
+Bradford,Herrick Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Herrick Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,State Treasurer,,REP,Stacy L. Garrity,37,1,8,0,46
+Bradford,Leraysville Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Leraysville Borough,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Leroy Township,State Treasurer,,REP,Stacy L. Garrity,95,0,22,0,117
+Bradford,Leroy Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Leroy Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,State Treasurer,,REP,Stacy L. Garrity,132,4,35,4,175
+Bradford,Litchfield Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Litchfield Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,State Treasurer,,REP,Stacy L. Garrity,58,1,13,0,72
+Bradford,Monroe Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Monroe Borough,State Treasurer,,REP,Write-In,1,0,1,0,2
+Bradford,Monroe Township,State Treasurer,,REP,Stacy L. Garrity,120,4,31,6,161
+Bradford,Monroe Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Monroe Township,State Treasurer,,REP,Write-In,1,0,0,0,1
+Bradford,New Albany Borough,State Treasurer,,REP,Stacy L. Garrity,26,0,1,0,27
+Bradford,New Albany Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,New Albany Borough,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Orwell Township,State Treasurer,,REP,Stacy L. Garrity,140,8,50,3,201
+Bradford,Orwell Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Orwell Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Overton Township,State Treasurer,,REP,Stacy L. Garrity,29,1,5,1,36
+Bradford,Overton Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Overton Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Pike Township,State Treasurer,,REP,Stacy L. Garrity,82,3,16,4,105
+Bradford,Pike Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Pike Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,State Treasurer,,REP,Stacy L. Garrity,177,10,19,5,211
+Bradford,Ridgebury Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Ridgebury Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Rome Borough,State Treasurer,,REP,Stacy L. Garrity,23,4,12,0,39
+Bradford,Rome Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Rome Borough,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Rome Township,State Treasurer,,REP,Stacy L. Garrity,145,10,37,2,194
+Bradford,Rome Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Rome Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,State Treasurer,,REP,Stacy L. Garrity,47,1,16,0,64
+Bradford,Sayre Borough 1St Ward,State Treasurer,,REP,Joseph Torsella,0,0,3,0,3
+Bradford,Sayre Borough 1St Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,State Treasurer,,REP,Stacy L. Garrity,132,2,45,4,183
+Bradford,Sayre Borough 2Nd Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,State Treasurer,,REP,Stacy L. Garrity,34,2,4,0,40
+Bradford,Sayre Borough 3Rd Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,State Treasurer,,REP,Stacy L. Garrity,75,5,20,3,103
+Bradford,Sayre Borough 4Th Ward,State Treasurer,,REP,Joseph Torsella,0,0,1,0,1
+Bradford,Sayre Borough 4Th Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,State Treasurer,,REP,Stacy L. Garrity,16,1,2,0,19
+Bradford,Sayre Borough 5Th Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,State Treasurer,,REP,Stacy L. Garrity,119,11,33,2,165
+Bradford,Sheshequin Township,State Treasurer,,REP,Joseph Torsella,0,0,2,0,2
+Bradford,Sheshequin Township,State Treasurer,,REP,Write-In,1,0,1,0,2
+Bradford,Smithfield Township,State Treasurer,,REP,Stacy L. Garrity,174,6,46,4,230
+Bradford,Smithfield Township,State Treasurer,,REP,Joseph Torsella,0,0,1,0,1
+Bradford,Smithfield Township,State Treasurer,,REP,Write-In,1,0,0,0,1
+Bradford,South Creek Township,State Treasurer,,REP,Stacy L. Garrity,140,3,31,3,177
+Bradford,South Creek Township,State Treasurer,,REP,Joseph Torsella,0,0,2,0,2
+Bradford,South Creek Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,State Treasurer,,REP,Stacy L. Garrity,80,2,28,1,111
+Bradford,South Waverly Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,South Waverly Borough,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Springfield Township,State Treasurer,,REP,Stacy L. Garrity,134,4,33,14,185
+Bradford,Springfield Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Springfield Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,State Treasurer,,REP,Stacy L. Garrity,57,6,19,3,85
+Bradford,Standing Stone Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Standing Stone Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Stevens Township,State Treasurer,,REP,Stacy L. Garrity,62,2,12,1,77
+Bradford,Stevens Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Stevens Township,State Treasurer,,REP,Write-In,1,1,1,0,3
+Bradford,Sylvania Borough,State Treasurer,,REP,Stacy L. Garrity,27,0,8,0,35
+Bradford,Sylvania Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Sylvania Borough,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Terry Township,State Treasurer,,REP,Stacy L. Garrity,125,1,24,1,151
+Bradford,Terry Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Terry Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,State Treasurer,,REP,Stacy L. Garrity,61,0,14,1,76
+Bradford,Towanda Borough 1St Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,State Treasurer,,REP,Stacy L. Garrity,62,5,21,4,92
+Bradford,Towanda Borough 2Nd Ward,State Treasurer,,REP,Joseph Torsella,0,1,0,0,1
+Bradford,Towanda Borough 2Nd Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,State Treasurer,,REP,Stacy L. Garrity,110,6,47,2,165
+Bradford,Towanda Borough 3Rd Ward,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Township,State Treasurer,,REP,Stacy L. Garrity,74,6,21,0,101
+Bradford,Towanda Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Towanda Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,State Treasurer,,REP,Stacy L. Garrity,83,7,41,0,131
+Bradford,North Towanda Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,North Towanda Township,State Treasurer,,REP,Write-In,0,0,2,0,2
+Bradford,Troy Borough,State Treasurer,,REP,Stacy L. Garrity,120,3,24,10,157
+Bradford,Troy Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Troy Borough,State Treasurer,,REP,Write-In,1,0,0,0,1
+Bradford,Troy Township,State Treasurer,,REP,Stacy L. Garrity,210,8,76,9,303
+Bradford,Troy Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Troy Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,State Treasurer,,REP,Stacy L. Garrity,148,9,29,3,189
+Bradford,Tuscarora Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Tuscarora Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Ulster Township,State Treasurer,,REP,Stacy L. Garrity,105,10,17,0,132
+Bradford,Ulster Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Ulster Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Warren Township,State Treasurer,,REP,Stacy L. Garrity,141,5,23,5,174
+Bradford,Warren Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Warren Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Wells Township,State Treasurer,,REP,Stacy L. Garrity,154,2,11,2,169
+Bradford,Wells Township,State Treasurer,,REP,Joseph Torsella,0,0,2,0,2
+Bradford,Wells Township,State Treasurer,,REP,Write-In,1,0,1,0,2
+Bradford,Wilmot Township,State Treasurer,,REP,Stacy L. Garrity,143,7,38,12,200
+Bradford,Wilmot Township,State Treasurer,,REP,Joseph Torsella,0,0,1,0,1
+Bradford,Wilmot Township,State Treasurer,,REP,Write-In,0,0,1,0,1
+Bradford,Windham Township,State Treasurer,,REP,Stacy L. Garrity,90,3,32,9,134
+Bradford,Windham Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Windham Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,State Treasurer,,REP,Stacy L. Garrity,65,1,13,6,85
+Bradford,Wyalusing Borough,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Wyalusing Borough,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,State Treasurer,,REP,Stacy L. Garrity,186,13,41,5,245
+Bradford,Wyalusing Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Wyalusing Township,State Treasurer,,REP,Write-In,1,0,0,0,1
+Bradford,Wysox Township,State Treasurer,,REP,Stacy L. Garrity,174,11,52,1,238
+Bradford,Wysox Township,State Treasurer,,REP,Joseph Torsella,0,0,0,0,0
+Bradford,Wysox Township,State Treasurer,,REP,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Representative In Congress,12,REP,Fred Keller,32,0,3,0,35
+Bradford,Alba Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Alba Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Alba Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In Congress,12,REP,Fred Keller,98,3,30,5,136
+Bradford,Albany Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Albany Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Albany Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Representative In Congress,12,REP,Fred Keller,29,0,0,0,29
+Bradford,Armenia Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Armenia Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Armenia Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Representative In Congress,12,REP,Fred Keller,102,7,33,2,144
+Bradford,Asylum Township,Representative In Congress,12,REP,Lee Griffin,0,0,1,0,1
+Bradford,Asylum Township,Representative In Congress,12,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Asylum Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,REP,Fred Keller,40,3,8,1,52
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In Congress,12,REP,Write-In,1,0,1,0,2
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,REP,Fred Keller,31,1,7,0,39
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,REP,Fred Keller,49,0,14,2,65
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,REP,Fred Keller,58,3,26,3,90
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Athens Township 1St District,Representative In Congress,12,REP,Fred Keller,135,6,38,5,184
+Bradford,Athens Township 1St District,Representative In Congress,12,REP,Lee Griffin,0,0,1,0,1
+Bradford,Athens Township 1St District,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In Congress,12,REP,Fred Keller,173,15,77,10,275
+Bradford,Athens Township 2Nd District,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In Congress,12,REP,Write-In,2,0,0,0,2
+Bradford,Burlington Borough,Representative In Congress,12,REP,Fred Keller,16,0,1,0,17
+Bradford,Burlington Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Burlington Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Burlington Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Representative In Congress,12,REP,Fred Keller,86,2,33,3,124
+Bradford,Burlington Township,Representative In Congress,12,REP,Lee Griffin,0,0,1,0,1
+Bradford,Burlington Township,Representative In Congress,12,REP,Doug Mclinko,0,0,1,0,1
+Bradford,Burlington Township,Representative In Congress,12,REP,Write-In,0,0,1,0,1
+Bradford,West Burlington Township,Representative In Congress,12,REP,Fred Keller,72,1,11,2,86
+Bradford,West Burlington Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,West Burlington Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,West Burlington Township,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Canton Borough,Representative In Congress,12,REP,Fred Keller,144,6,31,6,187
+Bradford,Canton Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Canton Borough,Representative In Congress,12,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Canton Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Canton Township,Representative In Congress,12,REP,Fred Keller,241,8,42,11,302
+Bradford,Canton Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Canton Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Canton Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Representative In Congress,12,REP,Fred Keller,122,1,28,4,155
+Bradford,Columbia Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Columbia Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Columbia Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In Congress,12,REP,Fred Keller,64,4,13,1,82
+Bradford,Franklin Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Franklin Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Franklin Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Granville Township,Representative In Congress,12,REP,Fred Keller,92,0,19,0,111
+Bradford,Granville Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Granville Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Granville Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Representative In Congress,12,REP,Fred Keller,115,3,19,2,139
+Bradford,Herrick Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Herrick Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Herrick Township,Representative In Congress,12,REP,Write-In,2,0,0,0,2
+Bradford,Leraysville Borough,Representative In Congress,12,REP,Fred Keller,35,2,6,0,43
+Bradford,Leraysville Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Representative In Congress,12,REP,Fred Keller,95,0,21,0,116
+Bradford,Leroy Township,Representative In Congress,12,REP,Lee Griffin,0,0,1,0,1
+Bradford,Leroy Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Leroy Township,Representative In Congress,12,REP,Write-In,1,0,2,0,3
+Bradford,Litchfield Township,Representative In Congress,12,REP,Fred Keller,122,3,30,3,158
+Bradford,Litchfield Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Litchfield Township,Representative In Congress,12,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Litchfield Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Representative In Congress,12,REP,Fred Keller,57,1,8,0,66
+Bradford,Monroe Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Monroe Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Monroe Borough,Representative In Congress,12,REP,Write-In,0,0,3,0,3
+Bradford,Monroe Township,Representative In Congress,12,REP,Fred Keller,120,4,30,5,159
+Bradford,Monroe Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,1,1
+Bradford,Monroe Township,Representative In Congress,12,REP,Doug Mclinko,0,0,1,0,1
+Bradford,Monroe Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Representative In Congress,12,REP,Fred Keller,24,0,1,0,25
+Bradford,New Albany Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,New Albany Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,New Albany Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Representative In Congress,12,REP,Fred Keller,128,8,52,2,190
+Bradford,Orwell Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Orwell Township,Representative In Congress,12,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Orwell Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Overton Township,Representative In Congress,12,REP,Fred Keller,30,1,5,1,37
+Bradford,Overton Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Overton Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Overton Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Pike Township,Representative In Congress,12,REP,Fred Keller,77,3,16,4,100
+Bradford,Pike Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Pike Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Pike Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In Congress,12,REP,Fred Keller,171,9,19,5,204
+Bradford,Ridgebury Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In Congress,12,REP,Fred Keller,24,3,10,0,37
+Bradford,Rome Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Rome Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Rome Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Rome Township,Representative In Congress,12,REP,Fred Keller,144,10,39,4,197
+Bradford,Rome Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Rome Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Rome Township,Representative In Congress,12,REP,Write-In,0,0,1,0,1
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,REP,Fred Keller,45,1,15,0,61
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,REP,Lee Griffin,0,0,3,0,3
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,REP,Fred Keller,122,3,44,3,172
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,REP,Lee Griffin,0,0,1,0,1
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In Congress,12,REP,Write-In,1,0,0,1,2
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,REP,Fred Keller,31,2,4,0,37
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,REP,Fred Keller,68,4,16,3,91
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,REP,Lee Griffin,0,0,1,0,1
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,REP,Fred Keller,16,1,2,0,19
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In Congress,12,REP,Fred Keller,113,12,32,2,159
+Bradford,Sheshequin Township,Representative In Congress,12,REP,Lee Griffin,0,0,3,0,3
+Bradford,Sheshequin Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Smithfield Township,Representative In Congress,12,REP,Fred Keller,170,6,46,6,228
+Bradford,Smithfield Township,Representative In Congress,12,REP,Lee Griffin,0,0,1,0,1
+Bradford,Smithfield Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Smithfield Township,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,South Creek Township,Representative In Congress,12,REP,Fred Keller,131,3,28,3,165
+Bradford,South Creek Township,Representative In Congress,12,REP,Lee Griffin,0,0,3,0,3
+Bradford,South Creek Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,South Creek Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In Congress,12,REP,Fred Keller,75,2,27,1,105
+Bradford,South Waverly Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Representative In Congress,12,REP,Fred Keller,135,3,30,13,181
+Bradford,Springfield Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Springfield Township,Representative In Congress,12,REP,Doug Mclinko,2,0,0,0,2
+Bradford,Springfield Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In Congress,12,REP,Fred Keller,52,6,20,2,80
+Bradford,Standing Stone Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Representative In Congress,12,REP,Fred Keller,64,3,14,1,82
+Bradford,Stevens Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Stevens Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Stevens Township,Representative In Congress,12,REP,Write-In,1,0,1,0,2
+Bradford,Sylvania Borough,Representative In Congress,12,REP,Fred Keller,28,0,8,0,36
+Bradford,Sylvania Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Terry Township,Representative In Congress,12,REP,Fred Keller,120,2,24,1,147
+Bradford,Terry Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Terry Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Terry Township,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,REP,Fred Keller,60,0,13,1,74
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,REP,Fred Keller,60,5,19,4,88
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,REP,Lee Griffin,0,1,0,0,1
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,REP,Fred Keller,99,4,42,1,146
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Township,Representative In Congress,12,REP,Fred Keller,70,9,20,0,99
+Bradford,Towanda Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Towanda Township,Representative In Congress,12,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Towanda Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Representative In Congress,12,REP,Fred Keller,81,5,41,0,127
+Bradford,North Towanda Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,North Towanda Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,North Towanda Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Representative In Congress,12,REP,Fred Keller,110,4,21,10,145
+Bradford,Troy Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Troy Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Troy Borough,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Troy Township,Representative In Congress,12,REP,Fred Keller,207,8,75,7,297
+Bradford,Troy Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Troy Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Troy Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In Congress,12,REP,Fred Keller,147,9,33,3,192
+Bradford,Tuscarora Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Representative In Congress,12,REP,Fred Keller,103,10,18,0,131
+Bradford,Ulster Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Ulster Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Ulster Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Warren Township,Representative In Congress,12,REP,Fred Keller,136,5,25,4,170
+Bradford,Warren Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Warren Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Warren Township,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Wells Township,Representative In Congress,12,REP,Fred Keller,147,2,10,2,161
+Bradford,Wells Township,Representative In Congress,12,REP,Lee Griffin,0,0,2,0,2
+Bradford,Wells Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Wells Township,Representative In Congress,12,REP,Write-In,1,0,1,0,2
+Bradford,Wilmot Township,Representative In Congress,12,REP,Fred Keller,138,7,43,11,199
+Bradford,Wilmot Township,Representative In Congress,12,REP,Lee Griffin,0,0,1,0,1
+Bradford,Wilmot Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Wilmot Township,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Windham Township,Representative In Congress,12,REP,Fred Keller,86,3,31,9,129
+Bradford,Windham Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Windham Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Windham Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In Congress,12,REP,Fred Keller,62,1,12,6,81
+Bradford,Wyalusing Borough,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In Congress,12,REP,Write-In,1,0,0,0,1
+Bradford,Wyalusing Township,Representative In Congress,12,REP,Fred Keller,178,13,40,4,235
+Bradford,Wyalusing Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In Congress,12,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In Congress,12,REP,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Representative In Congress,12,REP,Fred Keller,156,11,48,1,216
+Bradford,Wysox Township,Representative In Congress,12,REP,Lee Griffin,0,0,0,0,0
+Bradford,Wysox Township,Representative In Congress,12,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Wysox Township,Representative In Congress,12,REP,Write-In,1,0,1,0,2
+Bradford,Alba Borough,Senator In The General Assembly,23,REP,Gene Yaw,32,0,3,0,35
+Bradford,Alba Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Alba Borough,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Alba Borough,Representative In The General Assembly,68,,Clint Owlett,32,0,3,0,35
+Bradford,Alba Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Albany Township,Senator In The General Assembly,23,REP,Gene Yaw,101,4,30,5,140
+Bradford,Albany Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Albany Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Senator In The General Assembly,23,REP,Gene Yaw,30,0,0,0,30
+Bradford,Armenia Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Armenia Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,68,,Clint Owlett,32,0,1,0,33
+Bradford,Armenia Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Senator In The General Assembly,23,REP,Gene Yaw,103,6,33,2,144
+Bradford,Asylum Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Asylum Township,Senator In The General Assembly,23,REP,Write-In,0,1,0,0,1
+Bradford,Asylum Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,REP,Gene Yaw,40,3,12,1,56
+Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,REP,Gene Yaw,33,3,7,0,43
+Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,REP,Gene Yaw,47,0,14,2,63
+Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,REP,Gene Yaw,61,3,26,3,93
+Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Senator In The General Assembly,23,REP,Gene Yaw,140,6,41,5,192
+Bradford,Athens Township 1St District,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
+Bradford,Athens Township 1St District,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,REP,Gene Yaw,173,17,77,10,277
+Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Senator In The General Assembly,23,REP,Gene Yaw,19,0,1,0,20
+Bradford,Burlington Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Burlington Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Senator In The General Assembly,23,REP,Gene Yaw,83,2,31,3,119
+Bradford,Burlington Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
+Bradford,Burlington Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Burlington Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Senator In The General Assembly,23,REP,Gene Yaw,73,1,10,2,86
+Bradford,West Burlington Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,West Burlington Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,68,,Clint Owlett,79,1,13,2,95
+Bradford,West Burlington Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Senator In The General Assembly,23,REP,Gene Yaw,150,6,33,7,196
+Bradford,Canton Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Canton Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,68,,Clint Owlett,152,6,35,7,200
+Bradford,Canton Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Canton Township,Senator In The General Assembly,23,REP,Gene Yaw,243,8,42,11,304
+Bradford,Canton Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Canton Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Canton Township,Representative In The General Assembly,68,,Clint Owlett,252,8,42,12,314
+Bradford,Canton Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Senator In The General Assembly,23,REP,Gene Yaw,124,1,28,4,157
+Bradford,Columbia Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Columbia Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Columbia Township,Representative In The General Assembly,68,,Clint Owlett,131,1,29,4,165
+Bradford,Columbia Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Senator In The General Assembly,23,REP,Gene Yaw,65,4,14,1,84
+Bradford,Franklin Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Franklin Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Granville Township,Senator In The General Assembly,23,REP,Gene Yaw,89,1,20,1,111
+Bradford,Granville Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Granville Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,68,,Clint Owlett,92,1,20,1,114
+Bradford,Granville Township,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Herrick Township,Senator In The General Assembly,23,REP,Gene Yaw,115,3,19,2,139
+Bradford,Herrick Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
+Bradford,Herrick Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Herrick Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Senator In The General Assembly,23,REP,Gene Yaw,37,2,8,0,47
+Bradford,Leraysville Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Leraysville Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Senator In The General Assembly,23,REP,Gene Yaw,100,0,24,0,124
+Bradford,Leroy Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Leroy Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Senator In The General Assembly,23,REP,Gene Yaw,125,3,29,3,160
+Bradford,Litchfield Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Litchfield Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Monroe Borough,Senator In The General Assembly,23,REP,Gene Yaw,59,1,11,0,71
+Bradford,Monroe Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Monroe Borough,Senator In The General Assembly,23,REP,Write-In,1,0,1,0,2
+Bradford,Monroe Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Monroe Township,Senator In The General Assembly,23,REP,Gene Yaw,115,4,28,6,153
+Bradford,Monroe Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Monroe Township,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
+Bradford,Monroe Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Senator In The General Assembly,23,REP,Gene Yaw,26,1,1,0,28
+Bradford,New Albany Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,New Albany Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Senator In The General Assembly,23,REP,Gene Yaw,133,8,52,2,195
+Bradford,Orwell Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Orwell Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Overton Township,Senator In The General Assembly,23,REP,Gene Yaw,31,1,5,1,38
+Bradford,Overton Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Overton Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Pike Township,Senator In The General Assembly,23,REP,Gene Yaw,75,3,16,4,98
+Bradford,Pike Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Pike Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Pike Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Ridgebury Township,Senator In The General Assembly,23,REP,Gene Yaw,173,9,20,5,207
+Bradford,Ridgebury Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Ridgebury Township,Senator In The General Assembly,23,REP,Write-In,1,1,0,0,2
+Bradford,Ridgebury Township,Representative In The General Assembly,68,,Clint Owlett,175,10,22,5,212
+Bradford,Ridgebury Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Senator In The General Assembly,23,REP,Gene Yaw,23,2,11,0,36
+Bradford,Rome Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Rome Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Rome Township,Senator In The General Assembly,23,REP,Gene Yaw,144,11,39,4,198
+Bradford,Rome Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Rome Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Rome Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,REP,Gene Yaw,46,1,16,0,63
+Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,3,0,3
+Bradford,Sayre Borough 1St Ward,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,REP,Gene Yaw,127,3,45,2,177
+Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
+Bradford,Sayre Borough 2Nd Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,1,1
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,REP,Gene Yaw,33,2,5,0,40
+Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,REP,Gene Yaw,75,4,18,3,100
+Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
+Bradford,Sayre Borough 4Th Ward,Senator In The General Assembly,23,REP,Write-In,0,0,1,0,1
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,REP,Gene Yaw,16,1,2,0,19
+Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Senator In The General Assembly,23,REP,Gene Yaw,114,12,33,3,162
+Bradford,Sheshequin Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,3,0,3
+Bradford,Sheshequin Township,Senator In The General Assembly,23,REP,Write-In,3,0,0,0,3
+Bradford,Sheshequin Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Smithfield Township,Senator In The General Assembly,23,REP,Gene Yaw,171,6,44,6,227
+Bradford,Smithfield Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
+Bradford,Smithfield Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Smithfield Township,Representative In The General Assembly,68,,Clint Owlett,173,6,49,5,233
+Bradford,Smithfield Township,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,South Creek Township,Senator In The General Assembly,23,REP,Gene Yaw,136,3,29,3,171
+Bradford,South Creek Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,2,0,2
+Bradford,South Creek Township,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
+Bradford,South Creek Township,Representative In The General Assembly,68,,Clint Owlett,142,3,29,3,177
+Bradford,South Creek Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Senator In The General Assembly,23,REP,Gene Yaw,78,2,28,1,109
+Bradford,South Waverly Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,South Waverly Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Senator In The General Assembly,23,REP,Gene Yaw,131,5,32,12,180
+Bradford,Springfield Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Springfield Township,Senator In The General Assembly,23,REP,Write-In,4,0,1,1,6
+Bradford,Springfield Township,Representative In The General Assembly,68,,Clint Owlett,145,4,34,13,196
+Bradford,Springfield Township,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Standing Stone Township,Senator In The General Assembly,23,REP,Gene Yaw,54,6,19,2,81
+Bradford,Standing Stone Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Standing Stone Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Stevens Township,Senator In The General Assembly,23,REP,Gene Yaw,66,3,12,1,82
+Bradford,Stevens Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Stevens Township,Senator In The General Assembly,23,REP,Write-In,1,0,1,0,2
+Bradford,Stevens Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,Senator In The General Assembly,23,REP,Gene Yaw,28,0,9,0,37
+Bradford,Sylvania Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Sylvania Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,68,,Clint Owlett,29,0,8,0,37
+Bradford,Sylvania Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Terry Township,Senator In The General Assembly,23,REP,Gene Yaw,118,1,23,1,143
+Bradford,Terry Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Terry Township,Senator In The General Assembly,23,REP,Write-In,2,0,1,0,3
+Bradford,Terry Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,REP,Gene Yaw,60,0,14,1,75
+Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,REP,Gene Yaw,61,5,21,4,91
+Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Senator In The General Assembly,23,REP,Write-In,0,1,0,0,1
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,REP,Gene Yaw,102,3,42,2,149
+Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
+Bradford,Towanda Borough 3Rd Ward,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Senator In The General Assembly,23,REP,Gene Yaw,73,10,19,0,102
+Bradford,Towanda Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Towanda Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Senator In The General Assembly,23,REP,Gene Yaw,81,6,42,0,129
+Bradford,North Towanda Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,North Towanda Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,North Towanda Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Troy Borough,Senator In The General Assembly,23,REP,Gene Yaw,116,4,21,10,151
+Bradford,Troy Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Troy Borough,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Troy Borough,Representative In The General Assembly,68,,Clint Owlett,123,4,23,10,160
+Bradford,Troy Borough,Representative In The General Assembly,68,,Write-In,1,0,0,0,1
+Bradford,Troy Township,Senator In The General Assembly,23,REP,Gene Yaw,209,9,73,8,299
+Bradford,Troy Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Troy Township,Senator In The General Assembly,23,REP,Write-In,1,0,1,0,2
+Bradford,Troy Township,Representative In The General Assembly,68,,Clint Owlett,218,9,78,9,314
+Bradford,Troy Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Senator In The General Assembly,23,REP,Gene Yaw,144,9,30,3,186
+Bradford,Tuscarora Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Tuscarora Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Tuscarora Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Senator In The General Assembly,23,REP,Gene Yaw,103,10,17,0,130
+Bradford,Ulster Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Ulster Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Warren Township,Senator In The General Assembly,23,REP,Gene Yaw,137,5,24,5,171
+Bradford,Warren Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Warren Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wells Township,Senator In The General Assembly,23,REP,Gene Yaw,154,2,11,2,169
+Bradford,Wells Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,2,0,2
+Bradford,Wells Township,Senator In The General Assembly,23,REP,Write-In,1,0,1,0,2
+Bradford,Wells Township,Representative In The General Assembly,68,,Clint Owlett,156,2,14,2,174
+Bradford,Wells Township,Representative In The General Assembly,68,,Write-In,0,0,1,0,1
+Bradford,Wilmot Township,Senator In The General Assembly,23,REP,Gene Yaw,130,9,40,11,190
+Bradford,Wilmot Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,1,0,1
+Bradford,Wilmot Township,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
+Bradford,Wilmot Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Windham Township,Senator In The General Assembly,23,REP,Gene Yaw,82,3,29,9,123
+Bradford,Windham Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Windham Township,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Senator In The General Assembly,23,REP,Gene Yaw,61,1,10,6,78
+Bradford,Wyalusing Borough,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Wyalusing Borough,Senator In The General Assembly,23,REP,Write-In,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wyalusing Township,Senator In The General Assembly,23,REP,Gene Yaw,167,13,40,4,224
+Bradford,Wyalusing Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Wyalusing Township,Senator In The General Assembly,23,REP,Write-In,2,0,0,0,2
+Bradford,Wyalusing Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Senator In The General Assembly,23,REP,Gene Yaw,166,11,49,1,227
+Bradford,Wysox Township,Senator In The General Assembly,23,REP,Jackie Baker,0,0,0,0,0
+Bradford,Wysox Township,Senator In The General Assembly,23,REP,Write-In,1,0,0,0,1
+Bradford,Wysox Township,Representative In The General Assembly,68,,Clint Owlett,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,68,,Write-In,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Alba Borough,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,110,REP,Tina Pickett,99,4,30,5,138
+Bradford,Albany Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Albany Township,Representative In The General Assembly,110,REP,Write-In,0,0,1,0,1
+Bradford,Armenia Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Armenia Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,110,REP,Tina Pickett,110,7,36,2,155
+Bradford,Asylum Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Asylum Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,REP,Tina Pickett,39,4,12,1,56
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Athens Borough 1St Ward,Representative In The General Assembly,110,REP,Write-In,3,0,0,0,3
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,REP,Tina Pickett,35,3,7,0,45
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Athens Borough 2Nd Ward,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,REP,Tina Pickett,51,0,14,2,67
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Athens Borough 3Rd Ward,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,REP,Tina Pickett,60,3,26,3,92
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Athens Borough 4Th Ward,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,REP,Tina Pickett,147,7,43,5,202
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,REP,James Shaw,2,0,0,0,2
+Bradford,Athens Township 1St District,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,REP,Tina Pickett,175,20,81,10,286
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,REP,James Shaw,2,0,0,0,2
+Bradford,Athens Township 2Nd District,Representative In The General Assembly,110,REP,Write-In,3,0,1,0,4
+Bradford,Burlington Borough,Representative In The General Assembly,110,REP,Tina Pickett,18,0,1,0,19
+Bradford,Burlington Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Burlington Borough,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,110,REP,Tina Pickett,91,2,34,3,130
+Bradford,Burlington Township,Representative In The General Assembly,110,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Burlington Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Burlington Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,West Burlington Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Canton Borough,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Canton Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Columbia Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,110,REP,Tina Pickett,62,4,14,1,81
+Bradford,Franklin Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Franklin Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Granville Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Granville Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,110,REP,Tina Pickett,122,3,22,2,149
+Bradford,Herrick Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Herrick Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Leraysville Borough,Representative In The General Assembly,110,REP,Tina Pickett,38,2,9,0,49
+Bradford,Leraysville Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Leraysville Borough,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Leroy Township,Representative In The General Assembly,110,REP,Tina Pickett,100,0,25,0,125
+Bradford,Leroy Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Leroy Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Litchfield Township,Representative In The General Assembly,110,REP,Tina Pickett,127,4,34,4,169
+Bradford,Litchfield Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Litchfield Township,Representative In The General Assembly,110,REP,Write-In,0,0,1,0,1
+Bradford,Monroe Borough,Representative In The General Assembly,110,REP,Tina Pickett,52,1,12,0,65
+Bradford,Monroe Borough,Representative In The General Assembly,110,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Monroe Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Monroe Borough,Representative In The General Assembly,110,REP,James Shaw,1,0,0,0,1
+Bradford,Monroe Borough,Representative In The General Assembly,110,REP,Write-In,1,0,1,0,2
+Bradford,Monroe Township,Representative In The General Assembly,110,REP,Tina Pickett,124,4,33,7,168
+Bradford,Monroe Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Monroe Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,110,REP,Tina Pickett,28,1,1,0,30
+Bradford,New Albany Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,New Albany Borough,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,110,REP,Tina Pickett,138,8,50,3,199
+Bradford,Orwell Township,Representative In The General Assembly,110,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Orwell Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Orwell Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Overton Township,Representative In The General Assembly,110,REP,Tina Pickett,29,1,5,0,35
+Bradford,Overton Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Overton Township,Representative In The General Assembly,110,REP,Write-In,2,0,0,0,2
+Bradford,Pike Township,Representative In The General Assembly,110,REP,Tina Pickett,81,3,14,4,102
+Bradford,Pike Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Pike Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Ridgebury Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Ridgebury Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,110,REP,Tina Pickett,29,4,9,0,42
+Bradford,Rome Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,1,0,1
+Bradford,Rome Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Rome Borough,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,110,REP,Tina Pickett,149,11,40,4,204
+Bradford,Rome Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Rome Township,Representative In The General Assembly,110,REP,Write-In,2,0,0,0,2
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,REP,Tina Pickett,46,1,18,0,65
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,REP,James Shaw,3,0,0,0,3
+Bradford,Sayre Borough 1St Ward,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,REP,Tina Pickett,123,3,47,2,175
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,REP,James Shaw,2,0,0,1,3
+Bradford,Sayre Borough 2Nd Ward,Representative In The General Assembly,110,REP,Write-In,2,0,0,0,2
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,REP,Tina Pickett,32,2,4,0,38
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Sayre Borough 3Rd Ward,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,REP,Tina Pickett,69,5,18,4,96
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,1,0,1
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,REP,James Shaw,1,0,0,0,1
+Bradford,Sayre Borough 4Th Ward,Representative In The General Assembly,110,REP,Write-In,2,0,0,0,2
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,REP,Tina Pickett,16,1,2,0,19
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Sayre Borough 5Th Ward,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,110,REP,Tina Pickett,116,11,33,3,163
+Bradford,Sheshequin Township,Representative In The General Assembly,110,REP,Doug Mclinko,4,0,0,0,4
+Bradford,Sheshequin Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Sheshequin Township,Representative In The General Assembly,110,REP,Write-In,3,1,0,0,4
+Bradford,Smithfield Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Smithfield Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Smithfield Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Smithfield Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Smithfield Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,South Creek Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,110,REP,Tina Pickett,81,2,28,1,112
+Bradford,South Waverly Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,South Waverly Borough,Representative In The General Assembly,110,REP,James Shaw,1,0,0,0,1
+Bradford,South Waverly Borough,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Springfield Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,110,REP,Tina Pickett,59,4,21,3,87
+Bradford,Standing Stone Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Standing Stone Township,Representative In The General Assembly,110,REP,Write-In,0,1,0,0,1
+Bradford,Stevens Township,Representative In The General Assembly,110,REP,Tina Pickett,72,3,14,1,90
+Bradford,Stevens Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Stevens Township,Representative In The General Assembly,110,REP,Write-In,1,0,1,0,2
+Bradford,Sylvania Borough,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Sylvania Borough,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,110,REP,Tina Pickett,125,2,24,1,152
+Bradford,Terry Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Terry Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,REP,Tina Pickett,61,0,14,1,76
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,REP,James Shaw,1,0,0,0,1
+Bradford,Towanda Borough 1St Ward,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,REP,Tina Pickett,62,5,22,4,93
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Towanda Borough 2Nd Ward,Representative In The General Assembly,110,REP,Write-In,3,1,0,0,4
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,REP,Tina Pickett,106,7,46,2,161
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Towanda Borough 3Rd Ward,Representative In The General Assembly,110,REP,Write-In,3,0,2,0,5
+Bradford,Towanda Township,Representative In The General Assembly,110,REP,Tina Pickett,72,10,20,0,102
+Bradford,Towanda Township,Representative In The General Assembly,110,REP,Doug Mclinko,1,0,0,0,1
+Bradford,Towanda Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Towanda Township,Representative In The General Assembly,110,REP,James Shaw,1,0,0,0,1
+Bradford,Towanda Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,110,REP,Tina Pickett,85,5,42,0,132
+Bradford,North Towanda Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,North Towanda Township,Representative In The General Assembly,110,REP,Write-In,1,0,1,0,2
+Bradford,Troy Borough,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Troy Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Troy Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Troy Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Troy Borough,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Troy Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,110,REP,Tina Pickett,146,8,33,3,190
+Bradford,Tuscarora Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Tuscarora Township,Representative In The General Assembly,110,REP,Write-In,2,1,0,0,3
+Bradford,Ulster Township,Representative In The General Assembly,110,REP,Tina Pickett,104,10,19,0,133
+Bradford,Ulster Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Ulster Township,Representative In The General Assembly,110,REP,James Shaw,1,0,0,0,1
+Bradford,Ulster Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,110,REP,Tina Pickett,142,5,25,5,177
+Bradford,Warren Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Warren Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Wells Township,Representative In The General Assembly,110,REP,Tina Pickett,0,0,0,0,0
+Bradford,Wells Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Wells Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Wells Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Wells Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,110,REP,Tina Pickett,144,9,46,12,211
+Bradford,Wilmot Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Wilmot Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Windham Township,Representative In The General Assembly,110,REP,Tina Pickett,93,3,33,9,138
+Bradford,Windham Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Windham Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,REP,Tina Pickett,66,1,11,6,84
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Wyalusing Borough,Representative In The General Assembly,110,REP,Write-In,1,0,1,0,2
+Bradford,Wyalusing Township,Representative In The General Assembly,110,REP,Tina Pickett,186,13,40,5,244
+Bradford,Wyalusing Township,Representative In The General Assembly,110,REP,Doug Mclinko,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Wyalusing Township,Representative In The General Assembly,110,REP,Write-In,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,110,REP,Tina Pickett,172,10,52,1,235
+Bradford,Wysox Township,Representative In The General Assembly,110,REP,Doug Mclinko,2,0,0,0,2
+Bradford,Wysox Township,Representative In The General Assembly,110,REP,James J. Daly,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,110,REP,James Shaw,0,0,0,0,0
+Bradford,Wysox Township,Representative In The General Assembly,110,REP,Write-In,1,0,0,0,1

--- a/2020/20200602__pa__primary__columbia__precinct.csv
+++ b/2020/20200602__pa__primary__columbia__precinct.csv
@@ -1,88 +1,88 @@
 county,precinct,office,district,party,candidate,votes
-Columbia,Beaver Twp,Turnout,,,Registered Voters,577
-Columbia,Beaver Twp,Turnout,,,Ballots Cast,219
-Columbia,Benton Twp,Turnout,,,Registered Voters,844
-Columbia,Benton Twp,Turnout,,,Ballots Cast,312
-Columbia,Benton Borough,Turnout,,,Registered Voters,466
-Columbia,Benton Borough,Turnout,,,Ballots Cast,171
-Columbia,Berwick 1St Ward,Turnout,,,Registered Voters,1915
-Columbia,Berwick 1St Ward,Turnout,,,Ballots Cast,593
-Columbia,Berwick 2Nd Ward,Turnout,,,Registered Voters,678
-Columbia,Berwick 2Nd Ward,Turnout,,,Ballots Cast,181
-Columbia,Berwick 3Rd Ward,Turnout,,,Registered Voters,1126
-Columbia,Berwick 3Rd Ward,Turnout,,,Ballots Cast,315
-Columbia,Berwick 4Th Ward,Turnout,,,Registered Voters,1522
-Columbia,Berwick 4Th Ward,Turnout,,,Ballots Cast,497
-Columbia,Bloomsburg 1St Ward,Turnout,,,Registered Voters,945
-Columbia,Bloomsburg 1St Ward,Turnout,,,Ballots Cast,175
-Columbia,Bloomsburg 2Nd Ward,Turnout,,,Registered Voters,1145
-Columbia,Bloomsburg 2Nd Ward,Turnout,,,Ballots Cast,320
-Columbia,Bloomsburg 3-1 Ward,Turnout,,,Registered Voters,1763
-Columbia,Bloomsburg 3-1 Ward,Turnout,,,Ballots Cast,385
-Columbia,Bloomsburg 3-2 Ward,Turnout,,,Registered Voters,1701
-Columbia,Bloomsburg 3-2 Ward,Turnout,,,Ballots Cast,45
-Columbia,Bloomsburg 4Th Ward,Turnout,,,Registered Voters,1308
-Columbia,Bloomsburg 4Th Ward,Turnout,,,Ballots Cast,428
-Columbia,Briarcreek Twp Northeast,Turnout,,,Registered Voters,918
-Columbia,Briarcreek Twp Northeast,Turnout,,,Ballots Cast,307
-Columbia,Briarcreek Twp West,Turnout,,,Registered Voters,942
-Columbia,Briarcreek Twp West,Turnout,,,Ballots Cast,333
-Columbia,Briarcreek Borough,Turnout,,,Registered Voters,281
-Columbia,Briarcreek Borough,Turnout,,,Ballots Cast,81
-Columbia,Catawissa Twp,Turnout,,,Registered Voters,624
-Columbia,Catawissa Twp,Turnout,,,Ballots Cast,206
-Columbia,Catawissa Borough,Turnout,,,Registered Voters,754
-Columbia,Catawissa Borough,Turnout,,,Ballots Cast,224
-Columbia,Centralia Borough,Turnout,,,Registered Voters,3
-Columbia,Centralia Borough,Turnout,,,Ballots Cast,3
-Columbia,Cleveland Twp,Turnout,,,Registered Voters,684
-Columbia,Cleveland Twp,Turnout,,,Ballots Cast,239
-Columbia,Conyngham Twp,Turnout,,,Registered Voters,404
-Columbia,Conyngham Twp,Turnout,,,Ballots Cast,145
-Columbia,Fishingcreek Twp,Turnout,,,Registered Voters,951
-Columbia,Fishingcreek Twp,Turnout,,,Ballots Cast,317
-Columbia,Franklin Twp,Turnout,,,Registered Voters,366
-Columbia,Franklin Twp,Turnout,,,Ballots Cast,138
-Columbia,Greenwood Twp,Turnout,,,Registered Voters,1118
-Columbia,Greenwood Twp,Turnout,,,Ballots Cast,387
-Columbia,Hemlock Twp,Turnout,,,Registered Voters,1511
-Columbia,Hemlock Twp,Turnout,,,Ballots Cast,590
-Columbia,Jackson Twp,Turnout,,,Registered Voters,413
-Columbia,Jackson Twp,Turnout,,,Ballots Cast,154
-Columbia,Locust Twp,Turnout,,,Registered Voters,899
-Columbia,Locust Twp,Turnout,,,Ballots Cast,321
-Columbia,Madison Twp,Turnout,,,Registered Voters,916
-Columbia,Madison Twp,Turnout,,,Ballots Cast,386
-Columbia,Main Twp,Turnout,,,Registered Voters,832
-Columbia,Main Twp,Turnout,,,Ballots Cast,296
-Columbia,Mifflin Twp,Turnout,,,Registered Voters,1398
-Columbia,Mifflin Twp,Turnout,,,Ballots Cast,473
-Columbia,Millville Borough,Turnout,,,Registered Voters,537
-Columbia,Millville Borough,Turnout,,,Ballots Cast,201
-Columbia,Montour Twp,Turnout,,,Registered Voters,782
-Columbia,Montour Twp,Turnout,,,Ballots Cast,248
-Columbia,Mount Pleasant Twp,Turnout,,,Registered Voters,1008
-Columbia,Mount Pleasant Twp,Turnout,,,Ballots Cast,405
-Columbia,North Centre Twp,Turnout,,,Registered Voters,1262
-Columbia,North Centre Twp,Turnout,,,Ballots Cast,410
-Columbia,Orange Twp,Turnout,,,Registered Voters,777
-Columbia,Orange Twp,Turnout,,,Ballots Cast,297
-Columbia,Orangeville Borough,Turnout,,,Registered Voters,219
-Columbia,Orangeville Borough,Turnout,,,Ballots Cast,76
-Columbia,Pine Twp,Turnout,,,Registered Voters,639
-Columbia,Pine Twp,Turnout,,,Ballots Cast,225
-Columbia,Roaringcreek Twp,Turnout,,,Registered Voters,370
-Columbia,Roaringcreek Twp,Turnout,,,Ballots Cast,159
-Columbia,Scott Twp East,Turnout,,,Registered Voters,1917
-Columbia,Scott Twp East,Turnout,,,Ballots Cast,688
-Columbia,Scott Twp West,Turnout,,,Registered Voters,1752
-Columbia,Scott Twp West,Turnout,,,Ballots Cast,533
-Columbia,South Centre Twp,Turnout,,,Registered Voters,1062
-Columbia,South Centre Twp,Turnout,,,Ballots Cast,320
-Columbia,Stillwater Borough,Turnout,,,Registered Voters,127
-Columbia,Stillwater Borough,Turnout,,,Ballots Cast,54
-Columbia,Sugarloaf Twp,Turnout,,,Registered Voters,584
-Columbia,Sugarloaf Twp,Turnout,,,Ballots Cast,225
+Columbia,Beaver Twp,Registered Voters,,,,577
+Columbia,Beaver Twp,Ballots Cast,,,,219
+Columbia,Benton Twp,Registered Voters,,,,844
+Columbia,Benton Twp,Ballots Cast,,,,312
+Columbia,Benton Borough,Registered Voters,,,,466
+Columbia,Benton Borough,Ballots Cast,,,,171
+Columbia,Berwick 1St Ward,Registered Voters,,,,1915
+Columbia,Berwick 1St Ward,Ballots Cast,,,,593
+Columbia,Berwick 2Nd Ward,Registered Voters,,,,678
+Columbia,Berwick 2Nd Ward,Ballots Cast,,,,181
+Columbia,Berwick 3Rd Ward,Registered Voters,,,,1126
+Columbia,Berwick 3Rd Ward,Ballots Cast,,,,315
+Columbia,Berwick 4Th Ward,Registered Voters,,,,1522
+Columbia,Berwick 4Th Ward,Ballots Cast,,,,497
+Columbia,Bloomsburg 1St Ward,Registered Voters,,,,945
+Columbia,Bloomsburg 1St Ward,Ballots Cast,,,,175
+Columbia,Bloomsburg 2Nd Ward,Registered Voters,,,,1145
+Columbia,Bloomsburg 2Nd Ward,Ballots Cast,,,,320
+Columbia,Bloomsburg 3-1 Ward,Registered Voters,,,,1763
+Columbia,Bloomsburg 3-1 Ward,Ballots Cast,,,,385
+Columbia,Bloomsburg 3-2 Ward,Registered Voters,,,,1701
+Columbia,Bloomsburg 3-2 Ward,Ballots Cast,,,,45
+Columbia,Bloomsburg 4Th Ward,Registered Voters,,,,1308
+Columbia,Bloomsburg 4Th Ward,Ballots Cast,,,,428
+Columbia,Briarcreek Twp Northeast,Registered Voters,,,,918
+Columbia,Briarcreek Twp Northeast,Ballots Cast,,,,307
+Columbia,Briarcreek Twp West,Registered Voters,,,,942
+Columbia,Briarcreek Twp West,Ballots Cast,,,,333
+Columbia,Briarcreek Borough,Registered Voters,,,,281
+Columbia,Briarcreek Borough,Ballots Cast,,,,81
+Columbia,Catawissa Twp,Registered Voters,,,,624
+Columbia,Catawissa Twp,Ballots Cast,,,,206
+Columbia,Catawissa Borough,Registered Voters,,,,754
+Columbia,Catawissa Borough,Ballots Cast,,,,224
+Columbia,Centralia Borough,Registered Voters,,,,3
+Columbia,Centralia Borough,Ballots Cast,,,,3
+Columbia,Cleveland Twp,Registered Voters,,,,684
+Columbia,Cleveland Twp,Ballots Cast,,,,239
+Columbia,Conyngham Twp,Registered Voters,,,,404
+Columbia,Conyngham Twp,Ballots Cast,,,,145
+Columbia,Fishingcreek Twp,Registered Voters,,,,951
+Columbia,Fishingcreek Twp,Ballots Cast,,,,317
+Columbia,Franklin Twp,Registered Voters,,,,366
+Columbia,Franklin Twp,Ballots Cast,,,,138
+Columbia,Greenwood Twp,Registered Voters,,,,1118
+Columbia,Greenwood Twp,Ballots Cast,,,,387
+Columbia,Hemlock Twp,Registered Voters,,,,1511
+Columbia,Hemlock Twp,Ballots Cast,,,,590
+Columbia,Jackson Twp,Registered Voters,,,,413
+Columbia,Jackson Twp,Ballots Cast,,,,154
+Columbia,Locust Twp,Registered Voters,,,,899
+Columbia,Locust Twp,Ballots Cast,,,,321
+Columbia,Madison Twp,Registered Voters,,,,916
+Columbia,Madison Twp,Ballots Cast,,,,386
+Columbia,Main Twp,Registered Voters,,,,832
+Columbia,Main Twp,Ballots Cast,,,,296
+Columbia,Mifflin Twp,Registered Voters,,,,1398
+Columbia,Mifflin Twp,Ballots Cast,,,,473
+Columbia,Millville Borough,Registered Voters,,,,537
+Columbia,Millville Borough,Ballots Cast,,,,201
+Columbia,Montour Twp,Registered Voters,,,,782
+Columbia,Montour Twp,Ballots Cast,,,,248
+Columbia,Mount Pleasant Twp,Registered Voters,,,,1008
+Columbia,Mount Pleasant Twp,Ballots Cast,,,,405
+Columbia,North Centre Twp,Registered Voters,,,,1262
+Columbia,North Centre Twp,Ballots Cast,,,,410
+Columbia,Orange Twp,Registered Voters,,,,777
+Columbia,Orange Twp,Ballots Cast,,,,297
+Columbia,Orangeville Borough,Registered Voters,,,,219
+Columbia,Orangeville Borough,Ballots Cast,,,,76
+Columbia,Pine Twp,Registered Voters,,,,639
+Columbia,Pine Twp,Ballots Cast,,,,225
+Columbia,Roaringcreek Twp,Registered Voters,,,,370
+Columbia,Roaringcreek Twp,Ballots Cast,,,,159
+Columbia,Scott Twp East,Registered Voters,,,,1917
+Columbia,Scott Twp East,Ballots Cast,,,,688
+Columbia,Scott Twp West,Registered Voters,,,,1752
+Columbia,Scott Twp West,Ballots Cast,,,,533
+Columbia,South Centre Twp,Registered Voters,,,,1062
+Columbia,South Centre Twp,Ballots Cast,,,,320
+Columbia,Stillwater Borough,Registered Voters,,,,127
+Columbia,Stillwater Borough,Ballots Cast,,,,54
+Columbia,Sugarloaf Twp,Registered Voters,,,,584
+Columbia,Sugarloaf Twp,Ballots Cast,,,,225
 Columbia,Beaver Twp,President Of The United States,,DEM,Bernie Sanders,15
 Columbia,Beaver Twp,President Of The United States,,DEM,Joseph R Biden,49
 Columbia,Beaver Twp,President Of The United States,,DEM,Tulsi Gabbard,9

--- a/2020/20200602__pa__primary__columbia__precinct.csv
+++ b/2020/20200602__pa__primary__columbia__precinct.csv
@@ -1,4 +1,88 @@
 county,precinct,office,district,party,candidate,votes
+Columbia,Beaver Twp,Turnout,,,Registered Voters,577
+Columbia,Beaver Twp,Turnout,,,Ballots Cast,219
+Columbia,Benton Twp,Turnout,,,Registered Voters,844
+Columbia,Benton Twp,Turnout,,,Ballots Cast,312
+Columbia,Benton Borough,Turnout,,,Registered Voters,466
+Columbia,Benton Borough,Turnout,,,Ballots Cast,171
+Columbia,Berwick 1St Ward,Turnout,,,Registered Voters,1915
+Columbia,Berwick 1St Ward,Turnout,,,Ballots Cast,593
+Columbia,Berwick 2Nd Ward,Turnout,,,Registered Voters,678
+Columbia,Berwick 2Nd Ward,Turnout,,,Ballots Cast,181
+Columbia,Berwick 3Rd Ward,Turnout,,,Registered Voters,1126
+Columbia,Berwick 3Rd Ward,Turnout,,,Ballots Cast,315
+Columbia,Berwick 4Th Ward,Turnout,,,Registered Voters,1522
+Columbia,Berwick 4Th Ward,Turnout,,,Ballots Cast,497
+Columbia,Bloomsburg 1St Ward,Turnout,,,Registered Voters,945
+Columbia,Bloomsburg 1St Ward,Turnout,,,Ballots Cast,175
+Columbia,Bloomsburg 2Nd Ward,Turnout,,,Registered Voters,1145
+Columbia,Bloomsburg 2Nd Ward,Turnout,,,Ballots Cast,320
+Columbia,Bloomsburg 3-1 Ward,Turnout,,,Registered Voters,1763
+Columbia,Bloomsburg 3-1 Ward,Turnout,,,Ballots Cast,385
+Columbia,Bloomsburg 3-2 Ward,Turnout,,,Registered Voters,1701
+Columbia,Bloomsburg 3-2 Ward,Turnout,,,Ballots Cast,45
+Columbia,Bloomsburg 4Th Ward,Turnout,,,Registered Voters,1308
+Columbia,Bloomsburg 4Th Ward,Turnout,,,Ballots Cast,428
+Columbia,Briarcreek Twp Northeast,Turnout,,,Registered Voters,918
+Columbia,Briarcreek Twp Northeast,Turnout,,,Ballots Cast,307
+Columbia,Briarcreek Twp West,Turnout,,,Registered Voters,942
+Columbia,Briarcreek Twp West,Turnout,,,Ballots Cast,333
+Columbia,Briarcreek Borough,Turnout,,,Registered Voters,281
+Columbia,Briarcreek Borough,Turnout,,,Ballots Cast,81
+Columbia,Catawissa Twp,Turnout,,,Registered Voters,624
+Columbia,Catawissa Twp,Turnout,,,Ballots Cast,206
+Columbia,Catawissa Borough,Turnout,,,Registered Voters,754
+Columbia,Catawissa Borough,Turnout,,,Ballots Cast,224
+Columbia,Centralia Borough,Turnout,,,Registered Voters,3
+Columbia,Centralia Borough,Turnout,,,Ballots Cast,3
+Columbia,Cleveland Twp,Turnout,,,Registered Voters,684
+Columbia,Cleveland Twp,Turnout,,,Ballots Cast,239
+Columbia,Conyngham Twp,Turnout,,,Registered Voters,404
+Columbia,Conyngham Twp,Turnout,,,Ballots Cast,145
+Columbia,Fishingcreek Twp,Turnout,,,Registered Voters,951
+Columbia,Fishingcreek Twp,Turnout,,,Ballots Cast,317
+Columbia,Franklin Twp,Turnout,,,Registered Voters,366
+Columbia,Franklin Twp,Turnout,,,Ballots Cast,138
+Columbia,Greenwood Twp,Turnout,,,Registered Voters,1118
+Columbia,Greenwood Twp,Turnout,,,Ballots Cast,387
+Columbia,Hemlock Twp,Turnout,,,Registered Voters,1511
+Columbia,Hemlock Twp,Turnout,,,Ballots Cast,590
+Columbia,Jackson Twp,Turnout,,,Registered Voters,413
+Columbia,Jackson Twp,Turnout,,,Ballots Cast,154
+Columbia,Locust Twp,Turnout,,,Registered Voters,899
+Columbia,Locust Twp,Turnout,,,Ballots Cast,321
+Columbia,Madison Twp,Turnout,,,Registered Voters,916
+Columbia,Madison Twp,Turnout,,,Ballots Cast,386
+Columbia,Main Twp,Turnout,,,Registered Voters,832
+Columbia,Main Twp,Turnout,,,Ballots Cast,296
+Columbia,Mifflin Twp,Turnout,,,Registered Voters,1398
+Columbia,Mifflin Twp,Turnout,,,Ballots Cast,473
+Columbia,Millville Borough,Turnout,,,Registered Voters,537
+Columbia,Millville Borough,Turnout,,,Ballots Cast,201
+Columbia,Montour Twp,Turnout,,,Registered Voters,782
+Columbia,Montour Twp,Turnout,,,Ballots Cast,248
+Columbia,Mount Pleasant Twp,Turnout,,,Registered Voters,1008
+Columbia,Mount Pleasant Twp,Turnout,,,Ballots Cast,405
+Columbia,North Centre Twp,Turnout,,,Registered Voters,1262
+Columbia,North Centre Twp,Turnout,,,Ballots Cast,410
+Columbia,Orange Twp,Turnout,,,Registered Voters,777
+Columbia,Orange Twp,Turnout,,,Ballots Cast,297
+Columbia,Orangeville Borough,Turnout,,,Registered Voters,219
+Columbia,Orangeville Borough,Turnout,,,Ballots Cast,76
+Columbia,Pine Twp,Turnout,,,Registered Voters,639
+Columbia,Pine Twp,Turnout,,,Ballots Cast,225
+Columbia,Roaringcreek Twp,Turnout,,,Registered Voters,370
+Columbia,Roaringcreek Twp,Turnout,,,Ballots Cast,159
+Columbia,Scott Twp East,Turnout,,,Registered Voters,1917
+Columbia,Scott Twp East,Turnout,,,Ballots Cast,688
+Columbia,Scott Twp West,Turnout,,,Registered Voters,1752
+Columbia,Scott Twp West,Turnout,,,Ballots Cast,533
+Columbia,South Centre Twp,Turnout,,,Registered Voters,1062
+Columbia,South Centre Twp,Turnout,,,Ballots Cast,320
+Columbia,Stillwater Borough,Turnout,,,Registered Voters,127
+Columbia,Stillwater Borough,Turnout,,,Ballots Cast,54
+Columbia,Sugarloaf Twp,Turnout,,,Registered Voters,584
+Columbia,Sugarloaf Twp,Turnout,,,Ballots Cast,225
 Columbia,Beaver Twp,President Of The United States,,DEM,Bernie Sanders,15
 Columbia,Beaver Twp,President Of The United States,,DEM,Joseph R Biden,49
 Columbia,Beaver Twp,President Of The United States,,DEM,Tulsi Gabbard,9

--- a/2020/20200602__pa__primary__columbia__precinct.csv
+++ b/2020/20200602__pa__primary__columbia__precinct.csv
@@ -1,0 +1,2605 @@
+county,precinct,office,district,party,candidate,votes
+Columbia,Beaver Twp,President Of The United States,,DEM,Bernie Sanders,15
+Columbia,Beaver Twp,President Of The United States,,DEM,Joseph R Biden,49
+Columbia,Beaver Twp,President Of The United States,,DEM,Tulsi Gabbard,9
+Columbia,Beaver Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Beaver Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Beaver Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Beaver Twp,President Of The United States,,DEM,Write-In,7
+Columbia,Benton Twp,President Of The United States,,DEM,Bernie Sanders,17
+Columbia,Benton Twp,President Of The United States,,DEM,Joseph R Biden,57
+Columbia,Benton Twp,President Of The United States,,DEM,Tulsi Gabbard,7
+Columbia,Benton Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Benton Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Benton Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Benton Twp,President Of The United States,,DEM,Write-In,8
+Columbia,Benton Borough,President Of The United States,,DEM,Bernie Sanders,21
+Columbia,Benton Borough,President Of The United States,,DEM,Joseph R Biden,34
+Columbia,Benton Borough,President Of The United States,,DEM,Tulsi Gabbard,1
+Columbia,Benton Borough,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Benton Borough,President Of The United States,,DEM,Robert Casey,0
+Columbia,Benton Borough,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Benton Borough,President Of The United States,,DEM,Write-In,0
+Columbia,Berwick 1St Ward,President Of The United States,,DEM,Bernie Sanders,43
+Columbia,Berwick 1St Ward,President Of The United States,,DEM,Joseph R Biden,146
+Columbia,Berwick 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,11
+Columbia,Berwick 1St Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Berwick 1St Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Berwick 1St Ward,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Berwick 1St Ward,President Of The United States,,DEM,Write-In,15
+Columbia,Berwick 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,14
+Columbia,Berwick 2Nd Ward,President Of The United States,,DEM,Joseph R Biden,66
+Columbia,Berwick 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,6
+Columbia,Berwick 2Nd Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Berwick 2Nd Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Berwick 2Nd Ward,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Berwick 2Nd Ward,President Of The United States,,DEM,Write-In,4
+Columbia,Berwick 3Rd Ward,President Of The United States,,DEM,Bernie Sanders,20
+Columbia,Berwick 3Rd Ward,President Of The United States,,DEM,Joseph R Biden,108
+Columbia,Berwick 3Rd Ward,President Of The United States,,DEM,Tulsi Gabbard,12
+Columbia,Berwick 3Rd Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Berwick 3Rd Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Berwick 3Rd Ward,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Berwick 3Rd Ward,President Of The United States,,DEM,Write-In,12
+Columbia,Berwick 4Th Ward,President Of The United States,,DEM,Bernie Sanders,21
+Columbia,Berwick 4Th Ward,President Of The United States,,DEM,Joseph R Biden,143
+Columbia,Berwick 4Th Ward,President Of The United States,,DEM,Tulsi Gabbard,14
+Columbia,Berwick 4Th Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Berwick 4Th Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Berwick 4Th Ward,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Berwick 4Th Ward,President Of The United States,,DEM,Write-In,18
+Columbia,Bloomsburg 1St Ward,President Of The United States,,DEM,Bernie Sanders,40
+Columbia,Bloomsburg 1St Ward,President Of The United States,,DEM,Joseph R Biden,60
+Columbia,Bloomsburg 1St Ward,President Of The United States,,DEM,Tulsi Gabbard,2
+Columbia,Bloomsburg 1St Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Bloomsburg 1St Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Bloomsburg 1St Ward,President Of The United States,,DEM,Kamala Harris,1
+Columbia,Bloomsburg 1St Ward,President Of The United States,,DEM,Write-In,3
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,DEM,Bernie Sanders,62
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,DEM,Joseph R Biden,126
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,DEM,Tulsi Gabbard,6
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,DEM,Write-In,9
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,DEM,Bernie Sanders,81
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,DEM,Joseph R Biden,183
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,DEM,Tulsi Gabbard,4
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,DEM,Write-In,5
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,DEM,Bernie Sanders,26
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,DEM,Joseph R Biden,17
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,DEM,Tulsi Gabbard,0
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,DEM,Write-In,0
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,DEM,Bernie Sanders,56
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,DEM,Joseph R Biden,163
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,DEM,Tulsi Gabbard,8
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,DEM,Robert Casey,0
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,DEM,Write-In,6
+Columbia,Briarcreek Twp Northeast,President Of The United States,,DEM,Bernie Sanders,16
+Columbia,Briarcreek Twp Northeast,President Of The United States,,DEM,Joseph R Biden,68
+Columbia,Briarcreek Twp Northeast,President Of The United States,,DEM,Tulsi Gabbard,12
+Columbia,Briarcreek Twp Northeast,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Briarcreek Twp Northeast,President Of The United States,,DEM,Robert Casey,0
+Columbia,Briarcreek Twp Northeast,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Briarcreek Twp Northeast,President Of The United States,,DEM,Write-In,3
+Columbia,Briarcreek Twp West,President Of The United States,,DEM,Bernie Sanders,18
+Columbia,Briarcreek Twp West,President Of The United States,,DEM,Joseph R Biden,75
+Columbia,Briarcreek Twp West,President Of The United States,,DEM,Tulsi Gabbard,7
+Columbia,Briarcreek Twp West,President Of The United States,,DEM,Donald J Trump,1
+Columbia,Briarcreek Twp West,President Of The United States,,DEM,Robert Casey,0
+Columbia,Briarcreek Twp West,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Briarcreek Twp West,President Of The United States,,DEM,Write-In,10
+Columbia,Briarcreek Borough,President Of The United States,,DEM,Bernie Sanders,4
+Columbia,Briarcreek Borough,President Of The United States,,DEM,Joseph R Biden,26
+Columbia,Briarcreek Borough,President Of The United States,,DEM,Tulsi Gabbard,2
+Columbia,Briarcreek Borough,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Briarcreek Borough,President Of The United States,,DEM,Robert Casey,0
+Columbia,Briarcreek Borough,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Briarcreek Borough,President Of The United States,,DEM,Write-In,1
+Columbia,Catawissa Twp,President Of The United States,,DEM,Bernie Sanders,22
+Columbia,Catawissa Twp,President Of The United States,,DEM,Joseph R Biden,46
+Columbia,Catawissa Twp,President Of The United States,,DEM,Tulsi Gabbard,3
+Columbia,Catawissa Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Catawissa Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Catawissa Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Catawissa Twp,President Of The United States,,DEM,Write-In,4
+Columbia,Catawissa Borough,President Of The United States,,DEM,Bernie Sanders,22
+Columbia,Catawissa Borough,President Of The United States,,DEM,Joseph R Biden,52
+Columbia,Catawissa Borough,President Of The United States,,DEM,Tulsi Gabbard,1
+Columbia,Catawissa Borough,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Catawissa Borough,President Of The United States,,DEM,Robert Casey,0
+Columbia,Catawissa Borough,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Catawissa Borough,President Of The United States,,DEM,Write-In,10
+Columbia,Centralia Borough,President Of The United States,,DEM,Bernie Sanders,1
+Columbia,Centralia Borough,President Of The United States,,DEM,Joseph R Biden,0
+Columbia,Centralia Borough,President Of The United States,,DEM,Tulsi Gabbard,0
+Columbia,Centralia Borough,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Centralia Borough,President Of The United States,,DEM,Robert Casey,0
+Columbia,Centralia Borough,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Centralia Borough,President Of The United States,,DEM,Write-In,0
+Columbia,Cleveland Twp,President Of The United States,,DEM,Bernie Sanders,10
+Columbia,Cleveland Twp,President Of The United States,,DEM,Joseph R Biden,58
+Columbia,Cleveland Twp,President Of The United States,,DEM,Tulsi Gabbard,1
+Columbia,Cleveland Twp,President Of The United States,,DEM,Donald J Trump,5
+Columbia,Cleveland Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Cleveland Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Cleveland Twp,President Of The United States,,DEM,Write-In,3
+Columbia,Conyngham Twp,President Of The United States,,DEM,Bernie Sanders,8
+Columbia,Conyngham Twp,President Of The United States,,DEM,Joseph R Biden,37
+Columbia,Conyngham Twp,President Of The United States,,DEM,Tulsi Gabbard,7
+Columbia,Conyngham Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Conyngham Twp,President Of The United States,,DEM,Robert Casey,1
+Columbia,Conyngham Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Conyngham Twp,President Of The United States,,DEM,Write-In,8
+Columbia,Fishingcreek Twp,President Of The United States,,DEM,Bernie Sanders,14
+Columbia,Fishingcreek Twp,President Of The United States,,DEM,Joseph R Biden,79
+Columbia,Fishingcreek Twp,President Of The United States,,DEM,Tulsi Gabbard,6
+Columbia,Fishingcreek Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Fishingcreek Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Fishingcreek Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Fishingcreek Twp,President Of The United States,,DEM,Write-In,5
+Columbia,Franklin Twp,President Of The United States,,DEM,Bernie Sanders,11
+Columbia,Franklin Twp,President Of The United States,,DEM,Joseph R Biden,32
+Columbia,Franklin Twp,President Of The United States,,DEM,Tulsi Gabbard,5
+Columbia,Franklin Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Franklin Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Franklin Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Franklin Twp,President Of The United States,,DEM,Write-In,3
+Columbia,Greenwood Twp,President Of The United States,,DEM,Bernie Sanders,21
+Columbia,Greenwood Twp,President Of The United States,,DEM,Joseph R Biden,84
+Columbia,Greenwood Twp,President Of The United States,,DEM,Tulsi Gabbard,9
+Columbia,Greenwood Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Greenwood Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Greenwood Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Greenwood Twp,President Of The United States,,DEM,Write-In,10
+Columbia,Hemlock Twp,President Of The United States,,DEM,Bernie Sanders,38
+Columbia,Hemlock Twp,President Of The United States,,DEM,Joseph R Biden,182
+Columbia,Hemlock Twp,President Of The United States,,DEM,Tulsi Gabbard,7
+Columbia,Hemlock Twp,President Of The United States,,DEM,Donald J Trump,1
+Columbia,Hemlock Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Hemlock Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Hemlock Twp,President Of The United States,,DEM,Write-In,10
+Columbia,Jackson Twp,President Of The United States,,DEM,Bernie Sanders,7
+Columbia,Jackson Twp,President Of The United States,,DEM,Joseph R Biden,22
+Columbia,Jackson Twp,President Of The United States,,DEM,Tulsi Gabbard,1
+Columbia,Jackson Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Jackson Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Jackson Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Jackson Twp,President Of The United States,,DEM,Write-In,6
+Columbia,Locust Twp,President Of The United States,,DEM,Bernie Sanders,19
+Columbia,Locust Twp,President Of The United States,,DEM,Joseph R Biden,86
+Columbia,Locust Twp,President Of The United States,,DEM,Tulsi Gabbard,5
+Columbia,Locust Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Locust Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Locust Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Locust Twp,President Of The United States,,DEM,Write-In,11
+Columbia,Madison Twp,President Of The United States,,DEM,Bernie Sanders,19
+Columbia,Madison Twp,President Of The United States,,DEM,Joseph R Biden,76
+Columbia,Madison Twp,President Of The United States,,DEM,Tulsi Gabbard,8
+Columbia,Madison Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Madison Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Madison Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Madison Twp,President Of The United States,,DEM,Write-In,6
+Columbia,Main Twp,President Of The United States,,DEM,Bernie Sanders,18
+Columbia,Main Twp,President Of The United States,,DEM,Joseph R Biden,110
+Columbia,Main Twp,President Of The United States,,DEM,Tulsi Gabbard,8
+Columbia,Main Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Main Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Main Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Main Twp,President Of The United States,,DEM,Write-In,11
+Columbia,Mifflin Twp,President Of The United States,,DEM,Bernie Sanders,32
+Columbia,Mifflin Twp,President Of The United States,,DEM,Joseph R Biden,134
+Columbia,Mifflin Twp,President Of The United States,,DEM,Tulsi Gabbard,13
+Columbia,Mifflin Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Mifflin Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Mifflin Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Mifflin Twp,President Of The United States,,DEM,Write-In,14
+Columbia,Millville Borough,President Of The United States,,DEM,Bernie Sanders,17
+Columbia,Millville Borough,President Of The United States,,DEM,Joseph R Biden,38
+Columbia,Millville Borough,President Of The United States,,DEM,Tulsi Gabbard,2
+Columbia,Millville Borough,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Millville Borough,President Of The United States,,DEM,Robert Casey,0
+Columbia,Millville Borough,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Millville Borough,President Of The United States,,DEM,Write-In,4
+Columbia,Montour Twp,President Of The United States,,DEM,Bernie Sanders,17
+Columbia,Montour Twp,President Of The United States,,DEM,Joseph R Biden,82
+Columbia,Montour Twp,President Of The United States,,DEM,Tulsi Gabbard,4
+Columbia,Montour Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Montour Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Montour Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Montour Twp,President Of The United States,,DEM,Write-In,8
+Columbia,Mount Pleasant Twp,President Of The United States,,DEM,Bernie Sanders,28
+Columbia,Mount Pleasant Twp,President Of The United States,,DEM,Joseph R Biden,95
+Columbia,Mount Pleasant Twp,President Of The United States,,DEM,Tulsi Gabbard,7
+Columbia,Mount Pleasant Twp,President Of The United States,,DEM,Donald J Trump,2
+Columbia,Mount Pleasant Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Mount Pleasant Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Mount Pleasant Twp,President Of The United States,,DEM,Write-In,12
+Columbia,North Centre Twp,President Of The United States,,DEM,Bernie Sanders,19
+Columbia,North Centre Twp,President Of The United States,,DEM,Joseph R Biden,93
+Columbia,North Centre Twp,President Of The United States,,DEM,Tulsi Gabbard,7
+Columbia,North Centre Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,North Centre Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,North Centre Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,North Centre Twp,President Of The United States,,DEM,Write-In,11
+Columbia,Orange Twp,President Of The United States,,DEM,Bernie Sanders,28
+Columbia,Orange Twp,President Of The United States,,DEM,Joseph R Biden,88
+Columbia,Orange Twp,President Of The United States,,DEM,Tulsi Gabbard,4
+Columbia,Orange Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Orange Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Orange Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Orange Twp,President Of The United States,,DEM,Write-In,9
+Columbia,Orangeville Borough,President Of The United States,,DEM,Bernie Sanders,11
+Columbia,Orangeville Borough,President Of The United States,,DEM,Joseph R Biden,21
+Columbia,Orangeville Borough,President Of The United States,,DEM,Tulsi Gabbard,3
+Columbia,Orangeville Borough,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Orangeville Borough,President Of The United States,,DEM,Robert Casey,0
+Columbia,Orangeville Borough,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Orangeville Borough,President Of The United States,,DEM,Write-In,2
+Columbia,Pine Twp,President Of The United States,,DEM,Bernie Sanders,9
+Columbia,Pine Twp,President Of The United States,,DEM,Joseph R Biden,44
+Columbia,Pine Twp,President Of The United States,,DEM,Tulsi Gabbard,2
+Columbia,Pine Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Pine Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Pine Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Pine Twp,President Of The United States,,DEM,Write-In,4
+Columbia,Roaringcreek Twp,President Of The United States,,DEM,Bernie Sanders,1
+Columbia,Roaringcreek Twp,President Of The United States,,DEM,Joseph R Biden,42
+Columbia,Roaringcreek Twp,President Of The United States,,DEM,Tulsi Gabbard,1
+Columbia,Roaringcreek Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Roaringcreek Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Roaringcreek Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Roaringcreek Twp,President Of The United States,,DEM,Write-In,4
+Columbia,Scott Twp East,President Of The United States,,DEM,Bernie Sanders,45
+Columbia,Scott Twp East,President Of The United States,,DEM,Joseph R Biden,259
+Columbia,Scott Twp East,President Of The United States,,DEM,Tulsi Gabbard,8
+Columbia,Scott Twp East,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Scott Twp East,President Of The United States,,DEM,Robert Casey,0
+Columbia,Scott Twp East,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Scott Twp East,President Of The United States,,DEM,Write-In,16
+Columbia,Scott Twp West,President Of The United States,,DEM,Bernie Sanders,39
+Columbia,Scott Twp West,President Of The United States,,DEM,Joseph R Biden,200
+Columbia,Scott Twp West,President Of The United States,,DEM,Tulsi Gabbard,14
+Columbia,Scott Twp West,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Scott Twp West,President Of The United States,,DEM,Robert Casey,0
+Columbia,Scott Twp West,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Scott Twp West,President Of The United States,,DEM,Write-In,9
+Columbia,South Centre Twp,President Of The United States,,DEM,Bernie Sanders,25
+Columbia,South Centre Twp,President Of The United States,,DEM,Joseph R Biden,79
+Columbia,South Centre Twp,President Of The United States,,DEM,Tulsi Gabbard,5
+Columbia,South Centre Twp,President Of The United States,,DEM,Donald J Trump,4
+Columbia,South Centre Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,South Centre Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,South Centre Twp,President Of The United States,,DEM,Write-In,9
+Columbia,Stillwater Borough,President Of The United States,,DEM,Bernie Sanders,3
+Columbia,Stillwater Borough,President Of The United States,,DEM,Joseph R Biden,11
+Columbia,Stillwater Borough,President Of The United States,,DEM,Tulsi Gabbard,0
+Columbia,Stillwater Borough,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Stillwater Borough,President Of The United States,,DEM,Robert Casey,0
+Columbia,Stillwater Borough,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Stillwater Borough,President Of The United States,,DEM,Write-In,3
+Columbia,Sugarloaf Twp,President Of The United States,,DEM,Bernie Sanders,8
+Columbia,Sugarloaf Twp,President Of The United States,,DEM,Joseph R Biden,39
+Columbia,Sugarloaf Twp,President Of The United States,,DEM,Tulsi Gabbard,1
+Columbia,Sugarloaf Twp,President Of The United States,,DEM,Donald J Trump,0
+Columbia,Sugarloaf Twp,President Of The United States,,DEM,Robert Casey,0
+Columbia,Sugarloaf Twp,President Of The United States,,DEM,Kamala Harris,0
+Columbia,Sugarloaf Twp,President Of The United States,,DEM,Write-In,2
+Columbia,Beaver Twp,Attorney General,,DEM,Josh Shapiro,72
+Columbia,Beaver Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Beaver Twp,Attorney General,,DEM,Write-In,0
+Columbia,Benton Twp,Attorney General,,DEM,Josh Shapiro,85
+Columbia,Benton Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Benton Twp,Attorney General,,DEM,Write-In,1
+Columbia,Benton Borough,Attorney General,,DEM,Josh Shapiro,52
+Columbia,Benton Borough,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Benton Borough,Attorney General,,DEM,Write-In,0
+Columbia,Berwick 1St Ward,Attorney General,,DEM,Josh Shapiro,203
+Columbia,Berwick 1St Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Berwick 1St Ward,Attorney General,,DEM,Write-In,3
+Columbia,Berwick 2Nd Ward,Attorney General,,DEM,Josh Shapiro,86
+Columbia,Berwick 2Nd Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Berwick 2Nd Ward,Attorney General,,DEM,Write-In,0
+Columbia,Berwick 3Rd Ward,Attorney General,,DEM,Josh Shapiro,143
+Columbia,Berwick 3Rd Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Berwick 3Rd Ward,Attorney General,,DEM,Write-In,3
+Columbia,Berwick 4Th Ward,Attorney General,,DEM,Josh Shapiro,178
+Columbia,Berwick 4Th Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Berwick 4Th Ward,Attorney General,,DEM,Write-In,0
+Columbia,Bloomsburg 1St Ward,Attorney General,,DEM,Josh Shapiro,95
+Columbia,Bloomsburg 1St Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Bloomsburg 1St Ward,Attorney General,,DEM,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Attorney General,,DEM,Josh Shapiro,185
+Columbia,Bloomsburg 2Nd Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Bloomsburg 2Nd Ward,Attorney General,,DEM,Write-In,2
+Columbia,Bloomsburg 3-1 Ward,Attorney General,,DEM,Josh Shapiro,246
+Columbia,Bloomsburg 3-1 Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Bloomsburg 3-1 Ward,Attorney General,,DEM,Write-In,2
+Columbia,Bloomsburg 3-2 Ward,Attorney General,,DEM,Josh Shapiro,38
+Columbia,Bloomsburg 3-2 Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Bloomsburg 3-2 Ward,Attorney General,,DEM,Write-In,1
+Columbia,Bloomsburg 4Th Ward,Attorney General,,DEM,Josh Shapiro,220
+Columbia,Bloomsburg 4Th Ward,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Bloomsburg 4Th Ward,Attorney General,,DEM,Write-In,2
+Columbia,Briarcreek Twp Northeast,Attorney General,,DEM,Josh Shapiro,93
+Columbia,Briarcreek Twp Northeast,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Briarcreek Twp Northeast,Attorney General,,DEM,Write-In,1
+Columbia,Briarcreek Twp West,Attorney General,,DEM,Josh Shapiro,106
+Columbia,Briarcreek Twp West,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Briarcreek Twp West,Attorney General,,DEM,Write-In,0
+Columbia,Briarcreek Borough,Attorney General,,DEM,Josh Shapiro,34
+Columbia,Briarcreek Borough,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Briarcreek Borough,Attorney General,,DEM,Write-In,0
+Columbia,Catawissa Twp,Attorney General,,DEM,Josh Shapiro,71
+Columbia,Catawissa Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Catawissa Twp,Attorney General,,DEM,Write-In,0
+Columbia,Catawissa Borough,Attorney General,,DEM,Josh Shapiro,79
+Columbia,Catawissa Borough,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Catawissa Borough,Attorney General,,DEM,Write-In,0
+Columbia,Centralia Borough,Attorney General,,DEM,Josh Shapiro,1
+Columbia,Centralia Borough,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Centralia Borough,Attorney General,,DEM,Write-In,0
+Columbia,Cleveland Twp,Attorney General,,DEM,Josh Shapiro,75
+Columbia,Cleveland Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Cleveland Twp,Attorney General,,DEM,Write-In,0
+Columbia,Conyngham Twp,Attorney General,,DEM,Josh Shapiro,56
+Columbia,Conyngham Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Conyngham Twp,Attorney General,,DEM,Write-In,2
+Columbia,Fishingcreek Twp,Attorney General,,DEM,Josh Shapiro,100
+Columbia,Fishingcreek Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Fishingcreek Twp,Attorney General,,DEM,Write-In,3
+Columbia,Franklin Twp,Attorney General,,DEM,Josh Shapiro,43
+Columbia,Franklin Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Franklin Twp,Attorney General,,DEM,Write-In,2
+Columbia,Greenwood Twp,Attorney General,,DEM,Josh Shapiro,112
+Columbia,Greenwood Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Greenwood Twp,Attorney General,,DEM,Write-In,0
+Columbia,Hemlock Twp,Attorney General,,DEM,Josh Shapiro,226
+Columbia,Hemlock Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Hemlock Twp,Attorney General,,DEM,Write-In,1
+Columbia,Jackson Twp,Attorney General,,DEM,Josh Shapiro,32
+Columbia,Jackson Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Jackson Twp,Attorney General,,DEM,Write-In,1
+Columbia,Locust Twp,Attorney General,,DEM,Josh Shapiro,109
+Columbia,Locust Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Locust Twp,Attorney General,,DEM,Write-In,2
+Columbia,Madison Twp,Attorney General,,DEM,Josh Shapiro,103
+Columbia,Madison Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Madison Twp,Attorney General,,DEM,Write-In,2
+Columbia,Main Twp,Attorney General,,DEM,Josh Shapiro,129
+Columbia,Main Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Main Twp,Attorney General,,DEM,Write-In,0
+Columbia,Mifflin Twp,Attorney General,,DEM,Josh Shapiro,188
+Columbia,Mifflin Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Mifflin Twp,Attorney General,,DEM,Write-In,2
+Columbia,Millville Borough,Attorney General,,DEM,Josh Shapiro,51
+Columbia,Millville Borough,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Millville Borough,Attorney General,,DEM,Write-In,1
+Columbia,Montour Twp,Attorney General,,DEM,Josh Shapiro,101
+Columbia,Montour Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Montour Twp,Attorney General,,DEM,Write-In,1
+Columbia,Mount Pleasant Twp,Attorney General,,DEM,Josh Shapiro,128
+Columbia,Mount Pleasant Twp,Attorney General,,DEM,Heather Heidelbaugh,1
+Columbia,Mount Pleasant Twp,Attorney General,,DEM,Write-In,2
+Columbia,North Centre Twp,Attorney General,,DEM,Josh Shapiro,128
+Columbia,North Centre Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,North Centre Twp,Attorney General,,DEM,Write-In,1
+Columbia,Orange Twp,Attorney General,,DEM,Josh Shapiro,118
+Columbia,Orange Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Orange Twp,Attorney General,,DEM,Write-In,0
+Columbia,Orangeville Borough,Attorney General,,DEM,Josh Shapiro,33
+Columbia,Orangeville Borough,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Orangeville Borough,Attorney General,,DEM,Write-In,0
+Columbia,Pine Twp,Attorney General,,DEM,Josh Shapiro,54
+Columbia,Pine Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Pine Twp,Attorney General,,DEM,Write-In,0
+Columbia,Roaringcreek Twp,Attorney General,,DEM,Josh Shapiro,45
+Columbia,Roaringcreek Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Roaringcreek Twp,Attorney General,,DEM,Write-In,0
+Columbia,Scott Twp East,Attorney General,,DEM,Josh Shapiro,313
+Columbia,Scott Twp East,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Scott Twp East,Attorney General,,DEM,Write-In,2
+Columbia,Scott Twp West,Attorney General,,DEM,Josh Shapiro,251
+Columbia,Scott Twp West,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Scott Twp West,Attorney General,,DEM,Write-In,4
+Columbia,South Centre Twp,Attorney General,,DEM,Josh Shapiro,105
+Columbia,South Centre Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,South Centre Twp,Attorney General,,DEM,Write-In,3
+Columbia,Stillwater Borough,Attorney General,,DEM,Josh Shapiro,16
+Columbia,Stillwater Borough,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Stillwater Borough,Attorney General,,DEM,Write-In,0
+Columbia,Sugarloaf Twp,Attorney General,,DEM,Josh Shapiro,47
+Columbia,Sugarloaf Twp,Attorney General,,DEM,Heather Heidelbaugh,0
+Columbia,Sugarloaf Twp,Attorney General,,DEM,Write-In,0
+Columbia,Beaver Twp,Auditor General,,DEM,H Scott Conklin,18
+Columbia,Beaver Twp,Auditor General,,DEM,Michael Lamb,13
+Columbia,Beaver Twp,Auditor General,,DEM,Tracie Fountain,16
+Columbia,Beaver Twp,Auditor General,,DEM,Rose Rosie Marie Davis,14
+Columbia,Beaver Twp,Auditor General,,DEM,Nina Ahmad,6
+Columbia,Beaver Twp,Auditor General,,DEM,Christina M Hartman,12
+Columbia,Beaver Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Beaver Twp,Auditor General,,DEM,Write-In,0
+Columbia,Benton Twp,Auditor General,,DEM,H Scott Conklin,15
+Columbia,Benton Twp,Auditor General,,DEM,Michael Lamb,12
+Columbia,Benton Twp,Auditor General,,DEM,Tracie Fountain,12
+Columbia,Benton Twp,Auditor General,,DEM,Rose Rosie Marie Davis,10
+Columbia,Benton Twp,Auditor General,,DEM,Nina Ahmad,14
+Columbia,Benton Twp,Auditor General,,DEM,Christina M Hartman,17
+Columbia,Benton Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Benton Twp,Auditor General,,DEM,Write-In,2
+Columbia,Benton Borough,Auditor General,,DEM,H Scott Conklin,6
+Columbia,Benton Borough,Auditor General,,DEM,Michael Lamb,10
+Columbia,Benton Borough,Auditor General,,DEM,Tracie Fountain,6
+Columbia,Benton Borough,Auditor General,,DEM,Rose Rosie Marie Davis,8
+Columbia,Benton Borough,Auditor General,,DEM,Nina Ahmad,12
+Columbia,Benton Borough,Auditor General,,DEM,Christina M Hartman,11
+Columbia,Benton Borough,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Benton Borough,Auditor General,,DEM,Write-In,0
+Columbia,Berwick 1St Ward,Auditor General,,DEM,H Scott Conklin,41
+Columbia,Berwick 1St Ward,Auditor General,,DEM,Michael Lamb,33
+Columbia,Berwick 1St Ward,Auditor General,,DEM,Tracie Fountain,19
+Columbia,Berwick 1St Ward,Auditor General,,DEM,Rose Rosie Marie Davis,32
+Columbia,Berwick 1St Ward,Auditor General,,DEM,Nina Ahmad,36
+Columbia,Berwick 1St Ward,Auditor General,,DEM,Christina M Hartman,41
+Columbia,Berwick 1St Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Berwick 1St Ward,Auditor General,,DEM,Write-In,1
+Columbia,Berwick 2Nd Ward,Auditor General,,DEM,H Scott Conklin,21
+Columbia,Berwick 2Nd Ward,Auditor General,,DEM,Michael Lamb,11
+Columbia,Berwick 2Nd Ward,Auditor General,,DEM,Tracie Fountain,8
+Columbia,Berwick 2Nd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,11
+Columbia,Berwick 2Nd Ward,Auditor General,,DEM,Nina Ahmad,21
+Columbia,Berwick 2Nd Ward,Auditor General,,DEM,Christina M Hartman,14
+Columbia,Berwick 2Nd Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Berwick 2Nd Ward,Auditor General,,DEM,Write-In,0
+Columbia,Berwick 3Rd Ward,Auditor General,,DEM,H Scott Conklin,35
+Columbia,Berwick 3Rd Ward,Auditor General,,DEM,Michael Lamb,22
+Columbia,Berwick 3Rd Ward,Auditor General,,DEM,Tracie Fountain,13
+Columbia,Berwick 3Rd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,21
+Columbia,Berwick 3Rd Ward,Auditor General,,DEM,Nina Ahmad,25
+Columbia,Berwick 3Rd Ward,Auditor General,,DEM,Christina M Hartman,22
+Columbia,Berwick 3Rd Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Berwick 3Rd Ward,Auditor General,,DEM,Write-In,4
+Columbia,Berwick 4Th Ward,Auditor General,,DEM,H Scott Conklin,50
+Columbia,Berwick 4Th Ward,Auditor General,,DEM,Michael Lamb,23
+Columbia,Berwick 4Th Ward,Auditor General,,DEM,Tracie Fountain,16
+Columbia,Berwick 4Th Ward,Auditor General,,DEM,Rose Rosie Marie Davis,23
+Columbia,Berwick 4Th Ward,Auditor General,,DEM,Nina Ahmad,32
+Columbia,Berwick 4Th Ward,Auditor General,,DEM,Christina M Hartman,40
+Columbia,Berwick 4Th Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Berwick 4Th Ward,Auditor General,,DEM,Write-In,0
+Columbia,Bloomsburg 1St Ward,Auditor General,,DEM,H Scott Conklin,16
+Columbia,Bloomsburg 1St Ward,Auditor General,,DEM,Michael Lamb,12
+Columbia,Bloomsburg 1St Ward,Auditor General,,DEM,Tracie Fountain,9
+Columbia,Bloomsburg 1St Ward,Auditor General,,DEM,Rose Rosie Marie Davis,10
+Columbia,Bloomsburg 1St Ward,Auditor General,,DEM,Nina Ahmad,33
+Columbia,Bloomsburg 1St Ward,Auditor General,,DEM,Christina M Hartman,15
+Columbia,Bloomsburg 1St Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Bloomsburg 1St Ward,Auditor General,,DEM,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,DEM,H Scott Conklin,27
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,DEM,Michael Lamb,25
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,DEM,Tracie Fountain,41
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,DEM,Rose Rosie Marie Davis,11
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,DEM,Nina Ahmad,49
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,DEM,Christina M Hartman,34
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,DEM,Write-In,1
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,DEM,H Scott Conklin,46
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,DEM,Michael Lamb,28
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,DEM,Tracie Fountain,48
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,DEM,Rose Rosie Marie Davis,23
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,DEM,Nina Ahmad,73
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,DEM,Christina M Hartman,36
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,DEM,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,DEM,H Scott Conklin,3
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,DEM,Michael Lamb,7
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,DEM,Tracie Fountain,8
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,DEM,Rose Rosie Marie Davis,4
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,DEM,Nina Ahmad,16
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,DEM,Christina M Hartman,2
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,DEM,Write-In,0
+Columbia,Bloomsburg 4Th Ward,Auditor General,,DEM,H Scott Conklin,47
+Columbia,Bloomsburg 4Th Ward,Auditor General,,DEM,Michael Lamb,23
+Columbia,Bloomsburg 4Th Ward,Auditor General,,DEM,Tracie Fountain,25
+Columbia,Bloomsburg 4Th Ward,Auditor General,,DEM,Rose Rosie Marie Davis,22
+Columbia,Bloomsburg 4Th Ward,Auditor General,,DEM,Nina Ahmad,56
+Columbia,Bloomsburg 4Th Ward,Auditor General,,DEM,Christina M Hartman,40
+Columbia,Bloomsburg 4Th Ward,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Bloomsburg 4Th Ward,Auditor General,,DEM,Write-In,2
+Columbia,Briarcreek Twp Northeast,Auditor General,,DEM,H Scott Conklin,24
+Columbia,Briarcreek Twp Northeast,Auditor General,,DEM,Michael Lamb,13
+Columbia,Briarcreek Twp Northeast,Auditor General,,DEM,Tracie Fountain,5
+Columbia,Briarcreek Twp Northeast,Auditor General,,DEM,Rose Rosie Marie Davis,14
+Columbia,Briarcreek Twp Northeast,Auditor General,,DEM,Nina Ahmad,16
+Columbia,Briarcreek Twp Northeast,Auditor General,,DEM,Christina M Hartman,23
+Columbia,Briarcreek Twp Northeast,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Briarcreek Twp Northeast,Auditor General,,DEM,Write-In,0
+Columbia,Briarcreek Twp West,Auditor General,,DEM,H Scott Conklin,29
+Columbia,Briarcreek Twp West,Auditor General,,DEM,Michael Lamb,13
+Columbia,Briarcreek Twp West,Auditor General,,DEM,Tracie Fountain,14
+Columbia,Briarcreek Twp West,Auditor General,,DEM,Rose Rosie Marie Davis,13
+Columbia,Briarcreek Twp West,Auditor General,,DEM,Nina Ahmad,14
+Columbia,Briarcreek Twp West,Auditor General,,DEM,Christina M Hartman,26
+Columbia,Briarcreek Twp West,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Briarcreek Twp West,Auditor General,,DEM,Write-In,0
+Columbia,Briarcreek Borough,Auditor General,,DEM,H Scott Conklin,9
+Columbia,Briarcreek Borough,Auditor General,,DEM,Michael Lamb,7
+Columbia,Briarcreek Borough,Auditor General,,DEM,Tracie Fountain,0
+Columbia,Briarcreek Borough,Auditor General,,DEM,Rose Rosie Marie Davis,4
+Columbia,Briarcreek Borough,Auditor General,,DEM,Nina Ahmad,6
+Columbia,Briarcreek Borough,Auditor General,,DEM,Christina M Hartman,8
+Columbia,Briarcreek Borough,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Briarcreek Borough,Auditor General,,DEM,Write-In,0
+Columbia,Catawissa Twp,Auditor General,,DEM,H Scott Conklin,16
+Columbia,Catawissa Twp,Auditor General,,DEM,Michael Lamb,10
+Columbia,Catawissa Twp,Auditor General,,DEM,Tracie Fountain,13
+Columbia,Catawissa Twp,Auditor General,,DEM,Rose Rosie Marie Davis,5
+Columbia,Catawissa Twp,Auditor General,,DEM,Nina Ahmad,11
+Columbia,Catawissa Twp,Auditor General,,DEM,Christina M Hartman,11
+Columbia,Catawissa Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Catawissa Twp,Auditor General,,DEM,Write-In,0
+Columbia,Catawissa Borough,Auditor General,,DEM,H Scott Conklin,11
+Columbia,Catawissa Borough,Auditor General,,DEM,Michael Lamb,13
+Columbia,Catawissa Borough,Auditor General,,DEM,Tracie Fountain,12
+Columbia,Catawissa Borough,Auditor General,,DEM,Rose Rosie Marie Davis,10
+Columbia,Catawissa Borough,Auditor General,,DEM,Nina Ahmad,17
+Columbia,Catawissa Borough,Auditor General,,DEM,Christina M Hartman,17
+Columbia,Catawissa Borough,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Catawissa Borough,Auditor General,,DEM,Write-In,0
+Columbia,Centralia Borough,Auditor General,,DEM,H Scott Conklin,0
+Columbia,Centralia Borough,Auditor General,,DEM,Michael Lamb,0
+Columbia,Centralia Borough,Auditor General,,DEM,Tracie Fountain,0
+Columbia,Centralia Borough,Auditor General,,DEM,Rose Rosie Marie Davis,0
+Columbia,Centralia Borough,Auditor General,,DEM,Nina Ahmad,0
+Columbia,Centralia Borough,Auditor General,,DEM,Christina M Hartman,1
+Columbia,Centralia Borough,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Centralia Borough,Auditor General,,DEM,Write-In,0
+Columbia,Cleveland Twp,Auditor General,,DEM,H Scott Conklin,18
+Columbia,Cleveland Twp,Auditor General,,DEM,Michael Lamb,17
+Columbia,Cleveland Twp,Auditor General,,DEM,Tracie Fountain,13
+Columbia,Cleveland Twp,Auditor General,,DEM,Rose Rosie Marie Davis,2
+Columbia,Cleveland Twp,Auditor General,,DEM,Nina Ahmad,11
+Columbia,Cleveland Twp,Auditor General,,DEM,Christina M Hartman,12
+Columbia,Cleveland Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Cleveland Twp,Auditor General,,DEM,Write-In,0
+Columbia,Conyngham Twp,Auditor General,,DEM,H Scott Conklin,8
+Columbia,Conyngham Twp,Auditor General,,DEM,Michael Lamb,11
+Columbia,Conyngham Twp,Auditor General,,DEM,Tracie Fountain,8
+Columbia,Conyngham Twp,Auditor General,,DEM,Rose Rosie Marie Davis,9
+Columbia,Conyngham Twp,Auditor General,,DEM,Nina Ahmad,5
+Columbia,Conyngham Twp,Auditor General,,DEM,Christina M Hartman,17
+Columbia,Conyngham Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Conyngham Twp,Auditor General,,DEM,Write-In,1
+Columbia,Fishingcreek Twp,Auditor General,,DEM,H Scott Conklin,30
+Columbia,Fishingcreek Twp,Auditor General,,DEM,Michael Lamb,13
+Columbia,Fishingcreek Twp,Auditor General,,DEM,Tracie Fountain,7
+Columbia,Fishingcreek Twp,Auditor General,,DEM,Rose Rosie Marie Davis,7
+Columbia,Fishingcreek Twp,Auditor General,,DEM,Nina Ahmad,15
+Columbia,Fishingcreek Twp,Auditor General,,DEM,Christina M Hartman,26
+Columbia,Fishingcreek Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Fishingcreek Twp,Auditor General,,DEM,Write-In,2
+Columbia,Franklin Twp,Auditor General,,DEM,H Scott Conklin,8
+Columbia,Franklin Twp,Auditor General,,DEM,Michael Lamb,6
+Columbia,Franklin Twp,Auditor General,,DEM,Tracie Fountain,8
+Columbia,Franklin Twp,Auditor General,,DEM,Rose Rosie Marie Davis,2
+Columbia,Franklin Twp,Auditor General,,DEM,Nina Ahmad,8
+Columbia,Franklin Twp,Auditor General,,DEM,Christina M Hartman,12
+Columbia,Franklin Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Franklin Twp,Auditor General,,DEM,Write-In,2
+Columbia,Greenwood Twp,Auditor General,,DEM,H Scott Conklin,25
+Columbia,Greenwood Twp,Auditor General,,DEM,Michael Lamb,14
+Columbia,Greenwood Twp,Auditor General,,DEM,Tracie Fountain,18
+Columbia,Greenwood Twp,Auditor General,,DEM,Rose Rosie Marie Davis,12
+Columbia,Greenwood Twp,Auditor General,,DEM,Nina Ahmad,15
+Columbia,Greenwood Twp,Auditor General,,DEM,Christina M Hartman,25
+Columbia,Greenwood Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Greenwood Twp,Auditor General,,DEM,Write-In,0
+Columbia,Hemlock Twp,Auditor General,,DEM,H Scott Conklin,48
+Columbia,Hemlock Twp,Auditor General,,DEM,Michael Lamb,28
+Columbia,Hemlock Twp,Auditor General,,DEM,Tracie Fountain,32
+Columbia,Hemlock Twp,Auditor General,,DEM,Rose Rosie Marie Davis,18
+Columbia,Hemlock Twp,Auditor General,,DEM,Nina Ahmad,46
+Columbia,Hemlock Twp,Auditor General,,DEM,Christina M Hartman,46
+Columbia,Hemlock Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Hemlock Twp,Auditor General,,DEM,Write-In,1
+Columbia,Jackson Twp,Auditor General,,DEM,H Scott Conklin,5
+Columbia,Jackson Twp,Auditor General,,DEM,Michael Lamb,4
+Columbia,Jackson Twp,Auditor General,,DEM,Tracie Fountain,5
+Columbia,Jackson Twp,Auditor General,,DEM,Rose Rosie Marie Davis,2
+Columbia,Jackson Twp,Auditor General,,DEM,Nina Ahmad,12
+Columbia,Jackson Twp,Auditor General,,DEM,Christina M Hartman,6
+Columbia,Jackson Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Jackson Twp,Auditor General,,DEM,Write-In,1
+Columbia,Locust Twp,Auditor General,,DEM,H Scott Conklin,36
+Columbia,Locust Twp,Auditor General,,DEM,Michael Lamb,12
+Columbia,Locust Twp,Auditor General,,DEM,Tracie Fountain,14
+Columbia,Locust Twp,Auditor General,,DEM,Rose Rosie Marie Davis,10
+Columbia,Locust Twp,Auditor General,,DEM,Nina Ahmad,17
+Columbia,Locust Twp,Auditor General,,DEM,Christina M Hartman,26
+Columbia,Locust Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Locust Twp,Auditor General,,DEM,Write-In,1
+Columbia,Madison Twp,Auditor General,,DEM,H Scott Conklin,40
+Columbia,Madison Twp,Auditor General,,DEM,Michael Lamb,17
+Columbia,Madison Twp,Auditor General,,DEM,Tracie Fountain,10
+Columbia,Madison Twp,Auditor General,,DEM,Rose Rosie Marie Davis,8
+Columbia,Madison Twp,Auditor General,,DEM,Nina Ahmad,11
+Columbia,Madison Twp,Auditor General,,DEM,Christina M Hartman,17
+Columbia,Madison Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Madison Twp,Auditor General,,DEM,Write-In,1
+Columbia,Main Twp,Auditor General,,DEM,H Scott Conklin,43
+Columbia,Main Twp,Auditor General,,DEM,Michael Lamb,16
+Columbia,Main Twp,Auditor General,,DEM,Tracie Fountain,10
+Columbia,Main Twp,Auditor General,,DEM,Rose Rosie Marie Davis,13
+Columbia,Main Twp,Auditor General,,DEM,Nina Ahmad,21
+Columbia,Main Twp,Auditor General,,DEM,Christina M Hartman,33
+Columbia,Main Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Main Twp,Auditor General,,DEM,Write-In,0
+Columbia,Mifflin Twp,Auditor General,,DEM,H Scott Conklin,46
+Columbia,Mifflin Twp,Auditor General,,DEM,Michael Lamb,39
+Columbia,Mifflin Twp,Auditor General,,DEM,Tracie Fountain,18
+Columbia,Mifflin Twp,Auditor General,,DEM,Rose Rosie Marie Davis,23
+Columbia,Mifflin Twp,Auditor General,,DEM,Nina Ahmad,26
+Columbia,Mifflin Twp,Auditor General,,DEM,Christina M Hartman,29
+Columbia,Mifflin Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Mifflin Twp,Auditor General,,DEM,Write-In,2
+Columbia,Millville Borough,Auditor General,,DEM,H Scott Conklin,10
+Columbia,Millville Borough,Auditor General,,DEM,Michael Lamb,5
+Columbia,Millville Borough,Auditor General,,DEM,Tracie Fountain,11
+Columbia,Millville Borough,Auditor General,,DEM,Rose Rosie Marie Davis,9
+Columbia,Millville Borough,Auditor General,,DEM,Nina Ahmad,9
+Columbia,Millville Borough,Auditor General,,DEM,Christina M Hartman,10
+Columbia,Millville Borough,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Millville Borough,Auditor General,,DEM,Write-In,1
+Columbia,Montour Twp,Auditor General,,DEM,H Scott Conklin,24
+Columbia,Montour Twp,Auditor General,,DEM,Michael Lamb,17
+Columbia,Montour Twp,Auditor General,,DEM,Tracie Fountain,13
+Columbia,Montour Twp,Auditor General,,DEM,Rose Rosie Marie Davis,9
+Columbia,Montour Twp,Auditor General,,DEM,Nina Ahmad,20
+Columbia,Montour Twp,Auditor General,,DEM,Christina M Hartman,21
+Columbia,Montour Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Montour Twp,Auditor General,,DEM,Write-In,1
+Columbia,Mount Pleasant Twp,Auditor General,,DEM,H Scott Conklin,39
+Columbia,Mount Pleasant Twp,Auditor General,,DEM,Michael Lamb,19
+Columbia,Mount Pleasant Twp,Auditor General,,DEM,Tracie Fountain,17
+Columbia,Mount Pleasant Twp,Auditor General,,DEM,Rose Rosie Marie Davis,10
+Columbia,Mount Pleasant Twp,Auditor General,,DEM,Nina Ahmad,18
+Columbia,Mount Pleasant Twp,Auditor General,,DEM,Christina M Hartman,19
+Columbia,Mount Pleasant Twp,Auditor General,,DEM,Timothy Defoor,1
+Columbia,Mount Pleasant Twp,Auditor General,,DEM,Write-In,2
+Columbia,North Centre Twp,Auditor General,,DEM,H Scott Conklin,41
+Columbia,North Centre Twp,Auditor General,,DEM,Michael Lamb,22
+Columbia,North Centre Twp,Auditor General,,DEM,Tracie Fountain,19
+Columbia,North Centre Twp,Auditor General,,DEM,Rose Rosie Marie Davis,13
+Columbia,North Centre Twp,Auditor General,,DEM,Nina Ahmad,19
+Columbia,North Centre Twp,Auditor General,,DEM,Christina M Hartman,17
+Columbia,North Centre Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,North Centre Twp,Auditor General,,DEM,Write-In,1
+Columbia,Orange Twp,Auditor General,,DEM,H Scott Conklin,30
+Columbia,Orange Twp,Auditor General,,DEM,Michael Lamb,15
+Columbia,Orange Twp,Auditor General,,DEM,Tracie Fountain,9
+Columbia,Orange Twp,Auditor General,,DEM,Rose Rosie Marie Davis,20
+Columbia,Orange Twp,Auditor General,,DEM,Nina Ahmad,27
+Columbia,Orange Twp,Auditor General,,DEM,Christina M Hartman,18
+Columbia,Orange Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Orange Twp,Auditor General,,DEM,Write-In,1
+Columbia,Orangeville Borough,Auditor General,,DEM,H Scott Conklin,6
+Columbia,Orangeville Borough,Auditor General,,DEM,Michael Lamb,4
+Columbia,Orangeville Borough,Auditor General,,DEM,Tracie Fountain,6
+Columbia,Orangeville Borough,Auditor General,,DEM,Rose Rosie Marie Davis,5
+Columbia,Orangeville Borough,Auditor General,,DEM,Nina Ahmad,7
+Columbia,Orangeville Borough,Auditor General,,DEM,Christina M Hartman,6
+Columbia,Orangeville Borough,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Orangeville Borough,Auditor General,,DEM,Write-In,0
+Columbia,Pine Twp,Auditor General,,DEM,H Scott Conklin,21
+Columbia,Pine Twp,Auditor General,,DEM,Michael Lamb,5
+Columbia,Pine Twp,Auditor General,,DEM,Tracie Fountain,5
+Columbia,Pine Twp,Auditor General,,DEM,Rose Rosie Marie Davis,7
+Columbia,Pine Twp,Auditor General,,DEM,Nina Ahmad,3
+Columbia,Pine Twp,Auditor General,,DEM,Christina M Hartman,6
+Columbia,Pine Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Pine Twp,Auditor General,,DEM,Write-In,0
+Columbia,Roaringcreek Twp,Auditor General,,DEM,H Scott Conklin,10
+Columbia,Roaringcreek Twp,Auditor General,,DEM,Michael Lamb,8
+Columbia,Roaringcreek Twp,Auditor General,,DEM,Tracie Fountain,6
+Columbia,Roaringcreek Twp,Auditor General,,DEM,Rose Rosie Marie Davis,7
+Columbia,Roaringcreek Twp,Auditor General,,DEM,Nina Ahmad,5
+Columbia,Roaringcreek Twp,Auditor General,,DEM,Christina M Hartman,7
+Columbia,Roaringcreek Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Roaringcreek Twp,Auditor General,,DEM,Write-In,0
+Columbia,Scott Twp East,Auditor General,,DEM,H Scott Conklin,73
+Columbia,Scott Twp East,Auditor General,,DEM,Michael Lamb,34
+Columbia,Scott Twp East,Auditor General,,DEM,Tracie Fountain,43
+Columbia,Scott Twp East,Auditor General,,DEM,Rose Rosie Marie Davis,27
+Columbia,Scott Twp East,Auditor General,,DEM,Nina Ahmad,70
+Columbia,Scott Twp East,Auditor General,,DEM,Christina M Hartman,61
+Columbia,Scott Twp East,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Scott Twp East,Auditor General,,DEM,Write-In,2
+Columbia,Scott Twp West,Auditor General,,DEM,H Scott Conklin,49
+Columbia,Scott Twp West,Auditor General,,DEM,Michael Lamb,40
+Columbia,Scott Twp West,Auditor General,,DEM,Tracie Fountain,40
+Columbia,Scott Twp West,Auditor General,,DEM,Rose Rosie Marie Davis,16
+Columbia,Scott Twp West,Auditor General,,DEM,Nina Ahmad,46
+Columbia,Scott Twp West,Auditor General,,DEM,Christina M Hartman,57
+Columbia,Scott Twp West,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Scott Twp West,Auditor General,,DEM,Write-In,1
+Columbia,South Centre Twp,Auditor General,,DEM,H Scott Conklin,30
+Columbia,South Centre Twp,Auditor General,,DEM,Michael Lamb,16
+Columbia,South Centre Twp,Auditor General,,DEM,Tracie Fountain,14
+Columbia,South Centre Twp,Auditor General,,DEM,Rose Rosie Marie Davis,11
+Columbia,South Centre Twp,Auditor General,,DEM,Nina Ahmad,16
+Columbia,South Centre Twp,Auditor General,,DEM,Christina M Hartman,18
+Columbia,South Centre Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,South Centre Twp,Auditor General,,DEM,Write-In,4
+Columbia,Stillwater Borough,Auditor General,,DEM,H Scott Conklin,3
+Columbia,Stillwater Borough,Auditor General,,DEM,Michael Lamb,3
+Columbia,Stillwater Borough,Auditor General,,DEM,Tracie Fountain,1
+Columbia,Stillwater Borough,Auditor General,,DEM,Rose Rosie Marie Davis,0
+Columbia,Stillwater Borough,Auditor General,,DEM,Nina Ahmad,0
+Columbia,Stillwater Borough,Auditor General,,DEM,Christina M Hartman,8
+Columbia,Stillwater Borough,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Stillwater Borough,Auditor General,,DEM,Write-In,0
+Columbia,Sugarloaf Twp,Auditor General,,DEM,H Scott Conklin,10
+Columbia,Sugarloaf Twp,Auditor General,,DEM,Michael Lamb,8
+Columbia,Sugarloaf Twp,Auditor General,,DEM,Tracie Fountain,7
+Columbia,Sugarloaf Twp,Auditor General,,DEM,Rose Rosie Marie Davis,7
+Columbia,Sugarloaf Twp,Auditor General,,DEM,Nina Ahmad,6
+Columbia,Sugarloaf Twp,Auditor General,,DEM,Christina M Hartman,11
+Columbia,Sugarloaf Twp,Auditor General,,DEM,Timothy Defoor,0
+Columbia,Sugarloaf Twp,Auditor General,,DEM,Write-In,0
+Columbia,Beaver Twp,State Treasurer,,DEM,Joe Torsella,74
+Columbia,Beaver Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Beaver Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Benton Twp,State Treasurer,,DEM,Joe Torsella,80
+Columbia,Benton Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Benton Twp,State Treasurer,,DEM,Write-In,2
+Columbia,Benton Borough,State Treasurer,,DEM,Joe Torsella,53
+Columbia,Benton Borough,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Benton Borough,State Treasurer,,DEM,Write-In,0
+Columbia,Berwick 1St Ward,State Treasurer,,DEM,Joe Torsella,213
+Columbia,Berwick 1St Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Berwick 1St Ward,State Treasurer,,DEM,Write-In,2
+Columbia,Berwick 2Nd Ward,State Treasurer,,DEM,Joe Torsella,88
+Columbia,Berwick 2Nd Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Berwick 2Nd Ward,State Treasurer,,DEM,Write-In,0
+Columbia,Berwick 3Rd Ward,State Treasurer,,DEM,Joe Torsella,152
+Columbia,Berwick 3Rd Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Berwick 3Rd Ward,State Treasurer,,DEM,Write-In,1
+Columbia,Berwick 4Th Ward,State Treasurer,,DEM,Joe Torsella,195
+Columbia,Berwick 4Th Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Berwick 4Th Ward,State Treasurer,,DEM,Write-In,0
+Columbia,Bloomsburg 1St Ward,State Treasurer,,DEM,Joe Torsella,94
+Columbia,Bloomsburg 1St Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Bloomsburg 1St Ward,State Treasurer,,DEM,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,State Treasurer,,DEM,Joe Torsella,177
+Columbia,Bloomsburg 2Nd Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Bloomsburg 2Nd Ward,State Treasurer,,DEM,Write-In,2
+Columbia,Bloomsburg 3-1 Ward,State Treasurer,,DEM,Joe Torsella,248
+Columbia,Bloomsburg 3-1 Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Bloomsburg 3-1 Ward,State Treasurer,,DEM,Write-In,3
+Columbia,Bloomsburg 3-2 Ward,State Treasurer,,DEM,Joe Torsella,38
+Columbia,Bloomsburg 3-2 Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Bloomsburg 3-2 Ward,State Treasurer,,DEM,Write-In,0
+Columbia,Bloomsburg 4Th Ward,State Treasurer,,DEM,Joe Torsella,213
+Columbia,Bloomsburg 4Th Ward,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Bloomsburg 4Th Ward,State Treasurer,,DEM,Write-In,1
+Columbia,Briarcreek Twp Northeast,State Treasurer,,DEM,Joe Torsella,97
+Columbia,Briarcreek Twp Northeast,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Briarcreek Twp Northeast,State Treasurer,,DEM,Write-In,0
+Columbia,Briarcreek Twp West,State Treasurer,,DEM,Joe Torsella,110
+Columbia,Briarcreek Twp West,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Briarcreek Twp West,State Treasurer,,DEM,Write-In,0
+Columbia,Briarcreek Borough,State Treasurer,,DEM,Joe Torsella,33
+Columbia,Briarcreek Borough,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Briarcreek Borough,State Treasurer,,DEM,Write-In,0
+Columbia,Catawissa Twp,State Treasurer,,DEM,Joe Torsella,69
+Columbia,Catawissa Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Catawissa Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Catawissa Borough,State Treasurer,,DEM,Joe Torsella,78
+Columbia,Catawissa Borough,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Catawissa Borough,State Treasurer,,DEM,Write-In,0
+Columbia,Centralia Borough,State Treasurer,,DEM,Joe Torsella,1
+Columbia,Centralia Borough,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Centralia Borough,State Treasurer,,DEM,Write-In,0
+Columbia,Cleveland Twp,State Treasurer,,DEM,Joe Torsella,73
+Columbia,Cleveland Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Cleveland Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Conyngham Twp,State Treasurer,,DEM,Joe Torsella,56
+Columbia,Conyngham Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Conyngham Twp,State Treasurer,,DEM,Write-In,2
+Columbia,Fishingcreek Twp,State Treasurer,,DEM,Joe Torsella,103
+Columbia,Fishingcreek Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Fishingcreek Twp,State Treasurer,,DEM,Write-In,1
+Columbia,Franklin Twp,State Treasurer,,DEM,Joe Torsella,45
+Columbia,Franklin Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Franklin Twp,State Treasurer,,DEM,Write-In,2
+Columbia,Greenwood Twp,State Treasurer,,DEM,Joe Torsella,112
+Columbia,Greenwood Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Greenwood Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Hemlock Twp,State Treasurer,,DEM,Joe Torsella,223
+Columbia,Hemlock Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Hemlock Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Jackson Twp,State Treasurer,,DEM,Joe Torsella,34
+Columbia,Jackson Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Jackson Twp,State Treasurer,,DEM,Write-In,1
+Columbia,Locust Twp,State Treasurer,,DEM,Joe Torsella,108
+Columbia,Locust Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Locust Twp,State Treasurer,,DEM,Write-In,1
+Columbia,Madison Twp,State Treasurer,,DEM,Joe Torsella,102
+Columbia,Madison Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Madison Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Main Twp,State Treasurer,,DEM,Joe Torsella,125
+Columbia,Main Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Main Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Mifflin Twp,State Treasurer,,DEM,Joe Torsella,184
+Columbia,Mifflin Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Mifflin Twp,State Treasurer,,DEM,Write-In,3
+Columbia,Millville Borough,State Treasurer,,DEM,Joe Torsella,52
+Columbia,Millville Borough,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Millville Borough,State Treasurer,,DEM,Write-In,0
+Columbia,Montour Twp,State Treasurer,,DEM,Joe Torsella,98
+Columbia,Montour Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Montour Twp,State Treasurer,,DEM,Write-In,2
+Columbia,Mount Pleasant Twp,State Treasurer,,DEM,Joe Torsella,125
+Columbia,Mount Pleasant Twp,State Treasurer,,DEM,Stacy L Garrity,1
+Columbia,Mount Pleasant Twp,State Treasurer,,DEM,Write-In,3
+Columbia,North Centre Twp,State Treasurer,,DEM,Joe Torsella,127
+Columbia,North Centre Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,North Centre Twp,State Treasurer,,DEM,Write-In,1
+Columbia,Orange Twp,State Treasurer,,DEM,Joe Torsella,118
+Columbia,Orange Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Orange Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Orangeville Borough,State Treasurer,,DEM,Joe Torsella,34
+Columbia,Orangeville Borough,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Orangeville Borough,State Treasurer,,DEM,Write-In,0
+Columbia,Pine Twp,State Treasurer,,DEM,Joe Torsella,52
+Columbia,Pine Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Pine Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Roaringcreek Twp,State Treasurer,,DEM,Joe Torsella,44
+Columbia,Roaringcreek Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Roaringcreek Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Scott Twp East,State Treasurer,,DEM,Joe Torsella,314
+Columbia,Scott Twp East,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Scott Twp East,State Treasurer,,DEM,Write-In,1
+Columbia,Scott Twp West,State Treasurer,,DEM,Joe Torsella,245
+Columbia,Scott Twp West,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Scott Twp West,State Treasurer,,DEM,Write-In,4
+Columbia,South Centre Twp,State Treasurer,,DEM,Joe Torsella,109
+Columbia,South Centre Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,South Centre Twp,State Treasurer,,DEM,Write-In,3
+Columbia,Stillwater Borough,State Treasurer,,DEM,Joe Torsella,16
+Columbia,Stillwater Borough,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Stillwater Borough,State Treasurer,,DEM,Write-In,0
+Columbia,Sugarloaf Twp,State Treasurer,,DEM,Joe Torsella,45
+Columbia,Sugarloaf Twp,State Treasurer,,DEM,Stacy L Garrity,0
+Columbia,Sugarloaf Twp,State Treasurer,,DEM,Write-In,0
+Columbia,Beaver Twp,Representative In Congress,9,DEM,Laura Quick,49
+Columbia,Beaver Twp,Representative In Congress,9,DEM,Gary Wegman,29
+Columbia,Beaver Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Beaver Twp,Representative In Congress,9,DEM,Write-In,0
+Columbia,Benton Twp,Representative In Congress,9,DEM,Laura Quick,54
+Columbia,Benton Twp,Representative In Congress,9,DEM,Gary Wegman,26
+Columbia,Benton Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Benton Twp,Representative In Congress,9,DEM,Write-In,0
+Columbia,Benton Borough,Representative In Congress,9,DEM,Laura Quick,32
+Columbia,Benton Borough,Representative In Congress,9,DEM,Gary Wegman,21
+Columbia,Benton Borough,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Benton Borough,Representative In Congress,9,DEM,Write-In,0
+Columbia,Berwick 1St Ward,Representative In Congress,9,DEM,Laura Quick,139
+Columbia,Berwick 1St Ward,Representative In Congress,9,DEM,Gary Wegman,64
+Columbia,Berwick 1St Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Berwick 1St Ward,Representative In Congress,9,DEM,Write-In,3
+Columbia,Berwick 2Nd Ward,Representative In Congress,9,DEM,Laura Quick,56
+Columbia,Berwick 2Nd Ward,Representative In Congress,9,DEM,Gary Wegman,27
+Columbia,Berwick 2Nd Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Berwick 2Nd Ward,Representative In Congress,9,DEM,Write-In,2
+Columbia,Berwick 3Rd Ward,Representative In Congress,9,DEM,Laura Quick,80
+Columbia,Berwick 3Rd Ward,Representative In Congress,9,DEM,Gary Wegman,50
+Columbia,Berwick 3Rd Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Berwick 3Rd Ward,Representative In Congress,9,DEM,Write-In,2
+Columbia,Berwick 4Th Ward,Representative In Congress,9,DEM,Laura Quick,118
+Columbia,Berwick 4Th Ward,Representative In Congress,9,DEM,Gary Wegman,57
+Columbia,Berwick 4Th Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Berwick 4Th Ward,Representative In Congress,9,DEM,Write-In,4
+Columbia,Bloomsburg 1St Ward,Representative In Congress,9,DEM,Laura Quick,62
+Columbia,Bloomsburg 1St Ward,Representative In Congress,9,DEM,Gary Wegman,31
+Columbia,Bloomsburg 1St Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Bloomsburg 1St Ward,Representative In Congress,9,DEM,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Representative In Congress,9,DEM,Laura Quick,119
+Columbia,Bloomsburg 2Nd Ward,Representative In Congress,9,DEM,Gary Wegman,67
+Columbia,Bloomsburg 2Nd Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Bloomsburg 2Nd Ward,Representative In Congress,9,DEM,Write-In,1
+Columbia,Bloomsburg 3-1 Ward,Representative In Congress,9,DEM,Laura Quick,170
+Columbia,Bloomsburg 3-1 Ward,Representative In Congress,9,DEM,Gary Wegman,82
+Columbia,Bloomsburg 3-1 Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Bloomsburg 3-1 Ward,Representative In Congress,9,DEM,Write-In,1
+Columbia,Bloomsburg 3-2 Ward,Representative In Congress,9,DEM,Laura Quick,26
+Columbia,Bloomsburg 3-2 Ward,Representative In Congress,9,DEM,Gary Wegman,12
+Columbia,Bloomsburg 3-2 Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Bloomsburg 3-2 Ward,Representative In Congress,9,DEM,Write-In,0
+Columbia,Bloomsburg 4Th Ward,Representative In Congress,9,DEM,Laura Quick,155
+Columbia,Bloomsburg 4Th Ward,Representative In Congress,9,DEM,Gary Wegman,58
+Columbia,Bloomsburg 4Th Ward,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Bloomsburg 4Th Ward,Representative In Congress,9,DEM,Write-In,3
+Columbia,Briarcreek Twp Northeast,Representative In Congress,9,DEM,Laura Quick,62
+Columbia,Briarcreek Twp Northeast,Representative In Congress,9,DEM,Gary Wegman,32
+Columbia,Briarcreek Twp Northeast,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Briarcreek Twp Northeast,Representative In Congress,9,DEM,Write-In,1
+Columbia,Briarcreek Twp West,Representative In Congress,9,DEM,Laura Quick,67
+Columbia,Briarcreek Twp West,Representative In Congress,9,DEM,Gary Wegman,39
+Columbia,Briarcreek Twp West,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Briarcreek Twp West,Representative In Congress,9,DEM,Write-In,0
+Columbia,Briarcreek Borough,Representative In Congress,9,DEM,Laura Quick,27
+Columbia,Briarcreek Borough,Representative In Congress,9,DEM,Gary Wegman,6
+Columbia,Briarcreek Borough,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Briarcreek Borough,Representative In Congress,9,DEM,Write-In,0
+Columbia,Catawissa Twp,Representative In Congress,9,DEM,Laura Quick,35
+Columbia,Catawissa Twp,Representative In Congress,9,DEM,Gary Wegman,32
+Columbia,Catawissa Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Catawissa Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Catawissa Borough,Representative In Congress,9,DEM,Laura Quick,56
+Columbia,Catawissa Borough,Representative In Congress,9,DEM,Gary Wegman,20
+Columbia,Catawissa Borough,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Catawissa Borough,Representative In Congress,9,DEM,Write-In,0
+Columbia,Centralia Borough,Representative In Congress,9,DEM,Laura Quick,0
+Columbia,Centralia Borough,Representative In Congress,9,DEM,Gary Wegman,1
+Columbia,Centralia Borough,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Centralia Borough,Representative In Congress,9,DEM,Write-In,0
+Columbia,Cleveland Twp,Representative In Congress,9,DEM,Laura Quick,46
+Columbia,Cleveland Twp,Representative In Congress,9,DEM,Gary Wegman,27
+Columbia,Cleveland Twp,Representative In Congress,9,DEM,Dan Mueser,2
+Columbia,Cleveland Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Conyngham Twp,Representative In Congress,9,DEM,Laura Quick,32
+Columbia,Conyngham Twp,Representative In Congress,9,DEM,Gary Wegman,25
+Columbia,Conyngham Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Conyngham Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Fishingcreek Twp,Representative In Congress,9,DEM,Laura Quick,64
+Columbia,Fishingcreek Twp,Representative In Congress,9,DEM,Gary Wegman,33
+Columbia,Fishingcreek Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Fishingcreek Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Franklin Twp,Representative In Congress,9,DEM,Laura Quick,32
+Columbia,Franklin Twp,Representative In Congress,9,DEM,Gary Wegman,12
+Columbia,Franklin Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Franklin Twp,Representative In Congress,9,DEM,Write-In,2
+Columbia,Greenwood Twp,Representative In Congress,9,DEM,Laura Quick,60
+Columbia,Greenwood Twp,Representative In Congress,9,DEM,Gary Wegman,44
+Columbia,Greenwood Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Greenwood Twp,Representative In Congress,9,DEM,Write-In,3
+Columbia,Hemlock Twp,Representative In Congress,9,DEM,Laura Quick,157
+Columbia,Hemlock Twp,Representative In Congress,9,DEM,Gary Wegman,61
+Columbia,Hemlock Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Hemlock Twp,Representative In Congress,9,DEM,Write-In,0
+Columbia,Jackson Twp,Representative In Congress,9,DEM,Laura Quick,23
+Columbia,Jackson Twp,Representative In Congress,9,DEM,Gary Wegman,8
+Columbia,Jackson Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Jackson Twp,Representative In Congress,9,DEM,Write-In,3
+Columbia,Locust Twp,Representative In Congress,9,DEM,Laura Quick,74
+Columbia,Locust Twp,Representative In Congress,9,DEM,Gary Wegman,37
+Columbia,Locust Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Locust Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Madison Twp,Representative In Congress,9,DEM,Laura Quick,62
+Columbia,Madison Twp,Representative In Congress,9,DEM,Gary Wegman,35
+Columbia,Madison Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Madison Twp,Representative In Congress,9,DEM,Write-In,2
+Columbia,Main Twp,Representative In Congress,9,DEM,Laura Quick,94
+Columbia,Main Twp,Representative In Congress,9,DEM,Gary Wegman,37
+Columbia,Main Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Main Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Mifflin Twp,Representative In Congress,9,DEM,Laura Quick,136
+Columbia,Mifflin Twp,Representative In Congress,9,DEM,Gary Wegman,44
+Columbia,Mifflin Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Mifflin Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Millville Borough,Representative In Congress,9,DEM,Laura Quick,38
+Columbia,Millville Borough,Representative In Congress,9,DEM,Gary Wegman,15
+Columbia,Millville Borough,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Millville Borough,Representative In Congress,9,DEM,Write-In,1
+Columbia,Montour Twp,Representative In Congress,9,DEM,Laura Quick,77
+Columbia,Montour Twp,Representative In Congress,9,DEM,Gary Wegman,21
+Columbia,Montour Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Montour Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Mount Pleasant Twp,Representative In Congress,9,DEM,Laura Quick,77
+Columbia,Mount Pleasant Twp,Representative In Congress,9,DEM,Gary Wegman,40
+Columbia,Mount Pleasant Twp,Representative In Congress,9,DEM,Dan Mueser,2
+Columbia,Mount Pleasant Twp,Representative In Congress,9,DEM,Write-In,4
+Columbia,North Centre Twp,Representative In Congress,9,DEM,Laura Quick,82
+Columbia,North Centre Twp,Representative In Congress,9,DEM,Gary Wegman,44
+Columbia,North Centre Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,North Centre Twp,Representative In Congress,9,DEM,Write-In,3
+Columbia,Orange Twp,Representative In Congress,9,DEM,Laura Quick,78
+Columbia,Orange Twp,Representative In Congress,9,DEM,Gary Wegman,38
+Columbia,Orange Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Orange Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Orangeville Borough,Representative In Congress,9,DEM,Laura Quick,19
+Columbia,Orangeville Borough,Representative In Congress,9,DEM,Gary Wegman,13
+Columbia,Orangeville Borough,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Orangeville Borough,Representative In Congress,9,DEM,Write-In,0
+Columbia,Pine Twp,Representative In Congress,9,DEM,Laura Quick,32
+Columbia,Pine Twp,Representative In Congress,9,DEM,Gary Wegman,22
+Columbia,Pine Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Pine Twp,Representative In Congress,9,DEM,Write-In,1
+Columbia,Roaringcreek Twp,Representative In Congress,9,DEM,Laura Quick,30
+Columbia,Roaringcreek Twp,Representative In Congress,9,DEM,Gary Wegman,13
+Columbia,Roaringcreek Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Roaringcreek Twp,Representative In Congress,9,DEM,Write-In,0
+Columbia,Scott Twp East,Representative In Congress,9,DEM,Laura Quick,206
+Columbia,Scott Twp East,Representative In Congress,9,DEM,Gary Wegman,94
+Columbia,Scott Twp East,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Scott Twp East,Representative In Congress,9,DEM,Write-In,1
+Columbia,Scott Twp West,Representative In Congress,9,DEM,Laura Quick,175
+Columbia,Scott Twp West,Representative In Congress,9,DEM,Gary Wegman,67
+Columbia,Scott Twp West,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Scott Twp West,Representative In Congress,9,DEM,Write-In,2
+Columbia,South Centre Twp,Representative In Congress,9,DEM,Laura Quick,78
+Columbia,South Centre Twp,Representative In Congress,9,DEM,Gary Wegman,29
+Columbia,South Centre Twp,Representative In Congress,9,DEM,Dan Mueser,1
+Columbia,South Centre Twp,Representative In Congress,9,DEM,Write-In,5
+Columbia,Stillwater Borough,Representative In Congress,9,DEM,Laura Quick,10
+Columbia,Stillwater Borough,Representative In Congress,9,DEM,Gary Wegman,5
+Columbia,Stillwater Borough,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Stillwater Borough,Representative In Congress,9,DEM,Write-In,0
+Columbia,Sugarloaf Twp,Representative In Congress,9,DEM,Laura Quick,30
+Columbia,Sugarloaf Twp,Representative In Congress,9,DEM,Gary Wegman,13
+Columbia,Sugarloaf Twp,Representative In Congress,9,DEM,Dan Mueser,0
+Columbia,Sugarloaf Twp,Representative In Congress,9,DEM,Write-In,0
+Columbia,Beaver Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,74
+Columbia,Beaver Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Beaver Twp,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Beaver Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Benton Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,80
+Columbia,Benton Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Benton Twp,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Benton Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Benton Borough,Senator In The General Assembly,27,DEM,Michelle Siegel,52
+Columbia,Benton Borough,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Benton Borough,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Benton Borough,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Berwick 1St Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,194
+Columbia,Berwick 1St Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Berwick 1St Ward,Senator In The General Assembly,27,DEM,Write-In,5
+Columbia,Berwick 1St Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Berwick 2Nd Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,82
+Columbia,Berwick 2Nd Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Berwick 2Nd Ward,Senator In The General Assembly,27,DEM,Write-In,2
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Berwick 3Rd Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,131
+Columbia,Berwick 3Rd Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Berwick 3Rd Ward,Senator In The General Assembly,27,DEM,Write-In,4
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Berwick 4Th Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,177
+Columbia,Berwick 4Th Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Berwick 4Th Ward,Senator In The General Assembly,27,DEM,Write-In,2
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Bloomsburg 1St Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,93
+Columbia,Bloomsburg 1St Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Bloomsburg 1St Ward,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,171
+Columbia,Bloomsburg 2Nd Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Bloomsburg 2Nd Ward,Senator In The General Assembly,27,DEM,Write-In,4
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Bloomsburg 3-1 Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,238
+Columbia,Bloomsburg 3-1 Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Bloomsburg 3-1 Ward,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,38
+Columbia,Bloomsburg 3-2 Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Bloomsburg 3-2 Ward,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Bloomsburg 4Th Ward,Senator In The General Assembly,27,DEM,Michelle Siegel,209
+Columbia,Bloomsburg 4Th Ward,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Bloomsburg 4Th Ward,Senator In The General Assembly,27,DEM,Write-In,2
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Briarcreek Twp Northeast,Senator In The General Assembly,27,DEM,Michelle Siegel,90
+Columbia,Briarcreek Twp Northeast,Senator In The General Assembly,27,DEM,John R Gordner,1
+Columbia,Briarcreek Twp Northeast,Senator In The General Assembly,27,DEM,Write-In,2
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Briarcreek Twp West,Senator In The General Assembly,27,DEM,Michelle Siegel,103
+Columbia,Briarcreek Twp West,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Briarcreek Twp West,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Briarcreek Twp West,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Briarcreek Borough,Senator In The General Assembly,27,DEM,Michelle Siegel,32
+Columbia,Briarcreek Borough,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Briarcreek Borough,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Briarcreek Borough,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Catawissa Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,65
+Columbia,Catawissa Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Catawissa Twp,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Catawissa Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Catawissa Borough,Senator In The General Assembly,27,DEM,Michelle Siegel,74
+Columbia,Catawissa Borough,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Catawissa Borough,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Catawissa Borough,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Centralia Borough,Senator In The General Assembly,27,DEM,Michelle Siegel,1
+Columbia,Centralia Borough,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Centralia Borough,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Centralia Borough,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Cleveland Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,72
+Columbia,Cleveland Twp,Senator In The General Assembly,27,DEM,John R Gordner,2
+Columbia,Cleveland Twp,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Cleveland Twp,Representative In The General Assembly,107,DEM,Write-In,7
+Columbia,Conyngham Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,52
+Columbia,Conyngham Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Conyngham Twp,Senator In The General Assembly,27,DEM,Write-In,2
+Columbia,Conyngham Twp,Representative In The General Assembly,107,DEM,Write-In,4
+Columbia,Fishingcreek Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,98
+Columbia,Fishingcreek Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Fishingcreek Twp,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Fishingcreek Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Franklin Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,45
+Columbia,Franklin Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Franklin Twp,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Franklin Twp,Representative In The General Assembly,107,DEM,Write-In,7
+Columbia,Greenwood Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,103
+Columbia,Greenwood Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Greenwood Twp,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Greenwood Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Hemlock Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,219
+Columbia,Hemlock Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Hemlock Twp,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Hemlock Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Jackson Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,32
+Columbia,Jackson Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Jackson Twp,Senator In The General Assembly,27,DEM,Write-In,3
+Columbia,Jackson Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Locust Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,109
+Columbia,Locust Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Locust Twp,Senator In The General Assembly,27,DEM,Write-In,2
+Columbia,Locust Twp,Representative In The General Assembly,107,DEM,Write-In,9
+Columbia,Madison Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,98
+Columbia,Madison Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Madison Twp,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Madison Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Main Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,128
+Columbia,Main Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Main Twp,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Main Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Mifflin Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,179
+Columbia,Mifflin Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Mifflin Twp,Senator In The General Assembly,27,DEM,Write-In,2
+Columbia,Mifflin Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Millville Borough,Senator In The General Assembly,27,DEM,Michelle Siegel,53
+Columbia,Millville Borough,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Millville Borough,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Millville Borough,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Montour Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,93
+Columbia,Montour Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Montour Twp,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Montour Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Mount Pleasant Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,115
+Columbia,Mount Pleasant Twp,Senator In The General Assembly,27,DEM,John R Gordner,2
+Columbia,Mount Pleasant Twp,Senator In The General Assembly,27,DEM,Write-In,6
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,North Centre Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,127
+Columbia,North Centre Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,North Centre Twp,Senator In The General Assembly,27,DEM,Write-In,2
+Columbia,North Centre Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Orange Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,111
+Columbia,Orange Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Orange Twp,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Orange Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Orangeville Borough,Senator In The General Assembly,27,DEM,Michelle Siegel,31
+Columbia,Orangeville Borough,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Orangeville Borough,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Orangeville Borough,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Pine Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,53
+Columbia,Pine Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Pine Twp,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Pine Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Roaringcreek Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,42
+Columbia,Roaringcreek Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Roaringcreek Twp,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Roaringcreek Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Scott Twp East,Senator In The General Assembly,27,DEM,Michelle Siegel,295
+Columbia,Scott Twp East,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Scott Twp East,Senator In The General Assembly,27,DEM,Write-In,3
+Columbia,Scott Twp East,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Scott Twp West,Senator In The General Assembly,27,DEM,Michelle Siegel,235
+Columbia,Scott Twp West,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Scott Twp West,Senator In The General Assembly,27,DEM,Write-In,3
+Columbia,Scott Twp West,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,South Centre Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,101
+Columbia,South Centre Twp,Senator In The General Assembly,27,DEM,John R Gordner,3
+Columbia,South Centre Twp,Senator In The General Assembly,27,DEM,Write-In,5
+Columbia,South Centre Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Stillwater Borough,Senator In The General Assembly,27,DEM,Michelle Siegel,16
+Columbia,Stillwater Borough,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Stillwater Borough,Senator In The General Assembly,27,DEM,Write-In,1
+Columbia,Stillwater Borough,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Sugarloaf Twp,Senator In The General Assembly,27,DEM,Michelle Siegel,46
+Columbia,Sugarloaf Twp,Senator In The General Assembly,27,DEM,John R Gordner,0
+Columbia,Sugarloaf Twp,Senator In The General Assembly,27,DEM,Write-In,0
+Columbia,Sugarloaf Twp,Representative In The General Assembly,107,DEM,Write-In,0
+Columbia,Beaver Twp,Representative In The General Assembly,109,DEM,Bill Monahan,78
+Columbia,Beaver Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Beaver Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Beaver Twp,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Benton Twp,Representative In The General Assembly,109,DEM,Bill Monahan,86
+Columbia,Benton Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Benton Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Benton Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Benton Borough,Representative In The General Assembly,109,DEM,Bill Monahan,52
+Columbia,Benton Borough,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Benton Borough,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Benton Borough,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Berwick 1St Ward,Representative In The General Assembly,109,DEM,Bill Monahan,205
+Columbia,Berwick 1St Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Berwick 1St Ward,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Berwick 1St Ward,Representative In The General Assembly,109,DEM,Write-In,6
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,109,DEM,Bill Monahan,85
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,109,DEM,Write-In,4
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,109,DEM,Bill Monahan,142
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,109,DEM,Write-In,3
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,109,DEM,Bill Monahan,181
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,109,DEM,Bill Monahan,98
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,109,DEM,Bill Monahan,176
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,109,DEM,Bill Monahan,248
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,109,DEM,Write-In,3
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,109,DEM,Bill Monahan,37
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,109,DEM,Bill Monahan,207
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,109,DEM,Frances Mannino,1
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,109,DEM,Write-In,3
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,109,DEM,Bill Monahan,90
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,109,DEM,David Millard,1
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Briarcreek Twp West,Representative In The General Assembly,109,DEM,Bill Monahan,113
+Columbia,Briarcreek Twp West,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Briarcreek Twp West,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Briarcreek Twp West,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Briarcreek Borough,Representative In The General Assembly,109,DEM,Bill Monahan,29
+Columbia,Briarcreek Borough,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Briarcreek Borough,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Briarcreek Borough,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Catawissa Twp,Representative In The General Assembly,109,DEM,Bill Monahan,69
+Columbia,Catawissa Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Catawissa Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Catawissa Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Catawissa Borough,Representative In The General Assembly,109,DEM,Bill Monahan,76
+Columbia,Catawissa Borough,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Catawissa Borough,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Catawissa Borough,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Centralia Borough,Representative In The General Assembly,109,DEM,Bill Monahan,0
+Columbia,Centralia Borough,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Centralia Borough,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Centralia Borough,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Cleveland Twp,Representative In The General Assembly,109,DEM,Bill Monahan,0
+Columbia,Cleveland Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Cleveland Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Cleveland Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Conyngham Twp,Representative In The General Assembly,109,DEM,Bill Monahan,0
+Columbia,Conyngham Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Conyngham Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Conyngham Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Fishingcreek Twp,Representative In The General Assembly,109,DEM,Bill Monahan,102
+Columbia,Fishingcreek Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Fishingcreek Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Fishingcreek Twp,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Franklin Twp,Representative In The General Assembly,109,DEM,Bill Monahan,0
+Columbia,Franklin Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Franklin Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Franklin Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Greenwood Twp,Representative In The General Assembly,109,DEM,Bill Monahan,110
+Columbia,Greenwood Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Greenwood Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Greenwood Twp,Representative In The General Assembly,109,DEM,Write-In,2
+Columbia,Hemlock Twp,Representative In The General Assembly,109,DEM,Bill Monahan,222
+Columbia,Hemlock Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Hemlock Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Hemlock Twp,Representative In The General Assembly,109,DEM,Write-In,3
+Columbia,Jackson Twp,Representative In The General Assembly,109,DEM,Bill Monahan,34
+Columbia,Jackson Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Jackson Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Jackson Twp,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Locust Twp,Representative In The General Assembly,109,DEM,Bill Monahan,0
+Columbia,Locust Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Locust Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Locust Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Madison Twp,Representative In The General Assembly,109,DEM,Bill Monahan,100
+Columbia,Madison Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Madison Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Madison Twp,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Main Twp,Representative In The General Assembly,109,DEM,Bill Monahan,137
+Columbia,Main Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Main Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Main Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Mifflin Twp,Representative In The General Assembly,109,DEM,Bill Monahan,187
+Columbia,Mifflin Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Mifflin Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Mifflin Twp,Representative In The General Assembly,109,DEM,Write-In,3
+Columbia,Millville Borough,Representative In The General Assembly,109,DEM,Bill Monahan,53
+Columbia,Millville Borough,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Millville Borough,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Millville Borough,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Montour Twp,Representative In The General Assembly,109,DEM,Bill Monahan,93
+Columbia,Montour Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Montour Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Montour Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,109,DEM,Bill Monahan,113
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,109,DEM,David Millard,2
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,109,DEM,Write-In,9
+Columbia,North Centre Twp,Representative In The General Assembly,109,DEM,Bill Monahan,127
+Columbia,North Centre Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,North Centre Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,North Centre Twp,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Orange Twp,Representative In The General Assembly,109,DEM,Bill Monahan,112
+Columbia,Orange Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Orange Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Orange Twp,Representative In The General Assembly,109,DEM,Write-In,2
+Columbia,Orangeville Borough,Representative In The General Assembly,109,DEM,Bill Monahan,37
+Columbia,Orangeville Borough,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Orangeville Borough,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Orangeville Borough,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Pine Twp,Representative In The General Assembly,109,DEM,Bill Monahan,55
+Columbia,Pine Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Pine Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Pine Twp,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Roaringcreek Twp,Representative In The General Assembly,109,DEM,Bill Monahan,46
+Columbia,Roaringcreek Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Roaringcreek Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Roaringcreek Twp,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Scott Twp East,Representative In The General Assembly,109,DEM,Bill Monahan,304
+Columbia,Scott Twp East,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Scott Twp East,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Scott Twp East,Representative In The General Assembly,109,DEM,Write-In,3
+Columbia,Scott Twp West,Representative In The General Assembly,109,DEM,Bill Monahan,244
+Columbia,Scott Twp West,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Scott Twp West,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Scott Twp West,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,South Centre Twp,Representative In The General Assembly,109,DEM,Bill Monahan,109
+Columbia,South Centre Twp,Representative In The General Assembly,109,DEM,David Millard,1
+Columbia,South Centre Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,South Centre Twp,Representative In The General Assembly,109,DEM,Write-In,4
+Columbia,Stillwater Borough,Representative In The General Assembly,109,DEM,Bill Monahan,15
+Columbia,Stillwater Borough,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Stillwater Borough,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Stillwater Borough,Representative In The General Assembly,109,DEM,Write-In,1
+Columbia,Sugarloaf Twp,Representative In The General Assembly,109,DEM,Bill Monahan,47
+Columbia,Sugarloaf Twp,Representative In The General Assembly,109,DEM,David Millard,0
+Columbia,Sugarloaf Twp,Representative In The General Assembly,109,DEM,Frances Mannino,0
+Columbia,Sugarloaf Twp,Representative In The General Assembly,109,DEM,Write-In,0
+Columbia,Beaver Twp,President Of The United States,,REP,Donald J Trump,119
+Columbia,Beaver Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Beaver Twp,President Of The United States,,REP,Bill Weld,6
+Columbia,Beaver Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Beaver Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Beaver Twp,President Of The United States,,REP,Write-In,5
+Columbia,Benton Twp,President Of The United States,,REP,Donald J Trump,202
+Columbia,Benton Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Benton Twp,President Of The United States,,REP,Bill Weld,8
+Columbia,Benton Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Benton Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Benton Twp,President Of The United States,,REP,Write-In,7
+Columbia,Benton Borough,President Of The United States,,REP,Donald J Trump,98
+Columbia,Benton Borough,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Benton Borough,President Of The United States,,REP,Bill Weld,6
+Columbia,Benton Borough,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Benton Borough,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Benton Borough,President Of The United States,,REP,Write-In,2
+Columbia,Berwick 1St Ward,President Of The United States,,REP,Donald J Trump,337
+Columbia,Berwick 1St Ward,President Of The United States,,REP,Roque Rocky De La Fuente,5
+Columbia,Berwick 1St Ward,President Of The United States,,REP,Bill Weld,15
+Columbia,Berwick 1St Ward,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Berwick 1St Ward,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Berwick 1St Ward,President Of The United States,,REP,Write-In,6
+Columbia,Berwick 2Nd Ward,President Of The United States,,REP,Donald J Trump,80
+Columbia,Berwick 2Nd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Berwick 2Nd Ward,President Of The United States,,REP,Bill Weld,4
+Columbia,Berwick 2Nd Ward,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Berwick 2Nd Ward,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Berwick 2Nd Ward,President Of The United States,,REP,Write-In,2
+Columbia,Berwick 3Rd Ward,President Of The United States,,REP,Donald J Trump,146
+Columbia,Berwick 3Rd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0
+Columbia,Berwick 3Rd Ward,President Of The United States,,REP,Bill Weld,1
+Columbia,Berwick 3Rd Ward,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Berwick 3Rd Ward,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Berwick 3Rd Ward,President Of The United States,,REP,Write-In,3
+Columbia,Berwick 4Th Ward,President Of The United States,,REP,Donald J Trump,269
+Columbia,Berwick 4Th Ward,President Of The United States,,REP,Roque Rocky De La Fuente,3
+Columbia,Berwick 4Th Ward,President Of The United States,,REP,Bill Weld,12
+Columbia,Berwick 4Th Ward,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Berwick 4Th Ward,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Berwick 4Th Ward,President Of The United States,,REP,Write-In,3
+Columbia,Bloomsburg 1St Ward,President Of The United States,,REP,Donald J Trump,54
+Columbia,Bloomsburg 1St Ward,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Bloomsburg 1St Ward,President Of The United States,,REP,Bill Weld,3
+Columbia,Bloomsburg 1St Ward,President Of The United States,,REP,Bernie Sanders,1
+Columbia,Bloomsburg 1St Ward,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Bloomsburg 1St Ward,President Of The United States,,REP,Write-In,6
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,REP,Donald J Trump,91
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,REP,Bill Weld,12
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Bloomsburg 2Nd Ward,President Of The United States,,REP,Write-In,3
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,REP,Donald J Trump,86
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,REP,Bill Weld,8
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,REP,Joseph R Biden,1
+Columbia,Bloomsburg 3-1 Ward,President Of The United States,,REP,Write-In,4
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,REP,Donald J Trump,1
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,REP,Roque Rocky De La Fuente,0
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,REP,Bill Weld,0
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,REP,Bernie Sanders,1
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Bloomsburg 3-2 Ward,President Of The United States,,REP,Write-In,0
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,REP,Donald J Trump,168
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,REP,Roque Rocky De La Fuente,5
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,REP,Bill Weld,6
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Bloomsburg 4Th Ward,President Of The United States,,REP,Write-In,7
+Columbia,Briarcreek Twp Northeast,President Of The United States,,REP,Donald J Trump,191
+Columbia,Briarcreek Twp Northeast,President Of The United States,,REP,Roque Rocky De La Fuente,2
+Columbia,Briarcreek Twp Northeast,President Of The United States,,REP,Bill Weld,3
+Columbia,Briarcreek Twp Northeast,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Briarcreek Twp Northeast,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Briarcreek Twp Northeast,President Of The United States,,REP,Write-In,3
+Columbia,Briarcreek Twp West,President Of The United States,,REP,Donald J Trump,199
+Columbia,Briarcreek Twp West,President Of The United States,,REP,Roque Rocky De La Fuente,3
+Columbia,Briarcreek Twp West,President Of The United States,,REP,Bill Weld,6
+Columbia,Briarcreek Twp West,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Briarcreek Twp West,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Briarcreek Twp West,President Of The United States,,REP,Write-In,4
+Columbia,Briarcreek Borough,President Of The United States,,REP,Donald J Trump,38
+Columbia,Briarcreek Borough,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Briarcreek Borough,President Of The United States,,REP,Bill Weld,3
+Columbia,Briarcreek Borough,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Briarcreek Borough,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Briarcreek Borough,President Of The United States,,REP,Write-In,0
+Columbia,Catawissa Twp,President Of The United States,,REP,Donald J Trump,112
+Columbia,Catawissa Twp,President Of The United States,,REP,Roque Rocky De La Fuente,2
+Columbia,Catawissa Twp,President Of The United States,,REP,Bill Weld,6
+Columbia,Catawissa Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Catawissa Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Catawissa Twp,President Of The United States,,REP,Write-In,3
+Columbia,Catawissa Borough,President Of The United States,,REP,Donald J Trump,119
+Columbia,Catawissa Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0
+Columbia,Catawissa Borough,President Of The United States,,REP,Bill Weld,7
+Columbia,Catawissa Borough,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Catawissa Borough,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Catawissa Borough,President Of The United States,,REP,Write-In,4
+Columbia,Centralia Borough,President Of The United States,,REP,Donald J Trump,2
+Columbia,Centralia Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0
+Columbia,Centralia Borough,President Of The United States,,REP,Bill Weld,0
+Columbia,Centralia Borough,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Centralia Borough,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Centralia Borough,President Of The United States,,REP,Write-In,0
+Columbia,Cleveland Twp,President Of The United States,,REP,Donald J Trump,149
+Columbia,Cleveland Twp,President Of The United States,,REP,Roque Rocky De La Fuente,3
+Columbia,Cleveland Twp,President Of The United States,,REP,Bill Weld,5
+Columbia,Cleveland Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Cleveland Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Cleveland Twp,President Of The United States,,REP,Write-In,0
+Columbia,Conyngham Twp,President Of The United States,,REP,Donald J Trump,71
+Columbia,Conyngham Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Conyngham Twp,President Of The United States,,REP,Bill Weld,2
+Columbia,Conyngham Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Conyngham Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Conyngham Twp,President Of The United States,,REP,Write-In,4
+Columbia,Fishingcreek Twp,President Of The United States,,REP,Donald J Trump,183
+Columbia,Fishingcreek Twp,President Of The United States,,REP,Roque Rocky De La Fuente,3
+Columbia,Fishingcreek Twp,President Of The United States,,REP,Bill Weld,11
+Columbia,Fishingcreek Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Fishingcreek Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Fishingcreek Twp,President Of The United States,,REP,Write-In,5
+Columbia,Franklin Twp,President Of The United States,,REP,Donald J Trump,72
+Columbia,Franklin Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Franklin Twp,President Of The United States,,REP,Bill Weld,9
+Columbia,Franklin Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Franklin Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Franklin Twp,President Of The United States,,REP,Write-In,3
+Columbia,Greenwood Twp,President Of The United States,,REP,Donald J Trump,234
+Columbia,Greenwood Twp,President Of The United States,,REP,Roque Rocky De La Fuente,3
+Columbia,Greenwood Twp,President Of The United States,,REP,Bill Weld,11
+Columbia,Greenwood Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Greenwood Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Greenwood Twp,President Of The United States,,REP,Write-In,6
+Columbia,Hemlock Twp,President Of The United States,,REP,Donald J Trump,307
+Columbia,Hemlock Twp,President Of The United States,,REP,Roque Rocky De La Fuente,5
+Columbia,Hemlock Twp,President Of The United States,,REP,Bill Weld,18
+Columbia,Hemlock Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Hemlock Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Hemlock Twp,President Of The United States,,REP,Write-In,5
+Columbia,Jackson Twp,President Of The United States,,REP,Donald J Trump,112
+Columbia,Jackson Twp,President Of The United States,,REP,Roque Rocky De La Fuente,0
+Columbia,Jackson Twp,President Of The United States,,REP,Bill Weld,4
+Columbia,Jackson Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Jackson Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Jackson Twp,President Of The United States,,REP,Write-In,0
+Columbia,Locust Twp,President Of The United States,,REP,Donald J Trump,181
+Columbia,Locust Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Locust Twp,President Of The United States,,REP,Bill Weld,10
+Columbia,Locust Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Locust Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Locust Twp,President Of The United States,,REP,Write-In,3
+Columbia,Madison Twp,President Of The United States,,REP,Donald J Trump,253
+Columbia,Madison Twp,President Of The United States,,REP,Roque Rocky De La Fuente,2
+Columbia,Madison Twp,President Of The United States,,REP,Bill Weld,4
+Columbia,Madison Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Madison Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Madison Twp,President Of The United States,,REP,Write-In,4
+Columbia,Main Twp,President Of The United States,,REP,Donald J Trump,131
+Columbia,Main Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Main Twp,President Of The United States,,REP,Bill Weld,10
+Columbia,Main Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Main Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Main Twp,President Of The United States,,REP,Write-In,0
+Columbia,Mifflin Twp,President Of The United States,,REP,Donald J Trump,252
+Columbia,Mifflin Twp,President Of The United States,,REP,Roque Rocky De La Fuente,5
+Columbia,Mifflin Twp,President Of The United States,,REP,Bill Weld,6
+Columbia,Mifflin Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Mifflin Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Mifflin Twp,President Of The United States,,REP,Write-In,3
+Columbia,Millville Borough,President Of The United States,,REP,Donald J Trump,125
+Columbia,Millville Borough,President Of The United States,,REP,Roque Rocky De La Fuente,2
+Columbia,Millville Borough,President Of The United States,,REP,Bill Weld,6
+Columbia,Millville Borough,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Millville Borough,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Millville Borough,President Of The United States,,REP,Write-In,3
+Columbia,Montour Twp,President Of The United States,,REP,Donald J Trump,123
+Columbia,Montour Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Montour Twp,President Of The United States,,REP,Bill Weld,7
+Columbia,Montour Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Montour Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Montour Twp,President Of The United States,,REP,Write-In,1
+Columbia,Mount Pleasant Twp,President Of The United States,,REP,Donald J Trump,224
+Columbia,Mount Pleasant Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Mount Pleasant Twp,President Of The United States,,REP,Bill Weld,14
+Columbia,Mount Pleasant Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Mount Pleasant Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Mount Pleasant Twp,President Of The United States,,REP,Write-In,7
+Columbia,North Centre Twp,President Of The United States,,REP,Donald J Trump,256
+Columbia,North Centre Twp,President Of The United States,,REP,Roque Rocky De La Fuente,2
+Columbia,North Centre Twp,President Of The United States,,REP,Bill Weld,10
+Columbia,North Centre Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,North Centre Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,North Centre Twp,President Of The United States,,REP,Write-In,3
+Columbia,Orange Twp,President Of The United States,,REP,Donald J Trump,146
+Columbia,Orange Twp,President Of The United States,,REP,Roque Rocky De La Fuente,3
+Columbia,Orange Twp,President Of The United States,,REP,Bill Weld,7
+Columbia,Orange Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Orange Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Orange Twp,President Of The United States,,REP,Write-In,3
+Columbia,Orangeville Borough,President Of The United States,,REP,Donald J Trump,35
+Columbia,Orangeville Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0
+Columbia,Orangeville Borough,President Of The United States,,REP,Bill Weld,0
+Columbia,Orangeville Borough,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Orangeville Borough,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Orangeville Borough,President Of The United States,,REP,Write-In,2
+Columbia,Pine Twp,President Of The United States,,REP,Donald J Trump,158
+Columbia,Pine Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Pine Twp,President Of The United States,,REP,Bill Weld,3
+Columbia,Pine Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Pine Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Pine Twp,President Of The United States,,REP,Write-In,1
+Columbia,Roaringcreek Twp,President Of The United States,,REP,Donald J Trump,105
+Columbia,Roaringcreek Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Roaringcreek Twp,President Of The United States,,REP,Bill Weld,3
+Columbia,Roaringcreek Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Roaringcreek Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Roaringcreek Twp,President Of The United States,,REP,Write-In,0
+Columbia,Scott Twp East,President Of The United States,,REP,Donald J Trump,307
+Columbia,Scott Twp East,President Of The United States,,REP,Roque Rocky De La Fuente,3
+Columbia,Scott Twp East,President Of The United States,,REP,Bill Weld,17
+Columbia,Scott Twp East,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Scott Twp East,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Scott Twp East,President Of The United States,,REP,Write-In,14
+Columbia,Scott Twp West,President Of The United States,,REP,Donald J Trump,237
+Columbia,Scott Twp West,President Of The United States,,REP,Roque Rocky De La Fuente,0
+Columbia,Scott Twp West,President Of The United States,,REP,Bill Weld,18
+Columbia,Scott Twp West,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Scott Twp West,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Scott Twp West,President Of The United States,,REP,Write-In,5
+Columbia,South Centre Twp,President Of The United States,,REP,Donald J Trump,181
+Columbia,South Centre Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,South Centre Twp,President Of The United States,,REP,Bill Weld,6
+Columbia,South Centre Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,South Centre Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,South Centre Twp,President Of The United States,,REP,Write-In,3
+Columbia,Stillwater Borough,President Of The United States,,REP,Donald J Trump,31
+Columbia,Stillwater Borough,President Of The United States,,REP,Roque Rocky De La Fuente,0
+Columbia,Stillwater Borough,President Of The United States,,REP,Bill Weld,2
+Columbia,Stillwater Borough,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Stillwater Borough,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Stillwater Borough,President Of The United States,,REP,Write-In,1
+Columbia,Sugarloaf Twp,President Of The United States,,REP,Donald J Trump,167
+Columbia,Sugarloaf Twp,President Of The United States,,REP,Roque Rocky De La Fuente,1
+Columbia,Sugarloaf Twp,President Of The United States,,REP,Bill Weld,1
+Columbia,Sugarloaf Twp,President Of The United States,,REP,Bernie Sanders,0
+Columbia,Sugarloaf Twp,President Of The United States,,REP,Joseph R Biden,0
+Columbia,Sugarloaf Twp,President Of The United States,,REP,Write-In,0
+Columbia,Beaver Twp,Attorney General,,REP,Heather Heidelbaugh,115
+Columbia,Beaver Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Beaver Twp,Attorney General,,REP,Write-In,1
+Columbia,Beaver Twp,Auditor General,,REP,Timothy Defoor,112
+Columbia,Beaver Twp,Auditor General,,REP,Other,0
+Columbia,Beaver Twp,Auditor General,,REP,Write-In,0
+Columbia,Benton Twp,Attorney General,,REP,Heather Heidelbaugh,203
+Columbia,Benton Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Benton Twp,Attorney General,,REP,Write-In,0
+Columbia,Benton Twp,Auditor General,,REP,Timothy Defoor,201
+Columbia,Benton Twp,Auditor General,,REP,Other,0
+Columbia,Benton Twp,Auditor General,,REP,Write-In,1
+Columbia,Benton Borough,Attorney General,,REP,Heather Heidelbaugh,107
+Columbia,Benton Borough,Attorney General,,REP,Paul J Fedder,0
+Columbia,Benton Borough,Attorney General,,REP,Write-In,0
+Columbia,Benton Borough,Auditor General,,REP,Timothy Defoor,102
+Columbia,Benton Borough,Auditor General,,REP,Other,0
+Columbia,Benton Borough,Auditor General,,REP,Write-In,0
+Columbia,Berwick 1St Ward,Attorney General,,REP,Heather Heidelbaugh,339
+Columbia,Berwick 1St Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Berwick 1St Ward,Attorney General,,REP,Write-In,2
+Columbia,Berwick 1St Ward,Auditor General,,REP,Timothy Defoor,330
+Columbia,Berwick 1St Ward,Auditor General,,REP,Other,0
+Columbia,Berwick 1St Ward,Auditor General,,REP,Write-In,3
+Columbia,Berwick 2Nd Ward,Attorney General,,REP,Heather Heidelbaugh,83
+Columbia,Berwick 2Nd Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Berwick 2Nd Ward,Attorney General,,REP,Write-In,0
+Columbia,Berwick 2Nd Ward,Auditor General,,REP,Timothy Defoor,82
+Columbia,Berwick 2Nd Ward,Auditor General,,REP,Other,0
+Columbia,Berwick 2Nd Ward,Auditor General,,REP,Write-In,0
+Columbia,Berwick 3Rd Ward,Attorney General,,REP,Heather Heidelbaugh,138
+Columbia,Berwick 3Rd Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Berwick 3Rd Ward,Attorney General,,REP,Write-In,2
+Columbia,Berwick 3Rd Ward,Auditor General,,REP,Timothy Defoor,134
+Columbia,Berwick 3Rd Ward,Auditor General,,REP,Other,0
+Columbia,Berwick 3Rd Ward,Auditor General,,REP,Write-In,3
+Columbia,Berwick 4Th Ward,Attorney General,,REP,Heather Heidelbaugh,260
+Columbia,Berwick 4Th Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Berwick 4Th Ward,Attorney General,,REP,Write-In,1
+Columbia,Berwick 4Th Ward,Auditor General,,REP,Timothy Defoor,255
+Columbia,Berwick 4Th Ward,Auditor General,,REP,Other,0
+Columbia,Berwick 4Th Ward,Auditor General,,REP,Write-In,0
+Columbia,Bloomsburg 1St Ward,Attorney General,,REP,Heather Heidelbaugh,64
+Columbia,Bloomsburg 1St Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Bloomsburg 1St Ward,Attorney General,,REP,Write-In,0
+Columbia,Bloomsburg 1St Ward,Auditor General,,REP,Timothy Defoor,64
+Columbia,Bloomsburg 1St Ward,Auditor General,,REP,Other,0
+Columbia,Bloomsburg 1St Ward,Auditor General,,REP,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Attorney General,,REP,Heather Heidelbaugh,95
+Columbia,Bloomsburg 2Nd Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Bloomsburg 2Nd Ward,Attorney General,,REP,Write-In,1
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,REP,Timothy Defoor,98
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,REP,Other,0
+Columbia,Bloomsburg 2Nd Ward,Auditor General,,REP,Write-In,1
+Columbia,Bloomsburg 3-1 Ward,Attorney General,,REP,Heather Heidelbaugh,87
+Columbia,Bloomsburg 3-1 Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Bloomsburg 3-1 Ward,Attorney General,,REP,Write-In,3
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,REP,Timothy Defoor,90
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,REP,Other,0
+Columbia,Bloomsburg 3-1 Ward,Auditor General,,REP,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,Attorney General,,REP,Heather Heidelbaugh,1
+Columbia,Bloomsburg 3-2 Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Bloomsburg 3-2 Ward,Attorney General,,REP,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,REP,Timothy Defoor,1
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,REP,Other,0
+Columbia,Bloomsburg 3-2 Ward,Auditor General,,REP,Write-In,0
+Columbia,Bloomsburg 4Th Ward,Attorney General,,REP,Heather Heidelbaugh,165
+Columbia,Bloomsburg 4Th Ward,Attorney General,,REP,Paul J Fedder,0
+Columbia,Bloomsburg 4Th Ward,Attorney General,,REP,Write-In,1
+Columbia,Bloomsburg 4Th Ward,Auditor General,,REP,Timothy Defoor,162
+Columbia,Bloomsburg 4Th Ward,Auditor General,,REP,Other,0
+Columbia,Bloomsburg 4Th Ward,Auditor General,,REP,Write-In,1
+Columbia,Briarcreek Twp Northeast,Attorney General,,REP,Heather Heidelbaugh,180
+Columbia,Briarcreek Twp Northeast,Attorney General,,REP,Paul J Fedder,0
+Columbia,Briarcreek Twp Northeast,Attorney General,,REP,Write-In,0
+Columbia,Briarcreek Twp Northeast,Auditor General,,REP,Timothy Defoor,177
+Columbia,Briarcreek Twp Northeast,Auditor General,,REP,Other,0
+Columbia,Briarcreek Twp Northeast,Auditor General,,REP,Write-In,0
+Columbia,Briarcreek Twp West,Attorney General,,REP,Heather Heidelbaugh,188
+Columbia,Briarcreek Twp West,Attorney General,,REP,Paul J Fedder,0
+Columbia,Briarcreek Twp West,Attorney General,,REP,Write-In,3
+Columbia,Briarcreek Twp West,Auditor General,,REP,Timothy Defoor,184
+Columbia,Briarcreek Twp West,Auditor General,,REP,Other,0
+Columbia,Briarcreek Twp West,Auditor General,,REP,Write-In,2
+Columbia,Briarcreek Borough,Attorney General,,REP,Heather Heidelbaugh,39
+Columbia,Briarcreek Borough,Attorney General,,REP,Paul J Fedder,0
+Columbia,Briarcreek Borough,Attorney General,,REP,Write-In,0
+Columbia,Briarcreek Borough,Auditor General,,REP,Timothy Defoor,39
+Columbia,Briarcreek Borough,Auditor General,,REP,Other,0
+Columbia,Briarcreek Borough,Auditor General,,REP,Write-In,0
+Columbia,Catawissa Twp,Attorney General,,REP,Heather Heidelbaugh,114
+Columbia,Catawissa Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Catawissa Twp,Attorney General,,REP,Write-In,1
+Columbia,Catawissa Twp,Auditor General,,REP,Timothy Defoor,115
+Columbia,Catawissa Twp,Auditor General,,REP,Other,0
+Columbia,Catawissa Twp,Auditor General,,REP,Write-In,1
+Columbia,Catawissa Borough,Attorney General,,REP,Heather Heidelbaugh,121
+Columbia,Catawissa Borough,Attorney General,,REP,Paul J Fedder,0
+Columbia,Catawissa Borough,Attorney General,,REP,Write-In,0
+Columbia,Catawissa Borough,Auditor General,,REP,Timothy Defoor,118
+Columbia,Catawissa Borough,Auditor General,,REP,Other,0
+Columbia,Catawissa Borough,Auditor General,,REP,Write-In,0
+Columbia,Centralia Borough,Attorney General,,REP,Heather Heidelbaugh,0
+Columbia,Centralia Borough,Attorney General,,REP,Paul J Fedder,0
+Columbia,Centralia Borough,Attorney General,,REP,Write-In,0
+Columbia,Centralia Borough,Auditor General,,REP,Timothy Defoor,1
+Columbia,Centralia Borough,Auditor General,,REP,Other,0
+Columbia,Centralia Borough,Auditor General,,REP,Write-In,0
+Columbia,Cleveland Twp,Attorney General,,REP,Heather Heidelbaugh,135
+Columbia,Cleveland Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Cleveland Twp,Attorney General,,REP,Write-In,0
+Columbia,Cleveland Twp,Auditor General,,REP,Timothy Defoor,134
+Columbia,Cleveland Twp,Auditor General,,REP,Other,0
+Columbia,Cleveland Twp,Auditor General,,REP,Write-In,0
+Columbia,Conyngham Twp,Attorney General,,REP,Heather Heidelbaugh,68
+Columbia,Conyngham Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Conyngham Twp,Attorney General,,REP,Write-In,0
+Columbia,Conyngham Twp,Auditor General,,REP,Timothy Defoor,71
+Columbia,Conyngham Twp,Auditor General,,REP,Other,0
+Columbia,Conyngham Twp,Auditor General,,REP,Write-In,0
+Columbia,Fishingcreek Twp,Attorney General,,REP,Heather Heidelbaugh,187
+Columbia,Fishingcreek Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Fishingcreek Twp,Attorney General,,REP,Write-In,0
+Columbia,Fishingcreek Twp,Auditor General,,REP,Timothy Defoor,190
+Columbia,Fishingcreek Twp,Auditor General,,REP,Other,0
+Columbia,Fishingcreek Twp,Auditor General,,REP,Write-In,0
+Columbia,Franklin Twp,Attorney General,,REP,Heather Heidelbaugh,80
+Columbia,Franklin Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Franklin Twp,Attorney General,,REP,Write-In,0
+Columbia,Franklin Twp,Auditor General,,REP,Timothy Defoor,78
+Columbia,Franklin Twp,Auditor General,,REP,Other,0
+Columbia,Franklin Twp,Auditor General,,REP,Write-In,0
+Columbia,Greenwood Twp,Attorney General,,REP,Heather Heidelbaugh,220
+Columbia,Greenwood Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Greenwood Twp,Attorney General,,REP,Write-In,3
+Columbia,Greenwood Twp,Auditor General,,REP,Timothy Defoor,221
+Columbia,Greenwood Twp,Auditor General,,REP,Other,0
+Columbia,Greenwood Twp,Auditor General,,REP,Write-In,2
+Columbia,Hemlock Twp,Attorney General,,REP,Heather Heidelbaugh,313
+Columbia,Hemlock Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Hemlock Twp,Attorney General,,REP,Write-In,1
+Columbia,Hemlock Twp,Auditor General,,REP,Timothy Defoor,309
+Columbia,Hemlock Twp,Auditor General,,REP,Other,0
+Columbia,Hemlock Twp,Auditor General,,REP,Write-In,0
+Columbia,Jackson Twp,Attorney General,,REP,Heather Heidelbaugh,106
+Columbia,Jackson Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Jackson Twp,Attorney General,,REP,Write-In,0
+Columbia,Jackson Twp,Auditor General,,REP,Timothy Defoor,103
+Columbia,Jackson Twp,Auditor General,,REP,Other,0
+Columbia,Jackson Twp,Auditor General,,REP,Write-In,0
+Columbia,Locust Twp,Attorney General,,REP,Heather Heidelbaugh,185
+Columbia,Locust Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Locust Twp,Attorney General,,REP,Write-In,1
+Columbia,Locust Twp,Auditor General,,REP,Timothy Defoor,187
+Columbia,Locust Twp,Auditor General,,REP,Other,0
+Columbia,Locust Twp,Auditor General,,REP,Write-In,0
+Columbia,Madison Twp,Attorney General,,REP,Heather Heidelbaugh,241
+Columbia,Madison Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Madison Twp,Attorney General,,REP,Write-In,0
+Columbia,Madison Twp,Auditor General,,REP,Timothy Defoor,237
+Columbia,Madison Twp,Auditor General,,REP,Other,0
+Columbia,Madison Twp,Auditor General,,REP,Write-In,1
+Columbia,Main Twp,Attorney General,,REP,Heather Heidelbaugh,128
+Columbia,Main Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Main Twp,Attorney General,,REP,Write-In,2
+Columbia,Main Twp,Auditor General,,REP,Timothy Defoor,129
+Columbia,Main Twp,Auditor General,,REP,Other,0
+Columbia,Main Twp,Auditor General,,REP,Write-In,0
+Columbia,Mifflin Twp,Attorney General,,REP,Heather Heidelbaugh,252
+Columbia,Mifflin Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Mifflin Twp,Attorney General,,REP,Write-In,3
+Columbia,Mifflin Twp,Auditor General,,REP,Timothy Defoor,248
+Columbia,Mifflin Twp,Auditor General,,REP,Other,0
+Columbia,Mifflin Twp,Auditor General,,REP,Write-In,2
+Columbia,Millville Borough,Attorney General,,REP,Heather Heidelbaugh,122
+Columbia,Millville Borough,Attorney General,,REP,Paul J Fedder,0
+Columbia,Millville Borough,Attorney General,,REP,Write-In,2
+Columbia,Millville Borough,Auditor General,,REP,Timothy Defoor,121
+Columbia,Millville Borough,Auditor General,,REP,Other,0
+Columbia,Millville Borough,Auditor General,,REP,Write-In,2
+Columbia,Montour Twp,Attorney General,,REP,Heather Heidelbaugh,117
+Columbia,Montour Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Montour Twp,Attorney General,,REP,Write-In,1
+Columbia,Montour Twp,Auditor General,,REP,Timothy Defoor,114
+Columbia,Montour Twp,Auditor General,,REP,Other,0
+Columbia,Montour Twp,Auditor General,,REP,Write-In,0
+Columbia,Mount Pleasant Twp,Attorney General,,REP,Heather Heidelbaugh,226
+Columbia,Mount Pleasant Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Mount Pleasant Twp,Attorney General,,REP,Write-In,0
+Columbia,Mount Pleasant Twp,Auditor General,,REP,Timothy Defoor,228
+Columbia,Mount Pleasant Twp,Auditor General,,REP,Other,0
+Columbia,Mount Pleasant Twp,Auditor General,,REP,Write-In,0
+Columbia,North Centre Twp,Attorney General,,REP,Heather Heidelbaugh,245
+Columbia,North Centre Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,North Centre Twp,Attorney General,,REP,Write-In,1
+Columbia,North Centre Twp,Auditor General,,REP,Timothy Defoor,246
+Columbia,North Centre Twp,Auditor General,,REP,Other,0
+Columbia,North Centre Twp,Auditor General,,REP,Write-In,2
+Columbia,Orange Twp,Attorney General,,REP,Heather Heidelbaugh,147
+Columbia,Orange Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Orange Twp,Attorney General,,REP,Write-In,1
+Columbia,Orange Twp,Auditor General,,REP,Timothy Defoor,146
+Columbia,Orange Twp,Auditor General,,REP,Other,0
+Columbia,Orange Twp,Auditor General,,REP,Write-In,1
+Columbia,Orangeville Borough,Attorney General,,REP,Heather Heidelbaugh,34
+Columbia,Orangeville Borough,Attorney General,,REP,Paul J Fedder,0
+Columbia,Orangeville Borough,Attorney General,,REP,Write-In,1
+Columbia,Orangeville Borough,Auditor General,,REP,Timothy Defoor,34
+Columbia,Orangeville Borough,Auditor General,,REP,Other,0
+Columbia,Orangeville Borough,Auditor General,,REP,Write-In,1
+Columbia,Pine Twp,Attorney General,,REP,Heather Heidelbaugh,153
+Columbia,Pine Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Pine Twp,Attorney General,,REP,Write-In,0
+Columbia,Pine Twp,Auditor General,,REP,Timothy Defoor,151
+Columbia,Pine Twp,Auditor General,,REP,Other,0
+Columbia,Pine Twp,Auditor General,,REP,Write-In,1
+Columbia,Roaringcreek Twp,Attorney General,,REP,Heather Heidelbaugh,103
+Columbia,Roaringcreek Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Roaringcreek Twp,Attorney General,,REP,Write-In,1
+Columbia,Roaringcreek Twp,Auditor General,,REP,Timothy Defoor,100
+Columbia,Roaringcreek Twp,Auditor General,,REP,Other,0
+Columbia,Roaringcreek Twp,Auditor General,,REP,Write-In,0
+Columbia,Scott Twp East,Attorney General,,REP,Heather Heidelbaugh,316
+Columbia,Scott Twp East,Attorney General,,REP,Paul J Fedder,0
+Columbia,Scott Twp East,Attorney General,,REP,Write-In,2
+Columbia,Scott Twp East,Auditor General,,REP,Timothy Defoor,315
+Columbia,Scott Twp East,Auditor General,,REP,Other,0
+Columbia,Scott Twp East,Auditor General,,REP,Write-In,2
+Columbia,Scott Twp West,Attorney General,,REP,Heather Heidelbaugh,241
+Columbia,Scott Twp West,Attorney General,,REP,Paul J Fedder,0
+Columbia,Scott Twp West,Attorney General,,REP,Write-In,1
+Columbia,Scott Twp West,Auditor General,,REP,Timothy Defoor,239
+Columbia,Scott Twp West,Auditor General,,REP,Other,0
+Columbia,Scott Twp West,Auditor General,,REP,Write-In,1
+Columbia,South Centre Twp,Attorney General,,REP,Heather Heidelbaugh,183
+Columbia,South Centre Twp,Attorney General,,REP,Paul J Fedder,1
+Columbia,South Centre Twp,Attorney General,,REP,Write-In,2
+Columbia,South Centre Twp,Auditor General,,REP,Timothy Defoor,180
+Columbia,South Centre Twp,Auditor General,,REP,Other,1
+Columbia,South Centre Twp,Auditor General,,REP,Write-In,2
+Columbia,Stillwater Borough,Attorney General,,REP,Heather Heidelbaugh,36
+Columbia,Stillwater Borough,Attorney General,,REP,Paul J Fedder,0
+Columbia,Stillwater Borough,Attorney General,,REP,Write-In,0
+Columbia,Stillwater Borough,Auditor General,,REP,Timothy Defoor,35
+Columbia,Stillwater Borough,Auditor General,,REP,Other,0
+Columbia,Stillwater Borough,Auditor General,,REP,Write-In,0
+Columbia,Sugarloaf Twp,Attorney General,,REP,Heather Heidelbaugh,151
+Columbia,Sugarloaf Twp,Attorney General,,REP,Paul J Fedder,0
+Columbia,Sugarloaf Twp,Attorney General,,REP,Write-In,0
+Columbia,Sugarloaf Twp,Auditor General,,REP,Timothy Defoor,149
+Columbia,Sugarloaf Twp,Auditor General,,REP,Other,0
+Columbia,Sugarloaf Twp,Auditor General,,REP,Write-In,1
+Columbia,Beaver Twp,State Treasurer,,REP,Stacy L Garrity,115
+Columbia,Beaver Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Beaver Twp,State Treasurer,,REP,Other,0
+Columbia,Beaver Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Beaver Twp,State Treasurer,,REP,Write-In,0
+Columbia,Benton Twp,State Treasurer,,REP,Stacy L Garrity,203
+Columbia,Benton Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Benton Twp,State Treasurer,,REP,Other,0
+Columbia,Benton Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Benton Twp,State Treasurer,,REP,Write-In,0
+Columbia,Benton Borough,State Treasurer,,REP,Stacy L Garrity,105
+Columbia,Benton Borough,State Treasurer,,REP,Joe Torsella,0
+Columbia,Benton Borough,State Treasurer,,REP,Other,0
+Columbia,Benton Borough,State Treasurer,,REP,John Timbrell,0
+Columbia,Benton Borough,State Treasurer,,REP,Write-In,0
+Columbia,Berwick 1St Ward,State Treasurer,,REP,Stacy L Garrity,330
+Columbia,Berwick 1St Ward,State Treasurer,,REP,Joe Torsella,0
+Columbia,Berwick 1St Ward,State Treasurer,,REP,Other,0
+Columbia,Berwick 1St Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Berwick 1St Ward,State Treasurer,,REP,Write-In,4
+Columbia,Berwick 2Nd Ward,State Treasurer,,REP,Stacy L Garrity,80
+Columbia,Berwick 2Nd Ward,State Treasurer,,REP,Joe Torsella,0
+Columbia,Berwick 2Nd Ward,State Treasurer,,REP,Other,0
+Columbia,Berwick 2Nd Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Berwick 2Nd Ward,State Treasurer,,REP,Write-In,0
+Columbia,Berwick 3Rd Ward,State Treasurer,,REP,Stacy L Garrity,124
+Columbia,Berwick 3Rd Ward,State Treasurer,,REP,Joe Torsella,1
+Columbia,Berwick 3Rd Ward,State Treasurer,,REP,Other,0
+Columbia,Berwick 3Rd Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Berwick 3Rd Ward,State Treasurer,,REP,Write-In,8
+Columbia,Berwick 4Th Ward,State Treasurer,,REP,Stacy L Garrity,253
+Columbia,Berwick 4Th Ward,State Treasurer,,REP,Joe Torsella,0
+Columbia,Berwick 4Th Ward,State Treasurer,,REP,Other,0
+Columbia,Berwick 4Th Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Berwick 4Th Ward,State Treasurer,,REP,Write-In,0
+Columbia,Bloomsburg 1St Ward,State Treasurer,,REP,Stacy L Garrity,64
+Columbia,Bloomsburg 1St Ward,State Treasurer,,REP,Joe Torsella,0
+Columbia,Bloomsburg 1St Ward,State Treasurer,,REP,Other,0
+Columbia,Bloomsburg 1St Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Bloomsburg 1St Ward,State Treasurer,,REP,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,State Treasurer,,REP,Stacy L Garrity,96
+Columbia,Bloomsburg 2Nd Ward,State Treasurer,,REP,Joe Torsella,0
+Columbia,Bloomsburg 2Nd Ward,State Treasurer,,REP,Other,0
+Columbia,Bloomsburg 2Nd Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Bloomsburg 2Nd Ward,State Treasurer,,REP,Write-In,1
+Columbia,Bloomsburg 3-1 Ward,State Treasurer,,REP,Stacy L Garrity,92
+Columbia,Bloomsburg 3-1 Ward,State Treasurer,,REP,Joe Torsella,0
+Columbia,Bloomsburg 3-1 Ward,State Treasurer,,REP,Other,0
+Columbia,Bloomsburg 3-1 Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Bloomsburg 3-1 Ward,State Treasurer,,REP,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,State Treasurer,,REP,Stacy L Garrity,1
+Columbia,Bloomsburg 3-2 Ward,State Treasurer,,REP,Joe Torsella,0
+Columbia,Bloomsburg 3-2 Ward,State Treasurer,,REP,Other,0
+Columbia,Bloomsburg 3-2 Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Bloomsburg 3-2 Ward,State Treasurer,,REP,Write-In,0
+Columbia,Bloomsburg 4Th Ward,State Treasurer,,REP,Stacy L Garrity,162
+Columbia,Bloomsburg 4Th Ward,State Treasurer,,REP,Joe Torsella,0
+Columbia,Bloomsburg 4Th Ward,State Treasurer,,REP,Other,0
+Columbia,Bloomsburg 4Th Ward,State Treasurer,,REP,John Timbrell,0
+Columbia,Bloomsburg 4Th Ward,State Treasurer,,REP,Write-In,2
+Columbia,Briarcreek Twp Northeast,State Treasurer,,REP,Stacy L Garrity,178
+Columbia,Briarcreek Twp Northeast,State Treasurer,,REP,Joe Torsella,0
+Columbia,Briarcreek Twp Northeast,State Treasurer,,REP,Other,0
+Columbia,Briarcreek Twp Northeast,State Treasurer,,REP,John Timbrell,0
+Columbia,Briarcreek Twp Northeast,State Treasurer,,REP,Write-In,1
+Columbia,Briarcreek Twp West,State Treasurer,,REP,Stacy L Garrity,189
+Columbia,Briarcreek Twp West,State Treasurer,,REP,Joe Torsella,0
+Columbia,Briarcreek Twp West,State Treasurer,,REP,Other,0
+Columbia,Briarcreek Twp West,State Treasurer,,REP,John Timbrell,1
+Columbia,Briarcreek Twp West,State Treasurer,,REP,Write-In,2
+Columbia,Briarcreek Borough,State Treasurer,,REP,Stacy L Garrity,35
+Columbia,Briarcreek Borough,State Treasurer,,REP,Joe Torsella,0
+Columbia,Briarcreek Borough,State Treasurer,,REP,Other,0
+Columbia,Briarcreek Borough,State Treasurer,,REP,John Timbrell,0
+Columbia,Briarcreek Borough,State Treasurer,,REP,Write-In,0
+Columbia,Catawissa Twp,State Treasurer,,REP,Stacy L Garrity,114
+Columbia,Catawissa Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Catawissa Twp,State Treasurer,,REP,Other,0
+Columbia,Catawissa Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Catawissa Twp,State Treasurer,,REP,Write-In,1
+Columbia,Catawissa Borough,State Treasurer,,REP,Stacy L Garrity,118
+Columbia,Catawissa Borough,State Treasurer,,REP,Joe Torsella,0
+Columbia,Catawissa Borough,State Treasurer,,REP,Other,0
+Columbia,Catawissa Borough,State Treasurer,,REP,John Timbrell,0
+Columbia,Catawissa Borough,State Treasurer,,REP,Write-In,0
+Columbia,Centralia Borough,State Treasurer,,REP,Stacy L Garrity,1
+Columbia,Centralia Borough,State Treasurer,,REP,Joe Torsella,0
+Columbia,Centralia Borough,State Treasurer,,REP,Other,0
+Columbia,Centralia Borough,State Treasurer,,REP,John Timbrell,0
+Columbia,Centralia Borough,State Treasurer,,REP,Write-In,0
+Columbia,Cleveland Twp,State Treasurer,,REP,Stacy L Garrity,134
+Columbia,Cleveland Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Cleveland Twp,State Treasurer,,REP,Other,0
+Columbia,Cleveland Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Cleveland Twp,State Treasurer,,REP,Write-In,0
+Columbia,Conyngham Twp,State Treasurer,,REP,Stacy L Garrity,72
+Columbia,Conyngham Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Conyngham Twp,State Treasurer,,REP,Other,0
+Columbia,Conyngham Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Conyngham Twp,State Treasurer,,REP,Write-In,0
+Columbia,Fishingcreek Twp,State Treasurer,,REP,Stacy L Garrity,186
+Columbia,Fishingcreek Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Fishingcreek Twp,State Treasurer,,REP,Other,0
+Columbia,Fishingcreek Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Fishingcreek Twp,State Treasurer,,REP,Write-In,0
+Columbia,Franklin Twp,State Treasurer,,REP,Stacy L Garrity,78
+Columbia,Franklin Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Franklin Twp,State Treasurer,,REP,Other,0
+Columbia,Franklin Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Franklin Twp,State Treasurer,,REP,Write-In,0
+Columbia,Greenwood Twp,State Treasurer,,REP,Stacy L Garrity,222
+Columbia,Greenwood Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Greenwood Twp,State Treasurer,,REP,Other,0
+Columbia,Greenwood Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Greenwood Twp,State Treasurer,,REP,Write-In,3
+Columbia,Hemlock Twp,State Treasurer,,REP,Stacy L Garrity,306
+Columbia,Hemlock Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Hemlock Twp,State Treasurer,,REP,Other,0
+Columbia,Hemlock Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Hemlock Twp,State Treasurer,,REP,Write-In,0
+Columbia,Jackson Twp,State Treasurer,,REP,Stacy L Garrity,107
+Columbia,Jackson Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Jackson Twp,State Treasurer,,REP,Other,0
+Columbia,Jackson Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Jackson Twp,State Treasurer,,REP,Write-In,0
+Columbia,Locust Twp,State Treasurer,,REP,Stacy L Garrity,186
+Columbia,Locust Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Locust Twp,State Treasurer,,REP,Other,0
+Columbia,Locust Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Locust Twp,State Treasurer,,REP,Write-In,0
+Columbia,Madison Twp,State Treasurer,,REP,Stacy L Garrity,234
+Columbia,Madison Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Madison Twp,State Treasurer,,REP,Other,0
+Columbia,Madison Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Madison Twp,State Treasurer,,REP,Write-In,1
+Columbia,Main Twp,State Treasurer,,REP,Stacy L Garrity,131
+Columbia,Main Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Main Twp,State Treasurer,,REP,Other,0
+Columbia,Main Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Main Twp,State Treasurer,,REP,Write-In,0
+Columbia,Mifflin Twp,State Treasurer,,REP,Stacy L Garrity,245
+Columbia,Mifflin Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Mifflin Twp,State Treasurer,,REP,Other,0
+Columbia,Mifflin Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Mifflin Twp,State Treasurer,,REP,Write-In,2
+Columbia,Millville Borough,State Treasurer,,REP,Stacy L Garrity,122
+Columbia,Millville Borough,State Treasurer,,REP,Joe Torsella,0
+Columbia,Millville Borough,State Treasurer,,REP,Other,0
+Columbia,Millville Borough,State Treasurer,,REP,John Timbrell,0
+Columbia,Millville Borough,State Treasurer,,REP,Write-In,2
+Columbia,Montour Twp,State Treasurer,,REP,Stacy L Garrity,118
+Columbia,Montour Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Montour Twp,State Treasurer,,REP,Other,0
+Columbia,Montour Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Montour Twp,State Treasurer,,REP,Write-In,1
+Columbia,Mount Pleasant Twp,State Treasurer,,REP,Stacy L Garrity,226
+Columbia,Mount Pleasant Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Mount Pleasant Twp,State Treasurer,,REP,Other,0
+Columbia,Mount Pleasant Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Mount Pleasant Twp,State Treasurer,,REP,Write-In,0
+Columbia,North Centre Twp,State Treasurer,,REP,Stacy L Garrity,247
+Columbia,North Centre Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,North Centre Twp,State Treasurer,,REP,Other,0
+Columbia,North Centre Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,North Centre Twp,State Treasurer,,REP,Write-In,2
+Columbia,Orange Twp,State Treasurer,,REP,Stacy L Garrity,145
+Columbia,Orange Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Orange Twp,State Treasurer,,REP,Other,0
+Columbia,Orange Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Orange Twp,State Treasurer,,REP,Write-In,1
+Columbia,Orangeville Borough,State Treasurer,,REP,Stacy L Garrity,33
+Columbia,Orangeville Borough,State Treasurer,,REP,Joe Torsella,0
+Columbia,Orangeville Borough,State Treasurer,,REP,Other,0
+Columbia,Orangeville Borough,State Treasurer,,REP,John Timbrell,0
+Columbia,Orangeville Borough,State Treasurer,,REP,Write-In,1
+Columbia,Pine Twp,State Treasurer,,REP,Stacy L Garrity,153
+Columbia,Pine Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Pine Twp,State Treasurer,,REP,Other,0
+Columbia,Pine Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Pine Twp,State Treasurer,,REP,Write-In,1
+Columbia,Roaringcreek Twp,State Treasurer,,REP,Stacy L Garrity,100
+Columbia,Roaringcreek Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Roaringcreek Twp,State Treasurer,,REP,Other,0
+Columbia,Roaringcreek Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Roaringcreek Twp,State Treasurer,,REP,Write-In,0
+Columbia,Scott Twp East,State Treasurer,,REP,Stacy L Garrity,314
+Columbia,Scott Twp East,State Treasurer,,REP,Joe Torsella,0
+Columbia,Scott Twp East,State Treasurer,,REP,Other,0
+Columbia,Scott Twp East,State Treasurer,,REP,John Timbrell,0
+Columbia,Scott Twp East,State Treasurer,,REP,Write-In,4
+Columbia,Scott Twp West,State Treasurer,,REP,Stacy L Garrity,237
+Columbia,Scott Twp West,State Treasurer,,REP,Joe Torsella,0
+Columbia,Scott Twp West,State Treasurer,,REP,Other,0
+Columbia,Scott Twp West,State Treasurer,,REP,John Timbrell,0
+Columbia,Scott Twp West,State Treasurer,,REP,Write-In,1
+Columbia,South Centre Twp,State Treasurer,,REP,Stacy L Garrity,181
+Columbia,South Centre Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,South Centre Twp,State Treasurer,,REP,Other,1
+Columbia,South Centre Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,South Centre Twp,State Treasurer,,REP,Write-In,1
+Columbia,Stillwater Borough,State Treasurer,,REP,Stacy L Garrity,36
+Columbia,Stillwater Borough,State Treasurer,,REP,Joe Torsella,0
+Columbia,Stillwater Borough,State Treasurer,,REP,Other,0
+Columbia,Stillwater Borough,State Treasurer,,REP,John Timbrell,0
+Columbia,Stillwater Borough,State Treasurer,,REP,Write-In,0
+Columbia,Sugarloaf Twp,State Treasurer,,REP,Stacy L Garrity,147
+Columbia,Sugarloaf Twp,State Treasurer,,REP,Joe Torsella,0
+Columbia,Sugarloaf Twp,State Treasurer,,REP,Other,0
+Columbia,Sugarloaf Twp,State Treasurer,,REP,John Timbrell,0
+Columbia,Sugarloaf Twp,State Treasurer,,REP,Write-In,1
+Columbia,Beaver Twp,Representative In Congress,9,REP,Dan Meuser,115
+Columbia,Beaver Twp,Representative In Congress,9,REP,Other,0
+Columbia,Beaver Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Beaver Twp,Representative In Congress,9,REP,Write-In,1
+Columbia,Benton Twp,Representative In Congress,9,REP,Dan Meuser,208
+Columbia,Benton Twp,Representative In Congress,9,REP,Other,0
+Columbia,Benton Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Benton Twp,Representative In Congress,9,REP,Write-In,1
+Columbia,Benton Borough,Representative In Congress,9,REP,Dan Meuser,107
+Columbia,Benton Borough,Representative In Congress,9,REP,Other,0
+Columbia,Benton Borough,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Benton Borough,Representative In Congress,9,REP,Write-In,1
+Columbia,Berwick 1St Ward,Representative In Congress,9,REP,Dan Meuser,342
+Columbia,Berwick 1St Ward,Representative In Congress,9,REP,Other,0
+Columbia,Berwick 1St Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Berwick 1St Ward,Representative In Congress,9,REP,Write-In,4
+Columbia,Berwick 2Nd Ward,Representative In Congress,9,REP,Dan Meuser,83
+Columbia,Berwick 2Nd Ward,Representative In Congress,9,REP,Other,0
+Columbia,Berwick 2Nd Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Berwick 2Nd Ward,Representative In Congress,9,REP,Write-In,1
+Columbia,Berwick 3Rd Ward,Representative In Congress,9,REP,Dan Meuser,140
+Columbia,Berwick 3Rd Ward,Representative In Congress,9,REP,Other,0
+Columbia,Berwick 3Rd Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Berwick 3Rd Ward,Representative In Congress,9,REP,Write-In,2
+Columbia,Berwick 4Th Ward,Representative In Congress,9,REP,Dan Meuser,270
+Columbia,Berwick 4Th Ward,Representative In Congress,9,REP,Other,0
+Columbia,Berwick 4Th Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Berwick 4Th Ward,Representative In Congress,9,REP,Write-In,1
+Columbia,Bloomsburg 1St Ward,Representative In Congress,9,REP,Dan Meuser,65
+Columbia,Bloomsburg 1St Ward,Representative In Congress,9,REP,Other,0
+Columbia,Bloomsburg 1St Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Bloomsburg 1St Ward,Representative In Congress,9,REP,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Representative In Congress,9,REP,Dan Meuser,101
+Columbia,Bloomsburg 2Nd Ward,Representative In Congress,9,REP,Other,0
+Columbia,Bloomsburg 2Nd Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Bloomsburg 2Nd Ward,Representative In Congress,9,REP,Write-In,2
+Columbia,Bloomsburg 3-1 Ward,Representative In Congress,9,REP,Dan Meuser,95
+Columbia,Bloomsburg 3-1 Ward,Representative In Congress,9,REP,Other,0
+Columbia,Bloomsburg 3-1 Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Bloomsburg 3-1 Ward,Representative In Congress,9,REP,Write-In,1
+Columbia,Bloomsburg 3-2 Ward,Representative In Congress,9,REP,Dan Meuser,1
+Columbia,Bloomsburg 3-2 Ward,Representative In Congress,9,REP,Other,0
+Columbia,Bloomsburg 3-2 Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Bloomsburg 3-2 Ward,Representative In Congress,9,REP,Write-In,0
+Columbia,Bloomsburg 4Th Ward,Representative In Congress,9,REP,Dan Meuser,178
+Columbia,Bloomsburg 4Th Ward,Representative In Congress,9,REP,Other,0
+Columbia,Bloomsburg 4Th Ward,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Bloomsburg 4Th Ward,Representative In Congress,9,REP,Write-In,0
+Columbia,Briarcreek Twp Northeast,Representative In Congress,9,REP,Dan Meuser,185
+Columbia,Briarcreek Twp Northeast,Representative In Congress,9,REP,Other,0
+Columbia,Briarcreek Twp Northeast,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Briarcreek Twp Northeast,Representative In Congress,9,REP,Write-In,0
+Columbia,Briarcreek Twp West,Representative In Congress,9,REP,Dan Meuser,197
+Columbia,Briarcreek Twp West,Representative In Congress,9,REP,Other,0
+Columbia,Briarcreek Twp West,Representative In Congress,9,REP,John Timbrell,1
+Columbia,Briarcreek Twp West,Representative In Congress,9,REP,Write-In,2
+Columbia,Briarcreek Borough,Representative In Congress,9,REP,Dan Meuser,43
+Columbia,Briarcreek Borough,Representative In Congress,9,REP,Other,0
+Columbia,Briarcreek Borough,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Briarcreek Borough,Representative In Congress,9,REP,Write-In,0
+Columbia,Catawissa Twp,Representative In Congress,9,REP,Dan Meuser,121
+Columbia,Catawissa Twp,Representative In Congress,9,REP,Other,0
+Columbia,Catawissa Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Catawissa Twp,Representative In Congress,9,REP,Write-In,0
+Columbia,Catawissa Borough,Representative In Congress,9,REP,Dan Meuser,123
+Columbia,Catawissa Borough,Representative In Congress,9,REP,Other,0
+Columbia,Catawissa Borough,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Catawissa Borough,Representative In Congress,9,REP,Write-In,2
+Columbia,Centralia Borough,Representative In Congress,9,REP,Dan Meuser,2
+Columbia,Centralia Borough,Representative In Congress,9,REP,Other,0
+Columbia,Centralia Borough,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Centralia Borough,Representative In Congress,9,REP,Write-In,0
+Columbia,Cleveland Twp,Representative In Congress,9,REP,Dan Meuser,140
+Columbia,Cleveland Twp,Representative In Congress,9,REP,Other,0
+Columbia,Cleveland Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Cleveland Twp,Representative In Congress,9,REP,Write-In,0
+Columbia,Conyngham Twp,Representative In Congress,9,REP,Dan Meuser,69
+Columbia,Conyngham Twp,Representative In Congress,9,REP,Other,0
+Columbia,Conyngham Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Conyngham Twp,Representative In Congress,9,REP,Write-In,0
+Columbia,Fishingcreek Twp,Representative In Congress,9,REP,Dan Meuser,198
+Columbia,Fishingcreek Twp,Representative In Congress,9,REP,Other,0
+Columbia,Fishingcreek Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Fishingcreek Twp,Representative In Congress,9,REP,Write-In,0
+Columbia,Franklin Twp,Representative In Congress,9,REP,Dan Meuser,82
+Columbia,Franklin Twp,Representative In Congress,9,REP,Other,0
+Columbia,Franklin Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Franklin Twp,Representative In Congress,9,REP,Write-In,0
+Columbia,Greenwood Twp,Representative In Congress,9,REP,Dan Meuser,225
+Columbia,Greenwood Twp,Representative In Congress,9,REP,Other,0
+Columbia,Greenwood Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Greenwood Twp,Representative In Congress,9,REP,Write-In,5
+Columbia,Hemlock Twp,Representative In Congress,9,REP,Dan Meuser,314
+Columbia,Hemlock Twp,Representative In Congress,9,REP,Other,0
+Columbia,Hemlock Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Hemlock Twp,Representative In Congress,9,REP,Write-In,4
+Columbia,Jackson Twp,Representative In Congress,9,REP,Dan Meuser,107
+Columbia,Jackson Twp,Representative In Congress,9,REP,Other,0
+Columbia,Jackson Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Jackson Twp,Representative In Congress,9,REP,Write-In,0
+Columbia,Locust Twp,Representative In Congress,9,REP,Dan Meuser,188
+Columbia,Locust Twp,Representative In Congress,9,REP,Other,0
+Columbia,Locust Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Locust Twp,Representative In Congress,9,REP,Write-In,2
+Columbia,Madison Twp,Representative In Congress,9,REP,Dan Meuser,247
+Columbia,Madison Twp,Representative In Congress,9,REP,Other,0
+Columbia,Madison Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Madison Twp,Representative In Congress,9,REP,Write-In,1
+Columbia,Main Twp,Representative In Congress,9,REP,Dan Meuser,135
+Columbia,Main Twp,Representative In Congress,9,REP,Other,0
+Columbia,Main Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Main Twp,Representative In Congress,9,REP,Write-In,1
+Columbia,Mifflin Twp,Representative In Congress,9,REP,Dan Meuser,249
+Columbia,Mifflin Twp,Representative In Congress,9,REP,Other,0
+Columbia,Mifflin Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Mifflin Twp,Representative In Congress,9,REP,Write-In,3
+Columbia,Millville Borough,Representative In Congress,9,REP,Dan Meuser,126
+Columbia,Millville Borough,Representative In Congress,9,REP,Other,0
+Columbia,Millville Borough,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Millville Borough,Representative In Congress,9,REP,Write-In,3
+Columbia,Montour Twp,Representative In Congress,9,REP,Dan Meuser,125
+Columbia,Montour Twp,Representative In Congress,9,REP,Other,0
+Columbia,Montour Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Montour Twp,Representative In Congress,9,REP,Write-In,1
+Columbia,Mount Pleasant Twp,Representative In Congress,9,REP,Dan Meuser,239
+Columbia,Mount Pleasant Twp,Representative In Congress,9,REP,Other,0
+Columbia,Mount Pleasant Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Mount Pleasant Twp,Representative In Congress,9,REP,Write-In,0
+Columbia,North Centre Twp,Representative In Congress,9,REP,Dan Meuser,249
+Columbia,North Centre Twp,Representative In Congress,9,REP,Other,0
+Columbia,North Centre Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,North Centre Twp,Representative In Congress,9,REP,Write-In,2
+Columbia,Orange Twp,Representative In Congress,9,REP,Dan Meuser,147
+Columbia,Orange Twp,Representative In Congress,9,REP,Other,0
+Columbia,Orange Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Orange Twp,Representative In Congress,9,REP,Write-In,1
+Columbia,Orangeville Borough,Representative In Congress,9,REP,Dan Meuser,34
+Columbia,Orangeville Borough,Representative In Congress,9,REP,Other,0
+Columbia,Orangeville Borough,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Orangeville Borough,Representative In Congress,9,REP,Write-In,0
+Columbia,Pine Twp,Representative In Congress,9,REP,Dan Meuser,159
+Columbia,Pine Twp,Representative In Congress,9,REP,Other,0
+Columbia,Pine Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Pine Twp,Representative In Congress,9,REP,Write-In,1
+Columbia,Roaringcreek Twp,Representative In Congress,9,REP,Dan Meuser,98
+Columbia,Roaringcreek Twp,Representative In Congress,9,REP,Other,0
+Columbia,Roaringcreek Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Roaringcreek Twp,Representative In Congress,9,REP,Write-In,2
+Columbia,Scott Twp East,Representative In Congress,9,REP,Dan Meuser,319
+Columbia,Scott Twp East,Representative In Congress,9,REP,Other,0
+Columbia,Scott Twp East,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Scott Twp East,Representative In Congress,9,REP,Write-In,6
+Columbia,Scott Twp West,Representative In Congress,9,REP,Dan Meuser,242
+Columbia,Scott Twp West,Representative In Congress,9,REP,Other,0
+Columbia,Scott Twp West,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Scott Twp West,Representative In Congress,9,REP,Write-In,3
+Columbia,South Centre Twp,Representative In Congress,9,REP,Dan Meuser,183
+Columbia,South Centre Twp,Representative In Congress,9,REP,Other,1
+Columbia,South Centre Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,South Centre Twp,Representative In Congress,9,REP,Write-In,1
+Columbia,Stillwater Borough,Representative In Congress,9,REP,Dan Meuser,36
+Columbia,Stillwater Borough,Representative In Congress,9,REP,Other,0
+Columbia,Stillwater Borough,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Stillwater Borough,Representative In Congress,9,REP,Write-In,0
+Columbia,Sugarloaf Twp,Representative In Congress,9,REP,Dan Meuser,154
+Columbia,Sugarloaf Twp,Representative In Congress,9,REP,Other,0
+Columbia,Sugarloaf Twp,Representative In Congress,9,REP,John Timbrell,0
+Columbia,Sugarloaf Twp,Representative In Congress,9,REP,Write-In,0
+Columbia,Beaver Twp,Senator In The General Assembly,27,REP,John R Gordner,124
+Columbia,Beaver Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Beaver Twp,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,Beaver Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Beaver Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Benton Twp,Senator In The General Assembly,27,REP,John R Gordner,212
+Columbia,Benton Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Benton Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Benton Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Benton Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Benton Borough,Senator In The General Assembly,27,REP,John R Gordner,113
+Columbia,Benton Borough,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Benton Borough,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Benton Borough,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Benton Borough,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Berwick 1St Ward,Senator In The General Assembly,27,REP,John R Gordner,355
+Columbia,Berwick 1St Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Berwick 1St Ward,Senator In The General Assembly,27,REP,Write-In,2
+Columbia,Berwick 1St Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Berwick 1St Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Berwick 2Nd Ward,Senator In The General Assembly,27,REP,John R Gordner,88
+Columbia,Berwick 2Nd Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Berwick 2Nd Ward,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Berwick 3Rd Ward,Senator In The General Assembly,27,REP,John R Gordner,145
+Columbia,Berwick 3Rd Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Berwick 3Rd Ward,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Berwick 4Th Ward,Senator In The General Assembly,27,REP,John R Gordner,278
+Columbia,Berwick 4Th Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Berwick 4Th Ward,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Bloomsburg 1St Ward,Senator In The General Assembly,27,REP,John R Gordner,67
+Columbia,Bloomsburg 1St Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Bloomsburg 1St Ward,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Senator In The General Assembly,27,REP,John R Gordner,109
+Columbia,Bloomsburg 2Nd Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Bloomsburg 2Nd Ward,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Bloomsburg 3-1 Ward,Senator In The General Assembly,27,REP,John R Gordner,100
+Columbia,Bloomsburg 3-1 Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Bloomsburg 3-1 Ward,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,Senator In The General Assembly,27,REP,John R Gordner,1
+Columbia,Bloomsburg 3-2 Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Bloomsburg 3-2 Ward,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Bloomsburg 4Th Ward,Senator In The General Assembly,27,REP,John R Gordner,182
+Columbia,Bloomsburg 4Th Ward,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Bloomsburg 4Th Ward,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Briarcreek Twp Northeast,Senator In The General Assembly,27,REP,John R Gordner,197
+Columbia,Briarcreek Twp Northeast,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Briarcreek Twp Northeast,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Briarcreek Twp West,Senator In The General Assembly,27,REP,John R Gordner,207
+Columbia,Briarcreek Twp West,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Briarcreek Twp West,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Briarcreek Twp West,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Briarcreek Twp West,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Briarcreek Borough,Senator In The General Assembly,27,REP,John R Gordner,41
+Columbia,Briarcreek Borough,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Briarcreek Borough,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Briarcreek Borough,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Briarcreek Borough,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Catawissa Twp,Senator In The General Assembly,27,REP,John R Gordner,118
+Columbia,Catawissa Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Catawissa Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Catawissa Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Catawissa Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Catawissa Borough,Senator In The General Assembly,27,REP,John R Gordner,132
+Columbia,Catawissa Borough,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Catawissa Borough,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,Catawissa Borough,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Catawissa Borough,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Centralia Borough,Senator In The General Assembly,27,REP,John R Gordner,1
+Columbia,Centralia Borough,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Centralia Borough,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Centralia Borough,Representative In The General Assembly,107,REP,Kurt A Masser,2
+Columbia,Centralia Borough,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Cleveland Twp,Senator In The General Assembly,27,REP,John R Gordner,151
+Columbia,Cleveland Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Cleveland Twp,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,Cleveland Twp,Representative In The General Assembly,107,REP,Kurt A Masser,148
+Columbia,Cleveland Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Conyngham Twp,Senator In The General Assembly,27,REP,John R Gordner,72
+Columbia,Conyngham Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Conyngham Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Conyngham Twp,Representative In The General Assembly,107,REP,Kurt A Masser,70
+Columbia,Conyngham Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Fishingcreek Twp,Senator In The General Assembly,27,REP,John R Gordner,204
+Columbia,Fishingcreek Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Fishingcreek Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Fishingcreek Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Fishingcreek Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Franklin Twp,Senator In The General Assembly,27,REP,John R Gordner,83
+Columbia,Franklin Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Franklin Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Franklin Twp,Representative In The General Assembly,107,REP,Kurt A Masser,81
+Columbia,Franklin Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Greenwood Twp,Senator In The General Assembly,27,REP,John R Gordner,243
+Columbia,Greenwood Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Greenwood Twp,Senator In The General Assembly,27,REP,Write-In,2
+Columbia,Greenwood Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Greenwood Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Hemlock Twp,Senator In The General Assembly,27,REP,John R Gordner,329
+Columbia,Hemlock Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Hemlock Twp,Senator In The General Assembly,27,REP,Write-In,2
+Columbia,Hemlock Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Hemlock Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Jackson Twp,Senator In The General Assembly,27,REP,John R Gordner,113
+Columbia,Jackson Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Jackson Twp,Senator In The General Assembly,27,REP,Write-In,2
+Columbia,Jackson Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Jackson Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Locust Twp,Senator In The General Assembly,27,REP,John R Gordner,193
+Columbia,Locust Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Locust Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Locust Twp,Representative In The General Assembly,107,REP,Kurt A Masser,188
+Columbia,Locust Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Madison Twp,Senator In The General Assembly,27,REP,John R Gordner,259
+Columbia,Madison Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Madison Twp,Senator In The General Assembly,27,REP,Write-In,2
+Columbia,Madison Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Madison Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Main Twp,Senator In The General Assembly,27,REP,John R Gordner,143
+Columbia,Main Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Main Twp,Senator In The General Assembly,27,REP,Write-In,3
+Columbia,Main Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Main Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Mifflin Twp,Senator In The General Assembly,27,REP,John R Gordner,264
+Columbia,Mifflin Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Mifflin Twp,Senator In The General Assembly,27,REP,Write-In,2
+Columbia,Mifflin Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Mifflin Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Millville Borough,Senator In The General Assembly,27,REP,John R Gordner,130
+Columbia,Millville Borough,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Millville Borough,Senator In The General Assembly,27,REP,Write-In,2
+Columbia,Millville Borough,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Millville Borough,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Montour Twp,Senator In The General Assembly,27,REP,John R Gordner,127
+Columbia,Montour Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Montour Twp,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,Montour Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Montour Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Mount Pleasant Twp,Senator In The General Assembly,27,REP,John R Gordner,249
+Columbia,Mount Pleasant Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Mount Pleasant Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,North Centre Twp,Senator In The General Assembly,27,REP,John R Gordner,267
+Columbia,North Centre Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,North Centre Twp,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,North Centre Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,North Centre Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Orange Twp,Senator In The General Assembly,27,REP,John R Gordner,156
+Columbia,Orange Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Orange Twp,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,Orange Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Orange Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Orangeville Borough,Senator In The General Assembly,27,REP,John R Gordner,35
+Columbia,Orangeville Borough,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Orangeville Borough,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,Orangeville Borough,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Orangeville Borough,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Pine Twp,Senator In The General Assembly,27,REP,John R Gordner,161
+Columbia,Pine Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Pine Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Pine Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Pine Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Roaringcreek Twp,Senator In The General Assembly,27,REP,John R Gordner,105
+Columbia,Roaringcreek Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Roaringcreek Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Roaringcreek Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Roaringcreek Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Scott Twp East,Senator In The General Assembly,27,REP,John R Gordner,338
+Columbia,Scott Twp East,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Scott Twp East,Senator In The General Assembly,27,REP,Write-In,3
+Columbia,Scott Twp East,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Scott Twp East,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Scott Twp West,Senator In The General Assembly,27,REP,John R Gordner,253
+Columbia,Scott Twp West,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Scott Twp West,Senator In The General Assembly,27,REP,Write-In,1
+Columbia,Scott Twp West,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Scott Twp West,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,South Centre Twp,Senator In The General Assembly,27,REP,John R Gordner,190
+Columbia,South Centre Twp,Senator In The General Assembly,27,REP,Paul J Fedder,1
+Columbia,South Centre Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,South Centre Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,South Centre Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Stillwater Borough,Senator In The General Assembly,27,REP,John R Gordner,36
+Columbia,Stillwater Borough,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Stillwater Borough,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Stillwater Borough,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Stillwater Borough,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Sugarloaf Twp,Senator In The General Assembly,27,REP,John R Gordner,159
+Columbia,Sugarloaf Twp,Senator In The General Assembly,27,REP,Paul J Fedder,0
+Columbia,Sugarloaf Twp,Senator In The General Assembly,27,REP,Write-In,0
+Columbia,Sugarloaf Twp,Representative In The General Assembly,107,REP,Kurt A Masser,0
+Columbia,Sugarloaf Twp,Representative In The General Assembly,107,REP,Write-In,0
+Columbia,Beaver Twp,Representative In The General Assembly,109,REP,David Millard,119
+Columbia,Beaver Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Beaver Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Benton Twp,Representative In The General Assembly,109,REP,David Millard,206
+Columbia,Benton Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Benton Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Benton Borough,Representative In The General Assembly,109,REP,David Millard,111
+Columbia,Benton Borough,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Benton Borough,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Berwick 1St Ward,Representative In The General Assembly,109,REP,David Millard,348
+Columbia,Berwick 1St Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Berwick 1St Ward,Representative In The General Assembly,109,REP,Write-In,4
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,109,REP,David Millard,85
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Berwick 2Nd Ward,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,109,REP,David Millard,147
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Berwick 3Rd Ward,Representative In The General Assembly,109,REP,Write-In,1
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,109,REP,David Millard,275
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Berwick 4Th Ward,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,109,REP,David Millard,65
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Bloomsburg 1St Ward,Representative In The General Assembly,109,REP,Write-In,1
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,109,REP,David Millard,111
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Bloomsburg 2Nd Ward,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,109,REP,David Millard,98
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Bloomsburg 3-1 Ward,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,109,REP,David Millard,1
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Bloomsburg 3-2 Ward,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,109,REP,David Millard,176
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Bloomsburg 4Th Ward,Representative In The General Assembly,109,REP,Write-In,2
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,109,REP,David Millard,193
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Briarcreek Twp Northeast,Representative In The General Assembly,109,REP,Write-In,1
+Columbia,Briarcreek Twp West,Representative In The General Assembly,109,REP,David Millard,203
+Columbia,Briarcreek Twp West,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Briarcreek Twp West,Representative In The General Assembly,109,REP,Write-In,1
+Columbia,Briarcreek Borough,Representative In The General Assembly,109,REP,David Millard,40
+Columbia,Briarcreek Borough,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Briarcreek Borough,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Catawissa Twp,Representative In The General Assembly,109,REP,David Millard,122
+Columbia,Catawissa Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Catawissa Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Catawissa Borough,Representative In The General Assembly,109,REP,David Millard,130
+Columbia,Catawissa Borough,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Catawissa Borough,Representative In The General Assembly,109,REP,Write-In,1
+Columbia,Centralia Borough,Representative In The General Assembly,109,REP,David Millard,0
+Columbia,Centralia Borough,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Centralia Borough,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Cleveland Twp,Representative In The General Assembly,109,REP,David Millard,0
+Columbia,Cleveland Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Cleveland Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Conyngham Twp,Representative In The General Assembly,109,REP,David Millard,0
+Columbia,Conyngham Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Conyngham Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Fishingcreek Twp,Representative In The General Assembly,109,REP,David Millard,199
+Columbia,Fishingcreek Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Fishingcreek Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Franklin Twp,Representative In The General Assembly,109,REP,David Millard,0
+Columbia,Franklin Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Franklin Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Greenwood Twp,Representative In The General Assembly,109,REP,David Millard,245
+Columbia,Greenwood Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Greenwood Twp,Representative In The General Assembly,109,REP,Write-In,3
+Columbia,Hemlock Twp,Representative In The General Assembly,109,REP,David Millard,328
+Columbia,Hemlock Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Hemlock Twp,Representative In The General Assembly,109,REP,Write-In,2
+Columbia,Jackson Twp,Representative In The General Assembly,109,REP,David Millard,113
+Columbia,Jackson Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Jackson Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Locust Twp,Representative In The General Assembly,109,REP,David Millard,0
+Columbia,Locust Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Locust Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Madison Twp,Representative In The General Assembly,109,REP,David Millard,258
+Columbia,Madison Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Madison Twp,Representative In The General Assembly,109,REP,Write-In,2
+Columbia,Main Twp,Representative In The General Assembly,109,REP,David Millard,140
+Columbia,Main Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Main Twp,Representative In The General Assembly,109,REP,Write-In,3
+Columbia,Mifflin Twp,Representative In The General Assembly,109,REP,David Millard,259
+Columbia,Mifflin Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Mifflin Twp,Representative In The General Assembly,109,REP,Write-In,2
+Columbia,Millville Borough,Representative In The General Assembly,109,REP,David Millard,118
+Columbia,Millville Borough,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Millville Borough,Representative In The General Assembly,109,REP,Write-In,3
+Columbia,Montour Twp,Representative In The General Assembly,109,REP,David Millard,125
+Columbia,Montour Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Montour Twp,Representative In The General Assembly,109,REP,Write-In,1
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,109,REP,David Millard,242
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Mount Pleasant Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,North Centre Twp,Representative In The General Assembly,109,REP,David Millard,261
+Columbia,North Centre Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,North Centre Twp,Representative In The General Assembly,109,REP,Write-In,4
+Columbia,Orange Twp,Representative In The General Assembly,109,REP,David Millard,159
+Columbia,Orange Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Orange Twp,Representative In The General Assembly,109,REP,Write-In,2
+Columbia,Orangeville Borough,Representative In The General Assembly,109,REP,David Millard,36
+Columbia,Orangeville Borough,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Orangeville Borough,Representative In The General Assembly,109,REP,Write-In,1
+Columbia,Pine Twp,Representative In The General Assembly,109,REP,David Millard,159
+Columbia,Pine Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Pine Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Roaringcreek Twp,Representative In The General Assembly,109,REP,David Millard,101
+Columbia,Roaringcreek Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Roaringcreek Twp,Representative In The General Assembly,109,REP,Write-In,2
+Columbia,Scott Twp East,Representative In The General Assembly,109,REP,David Millard,332
+Columbia,Scott Twp East,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Scott Twp East,Representative In The General Assembly,109,REP,Write-In,3
+Columbia,Scott Twp West,Representative In The General Assembly,109,REP,David Millard,250
+Columbia,Scott Twp West,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Scott Twp West,Representative In The General Assembly,109,REP,Write-In,2
+Columbia,South Centre Twp,Representative In The General Assembly,109,REP,David Millard,187
+Columbia,South Centre Twp,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,South Centre Twp,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Stillwater Borough,Representative In The General Assembly,109,REP,David Millard,36
+Columbia,Stillwater Borough,Representative In The General Assembly,109,REP,J P Morgan,0
+Columbia,Stillwater Borough,Representative In The General Assembly,109,REP,Write-In,0
+Columbia,Sugarloaf Twp,Representative In The General Assembly,109,REP,David Millard,158
+Columbia,Sugarloaf Twp,Representative In The General Assembly,109,REP,J P Morgan,1
+Columbia,Sugarloaf Twp,Representative In The General Assembly,109,REP,Write-In,1

--- a/parsers/pa_bradford_primary_2020_results_parser.py
+++ b/parsers/pa_bradford_primary_2020_results_parser.py
@@ -232,8 +232,12 @@ class TableHeader:
 
     @staticmethod
     def _candidate_data_iter(table_headers):
+        party = ''
         for header, subheaders in table_headers:
-            party, office, district = TableHeader._parse_column_header(*header)
+            next_party, office, district = TableHeader._parse_column_header(*header)
+            assert(not next_party or not party or party == next_party)
+            if not party:
+                party = next_party
             for subheader in subheaders:
                 candidate = SUBHEADER_TO_CANDIDATE_MAPPING.get(subheader, subheader)
                 yield CandidateData(office.title(), district, party, candidate.title())

--- a/parsers/pa_bradford_primary_2020_results_parser.py
+++ b/parsers/pa_bradford_primary_2020_results_parser.py
@@ -1,0 +1,438 @@
+from collections import defaultdict, namedtuple
+from pdfreader import PageDoesNotExist, SimplePDFViewer
+import csv
+import os
+
+
+CandidateData = namedtuple('CandidateData', 'office district party candidate')
+ParsedRow = namedtuple('ParsedRow', 'county precinct office district party candidate '
+                                    'election_day absentee mail_in provisional votes')
+
+COUNTY = 'Bradford'
+
+OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__bradford__precinct.csv')
+OUTPUT_HEADER = ['county', 'precinct', 'office', 'district', 'party', 'candidate',
+                 'election_day', 'absentee', 'mail_in', 'provisional', 'votes']
+
+BRADFORD_FILE = os.path.join('..', '..', 'openelections-sources-pa', '2020',
+                             'Bradford PA Primary SOVC_JUNEFINALREPORT.pdf')
+BRADFORD_HEADER = [
+    '',
+    'Statement of Votes Cast',
+    ' BRADFORD COUNTY, PA',
+    'GENERAL PRIMARY ELECTION',
+    'JUNE 2, 2020',
+    'RESULTS', 'Date: 6/19/2020',
+    'Time: 2:43:10 PM EDT'
+]
+
+PARTY_MAP = {
+    '(REPUBLICAN)': 'REP',
+    '(DEMOCRATIC)': 'DEM'
+}
+
+TERMINAL_TABLE_HEADER_STRING = 'Jurisdiction Wide'
+FIRST_SUBHEADER_STRING = 'Reg.'
+TERMINAL_SUBHEADER_STRINGS = ('Write-in', 'Turnout')
+WRITE_IN_SUBSTRING = '(W)'
+CONGRESSIONAL_KEYWORDS = ('IN THE GENERAL ASSEMBLY', 'IN CONGRESS')
+INVALID_OFFICES = ('Delegate', 'Dlegate', 'Republican Committee')
+VOTE_CATEGORIES = ('Normal', 'Absentee', 'Mail-In', 'Provisional')
+
+VALID_SUBHEADERS = {
+    'Reg. Voters',
+    'Ballots Cast',
+    '% Turnout',
+    'Total Votes',
+    'BERNIE SANDERS',
+    'BERNIE SANDERS (W)',
+    'JOSEPH R. BIDEN',
+    'JOSEPH BIDEN  (W)',
+    'TULSI GABBARD',
+    'DONALD J. TRUMP',
+    'DONALD TRUMP  (W)',
+    'JOSH SHAPIRO',
+    'JOSH SHAPIRO  (W)',
+    'HEATHER HEIDELBAUG H',
+    'HEATHER HEIDELBAUG H  (W)',
+    'H. SCOTT CONKLIN',
+    'MICHAEL LAMB',
+    'TRACIE FOUNTAIN',
+    'ROSE ROSIE MARIE DAVIS',
+    'NINA AHMAD',
+    'CHRISTINA M. HARTMAN',
+    'CHRISTINA HARTMAN',
+    'CHRISTINA HARTMAN (W)',
+    'TIMOTHY DEFOOR',
+    'TIMOTHY DEFOOR  (W)',
+    'TRACIE FOUNTAIN',
+    'TRACIE FOUNTAIN (W)',
+    'JOE TORSELLA',
+    'JOSEPH TORSELLA',
+    'JOSEPH TORSELLA (W)',
+    'STACY L. GARRITY',
+    'STACY GARRITY  (W)',
+    'LEE GRIFFIN',
+    'LEE GRIFFIN (W)',
+    'FRED KELLER',
+    'FRED KELLER (W)',
+    'DOUG MCLINKO',
+    'DOUG MCLINKO  (W)',
+    'JACKIE BAKER',
+    'JACKIE BAKER  (W)',
+    'GENE YAW',
+    'GENE YAW (W)',
+    'CLINT OWLETT',
+    'CLINT OWLETT  (W)',
+    'TINA PICKETT',
+    'TINA PICKETT (W)',
+    'DONNA IANNONE  (W)',
+    'JAMES J DALY (W)',
+    'JAMES J DALY  (W)',
+    'JAMES SHAW',
+    'JAMES SHAW (W)',
+    'NANCI ROMMEL',
+    'KEITH BIERLY',
+    'RACHEL DELGREGO',
+    'RICK THOMAS',
+    'CAROLINE RIES',
+    'KIMBERLY HART',
+    'TARAN SAMARTH',
+    'DANNY MULDOWNEY',
+    'ROQUE ROCKY DE LA FUENTE',
+    'BILL WELD',
+    'DONALD HOFFMAN',
+    'CAROL SIDES',
+    'DAVE HUFFMAN',
+    'ALAN HALL',
+    'KRYSTLE BRISTOL',
+    'TODD ROBATIN',
+    'MARK J. HARRIS',
+    'DAVID ROCKWELL',
+    'DAVID ROCKWELL (W)',
+    'DANIEL F. CLARK',
+    'MARY J. HAYES',
+    'IRENE C. HARRIS',
+    'BRIAN R. HARRIS',
+    'O.B. BUDDY CROCKETT, JR.',
+    'NANCY C. CROCKETT',
+    'JOYCE A. GRANT',
+    'EDWARD S. GRANT',
+    'GERALD V. ALLEN',
+    'HOWARD J. SMITH',
+    'JAMES VAN BLARCOM',
+    'DARLENE VAN BLARCOM',
+    'W. THOMAS BLACKALL',
+    'DEEANN TOKACH',
+    'ERIC A. CHAFFEE',
+    'JASON C. KRISE',
+    'VERNON PERRY, III',
+    'NORMA MOORE',
+    'ANN EASTABROOK',
+    'PAT ANTHONY',
+    'DEAN CACCIAVILLA NO',
+    'DAWN I. CLOSE',
+    'DIANE ELLIOTT',
+    'GRACE GEORGE',
+    'JOHN P. GEORGE',
+    'ANDREW HICKEY',
+    'ERIC MATTHEWS',
+    'JANICE M. KELLOGG',
+    'VICTOR LAWSON',
+    'RICHARD HARRIS',
+    'BETTY HARRIS',
+    'DARYL MILLER',
+    'KAY MILLER',
+    'SEBRINA SHANKS',
+    'DAVID A. SHADDUCK',
+    'MARLETA L. SHADDUCK',
+    'CHAD M. SALSMAN',
+    'SUSAN L. SALSMAN',
+    'WILLIAM W. THEM',
+    'Write-in',
+}
+
+
+SUBHEADER_TO_CANDIDATE_MAPPING = {
+    'BERNIE SANDERS (W)': 'BERNIE SANDERS',
+    'JOSEPH BIDEN  (W)': 'JOSEPH R. BIDEN',
+    'DONALD TRUMP  (W)': 'DONALD J. TRUMP',
+    'JOSH SHAPIRO  (W)': 'JOSH SHAPIRO',
+    'HEATHER HEIDELBAUG H': 'HEATHER HEIDELBAUGH',
+    'HEATHER HEIDELBAUG H  (W)': 'HEATHER HEIDELBAUGH',
+    'CHRISTINA HARTMAN': 'CHRISTINA M. HARTMAN',
+    'CHRISTINA HARTMAN (W)': 'CHRISTINA M. HARTMAN',
+    'TIMOTHY DEFOOR  (W)': 'TIMOTHY DEFOOR',
+    'TRACIE FOUNTAIN (W)': 'TRACIE FOUNTAIN',
+    'JOE TORSELLA': 'JOSEPH TORSELLA',
+    'JOSEPH TORSELLA (W)': 'JOSEPH TORSELLA',
+    'STACY GARRITY  (W)': 'STACY L. GARRITY',
+    'LEE GRIFFIN (W)': 'LEE GRIFFIN',
+    'FRED KELLER (W)': 'FRED KELLER',
+    'DOUG MCLINKO  (W)': 'DOUG MCLINKO',
+    'JACKIE BAKER  (W)': 'JACKIE BAKER',
+    'GENE YAW (W)': 'GENE YAW',
+    'CLINT OWLETT  (W)': 'CLINT OWLETT',
+    'TINA PICKETT (W)': 'TINA PICKETT',
+    'DONNA IANNONE  (W)': 'DONNA IANNONE',
+    'JAMES J DALY (W)': 'JAMES J. DALY',
+    'JAMES J DALY  (W)': 'JAMES J. DALY',
+    'JAMES SHAW (W)': 'JAMES SHAW',
+    'DAVID ROCKWELL (W)': 'DAVID ROCKWELL',
+    'DEAN CACCIAVILLA NO': 'DEAN CACCIAVILLANO',
+}
+
+
+class PDFPageIterator:
+    def __init__(self, filename):
+        self._pdf_viewer = SimplePDFViewer(open(filename, 'rb'))
+        self._page_number = 0
+        self._rendered = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            self._go_to_next_pdf_page()
+        except PageDoesNotExist as e:
+            raise StopIteration(e)
+        return self
+
+    def get_page_number(self):
+        return self._page_number
+
+    def get_strings(self):
+        if not self._rendered:
+            self._pdf_viewer.render()
+            self._rendered = True
+        return self._pdf_viewer.canvas.strings
+
+    def _go_to_next_pdf_page(self):
+        if self._page_number != 0:
+            self._pdf_viewer.next()
+        self._page_number += 1
+        self._rendered = False
+
+
+class TableHeader:
+    def __init__(self, table_headers, unparsed_header_strings):
+        self._candidate_data = list(TableHeader._candidate_data_iter(table_headers))
+        self._unparsed_header_strings = unparsed_header_strings
+
+    def __iter__(self):
+        return iter(self._candidate_data)
+
+    def unparsed_length(self):
+        return len(self._unparsed_header_strings)
+
+    def strings_prefix_matches(self, strings):
+        unparsed_header_strings = strings[:self.unparsed_length()]
+        assert(self._unparsed_header_strings == unparsed_header_strings)
+
+    @staticmethod
+    def _candidate_data_iter(table_headers):
+        for header, subheaders in table_headers:
+            party, office, district = TableHeader._parse_column_header(*header)
+            for subheader in subheaders:
+                candidate = SUBHEADER_TO_CANDIDATE_MAPPING.get(subheader, subheader)
+                yield CandidateData(office.title(), district, party, candidate.title())
+
+    @staticmethod
+    def _parse_column_header(office, extra=''):
+        district = ''
+        party = ''
+        if extra in PARTY_MAP:
+            party = PARTY_MAP[extra]
+        else:
+            office = ' '.join([office, extra])
+        for keyword in CONGRESSIONAL_KEYWORDS:
+            if keyword in office:
+                office, district = office.rsplit(keyword, 1)
+                office += keyword
+                district = int(district.split(' ', 2)[1].replace('ST', '').replace('TH', '').replace('RD', ''))
+        return party, office.strip(), district
+
+
+class TableHeaderParser:
+    def __init__(self, strings, continued_table_header):
+        self._strings = strings
+        self._strings_offset = 0
+        self._table_headers = []
+        self._in_subheader_block = False
+        self._active_header = []
+        self._active_subheader = []
+        self._active_subheaders = []
+        self._terminal_header_string_seen = False
+        self._continued_table_header = continued_table_header
+        self._table_header = None
+
+    def get_header(self):
+        if not self._table_header:
+            if self._continued_table_header:
+                self._parse_continued_table_header()
+            else:
+                self._parse()
+        return self._table_header
+
+    def get_strings_offset(self):
+        return self._strings_offset
+
+    def _parse_continued_table_header(self):
+        self._continued_table_header.strings_prefix_matches(self._strings)
+        self._strings_offset = self._continued_table_header.unparsed_length()
+        self._table_header = self._continued_table_header
+
+    def _parse(self):
+        while not self._done():
+            s = self._strings[self._strings_offset]
+            self._process_string(s)
+            self._strings_offset += 1
+        if self._active_subheaders:
+            assert(not self._active_subheader)
+            self._finalize_header_block()
+        self._table_header = TableHeader(self._table_headers, self._strings[:self._strings_offset - 1])
+
+    def _done(self):
+        return self._terminal_header_string_seen or len(self._strings) <= self._strings_offset
+
+    def _process_string(self, s):
+        if s == TERMINAL_TABLE_HEADER_STRING:
+            self._terminal_header_string_seen = True
+        else:
+            self._process_start_subheader_state(s)
+            if not self._in_subheader_block:
+                self._process_header_string(s)
+            else:
+                self._process_subheader_string(s)
+
+    def _process_header_string(self, s):
+        self._active_header.append(s)
+
+    def _process_subheader_string(self, s):
+        if s == WRITE_IN_SUBSTRING:
+            self._active_subheaders[-1] += ' ' + WRITE_IN_SUBSTRING
+        else:
+            self._active_subheader.append(s)
+            self._process_active_subheader()
+            self._process_end_subheader_state(s)
+
+    def _process_active_subheader(self):
+        active_subheader_string = ' '.join(self._active_subheader)
+        if active_subheader_string in VALID_SUBHEADERS:
+            self._active_subheaders.append(active_subheader_string)
+            self._active_subheader = []
+
+    def _process_start_subheader_state(self, s):
+        if s == FIRST_SUBHEADER_STRING:
+            self._in_subheader_block = True
+            if self._active_subheaders:
+                self._finalize_header_block()
+
+    def _process_end_subheader_state(self, s):
+        if s in TERMINAL_SUBHEADER_STRINGS:
+            self._in_subheader_block = False
+            self._finalize_header_block()
+
+    def _finalize_header_block(self):
+        self._table_headers.append((self._active_header, self._active_subheaders))
+        self._active_header = []
+        self._active_subheaders = []
+
+
+class TableBodyParser:
+    def __init__(self, strings, table_headers):
+        self._is_office_section_active = True
+        self._strings_offset = 0
+        self._strings = strings
+        self._table_headers = table_headers
+        self._jurisdiction = None
+
+    def __iter__(self):
+        while self._strings_offset < len(self._strings):
+            self._jurisdiction = self._get_next_string()
+            if self._jurisdiction == 'Total':
+                self._is_office_section_active = False
+            if self._is_office_section_active:
+                yield from self._iterate_categories()
+
+    def _iterate_categories(self):
+        candidate_data_to_category_votes = defaultdict(list)
+        for category in VOTE_CATEGORIES:
+            self._parse_category_cell(category)
+            self._populate_category_data(candidate_data_to_category_votes)
+        for candidate_data in candidate_data_to_category_votes:
+            category_votes = candidate_data_to_category_votes[candidate_data]
+            row_data = [COUNTY, self._jurisdiction.title()] + list(candidate_data) \
+                + category_votes + [sum(category_votes)]
+            yield ParsedRow(*row_data)
+
+    def _populate_category_data(self, candidate_data_to_category_votes):
+        for candidate_data in self._table_headers:
+            if self._skipped_subheader(candidate_data):
+                self._get_next_string()  # metadata field
+            else:
+                vote_count = self._get_next_string()
+                vote_count = int(vote_count if vote_count != '-' else 0)
+                self._get_next_string()  # vote percent
+                candidate_data_to_category_votes[candidate_data].append(vote_count)
+
+    def is_office_section_active(self):
+        return self._is_office_section_active
+
+    @staticmethod
+    def _skipped_subheader(candidate_data):
+        return candidate_data.office == 'Turnout' or candidate_data.candidate in ('Reg. Voters', 'Total Votes')
+
+    def _parse_category_cell(self, category):
+        new_category = self._get_next_string().strip()
+        assert(category == new_category)
+
+    def _get_next_string(self):
+        s = self._strings[self._strings_offset]
+        self._strings_offset += 1
+        return s
+
+
+class PDFPageParser:
+    def __init__(self, page, continued_table_header):
+        strings = page.get_strings()
+        self._validate_header(strings, page.get_page_number())
+        strings = strings[len(BRADFORD_HEADER) + 1:]
+        table_header_parser = TableHeaderParser(strings, continued_table_header)
+        self._table_headers = table_header_parser.get_header()
+        strings = strings[table_header_parser.get_strings_offset():]
+        self._table_body_parser = TableBodyParser(strings, self._table_headers)
+
+    def __iter__(self):
+        return iter(self._table_body_parser)
+
+    def get_continued_table_header(self):
+        if not self._table_body_parser.is_office_section_active():
+            return None
+        return self._table_headers
+
+    @staticmethod
+    def _validate_header(strings, page_number):
+        header = strings[:len(BRADFORD_HEADER)]
+        page_number_string = strings[len(BRADFORD_HEADER)]
+        assert(header == BRADFORD_HEADER)
+        assert(page_number_string.split('/')[0].split()[-1] == str(page_number))
+
+
+def pdf_to_csv(pdf, csv_writer):
+    csv_writer.writeheader()
+    previous_table_header = None
+    for page in pdf:
+        print(f'processing page {page.get_page_number()}')
+        pdf_parser = PDFPageParser(page, previous_table_header)
+        for row in pdf_parser:
+            office_is_invalid = sum(invalid_office in row.office for invalid_office in INVALID_OFFICES)
+            if not office_is_invalid:
+                csv_writer.writerow(row._asdict())
+        previous_table_header = pdf_parser.get_continued_table_header()
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', newline='') as f:
+        pdf_to_csv(PDFPageIterator(BRADFORD_FILE), csv.DictWriter(f, OUTPUT_HEADER))

--- a/parsers/pa_bradford_primary_2020_results_parser.py
+++ b/parsers/pa_bradford_primary_2020_results_parser.py
@@ -221,7 +221,7 @@ class BradfordTableBodyParser(TableBodyParser):
 
     def _generate_row(self, candidate_data, category_votes):
         row_data = [COUNTY, self._jurisdiction.title()] + list(candidate_data)
-        if self._is_registered_voters_row(candidate_data):
+        if candidate_data.office == 'Registered Voters':
             assert(min(category_votes) == max(category_votes))
             row_data += [''] * len(VOTE_CATEGORIES) + [category_votes[0]]
         else:
@@ -231,9 +231,6 @@ class BradfordTableBodyParser(TableBodyParser):
     def _parse_category_cell(self, category):
         new_category = self._get_next_string().strip()
         assert(category == new_category)
-
-    def _is_registered_voters_row(self, candidate_data):
-        return candidate_data.office == 'Turnout' and candidate_data.candidate == 'Registered Voters'
 
 
 class BradfordPDFPageParser(PDFPageParser):

--- a/parsers/pa_columbia_primary_2020_results_parser.py
+++ b/parsers/pa_columbia_primary_2020_results_parser.py
@@ -1,0 +1,190 @@
+from collections import defaultdict, namedtuple
+import csv
+import os
+from parsers.pa_pdf_parser import PDFPageIterator, PDFPageParser,\
+    TableBodyParser, TableHeaderParser, TableHeader, pdf_to_csv
+
+
+ParsedRow = namedtuple('ParsedRow', 'county precinct office district party candidate votes')
+
+COUNTY = 'Columbia'
+
+OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__columbia__precinct.csv')
+OUTPUT_HEADER = ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']
+
+COLUMBIA_FILE = os.path.join('..', '..', 'openelections-sources-pa', '2020',
+                             'Columbia PA 2020GeneralPrimaryOfficialResults.pdf')
+COLUMBIA_HEADER = [
+    '',
+    'Statement of Votes Cast',
+    ' COLUMBIA COUNTY, PA',
+    'GENERAL PRIMARY ELECTION',
+    'JUNE 2, 2020',
+    'Results',
+    'Date: 6/17/2020',
+    'Time: 9:49:17 AM PDT'
+]
+LAST_VALID_PAGE_NUMBER = 36
+
+PARTY_MAP = {
+    '(REPUBLICAN)': 'REP',
+    '(DEMOCRATIC)': 'DEM'
+}
+
+TERMINAL_HEADER_STRING = 'Jurisdiction Wide'
+FIRST_SUBHEADER_STRING = 'Reg.'
+TERMINAL_SUBHEADER_STRINGS = ('Write-in', 'Blank')
+WRITE_IN_SUBSTRING = '(W)'
+CONGRESSIONAL_KEYWORDS = ('IN THE GENERAL ASSEMBLY', 'IN CONGRESS')
+INVALID_OFFICES = ('Delegate', 'Delagate',)
+
+VALID_SUBHEADERS = {
+    'Reg. Voters',
+    'Ballots Cast',
+    '% Turnout',
+    'Blank',
+    'Total Votes',
+    'BERNIE SANDERS',
+    'Bernie Sanders  (W)',
+    'JOSEPH R BIDEN',
+    'Joe Biden  (W)',
+    'TULSI GABBARD',
+    'DONALD J TRUMP',
+    'Donald J Trump  (W)',
+    'Robert Casey (W)',
+    'Kamala Harris (W)',
+    'JOSH SHAPIRO',
+    'HEATHER HEIDELBAUG H',
+    'Heather Heidelbaugh (W)',
+    'H SCOTT CONKLIN',
+    'MICHAEL LAMB',
+    'TRACIE FOUNTAIN',
+    'ROSE ROSIE MARIE DAVIS',
+    'NINA AHMAD',
+    'CHRISTINA M HARTMAN',
+    'TIMOTHY DEFOOR',
+    'Timothy Defoor (W)',
+    'JOE TORSELLA',
+    'Joe Torsella (W)',
+    'STACY L GARRITY',
+    'Stacy L Garrity (W)',
+    'LAURA QUICK',
+    'GARY WEGMAN',
+    'Dan Mueser (W)',
+    'MICHELLE SIEGEL',
+    'JOHN R GORDNER',
+    'John Gordner (W)',
+    'BILL MONAHAN',
+    'DAVID MILLARD',
+    'David Millard (W)',
+    'Frances Mannino  (W)',
+    'LEANNE BURCHICK',
+    'LIZ BETTINGER',
+    'VINCE DEMELFI',
+    'JIM SAFFORD',
+    'PHILA BACK',
+    'CATHERINE MAHON',
+    'DONNA LEA MERRITT',
+    'Donna Lea Merritt  (W)',
+    'ROQUE ROCKY DE LA FUENTE',
+    'BILL WELD',
+    'Paul J Fedder (W)',
+    'John Timbrell (W)',
+    'DAN MEUSER',
+    'KURT A MASSER',
+    'J P MORGAN (W)',
+    'ROCHELLE MARIE PASQUARIEL',
+    'ANDREW SHECKTOR',
+    'JANINE PENMAN',
+    'JOHN K REBER SR',
+    'GEORGE HALCOVAGE',
+    'CAROLYN L BONKOSKI',
+    'ELLE RULAVAGE',
+    'DAVID J MCELWEE',
+    'STEVEN MICHAEL WOLFE',
+    'Jasmin Watson (W)',
+    'Thomas Bond (W)',
+    'Ted Buriak Jr (W)',
+    'EUGENE Z BONKOSKI',
+    'JOHN CUSATIS',
+    'Other  (W)',
+    'Write-in',
+}
+
+
+SUBHEADER_TO_CANDIDATE_MAPPING = {
+    'Bernie Sanders  (W)': 'BERNIE SANDERS',
+    'Joe Biden  (W)': 'JOSEPH R BIDEN',
+    'Donald J Trump  (W)': 'DONALD J TRUMP',
+    'Robert Casey (W)': 'ROBERT CASEY',
+    'Kamala Harris (W)': 'KAMALA HARRIS',
+    'HEATHER HEIDELBAUG H': 'HEATHER HEIDELBAUGH',
+    'Heather Heidelbaugh (W)': 'HEATHER HEIDELBAUGH',
+    'Timothy Defoor (W)': 'TIMOTHY DEFOOR',
+    'Joe Torsella (W)': 'JOE TORSELLA',
+    'Stacy L Garrity (W)': 'STACY L GARRITY',
+    'Dan Mueser (W)': 'DAN MUESER',
+    'John Gordner (W)': 'JOHN R GORDNER',
+    'David Millard (W)': 'DAVID MILLARD',
+    'Frances Mannino  (W)': 'FRANCES MANNINO',
+    'Donna Lea Merritt  (W)': 'DONNA LEA MERRITT',
+    'Paul J Fedder (W)': 'PAUL J FEDDER',
+    'John Timbrell (W)': 'JOHN TIMBRELL',
+    'J P MORGAN (W)': 'J P MORGAN',
+    'Jasmin Watson (W)': 'JASMIN WATSON',
+    'Thomas Bond (W)': 'THOMAS BOND',
+    'Ted Buriak Jr (W)': 'TED BURIAK JR',
+    'Other  (W)': 'OTHER',
+}
+
+
+class ColumbiaTableHeader(TableHeader):
+    _congressional_keywords = CONGRESSIONAL_KEYWORDS
+    _party_map = PARTY_MAP
+    _subheader_to_candidate_mapping = SUBHEADER_TO_CANDIDATE_MAPPING
+
+
+class ColumbiaTableHeaderParser(TableHeaderParser):
+    _first_subheader_string = FIRST_SUBHEADER_STRING
+    _terminal_header_string = TERMINAL_HEADER_STRING
+    _terminal_subheader_strings = TERMINAL_SUBHEADER_STRINGS
+    _writein_substring = WRITE_IN_SUBSTRING
+    _valid_subheaders = VALID_SUBHEADERS
+    _table_header_clazz = ColumbiaTableHeader
+
+
+class ColumbiaTableBodyParser(TableBodyParser):
+    def iterate_jurisdiction_fields(self):
+        candidate_data_to_votes = defaultdict(list)
+        for candidate_data in self._table_headers:
+            self._populate_jurisdiction_data(candidate_data_to_votes, candidate_data)
+        for candidate_data in candidate_data_to_votes:
+            votes = candidate_data_to_votes[candidate_data]
+            row_data = [COUNTY, self._jurisdiction.title()] + list(candidate_data) + votes
+            row = ParsedRow(*row_data)
+            office_is_invalid = sum(invalid_office in row.office for invalid_office in INVALID_OFFICES)
+            if not office_is_invalid:
+                yield row
+
+    def _parse_category_cell(self, category):
+        new_category = self._get_next_string().strip()
+        assert(category == new_category)
+
+
+class ColumbiaPDFPageParser(PDFPageParser):
+    _standard_header = COLUMBIA_HEADER
+    _table_header_parser = ColumbiaTableHeaderParser
+    _table_body_parser = ColumbiaTableBodyParser
+
+
+class ColumbiaPDFPageIterator(PDFPageIterator):
+    def __next__(self):
+        next = super().__next__()
+        if self.get_page_number() > LAST_VALID_PAGE_NUMBER:
+            raise StopIteration
+        return next
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', newline='') as f:
+            pdf_to_csv(ColumbiaPDFPageIterator(COLUMBIA_FILE), csv.DictWriter(f, OUTPUT_HEADER), ColumbiaPDFPageParser)

--- a/parsers/pa_columbia_primary_2020_results_parser.py
+++ b/parsers/pa_columbia_primary_2020_results_parser.py
@@ -135,6 +135,7 @@ SUBHEADER_TO_CANDIDATE_MAPPING = {
     'Thomas Bond (W)': 'THOMAS BOND',
     'Ted Buriak Jr (W)': 'TED BURIAK JR',
     'Other  (W)': 'OTHER',
+    'Reg. Voters': 'Registered Voters'
 }
 
 
@@ -156,8 +157,14 @@ class ColumbiaTableHeaderParser(TableHeaderParser):
 class ColumbiaTableBodyParser(TableBodyParser):
     def iterate_jurisdiction_fields(self):
         candidate_data_to_votes = defaultdict(list)
+        self._populate_votes(candidate_data_to_votes)
+        yield from self._process_votes(candidate_data_to_votes)
+
+    def _populate_votes(self, candidate_data_to_votes):
         for candidate_data in self._table_headers:
             self._populate_jurisdiction_data(candidate_data_to_votes, candidate_data)
+
+    def _process_votes(self, candidate_data_to_votes):
         for candidate_data in candidate_data_to_votes:
             votes = candidate_data_to_votes[candidate_data]
             row_data = [COUNTY, self._jurisdiction.title()] + list(candidate_data) + votes

--- a/parsers/pa_pdf_parser.py
+++ b/parsers/pa_pdf_parser.py
@@ -228,6 +228,9 @@ class TableBodyParser:
             vote_count = int(vote_count if vote_count != '-' else 0)
             if not self._is_turnout_header(candidate_data):
                 self._get_next_string()  # vote percent
+            else:
+                # Registered Voters and Ballot Cast are treated as `office` instead of `candidate`
+                candidate_data = CandidateData(candidate_data.candidate, '', '', '')
             candidate_data_to_votes[candidate_data].append(vote_count)
 
     def _get_next_string(self):

--- a/parsers/pa_pdf_parser.py
+++ b/parsers/pa_pdf_parser.py
@@ -1,0 +1,271 @@
+from collections import namedtuple
+from pdfreader import PageDoesNotExist, SimplePDFViewer
+
+
+CandidateData = namedtuple('CandidateData', 'office district party candidate')
+
+
+class PDFPageIterator:
+    def __init__(self, filename):
+        self._pdf_viewer = SimplePDFViewer(open(filename, 'rb'))
+        self._page_number = 0
+        self._rendered = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            self._go_to_next_pdf_page()
+            return self
+        except PageDoesNotExist as e:
+            raise StopIteration(e)
+
+    def get_page_number(self):
+        return self._page_number
+
+    def get_strings(self):
+        if not self._rendered:
+            self._pdf_viewer.render()
+            self._rendered = True
+        return self._pdf_viewer.canvas.strings
+
+    def _go_to_next_pdf_page(self):
+        if self._page_number != 0:
+            self._pdf_viewer.next()
+        self._page_number += 1
+        self._rendered = False
+
+
+class TableHeader:
+    _congressional_keywords = None
+    _party_map = None
+    _subheader_to_candidate_mapping = None
+
+    def __init__(self, table_headers, unparsed_header_strings, party):
+        self._party = party
+        self._candidate_data = list(self._candidate_data_iter(table_headers))
+        self._unparsed_header_strings = unparsed_header_strings
+
+    def __iter__(self):
+        return iter(self._candidate_data)
+
+    def unparsed_length(self):
+        return len(self._unparsed_header_strings)
+
+    def strings_prefix_matches(self, strings):
+        unparsed_header_strings = strings[:self.unparsed_length()]
+        assert(self._unparsed_header_strings == unparsed_header_strings)
+
+    def get_party(self):
+        return self._party
+
+    def _candidate_data_iter(self, table_headers):
+        for header, subheaders in table_headers:
+            party, office, district = self._parse_column_header(*header)
+            if party:
+                self._party = party
+            for subheader in subheaders:
+                candidate = self._subheader_to_candidate_mapping.get(subheader, subheader)
+                yield CandidateData(office.title(), district, self._party, candidate.title())
+
+    def _parse_column_header(self, office, extra=''):
+        district = ''
+        party = ''
+        if extra in self._party_map:
+            party = self._party_map[extra]
+        else:
+            office = ' '.join([office, extra])
+        for keyword in self._congressional_keywords:
+            if keyword in office:
+                office, district = office.rsplit(keyword, 1)
+                office += keyword
+                district = int(district.split(' ', 2)[1].replace('ST', '').replace('TH', '').replace('RD', ''))
+        return party, office.strip(), district
+
+
+class TableHeaderParser:
+    _first_subheader_string = None
+    _terminal_header_string = None
+    _terminal_subheader_strings = None
+    _writein_substring = None
+    _valid_subheaders = None
+    _table_header_clazz  = None
+
+    def __init__(self, strings, continued_table_header, continued_table_party):
+        self._strings = strings
+        self._strings_offset = 0
+        self._continued_table_header = continued_table_header
+        self._continued_table_party = continued_table_party
+        self._table_headers = []  # list of strings with their subheaders
+        self._table_header = None  # class for managing table headers
+        # temporary parsing management fields
+        self._in_subheader_block = False
+        self._active_header = []
+        self._active_subheader = []
+        self._active_subheaders = []
+        self._terminal_header_string_seen = False
+
+    def get_header(self):
+        if not self._table_header:
+            if self._continued_table_header:
+                self._parse_continued_table_header()
+            else:
+                self._parse()
+        return self._table_header
+
+    def get_strings_offset(self):
+        return self._strings_offset
+
+    def get_party(self):
+        return self._table_header.get_party()
+
+    def _parse_continued_table_header(self):
+        self._continued_table_header.strings_prefix_matches(self._strings)
+        self._strings_offset = self._continued_table_header.unparsed_length()
+        self._table_header = self._continued_table_header
+
+    def _parse(self):
+        while not self._done():
+            s = self._strings[self._strings_offset]
+            self._process_string(s)
+            self._strings_offset += 1
+        if self._active_subheaders:
+            assert(not self._active_subheader)
+            self._finalize_header_block()
+        self._table_header = self._table_header_clazz(self._table_headers,
+                                                      self._strings[:self._strings_offset - 1],
+                                                      self._continued_table_party)
+
+    def _done(self):
+        return self._terminal_header_string_seen or len(self._strings) <= self._strings_offset
+
+    def _process_string(self, s):
+        if s == self._terminal_header_string:
+            self._terminal_header_string_seen = True
+        else:
+            self._process_start_subheader_state(s)
+            if not self._in_subheader_block:
+                self._process_header_string(s)
+            else:
+                self._process_subheader_string(s)
+
+    def _process_header_string(self, s):
+        self._active_header.append(s)
+
+    def _process_subheader_string(self, s):
+        if s == self._writein_substring and not self._active_subheader:
+            self._active_subheaders[-1] += ' ' + self._writein_substring
+        else:
+            self._active_subheader.append(s)
+            self._process_active_subheader()
+            self._process_end_subheader_state(s)
+
+    def _process_active_subheader(self):
+        active_subheader_string = ' '.join(self._active_subheader)
+        if active_subheader_string in self._valid_subheaders:
+            self._active_subheaders.append(active_subheader_string)
+            self._active_subheader = []
+
+    def _process_start_subheader_state(self, s):
+        if s == self._first_subheader_string:
+            self._in_subheader_block = True
+            if self._active_subheaders:
+                self._finalize_header_block()
+
+    def _process_end_subheader_state(self, s):
+        if s in self._terminal_subheader_strings:
+            self._in_subheader_block = False
+            self._finalize_header_block()
+
+    def _finalize_header_block(self):
+        self._table_headers.append((self._active_header, self._active_subheaders))
+        self._active_header = []
+        self._active_subheaders = []
+
+
+class TableBodyParser:
+    def __init__(self, strings, table_headers):
+        self._is_office_section_active = True
+        self._strings_offset = 0
+        self._strings = strings
+        self._table_headers = table_headers
+        self._jurisdiction = None
+
+    def __iter__(self):
+        while self._strings_offset < len(self._strings):
+            self._jurisdiction = self._get_next_string()
+            if self._jurisdiction == 'Total':
+                self._is_office_section_active = False
+            if self._is_office_section_active:
+                yield from self.iterate_jurisdiction_fields()
+
+    def iterate_jurisdiction_fields(self):
+        raise NotImplementedError
+
+    def is_office_section_active(self):
+        return self._is_office_section_active
+
+    @staticmethod
+    def _skipped_subheader(candidate_data):
+        return candidate_data.office == 'Turnout' or candidate_data.candidate in ('Reg. Voters', 'Total Votes')
+
+    def _populate_jurisdiction_data(self, candidate_data_to_votes, candidate_data):
+        if self._skipped_subheader(candidate_data):
+            self._get_next_string()  # metadata field
+        else:
+            vote_count = self._get_next_string()
+            vote_count = int(vote_count if vote_count != '-' else 0)
+            self._get_next_string()  # vote percent
+            candidate_data_to_votes[candidate_data].append(vote_count)
+
+    def _get_next_string(self):
+        s = self._strings[self._strings_offset]
+        self._strings_offset += 1
+        return s
+
+
+class PDFPageParser:
+    _standard_header = None
+    _table_header_parser = None
+    _table_body_parser = None
+
+    def __init__(self, page, continued_table_header, continued_party):
+        strings = page.get_strings()
+        self._validate_header(strings, page.get_page_number())
+        strings = strings[len(self._standard_header) + 1:]
+        table_header_parser = self._table_header_parser(strings, continued_table_header, continued_party)
+        self._table_headers = table_header_parser.get_header()
+        self._party = table_header_parser.get_party()
+        strings = strings[table_header_parser.get_strings_offset():]
+        self._table_body_parser = self._table_body_parser(strings, self._table_headers)
+
+    def __iter__(self):
+        return iter(self._table_body_parser)
+
+    def get_continued_table_header(self):
+        if not self._table_body_parser.is_office_section_active():
+            return None
+        return self._table_headers
+
+    def get_continued_party(self):
+        return self._party
+
+    def _validate_header(self, strings, page_number):
+        header = strings[:len(self._standard_header)]
+        page_number_string = strings[len(self._standard_header)]
+        assert(header == self._standard_header)
+        assert(page_number_string.split('/')[0].split()[-1] == str(page_number))
+
+
+def pdf_to_csv(pdf, csv_writer, pdf_page_parser_clazz):
+    csv_writer.writeheader()
+    previous_table_header = None
+    previous_party = ''
+    for page in pdf:
+        print(f'processing page {page.get_page_number()}')
+        pdf_page_parser = pdf_page_parser_clazz(page, previous_table_header, previous_party)
+        for row in pdf_page_parser:
+            csv_writer.writerow(row._asdict())
+        previous_table_header = pdf_page_parser.get_continued_table_header()
+        previous_party = pdf_page_parser.get_continued_party()


### PR DESCRIPTION
Bradford parser and results, 2020 Primary. This is my first parser and csv generator, so please let me know if there is anything I'm missing, misunderstanding, etc. Thanks!

Parser might be a bit heavyweight; my goal is that some of the logic could be reusable for other elections (looks like Columbia County has a similar format). The way the parser is structured is as follows:
* `pdf_to_csv` -> iterates pdf pages via `PDFPageIterator` -> create a `PDFPageParser` -> iterate rows
* Each `PDFPageParser` validates the header, extracts the table header with the `TableHeaderParser`, and preps the row iterator with `TableBodyParser`
* The `TableHeaderParser` will use the previous page's header if the previous page's office is still being processed; it will also validate the current page's header against the previous one. Otherwise, it does some pretty nasty intuiting of when the headers and subheaders begin and end, generally looking for the phrases "Jurisdiction Wide", "Write-in", "Turnout", and "Reg. Voters"
* The `TableBodyParser` will pivot the rows and columns of a given page into the standard OpenElections format.
* `TableHeader` object manages all the candidate header information, including extracting party, office, and district where possible. The candidate names themselves were in multiple string objects, so there is a huge `VALID_SUBHEADERS` definition, along with mapping improperly parsed and write-in candidates in `SUBHEADER_TO_CANDIDATE_MAPPING`, otherwise it's unclear where one candidate ends and another begins. 
