### PR TITLE
Northampton parser and results

### DIFF
--- a/2020/20200602__pa__primary__northampton__precinct.csv
+++ b/2020/20200602__pa__primary__northampton__precinct.csv
@@ -1,0 +1,6485 @@
+county,precinct,office,district,party,candidate,election_day,absentee,provisional,votes
+Northampton,ALLEN TWSP NORTHERN,Registered Voters,,,,,,,1822
+Northampton,ALLEN TWSP NORTHERN,Registered Voters,,DEM,,,,,732
+Northampton,ALLEN TWSP NORTHERN,Registered Voters,,REP,,,,,819
+Northampton,ALLEN TWSP NORTHERN,Registered Voters,,NPA,,,,,271
+Northampton,ALLEN TWSP NORTHERN,Ballots Cast,,,,266,444,8,718
+Northampton,ALLEN TWSP NORTHERN,Ballots Cast,,DEM,,60,283,3,346
+Northampton,ALLEN TWSP NORTHERN,Ballots Cast,,REP,,206,161,5,372
+Northampton,ALLEN TWSP NORTHERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,ALLEN TWSP NORTHERN,President,,DEM,Joseph R. Biden,35,224,2,261
+Northampton,ALLEN TWSP NORTHERN,President,,DEM,Bernie Sanders,13,39,1,53
+Northampton,ALLEN TWSP NORTHERN,President,,DEM,Tulsi Gabbard,5,11,0,16
+Northampton,ALLEN TWSP NORTHERN,President,,DEM,Write-in,4,1,0,5
+Northampton,ALLEN TWSP NORTHERN,Attorney General,,DEM,Josh Shapiro,42,259,3,304
+Northampton,ALLEN TWSP NORTHERN,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,DEM,Christina M. Hartman,14,69,1,84
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,DEM,Nina Ahmad,15,68,0,83
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,DEM,Michael Lamb,7,29,0,36
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,DEM,Rose Rosie Marie Davis,4,30,0,34
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,DEM,H Scott Conklin,9,11,0,20
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,DEM,Tracie Fountain,0,16,0,16
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,ALLEN TWSP NORTHERN,State Treasurer,,DEM,Joe Torsella,39,255,2,296
+Northampton,ALLEN TWSP NORTHERN,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,ALLEN TWSP NORTHERN,U.S. House,7,DEM,Susan Wild,47,270,2,319
+Northampton,ALLEN TWSP NORTHERN,U.S. House,7,DEM,Write-in,0,4,0,4
+Northampton,ALLEN TWSP NORTHERN,General Assembly,183,DEM,Jason Ruff,43,261,3,307
+Northampton,ALLEN TWSP NORTHERN,General Assembly,183,DEM,Write-in,0,3,0,3
+Northampton,ALLEN TWSP NORTHERN,President,,REP,Donald J Trump,197,142,5,344
+Northampton,ALLEN TWSP NORTHERN,President,,REP,Bill Weld,4,10,0,14
+Northampton,ALLEN TWSP NORTHERN,President,,REP,Roque Rocky De La Fuente,1,3,0,4
+Northampton,ALLEN TWSP NORTHERN,President,,REP,Write-in,0,3,0,3
+Northampton,ALLEN TWSP NORTHERN,Attorney General,,REP,Heather Heidelbaugh,177,132,4,313
+Northampton,ALLEN TWSP NORTHERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,REP,Timothy Defoor,175,124,4,303
+Northampton,ALLEN TWSP NORTHERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,ALLEN TWSP NORTHERN,State Treasurer,,REP,Stacy L. Garrity,178,125,4,307
+Northampton,ALLEN TWSP NORTHERN,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,ALLEN TWSP NORTHERN,U.S. House,7,REP,Lisa Scheller,122,62,2,186
+Northampton,ALLEN TWSP NORTHERN,U.S. House,7,REP,Dean N. Browning,80,86,2,168
+Northampton,ALLEN TWSP NORTHERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,ALLEN TWSP NORTHERN,General Assembly,183,REP,Zach Mako,189,151,4,344
+Northampton,ALLEN TWSP NORTHERN,General Assembly,183,REP,Write-in,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,Registered Voters,,,,,,,1995
+Northampton,ALLEN TWSP SOUTHERN,Registered Voters,,DEM,,,,,838
+Northampton,ALLEN TWSP SOUTHERN,Registered Voters,,REP,,,,,812
+Northampton,ALLEN TWSP SOUTHERN,Registered Voters,,NPA,,,,,345
+Northampton,ALLEN TWSP SOUTHERN,Ballots Cast,,,,198,401,7,606
+Northampton,ALLEN TWSP SOUTHERN,Ballots Cast,,DEM,,63,275,3,341
+Northampton,ALLEN TWSP SOUTHERN,Ballots Cast,,REP,,135,126,4,265
+Northampton,ALLEN TWSP SOUTHERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,President,,DEM,Joseph R. Biden,45,449,1,495
+Northampton,ALLEN TWSP SOUTHERN,President,,DEM,Bernie Sanders,14,33,2,49
+Northampton,ALLEN TWSP SOUTHERN,President,,DEM,Tulsi Gabbard,2,4,0,6
+Northampton,ALLEN TWSP SOUTHERN,President,,DEM,Write-in,2,2,0,4
+Northampton,ALLEN TWSP SOUTHERN,Attorney General,,DEM,Josh Shapiro,43,259,2,304
+Northampton,ALLEN TWSP SOUTHERN,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,DEM,Nina Ahmad,14,70,2,86
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,DEM,Christina M. Hartman,3,53,0,56
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,DEM,Rose Rosie Marie Davis,7,42,0,49
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,DEM,Michael Lamb,13,26,0,39
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,DEM,H Scott Conklin,9,22,0,31
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,DEM,Tracie Fountain,4,16,0,20
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,State Treasurer,,DEM,Joe Torsella,39,257,2,298
+Northampton,ALLEN TWSP SOUTHERN,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,ALLEN TWSP SOUTHERN,U.S. House,7,DEM,Susan Wild,49,266,2,317
+Northampton,ALLEN TWSP SOUTHERN,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,General Assembly,183,DEM,Jason Ruff,45,255,2,302
+Northampton,ALLEN TWSP SOUTHERN,General Assembly,183,DEM,Write-in,0,1,0,1
+Northampton,ALLEN TWSP SOUTHERN,President,,REP,Donald J Trump,129,105,4,238
+Northampton,ALLEN TWSP SOUTHERN,President,,REP,Bill Weld,4,12,0,16
+Northampton,ALLEN TWSP SOUTHERN,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,ALLEN TWSP SOUTHERN,President,,REP,Write-in,1,2,0,3
+Northampton,ALLEN TWSP SOUTHERN,Attorney General,,REP,Heather Heidelbaugh,114,106,4,224
+Northampton,ALLEN TWSP SOUTHERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,REP,Timothy Defoor,111,105,4,220
+Northampton,ALLEN TWSP SOUTHERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,State Treasurer,,REP,Stacy L. Garrity,113,107,4,224
+Northampton,ALLEN TWSP SOUTHERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,U.S. House,7,REP,Lisa Scheller,69,65,0,134
+Northampton,ALLEN TWSP SOUTHERN,U.S. House,7,REP,Dean N. Browning,63,54,4,121
+Northampton,ALLEN TWSP SOUTHERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,ALLEN TWSP SOUTHERN,General Assembly,183,REP,Zach Mako,117,114,4,235
+Northampton,ALLEN TWSP SOUTHERN,General Assembly,183,REP,Write-in,2,0,0,2
+Northampton,BANGOR BORO 1ST WARD,Registered Voters,,,,,,,871
+Northampton,BANGOR BORO 1ST WARD,Registered Voters,,DEM,,,,,342
+Northampton,BANGOR BORO 1ST WARD,Registered Voters,,REP,,,,,314
+Northampton,BANGOR BORO 1ST WARD,Registered Voters,,NPA,,,,,215
+Northampton,BANGOR BORO 1ST WARD,Ballots Cast,,,,96,72,6,174
+Northampton,BANGOR BORO 1ST WARD,Ballots Cast,,DEM,,35,52,2,89
+Northampton,BANGOR BORO 1ST WARD,Ballots Cast,,REP,,61,20,4,85
+Northampton,BANGOR BORO 1ST WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BANGOR BORO 1ST WARD,President,,DEM,Joseph R. Biden,22,37,2,61
+Northampton,BANGOR BORO 1ST WARD,President,,DEM,Bernie Sanders,10,12,0,22
+Northampton,BANGOR BORO 1ST WARD,President,,DEM,Tulsi Gabbard,3,0,0,3
+Northampton,BANGOR BORO 1ST WARD,President,,DEM,Write-in,0,1,0,1
+Northampton,BANGOR BORO 1ST WARD,Attorney General,,DEM,Josh Shapiro,23,45,2,70
+Northampton,BANGOR BORO 1ST WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,12,17,1,30
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,DEM,Nina Ahmad,5,12,0,17
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,DEM,Tracie Fountain,3,5,0,8
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,DEM,Christina M. Hartman,4,4,0,8
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,DEM,H Scott Conklin,2,4,0,6
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,DEM,Michael Lamb,3,2,0,5
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 1ST WARD,State Treasurer,,DEM,Joe Torsella,23,46,1,70
+Northampton,BANGOR BORO 1ST WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 1ST WARD,U.S. House,7,DEM,Susan Wild,25,48,2,75
+Northampton,BANGOR BORO 1ST WARD,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,BANGOR BORO 1ST WARD,General Assembly,137,DEM,Katelind Brennan,24,43,1,68
+Northampton,BANGOR BORO 1ST WARD,General Assembly,137,DEM,Write-in,1,0,0,1
+Northampton,BANGOR BORO 1ST WARD,President,,REP,Donald J Trump,54,12,4,70
+Northampton,BANGOR BORO 1ST WARD,President,,REP,Bill Weld,1,3,0,4
+Northampton,BANGOR BORO 1ST WARD,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Northampton,BANGOR BORO 1ST WARD,President,,REP,Write-in,2,1,0,3
+Northampton,BANGOR BORO 1ST WARD,Attorney General,,REP,Heather Heidelbaugh,49,16,3,68
+Northampton,BANGOR BORO 1ST WARD,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,REP,Timothy Defoor,47,16,2,65
+Northampton,BANGOR BORO 1ST WARD,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BANGOR BORO 1ST WARD,State Treasurer,,REP,Stacy L. Garrity,49,16,1,66
+Northampton,BANGOR BORO 1ST WARD,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BANGOR BORO 1ST WARD,U.S. House,7,REP,Lisa Scheller,32,9,2,43
+Northampton,BANGOR BORO 1ST WARD,U.S. House,7,REP,Dean N. Browning,25,9,1,35
+Northampton,BANGOR BORO 1ST WARD,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BANGOR BORO 1ST WARD,General Assembly,137,REP,Joe Emrick,58,18,2,78
+Northampton,BANGOR BORO 1ST WARD,General Assembly,137,REP,Write-in,0,2,0,2
+Northampton,BANGOR BORO 2ND WARD,Registered Voters,,,,,,,776
+Northampton,BANGOR BORO 2ND WARD,Registered Voters,,DEM,,,,,320
+Northampton,BANGOR BORO 2ND WARD,Registered Voters,,REP,,,,,287
+Northampton,BANGOR BORO 2ND WARD,Registered Voters,,NPA,,,,,169
+Northampton,BANGOR BORO 2ND WARD,Ballots Cast,,,,110,76,1,187
+Northampton,BANGOR BORO 2ND WARD,Ballots Cast,,DEM,,44,59,0,103
+Northampton,BANGOR BORO 2ND WARD,Ballots Cast,,REP,,66,17,1,84
+Northampton,BANGOR BORO 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BANGOR BORO 2ND WARD,President,,DEM,Joseph R. Biden,27,43,0,70
+Northampton,BANGOR BORO 2ND WARD,President,,DEM,Bernie Sanders,11,15,0,26
+Northampton,BANGOR BORO 2ND WARD,President,,DEM,Tulsi Gabbard,1,1,0,2
+Northampton,BANGOR BORO 2ND WARD,President,,DEM,Write-in,1,0,0,1
+Northampton,BANGOR BORO 2ND WARD,Attorney General,,DEM,Josh Shapiro,31,55,0,86
+Northampton,BANGOR BORO 2ND WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,10,26,0,36
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,DEM,Nina Ahmad,5,10,0,15
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,DEM,Michael Lamb,10,2,0,12
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,DEM,Tracie Fountain,5,7,0,12
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,DEM,H Scott Conklin,5,6,0,11
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,DEM,Christina M. Hartman,1,4,0,5
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 2ND WARD,State Treasurer,,DEM,Joe Torsella,28,56,0,84
+Northampton,BANGOR BORO 2ND WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 2ND WARD,U.S. House,7,DEM,Susan Wild,33,57,0,90
+Northampton,BANGOR BORO 2ND WARD,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,BANGOR BORO 2ND WARD,General Assembly,137,DEM,Katelind Brennan,28,53,0,81
+Northampton,BANGOR BORO 2ND WARD,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 2ND WARD,President,,REP,Donald J Trump,62,13,1,76
+Northampton,BANGOR BORO 2ND WARD,President,,REP,Bill Weld,2,3,0,5
+Northampton,BANGOR BORO 2ND WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,BANGOR BORO 2ND WARD,President,,REP,Write-in,0,0,0,0
+Northampton,BANGOR BORO 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,51,15,1,67
+Northampton,BANGOR BORO 2ND WARD,Attorney General,,REP,Write-in,1,0,0,1
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,REP,Timothy Defoor,50,15,1,66
+Northampton,BANGOR BORO 2ND WARD,Auditor General,,REP,Write-in,1,0,0,1
+Northampton,BANGOR BORO 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,51,14,1,66
+Northampton,BANGOR BORO 2ND WARD,State Treasurer,,REP,Write-in,1,0,0,1
+Northampton,BANGOR BORO 2ND WARD,U.S. House,7,REP,Dean N. Browning,36,6,1,43
+Northampton,BANGOR BORO 2ND WARD,U.S. House,7,REP,Lisa Scheller,28,9,0,37
+Northampton,BANGOR BORO 2ND WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BANGOR BORO 2ND WARD,General Assembly,137,REP,Joe Emrick,62,17,1,80
+Northampton,BANGOR BORO 2ND WARD,General Assembly,137,REP,Write-in,1,0,0,1
+Northampton,BANGOR BORO 3RD WARD,Registered Voters,,,,,,,785
+Northampton,BANGOR BORO 3RD WARD,Registered Voters,,DEM,,,,,288
+Northampton,BANGOR BORO 3RD WARD,Registered Voters,,REP,,,,,334
+Northampton,BANGOR BORO 3RD WARD,Registered Voters,,NPA,,,,,163
+Northampton,BANGOR BORO 3RD WARD,Ballots Cast,,,,127,94,3,224
+Northampton,BANGOR BORO 3RD WARD,Ballots Cast,,DEM,,47,60,1,108
+Northampton,BANGOR BORO 3RD WARD,Ballots Cast,,REP,,80,34,2,116
+Northampton,BANGOR BORO 3RD WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,President,,DEM,Joseph R. Biden,32,51,0,83
+Northampton,BANGOR BORO 3RD WARD,President,,DEM,Bernie Sanders,13,7,1,21
+Northampton,BANGOR BORO 3RD WARD,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,BANGOR BORO 3RD WARD,President,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,Attorney General,,DEM,Josh Shapiro,30,58,0,88
+Northampton,BANGOR BORO 3RD WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,DEM,Rose Rosie Marie Davis,10,27,0,37
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,DEM,Nina Ahmad,9,18,0,27
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,DEM,Michael Lamb,9,0,0,9
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,DEM,Christina M. Hartman,2,7,0,9
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,DEM,H Scott Conklin,7,1,0,8
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,DEM,Tracie Fountain,1,3,0,4
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,State Treasurer,,DEM,Joe Torsella,33,56,0,89
+Northampton,BANGOR BORO 3RD WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,U.S. House,7,DEM,Susan Wild,41,57,0,98
+Northampton,BANGOR BORO 3RD WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,General Assembly,137,DEM,Katelind Brennan,33,57,0,90
+Northampton,BANGOR BORO 3RD WARD,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,President,,REP,Donald J Trump,76,27,1,104
+Northampton,BANGOR BORO 3RD WARD,President,,REP,Bill Weld,2,2,0,4
+Northampton,BANGOR BORO 3RD WARD,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Northampton,BANGOR BORO 3RD WARD,President,,REP,Write-in,1,1,1,3
+Northampton,BANGOR BORO 3RD WARD,Attorney General,,REP,Heather Heidelbaugh,65,32,2,99
+Northampton,BANGOR BORO 3RD WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,REP,Timothy Defoor,65,32,1,98
+Northampton,BANGOR BORO 3RD WARD,Auditor General,,REP,Write-in,0,0,1,1
+Northampton,BANGOR BORO 3RD WARD,State Treasurer,,REP,Stacy L. Garrity,65,32,2,99
+Northampton,BANGOR BORO 3RD WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BANGOR BORO 3RD WARD,U.S. House,7,REP,Dean N. Browning,44,18,0,62
+Northampton,BANGOR BORO 3RD WARD,U.S. House,7,REP,Lisa Scheller,31,13,2,46
+Northampton,BANGOR BORO 3RD WARD,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,BANGOR BORO 3RD WARD,General Assembly,137,REP,Joe Emrick,76,33,1,110
+Northampton,BANGOR BORO 3RD WARD,General Assembly,137,REP,Write-in,0,0,1,1
+Northampton,BANGOR BORO 4TH WARD,Registered Voters,,,,,,,738
+Northampton,BANGOR BORO 4TH WARD,Registered Voters,,DEM,,,,,294
+Northampton,BANGOR BORO 4TH WARD,Registered Voters,,REP,,,,,320
+Northampton,BANGOR BORO 4TH WARD,Registered Voters,,NPA,,,,,124
+Northampton,BANGOR BORO 4TH WARD,Ballots Cast,,,,106,87,10,203
+Northampton,BANGOR BORO 4TH WARD,Ballots Cast,,DEM,,43,64,6,113
+Northampton,BANGOR BORO 4TH WARD,Ballots Cast,,REP,,63,23,4,90
+Northampton,BANGOR BORO 4TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,President,,DEM,Joseph R. Biden,23,49,5,77
+Northampton,BANGOR BORO 4TH WARD,President,,DEM,Bernie Sanders,7,13,1,21
+Northampton,BANGOR BORO 4TH WARD,President,,DEM,Tulsi Gabbard,4,1,0,5
+Northampton,BANGOR BORO 4TH WARD,President,,DEM,Write-in,1,0,0,1
+Northampton,BANGOR BORO 4TH WARD,Attorney General,,DEM,Josh Shapiro,32,58,5,95
+Northampton,BANGOR BORO 4TH WARD,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,10,23,1,34
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,DEM,Nina Ahmad,8,9,0,17
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,DEM,H Scott Conklin,6,5,1,12
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,DEM,Michael Lamb,7,5,0,12
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,DEM,Christina M. Hartman,2,6,2,10
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,DEM,Tracie Fountain,3,5,0,8
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,State Treasurer,,DEM,Joe Torsella,33,56,4,93
+Northampton,BANGOR BORO 4TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,U.S. House,7,DEM,Susan Wild,34,63,5,102
+Northampton,BANGOR BORO 4TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,General Assembly,137,DEM,Katelind Brennan,30,56,4,90
+Northampton,BANGOR BORO 4TH WARD,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,President,,REP,Donald J Trump,58,20,4,82
+Northampton,BANGOR BORO 4TH WARD,President,,REP,Bill Weld,0,3,0,3
+Northampton,BANGOR BORO 4TH WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,BANGOR BORO 4TH WARD,President,,REP,Write-in,1,0,0,1
+Northampton,BANGOR BORO 4TH WARD,Attorney General,,REP,Heather Heidelbaugh,48,20,4,72
+Northampton,BANGOR BORO 4TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,REP,Timothy Defoor,49,20,4,73
+Northampton,BANGOR BORO 4TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,State Treasurer,,REP,Stacy L. Garrity,49,21,4,74
+Northampton,BANGOR BORO 4TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,U.S. House,7,REP,Dean N. Browning,35,7,2,44
+Northampton,BANGOR BORO 4TH WARD,U.S. House,7,REP,Lisa Scheller,25,14,2,41
+Northampton,BANGOR BORO 4TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BANGOR BORO 4TH WARD,General Assembly,137,REP,Joe Emrick,56,23,4,83
+Northampton,BANGOR BORO 4TH WARD,General Assembly,137,REP,Write-in,1,0,0,1
+Northampton,BATH BORO,Registered Voters,,,,,,,1635
+Northampton,BATH BORO,Registered Voters,,DEM,,,,,681
+Northampton,BATH BORO,Registered Voters,,REP,,,,,650
+Northampton,BATH BORO,Registered Voters,,NPA,,,,,304
+Northampton,BATH BORO,Ballots Cast,,,,231,232,7,470
+Northampton,BATH BORO,Ballots Cast,,DEM,,59,170,1,230
+Northampton,BATH BORO,Ballots Cast,,REP,,172,62,6,240
+Northampton,BATH BORO,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BATH BORO,President,,DEM,Joseph R. Biden,43,141,0,184
+Northampton,BATH BORO,President,,DEM,Bernie Sanders,10,20,1,31
+Northampton,BATH BORO,President,,DEM,Tulsi Gabbard,3,3,0,6
+Northampton,BATH BORO,President,,DEM,Write-in,1,4,0,5
+Northampton,BATH BORO,Attorney General,,DEM,Josh Shapiro,48,156,1,205
+Northampton,BATH BORO,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BATH BORO,Auditor General,,DEM,Nina Ahmad,14,45,0,59
+Northampton,BATH BORO,Auditor General,,DEM,Christina M. Hartman,7,34,1,42
+Northampton,BATH BORO,Auditor General,,DEM,Rose Rosie Marie Davis,9,29,0,38
+Northampton,BATH BORO,Auditor General,,DEM,Michael Lamb,10,13,0,23
+Northampton,BATH BORO,Auditor General,,DEM,H Scott Conklin,9,13,0,22
+Northampton,BATH BORO,Auditor General,,DEM,Tracie Fountain,2,18,0,20
+Northampton,BATH BORO,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,BATH BORO,State Treasurer,,DEM,Joe Torsella,45,150,1,196
+Northampton,BATH BORO,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,BATH BORO,U.S. House,7,DEM,Susan Wild,49,161,1,211
+Northampton,BATH BORO,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,BATH BORO,General Assembly,138,DEM,Tara Zrinski,45,149,1,195
+Northampton,BATH BORO,General Assembly,138,DEM,Write-in,0,2,0,2
+Northampton,BATH BORO,President,,REP,Donald J Trump,165,51,5,221
+Northampton,BATH BORO,President,,REP,Bill Weld,1,7,0,8
+Northampton,BATH BORO,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Northampton,BATH BORO,President,,REP,Write-in,0,1,0,1
+Northampton,BATH BORO,Attorney General,,REP,Heather Heidelbaugh,135,53,3,191
+Northampton,BATH BORO,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BATH BORO,Auditor General,,REP,Timothy Defoor,137,52,4,193
+Northampton,BATH BORO,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BATH BORO,State Treasurer,,REP,Stacy L. Garrity,134,51,4,189
+Northampton,BATH BORO,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BATH BORO,U.S. House,7,REP,Dean N. Browning,96,34,3,133
+Northampton,BATH BORO,U.S. House,7,REP,Lisa Scheller,69,25,3,97
+Northampton,BATH BORO,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BATH BORO,General Assembly,138,REP,Ann Flood,83,37,2,122
+Northampton,BATH BORO,General Assembly,138,REP,Tony Tarsi,76,21,2,99
+Northampton,BATH BORO,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Registered Voters,,,,,,,1191
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Registered Voters,,DEM,,,,,778
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Registered Voters,,REP,,,,,166
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Registered Voters,,NPA,,,,,247
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Ballots Cast,,,,94,140,3,237
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Ballots Cast,,DEM,,71,132,3,206
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Ballots Cast,,REP,,23,8,0,31
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,President,,DEM,Joseph R. Biden,35,81,1,117
+Northampton,BETHLEHEM 1ST WARD NORTHERN,President,,DEM,Bernie Sanders,31,49,2,82
+Northampton,BETHLEHEM 1ST WARD NORTHERN,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,BETHLEHEM 1ST WARD NORTHERN,President,,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Attorney General,,DEM,Josh Shapiro,50,112,3,165
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,DEM,Nina Ahmad,26,41,1,68
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,DEM,Christina M. Hartman,4,19,1,24
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,DEM,Michael Lamb,12,11,0,23
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,DEM,Tracie Fountain,4,19,0,23
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,DEM,Rose Rosie Marie Davis,6,15,0,21
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,DEM,H Scott Conklin,7,4,1,12
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 1ST WARD NORTHERN,State Treasurer,,DEM,Joe Torsella,49,107,3,159
+Northampton,BETHLEHEM 1ST WARD NORTHERN,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 1ST WARD NORTHERN,U.S. House,7,DEM,Susan Wild,58,126,3,187
+Northampton,BETHLEHEM 1ST WARD NORTHERN,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,General Assembly,135,DEM,Steve Samuelson,48,112,3,163
+Northampton,BETHLEHEM 1ST WARD NORTHERN,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,President,,REP,Donald J Trump,21,8,0,29
+Northampton,BETHLEHEM 1ST WARD NORTHERN,President,,REP,Bill Weld,2,0,0,2
+Northampton,BETHLEHEM 1ST WARD NORTHERN,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Attorney General,,REP,Heather Heidelbaugh,19,5,0,24
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,REP,Timothy Defoor,20,5,0,25
+Northampton,BETHLEHEM 1ST WARD NORTHERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,State Treasurer,,REP,Stacy L. Garrity,18,5,0,23
+Northampton,BETHLEHEM 1ST WARD NORTHERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,U.S. House,7,REP,Lisa Scheller,12,6,0,18
+Northampton,BETHLEHEM 1ST WARD NORTHERN,U.S. House,7,REP,Dean N. Browning,11,2,0,13
+Northampton,BETHLEHEM 1ST WARD NORTHERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD NORTHERN,General Assembly,135,REP,Scott J Hough,20,6,0,26
+Northampton,BETHLEHEM 1ST WARD NORTHERN,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Registered Voters,,,,,,,1212
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Registered Voters,,DEM,,,,,765
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Registered Voters,,REP,,,,,152
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Registered Voters,,NPA,,,,,295
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Ballots Cast,,,,93,71,2,166
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Ballots Cast,,DEM,,70,59,2,131
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Ballots Cast,,REP,,23,12,0,35
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,President,,DEM,Joseph R. Biden,43,44,0,87
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,President,,DEM,Bernie Sanders,22,12,2,36
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,President,,DEM,Tulsi Gabbard,2,3,0,5
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,President,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Attorney General,,DEM,Josh Shapiro,42,53,2,97
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,DEM,Nina Ahmad,22,23,2,47
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,DEM,Michael Lamb,11,7,0,18
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,DEM,H Scott Conklin,11,3,0,14
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,DEM,Rose Rosie Marie Davis,3,9,0,12
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,DEM,Christina M. Hartman,5,7,0,12
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,DEM,Tracie Fountain,3,5,0,8
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,State Treasurer,,DEM,Joe Torsella,41,50,2,93
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,U.S. House,7,DEM,Susan Wild,54,58,2,114
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,General Assembly,135,DEM,Steve Samuelson,49,55,2,106
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,President,,REP,Donald J Trump,18,11,0,29
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,President,,REP,Bill Weld,2,0,0,2
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,President,,REP,Write-in,1,1,0,2
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Attorney General,,REP,Heather Heidelbaugh,18,8,0,26
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,REP,Timothy Defoor,19,8,0,27
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,State Treasurer,,REP,Stacy L. Garrity,18,8,0,26
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,U.S. House,7,REP,Dean N. Browning,14,7,0,21
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,U.S. House,7,REP,Lisa Scheller,7,3,0,10
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,General Assembly,135,REP,Scott J Hough,18,7,0,25
+Northampton,BETHLEHEM 1ST WARD SOUTHERN,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 2ND WARD,Registered Voters,,,,,,,1250
+Northampton,BETHLEHEM 2ND WARD,Registered Voters,,DEM,,,,,760
+Northampton,BETHLEHEM 2ND WARD,Registered Voters,,REP,,,,,193
+Northampton,BETHLEHEM 2ND WARD,Registered Voters,,NPA,,,,,297
+Northampton,BETHLEHEM 2ND WARD,Ballots Cast,,,,66,102,3,171
+Northampton,BETHLEHEM 2ND WARD,Ballots Cast,,DEM,,53,91,3,147
+Northampton,BETHLEHEM 2ND WARD,Ballots Cast,,REP,,13,11,0,24
+Northampton,BETHLEHEM 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 2ND WARD,President,,DEM,Joseph R. Biden,30,53,0,83
+Northampton,BETHLEHEM 2ND WARD,President,,DEM,Bernie Sanders,20,35,2,57
+Northampton,BETHLEHEM 2ND WARD,President,,DEM,Tulsi Gabbard,1,0,1,2
+Northampton,BETHLEHEM 2ND WARD,President,,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 2ND WARD,Attorney General,,DEM,Josh Shapiro,38,82,2,122
+Northampton,BETHLEHEM 2ND WARD,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,DEM,Nina Ahmad,16,47,3,66
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,DEM,Christina M. Hartman,4,12,0,16
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,DEM,Michael Lamb,9,6,0,15
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,6,7,0,13
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,DEM,Tracie Fountain,4,7,0,11
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,DEM,H Scott Conklin,6,3,0,9
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 2ND WARD,State Treasurer,,DEM,Joe Torsella,33,79,3,115
+Northampton,BETHLEHEM 2ND WARD,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 2ND WARD,U.S. House,7,DEM,Susan Wild,45,86,3,134
+Northampton,BETHLEHEM 2ND WARD,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 2ND WARD,General Assembly,135,DEM,Steve Samuelson,39,83,2,124
+Northampton,BETHLEHEM 2ND WARD,General Assembly,135,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 2ND WARD,President,,REP,Donald J Trump,13,7,0,20
+Northampton,BETHLEHEM 2ND WARD,President,,REP,Bill Weld,0,2,0,2
+Northampton,BETHLEHEM 2ND WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM 2ND WARD,President,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,12,8,0,20
+Northampton,BETHLEHEM 2ND WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,REP,Timothy Defoor,13,8,0,21
+Northampton,BETHLEHEM 2ND WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,13,8,0,21
+Northampton,BETHLEHEM 2ND WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 2ND WARD,U.S. House,7,REP,Dean N. Browning,8,3,0,11
+Northampton,BETHLEHEM 2ND WARD,U.S. House,7,REP,Lisa Scheller,5,5,0,10
+Northampton,BETHLEHEM 2ND WARD,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 2ND WARD,General Assembly,135,REP,Scott J Hough,12,7,0,19
+Northampton,BETHLEHEM 2ND WARD,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 3RD WARD,Registered Voters,,,,,,,3178
+Northampton,BETHLEHEM 3RD WARD,Registered Voters,,DEM,,,,,1635
+Northampton,BETHLEHEM 3RD WARD,Registered Voters,,REP,,,,,531
+Northampton,BETHLEHEM 3RD WARD,Registered Voters,,NPA,,,,,1012
+Northampton,BETHLEHEM 3RD WARD,Ballots Cast,,,,65,86,3,154
+Northampton,BETHLEHEM 3RD WARD,Ballots Cast,,DEM,,51,82,3,136
+Northampton,BETHLEHEM 3RD WARD,Ballots Cast,,REP,,14,4,0,18
+Northampton,BETHLEHEM 3RD WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 3RD WARD,President,,DEM,Joseph R. Biden,27,53,3,83
+Northampton,BETHLEHEM 3RD WARD,President,,DEM,Bernie Sanders,17,27,0,44
+Northampton,BETHLEHEM 3RD WARD,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,BETHLEHEM 3RD WARD,President,,DEM,Write-in,2,2,0,4
+Northampton,BETHLEHEM 3RD WARD,Attorney General,,DEM,Josh Shapiro,28,74,2,104
+Northampton,BETHLEHEM 3RD WARD,Attorney General,,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,DEM,Nina Ahmad,14,31,0,45
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,DEM,Tracie Fountain,1,12,1,14
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,DEM,Christina M. Hartman,2,12,0,14
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,DEM,Michael Lamb,6,6,1,13
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,DEM,Rose Rosie Marie Davis,5,8,0,13
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,DEM,H Scott Conklin,6,3,0,9
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 3RD WARD,State Treasurer,,DEM,Joe Torsella,28,72,2,102
+Northampton,BETHLEHEM 3RD WARD,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 3RD WARD,U.S. House,7,DEM,Susan Wild,31,80,2,113
+Northampton,BETHLEHEM 3RD WARD,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 3RD WARD,General Assembly,135,DEM,Steve Samuelson,35,74,3,112
+Northampton,BETHLEHEM 3RD WARD,General Assembly,135,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 3RD WARD,President,,REP,Donald J Trump,11,4,0,15
+Northampton,BETHLEHEM 3RD WARD,President,,REP,Bill Weld,3,0,0,3
+Northampton,BETHLEHEM 3RD WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM 3RD WARD,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 3RD WARD,Attorney General,,REP,Heather Heidelbaugh,8,4,0,12
+Northampton,BETHLEHEM 3RD WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,REP,Timothy Defoor,8,4,0,12
+Northampton,BETHLEHEM 3RD WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 3RD WARD,State Treasurer,,REP,Stacy L. Garrity,8,4,0,12
+Northampton,BETHLEHEM 3RD WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 3RD WARD,U.S. House,7,REP,Lisa Scheller,7,4,0,11
+Northampton,BETHLEHEM 3RD WARD,U.S. House,7,REP,Dean N. Browning,2,0,0,2
+Northampton,BETHLEHEM 3RD WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 3RD WARD,General Assembly,135,REP,Scott J Hough,8,4,0,12
+Northampton,BETHLEHEM 3RD WARD,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,Registered Voters,,,,,,,1489
+Northampton,BETHLEHEM 4TH WARD,Registered Voters,,DEM,,,,,196
+Northampton,BETHLEHEM 4TH WARD,Registered Voters,,REP,,,,,355
+Northampton,BETHLEHEM 4TH WARD,Registered Voters,,NPA,,,,,938
+Northampton,BETHLEHEM 4TH WARD,Ballots Cast,,,,74,88,3,165
+Northampton,BETHLEHEM 4TH WARD,Ballots Cast,,DEM,,60,80,3,143
+Northampton,BETHLEHEM 4TH WARD,Ballots Cast,,REP,,14,8,0,22
+Northampton,BETHLEHEM 4TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,President,,DEM,Joseph R. Biden,44,53,2,99
+Northampton,BETHLEHEM 4TH WARD,President,,DEM,Bernie Sanders,14,25,1,40
+Northampton,BETHLEHEM 4TH WARD,President,,DEM,Tulsi Gabbard,1,0,0,1
+Northampton,BETHLEHEM 4TH WARD,President,,DEM,Write-in,1,2,0,3
+Northampton,BETHLEHEM 4TH WARD,Attorney General,,DEM,Josh Shapiro,44,71,3,118
+Northampton,BETHLEHEM 4TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,DEM,Nina Ahmad,18,33,1,52
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,5,14,1,20
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,DEM,H Scott Conklin,11,4,0,15
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,DEM,Michael Lamb,10,5,0,15
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,DEM,Christina M. Hartman,2,13,0,15
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,DEM,Tracie Fountain,3,4,0,7
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,State Treasurer,,DEM,Joe Torsella,43,69,2,114
+Northampton,BETHLEHEM 4TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,U.S. House,7,DEM,Susan Wild,49,78,3,130
+Northampton,BETHLEHEM 4TH WARD,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 4TH WARD,General Assembly,135,DEM,Steve Samuelson,44,70,2,116
+Northampton,BETHLEHEM 4TH WARD,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,President,,REP,Donald J Trump,14,6,0,20
+Northampton,BETHLEHEM 4TH WARD,President,,REP,Bill Weld,0,1,0,1
+Northampton,BETHLEHEM 4TH WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,Attorney General,,REP,Heather Heidelbaugh,10,7,0,17
+Northampton,BETHLEHEM 4TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,REP,Timothy Defoor,10,7,0,17
+Northampton,BETHLEHEM 4TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,State Treasurer,,REP,Stacy L. Garrity,10,6,0,16
+Northampton,BETHLEHEM 4TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,U.S. House,7,REP,Lisa Scheller,7,6,0,13
+Northampton,BETHLEHEM 4TH WARD,U.S. House,7,REP,Dean N. Browning,5,1,0,6
+Northampton,BETHLEHEM 4TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 4TH WARD,General Assembly,135,REP,Scott J Hough,10,7,0,17
+Northampton,BETHLEHEM 4TH WARD,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 5TH WARD,Registered Voters,,,,,,,1929
+Northampton,BETHLEHEM 5TH WARD,Registered Voters,,DEM,,,,,1237
+Northampton,BETHLEHEM 5TH WARD,Registered Voters,,REP,,,,,229
+Northampton,BETHLEHEM 5TH WARD,Registered Voters,,NPA,,,,,463
+Northampton,BETHLEHEM 5TH WARD,Ballots Cast,,,,115,103,6,224
+Northampton,BETHLEHEM 5TH WARD,Ballots Cast,,DEM,,89,97,6,192
+Northampton,BETHLEHEM 5TH WARD,Ballots Cast,,REP,,26,6,0,32
+Northampton,BETHLEHEM 5TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 5TH WARD,President,,DEM,Joseph R. Biden,50,67,3,120
+Northampton,BETHLEHEM 5TH WARD,President,,DEM,Bernie Sanders,27,26,2,55
+Northampton,BETHLEHEM 5TH WARD,President,,DEM,Tulsi Gabbard,5,2,0,7
+Northampton,BETHLEHEM 5TH WARD,President,,DEM,Write-in,3,1,0,4
+Northampton,BETHLEHEM 5TH WARD,Attorney General,,DEM,Josh Shapiro,58,89,5,152
+Northampton,BETHLEHEM 5TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,DEM,Nina Ahmad,24,35,3,62
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,DEM,Michael Lamb,16,8,0,24
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,9,9,2,20
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,DEM,Christina M. Hartman,7,13,0,20
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,DEM,H Scott Conklin,12,6,0,18
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,DEM,Tracie Fountain,3,14,0,17
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 5TH WARD,State Treasurer,,DEM,Joe Torsella,59,84,5,148
+Northampton,BETHLEHEM 5TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 5TH WARD,U.S. House,7,DEM,Susan Wild,70,92,6,168
+Northampton,BETHLEHEM 5TH WARD,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 5TH WARD,General Assembly,135,DEM,Steve Samuelson,69,90,4,163
+Northampton,BETHLEHEM 5TH WARD,General Assembly,135,DEM,Write-in,0,0,1,1
+Northampton,BETHLEHEM 5TH WARD,President,,REP,Donald J Trump,20,2,0,22
+Northampton,BETHLEHEM 5TH WARD,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Northampton,BETHLEHEM 5TH WARD,President,,REP,Bill Weld,1,1,0,2
+Northampton,BETHLEHEM 5TH WARD,President,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 5TH WARD,Attorney General,,REP,Heather Heidelbaugh,21,3,0,24
+Northampton,BETHLEHEM 5TH WARD,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,REP,Timothy Defoor,20,2,0,22
+Northampton,BETHLEHEM 5TH WARD,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 5TH WARD,State Treasurer,,REP,Stacy L. Garrity,21,2,0,23
+Northampton,BETHLEHEM 5TH WARD,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 5TH WARD,U.S. House,7,REP,Dean N. Browning,14,2,0,16
+Northampton,BETHLEHEM 5TH WARD,U.S. House,7,REP,Lisa Scheller,11,1,0,12
+Northampton,BETHLEHEM 5TH WARD,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 5TH WARD,General Assembly,135,REP,Scott J Hough,19,2,0,21
+Northampton,BETHLEHEM 5TH WARD,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 6TH WARD,Registered Voters,,,,,,,807
+Northampton,BETHLEHEM 6TH WARD,Registered Voters,,DEM,,,,,472
+Northampton,BETHLEHEM 6TH WARD,Registered Voters,,REP,,,,,203
+Northampton,BETHLEHEM 6TH WARD,Registered Voters,,NPA,,,,,132
+Northampton,BETHLEHEM 6TH WARD,Ballots Cast,,,,82,268,6,356
+Northampton,BETHLEHEM 6TH WARD,Ballots Cast,,DEM,,54,216,5,275
+Northampton,BETHLEHEM 6TH WARD,Ballots Cast,,REP,,28,52,1,81
+Northampton,BETHLEHEM 6TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 6TH WARD,President,,DEM,Joseph R. Biden,28,180,1,209
+Northampton,BETHLEHEM 6TH WARD,President,,DEM,Bernie Sanders,23,29,4,56
+Northampton,BETHLEHEM 6TH WARD,President,,DEM,Tulsi Gabbard,2,3,0,5
+Northampton,BETHLEHEM 6TH WARD,President,,DEM,Write-in,1,2,0,3
+Northampton,BETHLEHEM 6TH WARD,Attorney General,,DEM,Josh Shapiro,37,199,4,240
+Northampton,BETHLEHEM 6TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,DEM,Nina Ahmad,16,87,2,105
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,DEM,Christina M. Hartman,2,28,0,30
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,DEM,Michael Lamb,8,19,0,27
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,8,19,0,27
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,DEM,Tracie Fountain,0,18,3,21
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,DEM,H Scott Conklin,11,6,0,17
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 6TH WARD,State Treasurer,,DEM,Joe Torsella,34,191,4,229
+Northampton,BETHLEHEM 6TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 6TH WARD,U.S. House,7,DEM,Susan Wild,46,211,5,262
+Northampton,BETHLEHEM 6TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 6TH WARD,General Assembly,135,DEM,Steve Samuelson,46,206,4,256
+Northampton,BETHLEHEM 6TH WARD,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 6TH WARD,President,,REP,Donald J Trump,24,38,0,62
+Northampton,BETHLEHEM 6TH WARD,President,,REP,Bill Weld,1,3,1,5
+Northampton,BETHLEHEM 6TH WARD,President,,REP,Roque Rocky De La Fuente,0,4,0,4
+Northampton,BETHLEHEM 6TH WARD,President,,REP,Write-in,0,6,0,6
+Northampton,BETHLEHEM 6TH WARD,Attorney General,,REP,Heather Heidelbaugh,22,45,1,68
+Northampton,BETHLEHEM 6TH WARD,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,REP,Timothy Defoor,22,46,0,68
+Northampton,BETHLEHEM 6TH WARD,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 6TH WARD,State Treasurer,,REP,Stacy L. Garrity,22,45,1,68
+Northampton,BETHLEHEM 6TH WARD,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 6TH WARD,U.S. House,7,REP,Lisa Scheller,17,32,1,50
+Northampton,BETHLEHEM 6TH WARD,U.S. House,7,REP,Dean N. Browning,10,14,0,24
+Northampton,BETHLEHEM 6TH WARD,U.S. House,7,REP,Write-in,0,3,0,3
+Northampton,BETHLEHEM 6TH WARD,General Assembly,135,REP,Scott J Hough,22,45,0,67
+Northampton,BETHLEHEM 6TH WARD,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 7TH WARD,Registered Voters,,,,,,,1568
+Northampton,BETHLEHEM 7TH WARD,Registered Voters,,DEM,,,,,960
+Northampton,BETHLEHEM 7TH WARD,Registered Voters,,REP,,,,,277
+Northampton,BETHLEHEM 7TH WARD,Registered Voters,,NPA,,,,,331
+Northampton,BETHLEHEM 7TH WARD,Ballots Cast,,,,139,243,5,387
+Northampton,BETHLEHEM 7TH WARD,Ballots Cast,,DEM,,107,216,5,328
+Northampton,BETHLEHEM 7TH WARD,Ballots Cast,,REP,,32,27,0,59
+Northampton,BETHLEHEM 7TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,President,,DEM,Joseph R. Biden,58,148,1,207
+Northampton,BETHLEHEM 7TH WARD,President,,DEM,Bernie Sanders,41,57,4,102
+Northampton,BETHLEHEM 7TH WARD,President,,DEM,Tulsi Gabbard,3,3,0,6
+Northampton,BETHLEHEM 7TH WARD,President,,DEM,Write-in,0,3,0,3
+Northampton,BETHLEHEM 7TH WARD,Attorney General,,DEM,Josh Shapiro,77,184,3,264
+Northampton,BETHLEHEM 7TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,DEM,Nina Ahmad,38,91,3,132
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,7,23,0,30
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,DEM,H Scott Conklin,15,13,1,29
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,DEM,Christina M. Hartman,6,21,0,27
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,DEM,Michael Lamb,16,10,0,26
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,DEM,Tracie Fountain,5,21,0,26
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,State Treasurer,,DEM,Joe Torsella,74,182,3,259
+Northampton,BETHLEHEM 7TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,U.S. House,7,DEM,Susan Wild,84,204,4,292
+Northampton,BETHLEHEM 7TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,General Assembly,135,DEM,Steve Samuelson,82,190,4,276
+Northampton,BETHLEHEM 7TH WARD,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,President,,REP,Donald J Trump,25,16,0,41
+Northampton,BETHLEHEM 7TH WARD,President,,REP,Bill Weld,4,5,0,9
+Northampton,BETHLEHEM 7TH WARD,President,,REP,Roque Rocky De La Fuente,2,4,0,6
+Northampton,BETHLEHEM 7TH WARD,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,Attorney General,,REP,Heather Heidelbaugh,29,21,0,50
+Northampton,BETHLEHEM 7TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,REP,Timothy Defoor,28,22,0,50
+Northampton,BETHLEHEM 7TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,State Treasurer,,REP,Stacy L. Garrity,28,23,0,51
+Northampton,BETHLEHEM 7TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 7TH WARD,U.S. House,7,REP,Lisa Scheller,15,15,0,30
+Northampton,BETHLEHEM 7TH WARD,U.S. House,7,REP,Dean N. Browning,16,5,0,21
+Northampton,BETHLEHEM 7TH WARD,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 7TH WARD,General Assembly,135,REP,Scott J Hough,26,21,0,47
+Northampton,BETHLEHEM 7TH WARD,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 8TH WARD,Registered Voters,,,,,,,1598
+Northampton,BETHLEHEM 8TH WARD,Registered Voters,,DEM,,,,,922
+Northampton,BETHLEHEM 8TH WARD,Registered Voters,,REP,,,,,340
+Northampton,BETHLEHEM 8TH WARD,Registered Voters,,NPA,,,,,336
+Northampton,BETHLEHEM 8TH WARD,Ballots Cast,,,,132,244,17,393
+Northampton,BETHLEHEM 8TH WARD,Ballots Cast,,DEM,,92,203,13,308
+Northampton,BETHLEHEM 8TH WARD,Ballots Cast,,REP,,40,41,4,85
+Northampton,BETHLEHEM 8TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,President,,DEM,Joseph R. Biden,57,137,7,201
+Northampton,BETHLEHEM 8TH WARD,President,,DEM,Bernie Sanders,27,50,6,83
+Northampton,BETHLEHEM 8TH WARD,President,,DEM,Tulsi Gabbard,5,4,0,9
+Northampton,BETHLEHEM 8TH WARD,President,,DEM,Write-in,1,9,0,10
+Northampton,BETHLEHEM 8TH WARD,Attorney General,,DEM,Josh Shapiro,72,182,12,266
+Northampton,BETHLEHEM 8TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,DEM,Nina Ahmad,32,61,6,99
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,DEM,Christina M. Hartman,10,38,0,48
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,DEM,H Scott Conklin,15,14,2,31
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,DEM,Michael Lamb,14,16,1,31
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,7,18,2,27
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,DEM,Tracie Fountain,1,24,0,25
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,State Treasurer,,DEM,Joe Torsella,66,179,11,256
+Northampton,BETHLEHEM 8TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,U.S. House,7,DEM,Susan Wild,78,197,12,287
+Northampton,BETHLEHEM 8TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,General Assembly,135,DEM,Steve Samuelson,76,192,12,280
+Northampton,BETHLEHEM 8TH WARD,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,President,,REP,Donald J Trump,34,30,3,67
+Northampton,BETHLEHEM 8TH WARD,President,,REP,Bill Weld,3,7,0,10
+Northampton,BETHLEHEM 8TH WARD,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,BETHLEHEM 8TH WARD,President,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 8TH WARD,Attorney General,,REP,Heather Heidelbaugh,30,35,3,68
+Northampton,BETHLEHEM 8TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,REP,Timothy Defoor,29,34,3,66
+Northampton,BETHLEHEM 8TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,State Treasurer,,REP,Stacy L. Garrity,28,34,4,66
+Northampton,BETHLEHEM 8TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,U.S. House,7,REP,Dean N. Browning,22,18,2,42
+Northampton,BETHLEHEM 8TH WARD,U.S. House,7,REP,Lisa Scheller,16,19,2,37
+Northampton,BETHLEHEM 8TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 8TH WARD,General Assembly,135,REP,Scott J Hough,33,34,3,70
+Northampton,BETHLEHEM 8TH WARD,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Registered Voters,,,,,,,727
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Registered Voters,,DEM,,,,,460
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Registered Voters,,REP,,,,,130
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Registered Voters,,NPA,,,,,137
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Ballots Cast,,,,65,105,0,170
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Ballots Cast,,DEM,,52,96,0,148
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Ballots Cast,,REP,,13,9,0,22
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,President,,DEM,Joseph R. Biden,26,67,0,93
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,President,,DEM,Bernie Sanders,23,23,0,46
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,President,,DEM,Tulsi Gabbard,1,2,0,3
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,President,,DEM,Write-in,0,4,0,4
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Attorney General,,DEM,Josh Shapiro,40,89,0,129
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,DEM,Nina Ahmad,16,34,0,50
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,DEM,Christina M. Hartman,5,17,0,22
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,6,11,0,17
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,DEM,Michael Lamb,7,7,0,14
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,DEM,Tracie Fountain,1,11,0,12
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,DEM,H Scott Conklin,4,4,0,8
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,State Treasurer,,DEM,Joe Torsella,37,89,0,126
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,U.S. House,7,DEM,Susan Wild,42,90,0,132
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,General Assembly,135,DEM,Steve Samuelson,39,92,0,131
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,President,,REP,Donald J Trump,12,8,0,20
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,President,,REP,Bill Weld,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Attorney General,,REP,Heather Heidelbaugh,9,8,0,17
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,REP,Timothy Defoor,10,9,0,19
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,State Treasurer,,REP,Stacy L. Garrity,9,8,0,17
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,U.S. House,7,REP,Dean N. Browning,8,4,0,12
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,U.S. House,7,REP,Lisa Scheller,3,5,0,8
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,General Assembly,135,REP,Scott J Hough,9,9,0,18
+Northampton,BETHLEHEM 9TH WARD 1ST DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Registered Voters,,,,,,,827
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Registered Voters,,DEM,,,,,487
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Registered Voters,,REP,,,,,166
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Registered Voters,,NPA,,,,,174
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Ballots Cast,,,,89,123,1,213
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Ballots Cast,,DEM,,63,107,1,171
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Ballots Cast,,REP,,26,16,0,42
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,President,,DEM,Joseph R. Biden,40,82,0,122
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,President,,DEM,Bernie Sanders,22,21,1,44
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,President,,DEM,Tulsi Gabbard,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,President,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Attorney General,,DEM,Josh Shapiro,40,95,1,136
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,DEM,Nina Ahmad,23,45,0,68
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,DEM,Christina M. Hartman,4,13,0,17
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,DEM,Tracie Fountain,6,10,0,16
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,3,11,1,15
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,DEM,H Scott Conklin,11,1,0,12
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,DEM,Michael Lamb,6,5,0,11
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,State Treasurer,,DEM,Joe Torsella,44,93,1,138
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,U.S. House,7,DEM,Susan Wild,50,105,1,156
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,General Assembly,135,DEM,Steve Samuelson,48,102,1,151
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,President,,REP,Donald J Trump,22,15,0,37
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,President,,REP,Bill Weld,3,1,0,4
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Attorney General,,REP,Heather Heidelbaugh,23,16,0,39
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,REP,Timothy Defoor,24,16,0,40
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,State Treasurer,,REP,Stacy L. Garrity,24,16,0,40
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,U.S. House,7,REP,Dean N. Browning,16,9,0,25
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,U.S. House,7,REP,Lisa Scheller,9,7,0,16
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,General Assembly,135,REP,Scott J Hough,23,15,0,38
+Northampton,BETHLEHEM 9TH WARD 2ND DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Registered Voters,,,,,,,1427
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Registered Voters,,DEM,,,,,802
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Registered Voters,,REP,,,,,334
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Registered Voters,,NPA,,,,,291
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Ballots Cast,,,,159,224,5,388
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Ballots Cast,,DEM,,102,191,3,296
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Ballots Cast,,REP,,57,33,2,92
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,President,,DEM,Joseph R. Biden,68,136,2,206
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,President,,DEM,Bernie Sanders,27,48,1,76
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,President,,DEM,Tulsi Gabbard,3,3,0,6
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,President,,DEM,Write-in,1,3,0,4
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Attorney General,,DEM,Josh Shapiro,73,171,3,247
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Attorney General,,DEM,Write-in,1,2,0,3
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,DEM,Nina Ahmad,27,65,1,93
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,DEM,Tracie Fountain,5,34,1,40
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,14,21,1,36
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,DEM,Christina M. Hartman,5,26,0,31
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,DEM,Michael Lamb,16,12,0,28
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,DEM,H Scott Conklin,20,6,0,26
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,State Treasurer,,DEM,Joe Torsella,72,164,3,239
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,State Treasurer,,DEM,Write-in,1,2,0,3
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,U.S. House,7,DEM,Susan Wild,88,184,3,275
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,General Assembly,135,DEM,Steve Samuelson,85,180,3,268
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,General Assembly,135,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,President,,REP,Donald J Trump,48,25,1,74
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,President,,REP,Bill Weld,2,5,0,7
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,President,,REP,Roque Rocky De La Fuente,3,1,0,4
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,President,,REP,Write-in,1,2,0,3
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Attorney General,,REP,Heather Heidelbaugh,44,28,2,74
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,REP,Timothy Defoor,45,29,2,76
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,State Treasurer,,REP,Stacy L. Garrity,45,27,2,74
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,U.S. House,7,REP,Lisa Scheller,24,20,1,45
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,U.S. House,7,REP,Dean N. Browning,31,11,1,43
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,General Assembly,135,REP,Scott J Hough,47,30,2,79
+Northampton,BETHLEHEM 9TH WARD 3RD DISTRICT,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Registered Voters,,,,,,,1400
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Registered Voters,,DEM,,,,,747
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Registered Voters,,REP,,,,,438
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Registered Voters,,NPA,,,,,215
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Ballots Cast,,,,150,394,6,550
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Ballots Cast,,DEM,,78,317,6,401
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Ballots Cast,,REP,,72,77,0,149
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,President,,DEM,Joseph R. Biden,49,240,4,293
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,President,,DEM,Bernie Sanders,21,67,2,90
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,President,,DEM,Tulsi Gabbard,6,3,0,9
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,President,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Attorney General,,DEM,Josh Shapiro,55,279,5,339
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,DEM,Nina Ahmad,25,107,2,134
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,DEM,Christina M. Hartman,7,54,0,61
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,DEM,Michael Lamb,9,31,0,40
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,DEM,Tracie Fountain,2,33,0,35
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,DEM,H Scott Conklin,10,24,0,34
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,7,23,2,32
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,State Treasurer,,DEM,Joe Torsella,54,281,6,341
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,U.S. House,7,DEM,Susan Wild,67,300,6,373
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,General Assembly,135,DEM,Steve Samuelson,67,296,6,369
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,President,,REP,Donald J Trump,62,60,0,122
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,President,,REP,Bill Weld,3,8,0,11
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,President,,REP,Write-in,3,2,0,5
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Attorney General,,REP,Heather Heidelbaugh,62,62,0,124
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,REP,Timothy Defoor,67,59,0,126
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,State Treasurer,,REP,Stacy L. Garrity,64,60,0,124
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,U.S. House,7,REP,Dean N. Browning,44,29,0,73
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,U.S. House,7,REP,Lisa Scheller,26,45,0,71
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,U.S. House,7,REP,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,General Assembly,135,REP,Scott J Hough,63,65,0,128
+Northampton,BETHLEHEM 14TH WARD 1ST DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Registered Voters,,,,,,,1902
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Registered Voters,,DEM,,,,,946
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Registered Voters,,REP,,,,,675
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Registered Voters,,NPA,,,,,281
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Ballots Cast,,,,210,528,9,747
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Ballots Cast,,DEM,,97,395,7,499
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Ballots Cast,,REP,,113,133,2,248
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,President,,DEM,Joseph R. Biden,67,335,6,408
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,President,,DEM,Bernie Sanders,22,36,1,59
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,President,,DEM,Tulsi Gabbard,4,16,0,20
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,President,,DEM,Write-in,3,4,0,7
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Attorney General,,DEM,Josh Shapiro,73,349,6,428
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Attorney General,,DEM,Write-in,0,4,0,4
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,DEM,Nina Ahmad,30,105,6,141
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,7,58,0,65
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,DEM,Christina M. Hartman,6,57,1,64
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,DEM,Michael Lamb,16,42,0,58
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,DEM,Tracie Fountain,10,38,0,48
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,DEM,H Scott Conklin,11,20,0,31
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,State Treasurer,,DEM,Joe Torsella,71,340,6,417
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,U.S. House,7,DEM,Susan Wild,85,363,7,455
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,U.S. House,7,DEM,Write-in,2,3,0,5
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,General Assembly,135,DEM,Steve Samuelson,81,362,7,450
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,President,,REP,Donald J Trump,106,99,2,207
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,President,,REP,Bill Weld,6,16,0,22
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,President,,REP,Write-in,0,13,0,13
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Attorney General,,REP,Heather Heidelbaugh,97,116,1,214
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Attorney General,,REP,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,REP,Timothy Defoor,98,113,1,212
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,Auditor General,,REP,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,State Treasurer,,REP,Stacy L. Garrity,99,114,1,214
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,U.S. House,7,REP,Lisa Scheller,52,81,2,135
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,U.S. House,7,REP,Dean N. Browning,59,44,0,103
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,General Assembly,135,REP,Scott J Hough,96,118,1,215
+Northampton,BETHLEHEM 14TH WARD 2ND DISTRICT,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Registered Voters,,,,,,,1419
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Registered Voters,,DEM,,,,,792
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Registered Voters,,REP,,,,,408
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Registered Voters,,NPA,,,,,219
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Ballots Cast,,,,181,348,6,535
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Ballots Cast,,DEM,,92,276,5,373
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Ballots Cast,,REP,,89,72,1,162
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,President,,DEM,Joseph R. Biden,64,215,5,284
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,President,,DEM,Bernie Sanders,23,43,0,66
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,President,,DEM,Tulsi Gabbard,2,4,0,6
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,President,,DEM,Write-in,1,5,0,6
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Attorney General,,DEM,Josh Shapiro,66,248,5,319
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,DEM,Nina Ahmad,30,66,1,97
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,DEM,Christina M. Hartman,8,63,3,74
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,DEM,Michael Lamb,15,25,0,40
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,8,29,0,37
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,DEM,H Scott Conklin,11,20,0,31
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,DEM,Tracie Fountain,3,27,0,30
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,State Treasurer,,DEM,Joe Torsella,59,235,5,299
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,U.S. House,7,DEM,Susan Wild,78,254,5,337
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,General Assembly,135,DEM,Steve Samuelson,76,257,5,338
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,General Assembly,135,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,President,,REP,Donald J Trump,78,53,1,132
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,President,,REP,Bill Weld,5,11,0,16
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,President,,REP,Write-in,1,4,0,5
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Attorney General,,REP,Heather Heidelbaugh,71,57,1,129
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,REP,Timothy Defoor,71,56,1,128
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,State Treasurer,,REP,Stacy L. Garrity,70,58,1,129
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,U.S. House,7,REP,Lisa Scheller,35,44,1,80
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,U.S. House,7,REP,Dean N. Browning,47,23,0,70
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,General Assembly,135,REP,Scott J Hough,74,57,1,132
+Northampton,BETHLEHEM 14TH WARD 3RD DISTRICT,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Registered Voters,,,,,,,1249
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Registered Voters,,DEM,,,,,750
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Registered Voters,,REP,,,,,304
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Registered Voters,,NPA,,,,,195
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Ballots Cast,,,,167,245,6,418
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Ballots Cast,,DEM,,99,197,6,302
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Ballots Cast,,REP,,68,48,0,116
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,President,,DEM,Joseph R. Biden,67,162,6,235
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,President,,DEM,Bernie Sanders,25,30,0,55
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,President,,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Attorney General,,DEM,Josh Shapiro,65,179,6,250
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,DEM,Nina Ahmad,31,62,4,97
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,6,38,1,45
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,DEM,Michael Lamb,17,20,0,37
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,7,23,0,30
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,DEM,Tracie Fountain,6,17,1,24
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,DEM,H Scott Conklin,14,7,0,21
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,State Treasurer,,DEM,Joe Torsella,62,170,6,238
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,U.S. House,7,DEM,Susan Wild,79,185,6,270
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,General Assembly,135,DEM,Steve Samuelson,77,188,6,271
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,President,,REP,Donald J Trump,61,43,0,104
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,President,,REP,Bill Weld,1,3,0,4
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,President,,REP,Roque Rocky De La Fuente,3,0,0,3
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,President,,REP,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,57,37,0,94
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,REP,Timothy Defoor,56,38,0,94
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,57,37,0,94
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,U.S. House,7,REP,Dean N. Browning,34,27,0,61
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,U.S. House,7,REP,Lisa Scheller,32,20,0,52
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,General Assembly,135,REP,Scott J Hough,52,40,0,92
+Northampton,BETHLEHEM 14TH WARD 4TH DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Registered Voters,,,,,,,1592
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Registered Voters,,DEM,,,,,887
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Registered Voters,,REP,,,,,454
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Registered Voters,,NPA,,,,,251
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Ballots Cast,,,,226,303,10,539
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Ballots Cast,,DEM,,116,253,5,374
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Ballots Cast,,REP,,110,50,5,165
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,President,,DEM,Joseph R. Biden,80,213,2,295
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,President,,DEM,Bernie Sanders,26,35,2,63
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,President,,DEM,Tulsi Gabbard,6,1,1,8
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,President,,DEM,Write-in,2,1,0,3
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Attorney General,,DEM,Josh Shapiro,86,234,4,324
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,DEM,Nina Ahmad,30,79,3,112
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,13,44,0,57
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,9,40,1,50
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,DEM,Michael Lamb,22,26,0,48
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,DEM,H Scott Conklin,14,16,0,30
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,DEM,Tracie Fountain,7,21,0,28
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,State Treasurer,,DEM,Joe Torsella,83,227,4,314
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,U.S. House,7,DEM,Susan Wild,95,244,5,344
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,General Assembly,135,DEM,Steve Samuelson,99,241,5,345
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,General Assembly,135,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,President,,REP,Donald J Trump,101,42,4,147
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,President,,REP,Bill Weld,5,6,1,12
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,89,48,4,141
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,REP,Timothy Defoor,88,46,4,138
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,89,46,4,139
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,U.S. House,7,REP,Dean N. Browning,59,24,3,86
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,U.S. House,7,REP,Lisa Scheller,47,24,2,73
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,General Assembly,135,REP,Scott J Hough,91,45,5,141
+Northampton,BETHLEHEM 14TH WARD 5TH DISTRICT,General Assembly,135,REP,Write-in,2,2,0,4
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Registered Voters,,,,,,,2240
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Registered Voters,,DEM,,,,,1203
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Registered Voters,,REP,,,,,594
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Registered Voters,,NPA,,,,,443
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Ballots Cast,,,,214,399,18,631
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Ballots Cast,,DEM,,108,319,13,440
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Ballots Cast,,REP,,106,80,5,191
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,President,,DEM,Joseph R. Biden,71,261,6,338
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,President,,DEM,Bernie Sanders,23,44,7,74
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,President,,DEM,Tulsi Gabbard,7,4,0,11
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,President,,DEM,Write-in,4,5,0,9
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Attorney General,,DEM,Josh Shapiro,74,293,13,380
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,DEM,Nina Ahmad,25,99,6,130
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,15,50,1,66
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,12,49,1,62
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,DEM,Michael Lamb,15,31,1,47
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,DEM,H Scott Conklin,17,18,1,36
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,DEM,Tracie Fountain,3,29,1,33
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,State Treasurer,,DEM,Joe Torsella,76,277,12,365
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,U.S. House,7,DEM,Susan Wild,87,306,12,405
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,General Assembly,135,DEM,Steve Samuelson,86,296,13,395
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,President,,REP,Donald J Trump,100,63,5,168
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,President,,REP,Bill Weld,2,10,0,12
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,President,,REP,Write-in,0,4,0,4
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,91,72,4,167
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,REP,Timothy Defoor,90,71,2,163
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,91,71,2,164
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,U.S. House,7,REP,Dean N. Browning,57,40,2,99
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,U.S. House,7,REP,Lisa Scheller,48,37,3,88
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,General Assembly,135,REP,Scott J Hough,93,70,2,165
+Northampton,BETHLEHEM 14TH WARD 6TH DISTRICT,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Registered Voters,,,,,,,1359
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Registered Voters,,DEM,,,,,685
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Registered Voters,,REP,,,,,470
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Registered Voters,,NPA,,,,,204
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Ballots Cast,,,,147,391,7,545
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Ballots Cast,,DEM,,46,311,7,364
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Ballots Cast,,REP,,101,80,0,181
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,President,,DEM,Joseph R. Biden,31,260,6,297
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,President,,DEM,Bernie Sanders,13,35,0,48
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,President,,DEM,Tulsi Gabbard,2,8,0,10
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,President,,DEM,Write-in,0,5,1,6
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Attorney General,,DEM,Josh Shapiro,33,267,7,307
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,DEM,Nina Ahmad,15,92,1,108
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,3,53,1,57
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,11,36,3,50
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,DEM,Tracie Fountain,1,43,2,46
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,DEM,Michael Lamb,6,37,0,43
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,DEM,H Scott Conklin,6,7,0,13
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,State Treasurer,,DEM,Joe Torsella,37,258,7,302
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,U.S. House,7,DEM,Susan Wild,42,293,7,342
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,General Assembly,135,DEM,Steve Samuelson,40,292,7,339
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,President,,REP,Donald J Trump,95,61,0,156
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,President,,REP,Bill Weld,4,11,0,15
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,President,,REP,Write-in,1,4,0,5
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,77,72,0,149
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Attorney General,,REP,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,REP,Timothy Defoor,79,69,0,148
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,78,71,0,149
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,U.S. House,7,REP,Lisa Scheller,55,44,0,99
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,U.S. House,7,REP,Dean N. Browning,44,33,0,77
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,General Assembly,135,REP,Scott J Hough,81,69,0,150
+Northampton,BETHLEHEM 14TH WARD 7TH DISTRICT,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Registered Voters,,,,,,,977
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Registered Voters,,DEM,,,,,551
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Registered Voters,,REP,,,,,276
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Registered Voters,,NPA,,,,,150
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Ballots Cast,,,,144,259,2,405
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Ballots Cast,,DEM,,78,222,1,301
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Ballots Cast,,REP,,66,37,1,104
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,President,,DEM,Joseph R. Biden,45,168,0,213
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,President,,DEM,Bernie Sanders,24,44,1,69
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,President,,DEM,Tulsi Gabbard,3,5,0,8
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,President,,DEM,Write-in,1,2,0,3
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Attorney General,,DEM,Josh Shapiro,62,210,1,273
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Attorney General,,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,DEM,Nina Ahmad,18,79,1,98
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,12,40,0,52
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,6,31,0,37
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,DEM,Tracie Fountain,7,22,0,29
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,DEM,Michael Lamb,12,16,0,28
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,DEM,H Scott Conklin,15,12,0,27
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,State Treasurer,,DEM,Joe Torsella,60,204,1,265
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,U.S. House,7,DEM,Susan Wild,63,215,1,279
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,General Assembly,135,DEM,Steve Samuelson,67,216,1,284
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,President,,REP,Donald J Trump,59,27,1,87
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,President,,REP,Bill Weld,2,3,0,5
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,President,,REP,Write-in,0,4,0,4
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,56,31,1,88
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,REP,Timothy Defoor,55,32,1,88
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,56,31,1,88
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,U.S. House,7,REP,Lisa Scheller,30,23,0,53
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,U.S. House,7,REP,Dean N. Browning,32,10,1,43
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,General Assembly,135,REP,Scott J Hough,54,34,1,89
+Northampton,BETHLEHEM 14TH WARD 8TH DISTRICT,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Registered Voters,,,,,,,1378
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Registered Voters,,DEM,,,,,810
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Registered Voters,,REP,,,,,374
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Registered Voters,,NPA,,,,,194
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Ballots Cast,,,,170,277,0,447
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Ballots Cast,,DEM,,110,206,0,316
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Ballots Cast,,REP,,60,71,0,131
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,President,,DEM,Joseph R. Biden,66,155,0,221
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,President,,DEM,Bernie Sanders,33,42,0,75
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,President,,DEM,Tulsi Gabbard,5,4,0,9
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,President,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Attorney General,,DEM,Josh Shapiro,84,187,0,271
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,DEM,Nina Ahmad,30,55,0,85
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,13,34,0,47
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,DEM,Christina M. Hartman,5,42,0,47
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,DEM,H Scott Conklin,26,14,0,40
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,DEM,Michael Lamb,13,13,0,26
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,DEM,Tracie Fountain,4,20,0,24
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,State Treasurer,,DEM,Joe Torsella,81,182,0,263
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,U.S. House,7,DEM,Susan Wild,94,200,0,294
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,General Assembly,135,DEM,Steve Samuelson,89,198,0,287
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,President,,REP,Donald J Trump,54,54,0,108
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,President,,REP,Bill Weld,2,8,0,10
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Attorney General,,REP,Heather Heidelbaugh,45,58,0,103
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,REP,Timothy Defoor,42,58,0,100
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,State Treasurer,,REP,Stacy L. Garrity,46,57,0,103
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,U.S. House,7,REP,Lisa Scheller,33,28,0,61
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,U.S. House,7,REP,Dean N. Browning,26,32,0,58
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,General Assembly,135,REP,Scott J Hough,45,56,0,101
+Northampton,BETHLEHEM 15TH WARD 1ST DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Registered Voters,,,,,,,1808
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Registered Voters,,DEM,,,,,1057
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Registered Voters,,REP,,,,,460
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Registered Voters,,NPA,,,,,291
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Ballots Cast,,,,245,349,14,608
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Ballots Cast,,DEM,,140,286,8,434
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Ballots Cast,,REP,,105,63,6,174
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,President,,DEM,Joseph R. Biden,87,235,3,325
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,President,,DEM,Bernie Sanders,37,43,4,84
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,President,,DEM,Tulsi Gabbard,4,5,0,9
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,President,,DEM,Write-in,3,1,1,5
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Attorney General,,DEM,Josh Shapiro,105,259,6,370
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,DEM,Nina Ahmad,36,96,3,135
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,18,45,0,63
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,DEM,Christina M. Hartman,15,42,2,59
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,DEM,Michael Lamb,18,30,1,49
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,DEM,H Scott Conklin,24,10,0,34
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,DEM,Tracie Fountain,8,25,1,34
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,State Treasurer,,DEM,Joe Torsella,98,250,6,354
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,U.S. House,7,DEM,Susan Wild,120,270,8,398
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,General Assembly,135,DEM,Steve Samuelson,122,260,7,389
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,President,,REP,Donald J Trump,93,46,5,144
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,President,,REP,Bill Weld,4,12,0,16
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,President,,REP,Write-in,2,1,0,3
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Attorney General,,REP,Heather Heidelbaugh,86,53,4,143
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,REP,Timothy Defoor,88,51,4,143
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,Auditor General,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,State Treasurer,,REP,Stacy L. Garrity,86,51,4,141
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,U.S. House,7,REP,Lisa Scheller,46,38,3,87
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,U.S. House,7,REP,Dean N. Browning,55,20,3,78
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,General Assembly,135,REP,Scott J Hough,90,52,4,146
+Northampton,BETHLEHEM 15TH WARD 2ND DISTRICT,General Assembly,135,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Registered Voters,,,,,,,2405
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Registered Voters,,DEM,,,,,1624
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Registered Voters,,REP,,,,,298
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Registered Voters,,NPA,,,,,483
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Ballots Cast,,,,179,169,8,356
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Ballots Cast,,DEM,,138,143,6,287
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Ballots Cast,,REP,,41,26,2,69
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,President,,DEM,Joseph R. Biden,101,114,4,219
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,President,,DEM,Bernie Sanders,32,26,2,60
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,President,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Attorney General,,DEM,Josh Shapiro,73,122,6,201
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,DEM,Nina Ahmad,23,60,5,88
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,DEM,Michael Lamb,23,10,0,33
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,13,19,0,32
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,DEM,H Scott Conklin,21,7,0,28
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,DEM,Christina M. Hartman,6,20,0,26
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,DEM,Tracie Fountain,2,4,1,7
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,State Treasurer,,DEM,Joe Torsella,75,120,6,201
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,U.S. House,7,DEM,Susan Wild,106,129,6,241
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,General Assembly,135,DEM,Steve Samuelson,88,123,6,217
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,President,,REP,Donald J Trump,33,20,2,55
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,President,,REP,Bill Weld,0,2,0,2
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Attorney General,,REP,Heather Heidelbaugh,28,25,1,54
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,REP,Timothy Defoor,27,26,1,54
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,State Treasurer,,REP,Stacy L. Garrity,27,24,0,51
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,U.S. House,7,REP,Dean N. Browning,22,13,0,35
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,U.S. House,7,REP,Lisa Scheller,14,12,1,27
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,General Assembly,135,REP,Scott J Hough,28,25,0,53
+Northampton,BETHLEHEM 15TH WARD 3RD DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,Registered Voters,,,,,,,1891
+Northampton,BETHLEHEM 16TH WARD,Registered Voters,,DEM,,,,,1010
+Northampton,BETHLEHEM 16TH WARD,Registered Voters,,REP,,,,,489
+Northampton,BETHLEHEM 16TH WARD,Registered Voters,,NPA,,,,,392
+Northampton,BETHLEHEM 16TH WARD,Ballots Cast,,,,113,250,2,365
+Northampton,BETHLEHEM 16TH WARD,Ballots Cast,,DEM,,57,193,2,252
+Northampton,BETHLEHEM 16TH WARD,Ballots Cast,,REP,,56,57,0,113
+Northampton,BETHLEHEM 16TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,President,,DEM,Joseph R. Biden,41,163,1,205
+Northampton,BETHLEHEM 16TH WARD,President,,DEM,Bernie Sanders,16,26,1,43
+Northampton,BETHLEHEM 16TH WARD,President,,DEM,Tulsi Gabbard,0,1,0,1
+Northampton,BETHLEHEM 16TH WARD,President,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 16TH WARD,Attorney General,,DEM,Josh Shapiro,39,177,2,218
+Northampton,BETHLEHEM 16TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,DEM,Nina Ahmad,12,56,1,69
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,DEM,Christina M. Hartman,3,32,0,35
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,DEM,Michael Lamb,11,21,0,32
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,6,20,1,27
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,DEM,H Scott Conklin,9,12,0,21
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,DEM,Tracie Fountain,1,20,0,21
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,State Treasurer,,DEM,Joe Torsella,34,169,2,205
+Northampton,BETHLEHEM 16TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,U.S. House,7,DEM,Susan Wild,47,183,2,232
+Northampton,BETHLEHEM 16TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,General Assembly,135,DEM,Steve Samuelson,39,175,2,216
+Northampton,BETHLEHEM 16TH WARD,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM 16TH WARD,President,,REP,Donald J Trump,51,43,0,94
+Northampton,BETHLEHEM 16TH WARD,President,,REP,Bill Weld,1,9,0,10
+Northampton,BETHLEHEM 16TH WARD,President,,REP,Roque Rocky De La Fuente,2,2,0,4
+Northampton,BETHLEHEM 16TH WARD,President,,REP,Write-in,1,3,0,4
+Northampton,BETHLEHEM 16TH WARD,Attorney General,,REP,Heather Heidelbaugh,46,45,0,91
+Northampton,BETHLEHEM 16TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,REP,Timothy Defoor,47,47,0,94
+Northampton,BETHLEHEM 16TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,State Treasurer,,REP,Stacy L. Garrity,46,49,0,95
+Northampton,BETHLEHEM 16TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,U.S. House,7,REP,Lisa Scheller,23,35,0,58
+Northampton,BETHLEHEM 16TH WARD,U.S. House,7,REP,Dean N. Browning,30,20,0,50
+Northampton,BETHLEHEM 16TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 16TH WARD,General Assembly,135,REP,Scott J Hough,45,47,0,92
+Northampton,BETHLEHEM 16TH WARD,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,Registered Voters,,,,,,,778
+Northampton,BETHLEHEM 17TH WARD,Registered Voters,,DEM,,,,,521
+Northampton,BETHLEHEM 17TH WARD,Registered Voters,,REP,,,,,81
+Northampton,BETHLEHEM 17TH WARD,Registered Voters,,NPA,,,,,176
+Northampton,BETHLEHEM 17TH WARD,Ballots Cast,,,,56,44,1,101
+Northampton,BETHLEHEM 17TH WARD,Ballots Cast,,DEM,,51,41,1,93
+Northampton,BETHLEHEM 17TH WARD,Ballots Cast,,REP,,5,3,0,8
+Northampton,BETHLEHEM 17TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,President,,DEM,Joseph R. Biden,33,32,1,66
+Northampton,BETHLEHEM 17TH WARD,President,,DEM,Bernie Sanders,12,7,0,19
+Northampton,BETHLEHEM 17TH WARD,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,BETHLEHEM 17TH WARD,President,,DEM,Write-in,2,1,0,3
+Northampton,BETHLEHEM 17TH WARD,Attorney General,,DEM,Josh Shapiro,36,34,0,70
+Northampton,BETHLEHEM 17TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,DEM,Nina Ahmad,9,6,0,15
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,DEM,H Scott Conklin,8,5,0,13
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,5,7,0,12
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,DEM,Christina M. Hartman,3,8,0,11
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,DEM,Michael Lamb,7,2,0,9
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,DEM,Tracie Fountain,3,4,0,7
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,State Treasurer,,DEM,Joe Torsella,30,33,0,63
+Northampton,BETHLEHEM 17TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,U.S. House,7,DEM,Susan Wild,42,40,0,82
+Northampton,BETHLEHEM 17TH WARD,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM 17TH WARD,General Assembly,135,DEM,Steve Samuelson,37,39,0,76
+Northampton,BETHLEHEM 17TH WARD,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,President,,REP,Donald J Trump,4,2,0,6
+Northampton,BETHLEHEM 17TH WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,President,,REP,Bill Weld,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,President,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM 17TH WARD,Attorney General,,REP,Heather Heidelbaugh,4,2,0,6
+Northampton,BETHLEHEM 17TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,REP,Timothy Defoor,4,2,0,6
+Northampton,BETHLEHEM 17TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,State Treasurer,,REP,Stacy L. Garrity,4,2,0,6
+Northampton,BETHLEHEM 17TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,U.S. House,7,REP,Dean N. Browning,3,1,0,4
+Northampton,BETHLEHEM 17TH WARD,U.S. House,7,REP,Lisa Scheller,1,1,0,2
+Northampton,BETHLEHEM 17TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM 17TH WARD,General Assembly,135,REP,Scott J Hough,4,2,0,6
+Northampton,BETHLEHEM 17TH WARD,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Registered Voters,,,,,,,1049
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Registered Voters,,DEM,,,,,465
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Registered Voters,,REP,,,,,399
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Registered Voters,,NPA,,,,,185
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Ballots Cast,,,,120,227,1,348
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Ballots Cast,,DEM,,43,163,0,206
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Ballots Cast,,REP,,77,64,1,142
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,President,,DEM,Joseph R. Biden,31,140,0,171
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,President,,DEM,Bernie Sanders,9,17,0,26
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,President,,DEM,Write-in,0,4,0,4
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Attorney General,,DEM,Josh Shapiro,29,149,0,178
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,DEM,Nina Ahmad,10,49,0,59
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,DEM,Christina M. Hartman,6,38,0,44
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,8,22,0,30
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,DEM,Michael Lamb,7,11,0,18
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,DEM,H Scott Conklin,6,10,0,16
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,DEM,Tracie Fountain,2,7,0,9
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,State Treasurer,,DEM,Joe Torsella,33,146,0,179
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,U.S. House,7,DEM,Susan Wild,32,158,0,190
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,General Assembly,138,DEM,Tara Zrinski,32,144,0,176
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,General Assembly,138,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,President,,REP,Donald J Trump,71,56,1,128
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,President,,REP,Bill Weld,1,5,0,6
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,President,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Attorney General,,REP,Heather Heidelbaugh,60,56,0,116
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,REP,Timothy Defoor,59,56,0,115
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,State Treasurer,,REP,Stacy L. Garrity,60,57,0,117
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,U.S. House,7,REP,Dean N. Browning,41,34,1,76
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,U.S. House,7,REP,Lisa Scheller,31,24,0,55
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,General Assembly,138,REP,Ann Flood,33,34,1,68
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,General Assembly,138,REP,Tony Tarsi,40,26,0,66
+Northampton,BETHLEHEM TWSP 1ST WARD 1ST DISTRICT,General Assembly,138,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Registered Voters,,,,,,,1218
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Registered Voters,,DEM,,,,,546
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Registered Voters,,REP,,,,,469
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Registered Voters,,NPA,,,,,203
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Ballots Cast,,,,166,284,8,458
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Ballots Cast,,DEM,,57,200,5,262
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Ballots Cast,,REP,,109,84,3,196
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,President,,DEM,Joseph R. Biden,38,176,2,216
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,President,,DEM,Bernie Sanders,15,15,2,32
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,President,,DEM,Tulsi Gabbard,2,3,0,5
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,President,,DEM,Write-in,1,3,0,4
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Attorney General,,DEM,Josh Shapiro,39,183,5,227
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,DEM,Nina Ahmad,17,61,2,80
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,DEM,Christina M. Hartman,2,48,1,51
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,DEM,Michael Lamb,11,19,2,32
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,7,23,0,30
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,DEM,Tracie Fountain,3,16,0,19
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,DEM,H Scott Conklin,7,11,0,18
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,State Treasurer,,DEM,Joe Torsella,33,182,3,218
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,U.S. House,7,DEM,Susan Wild,42,184,5,231
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,General Assembly,138,DEM,Tara Zrinski,40,181,3,224
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,General Assembly,138,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,President,,REP,Donald J Trump,98,71,3,172
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,President,,REP,Bill Weld,4,9,0,13
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,President,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Attorney General,,REP,Heather Heidelbaugh,83,72,3,158
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Attorney General,,REP,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,REP,Timothy Defoor,83,72,3,158
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,Auditor General,,REP,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,State Treasurer,,REP,Stacy L. Garrity,84,70,3,157
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,State Treasurer,,REP,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,U.S. House,7,REP,Dean N. Browning,51,43,1,95
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,U.S. House,7,REP,Lisa Scheller,55,36,2,93
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,General Assembly,138,REP,Tony Tarsi,66,37,2,105
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,General Assembly,138,REP,Ann Flood,34,41,1,76
+Northampton,BETHLEHEM TWSP 1ST WARD 2ND DISTRICT,General Assembly,138,REP,Write-in,1,0,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Registered Voters,,,,,,,1268
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Registered Voters,,DEM,,,,,586
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Registered Voters,,REP,,,,,426
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Registered Voters,,NPA,,,,,256
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Ballots Cast,,,,147,215,5,367
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Ballots Cast,,DEM,,53,158,2,213
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Ballots Cast,,REP,,94,57,3,154
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,President,,DEM,Joseph R. Biden,40,124,2,166
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,President,,DEM,Bernie Sanders,11,31,0,42
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,President,,DEM,Tulsi Gabbard,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,President,,DEM,Write-in,2,2,0,4
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Attorney General,,DEM,Josh Shapiro,35,146,2,183
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Attorney General,,DEM,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,DEM,Nina Ahmad,10,58,0,68
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,9,31,0,40
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,DEM,Christina M. Hartman,1,22,0,23
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,DEM,Tracie Fountain,6,12,2,20
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,DEM,Michael Lamb,8,11,0,19
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,DEM,H Scott Conklin,9,3,0,12
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,DEM,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,State Treasurer,,DEM,Joe Torsella,36,138,2,176
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,State Treasurer,,DEM,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,U.S. House,7,DEM,Susan Wild,43,151,2,196
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,U.S. House,7,DEM,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,General Assembly,138,DEM,Tara Zrinski,44,140,2,186
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,General Assembly,138,DEM,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,President,,REP,Donald J Trump,90,45,2,137
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,President,,REP,Bill Weld,2,8,1,11
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,President,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Attorney General,,REP,Heather Heidelbaugh,83,51,1,135
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,REP,Timothy Defoor,83,51,1,135
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,State Treasurer,,REP,Stacy L. Garrity,80,52,1,133
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,U.S. House,7,REP,Lisa Scheller,49,32,1,82
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,U.S. House,7,REP,Dean N. Browning,43,22,2,67
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,General Assembly,138,REP,Tony Tarsi,65,28,3,96
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,General Assembly,138,REP,Ann Flood,28,26,0,54
+Northampton,BETHLEHEM TWSP 1ST WARD 3RD DISTRICT,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Registered Voters,,,,,,,915
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Registered Voters,,DEM,,,,,384
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Registered Voters,,REP,,,,,359
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Registered Voters,,NPA,,,,,172
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Ballots Cast,,,,76,160,1,237
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Ballots Cast,,DEM,,23,97,1,121
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Ballots Cast,,REP,,53,63,0,116
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,President,,DEM,Joseph R. Biden,17,77,0,94
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,President,,DEM,Bernie Sanders,6,10,1,17
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,President,,DEM,Tulsi Gabbard,0,3,0,3
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,President,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Attorney General,,DEM,Josh Shapiro,18,83,1,102
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,DEM,Nina Ahmad,5,18,1,24
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,1,18,0,19
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,6,12,0,18
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,DEM,Michael Lamb,7,7,0,14
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,DEM,Tracie Fountain,1,11,0,12
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,DEM,H Scott Conklin,0,11,0,11
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,State Treasurer,,DEM,Joe Torsella,18,80,1,99
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,U.S. House,7,DEM,Susan Wild,21,92,1,114
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,General Assembly,138,DEM,Tara Zrinski,19,80,1,100
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,General Assembly,138,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,President,,REP,Donald J Trump,52,55,0,107
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,President,,REP,Bill Weld,0,6,0,6
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,46,54,0,100
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,REP,Timothy Defoor,46,53,0,99
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,46,54,0,100
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,U.S. House,7,REP,Dean N. Browning,23,31,0,54
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,U.S. House,7,REP,Lisa Scheller,28,25,0,53
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,General Assembly,138,REP,Tony Tarsi,35,28,0,63
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,General Assembly,138,REP,Ann Flood,14,29,0,43
+Northampton,BETHLEHEM TWSP 1ST WARD 4TH DISTRICT,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Registered Voters,,,,,,,1296
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Registered Voters,,DEM,,,,,687
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Registered Voters,,REP,,,,,376
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Registered Voters,,NPA,,,,,233
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Ballots Cast,,,,146,226,10,382
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Ballots Cast,,DEM,,64,181,7,252
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Ballots Cast,,REP,,82,45,3,130
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,President,,DEM,Joseph R. Biden,45,139,5,189
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,President,,DEM,Bernie Sanders,14,32,2,48
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,President,,DEM,Tulsi Gabbard,4,3,0,7
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,President,,DEM,Write-in,0,7,0,7
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Attorney General,,DEM,Josh Shapiro,42,163,7,212
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,DEM,Nina Ahmad,13,60,4,77
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,DEM,Christina M. Hartman,1,32,2,35
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,7,26,0,33
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,DEM,Michael Lamb,11,16,0,27
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,DEM,Tracie Fountain,6,14,1,21
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,DEM,H Scott Conklin,11,7,0,18
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,State Treasurer,,DEM,Joe Torsella,41,156,6,203
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,State Treasurer,,DEM,Write-in,0,3,0,3
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,U.S. House,7,DEM,Susan Wild,53,166,7,226
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,General Assembly,135,DEM,Steve Samuelson,49,168,7,224
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,General Assembly,135,DEM,Write-in,1,3,0,4
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,President,,REP,Donald J Trump,74,40,3,117
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,President,,REP,Roque Rocky De La Fuente,3,2,0,5
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,President,,REP,Bill Weld,1,1,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Attorney General,,REP,Heather Heidelbaugh,75,36,3,114
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,REP,Timothy Defoor,72,37,3,112
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,State Treasurer,,REP,Stacy L. Garrity,74,37,3,114
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,U.S. House,7,REP,Dean N. Browning,52,20,3,75
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,U.S. House,7,REP,Lisa Scheller,23,23,0,46
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,General Assembly,135,REP,Scott J Hough,73,39,3,115
+Northampton,BETHLEHEM TWSP 2ND WARD 1ST DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Registered Voters,,,,,,,1289
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Registered Voters,,DEM,,,,,647
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Registered Voters,,REP,,,,,433
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Registered Voters,,NPA,,,,,209
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Ballots Cast,,,,155,256,3,414
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Ballots Cast,,DEM,,80,197,2,279
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Ballots Cast,,REP,,75,59,1,135
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,President,,DEM,Joseph R. Biden,59,157,1,217
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,President,,DEM,Bernie Sanders,16,26,1,43
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,President,,DEM,Tulsi Gabbard,1,6,0,7
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,President,,DEM,Write-in,3,2,0,5
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Attorney General,,DEM,Josh Shapiro,56,186,2,244
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,DEM,Nina Ahmad,27,58,1,86
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,DEM,Christina M. Hartman,8,35,0,43
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,8,32,0,40
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,DEM,Michael Lamb,10,23,0,33
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,DEM,H Scott Conklin,10,13,0,23
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,DEM,Tracie Fountain,3,18,0,21
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,State Treasurer,,DEM,Joe Torsella,57,180,2,239
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,U.S. House,7,DEM,Susan Wild,73,189,2,264
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,General Assembly,135,DEM,Steve Samuelson,71,188,2,261
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,President,,REP,Donald J Trump,68,45,1,114
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,President,,REP,Bill Weld,3,7,0,10
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,President,,REP,Write-in,0,3,0,3
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Attorney General,,REP,Heather Heidelbaugh,64,49,1,114
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,REP,Timothy Defoor,62,51,1,114
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,State Treasurer,,REP,Stacy L. Garrity,64,50,1,115
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,U.S. House,7,REP,Dean N. Browning,41,27,1,69
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,U.S. House,7,REP,Lisa Scheller,33,29,0,62
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,General Assembly,135,REP,Scott J Hough,67,61,1,129
+Northampton,BETHLEHEM TWSP 2ND WARD 2ND DISTRICT,General Assembly,135,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Registered Voters,,,,,,,734
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Registered Voters,,DEM,,,,,396
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Registered Voters,,REP,,,,,222
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Registered Voters,,NPA,,,,,116
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Ballots Cast,,,,102,147,4,253
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Ballots Cast,,DEM,,52,121,2,175
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Ballots Cast,,REP,,50,26,2,78
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,President,,DEM,Joseph R. Biden,33,98,2,133
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,President,,DEM,Bernie Sanders,12,10,0,22
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,President,,DEM,Tulsi Gabbard,3,2,0,5
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,President,,DEM,Write-in,0,3,0,3
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Attorney General,,DEM,Josh Shapiro,27,111,1,139
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,DEM,Nina Ahmad,14,22,1,37
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,DEM,Christina M. Hartman,6,24,0,30
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,4,25,0,29
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,DEM,Michael Lamb,12,8,0,20
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,DEM,Tracie Fountain,1,15,0,16
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,DEM,H Scott Conklin,1,6,0,7
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,State Treasurer,,DEM,Joe Torsella,33,107,2,142
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,U.S. House,7,DEM,Susan Wild,41,117,2,160
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,General Assembly,135,DEM,Steve Samuelson,37,111,1,149
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,President,,REP,Donald J Trump,46,24,2,72
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,President,,REP,Bill Weld,1,1,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,President,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Attorney General,,REP,Heather Heidelbaugh,40,20,2,62
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,REP,Timothy Defoor,39,19,2,60
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,State Treasurer,,REP,Stacy L. Garrity,42,18,2,62
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,U.S. House,7,REP,Lisa Scheller,23,16,1,40
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,U.S. House,7,REP,Dean N. Browning,26,7,1,34
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,General Assembly,135,REP,Scott J Hough,41,19,2,62
+Northampton,BETHLEHEM TWSP 2ND WARD 3RD DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Registered Voters,,,,,,,910
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Registered Voters,,DEM,,,,,462
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Registered Voters,,REP,,,,,291
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Registered Voters,,NPA,,,,,157
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Ballots Cast,,,,105,231,2,338
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Ballots Cast,,DEM,,54,175,2,231
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Ballots Cast,,REP,,51,56,0,107
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,President,,DEM,Joseph R. Biden,29,147,2,178
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,President,,DEM,Bernie Sanders,14,20,0,34
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,President,,DEM,Tulsi Gabbard,1,6,0,7
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,President,,DEM,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Attorney General,,DEM,Josh Shapiro,31,165,2,198
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,DEM,Nina Ahmad,13,38,0,51
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,DEM,Michael Lamb,9,26,1,36
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,7,24,0,31
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,2,27,0,29
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,DEM,Tracie Fountain,1,25,1,27
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,DEM,H Scott Conklin,7,11,0,18
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,State Treasurer,,DEM,Joe Torsella,25,158,2,185
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,U.S. House,7,DEM,Susan Wild,38,163,2,203
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,General Assembly,135,DEM,Steve Samuelson,40,163,2,205
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,General Assembly,135,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,President,,REP,Donald J Trump,47,41,0,88
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,President,,REP,Bill Weld,2,9,0,11
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,President,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,34,48,0,82
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,REP,Timothy Defoor,35,48,0,83
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,Auditor General,,REP,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,35,47,0,82
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,U.S. House,7,REP,Lisa Scheller,22,28,0,50
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,U.S. House,7,REP,Dean N. Browning,25,23,0,48
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,General Assembly,135,REP,Scott J Hough,33,48,0,81
+Northampton,BETHLEHEM TWSP 2ND WARD 4TH DISTRICT,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Registered Voters,,,,,,,725
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Registered Voters,,DEM,,,,,397
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Registered Voters,,REP,,,,,187
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Registered Voters,,NPA,,,,,141
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Ballots Cast,,,,71,155,0,226
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Ballots Cast,,DEM,,34,115,0,149
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Ballots Cast,,REP,,37,40,0,77
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,President,,DEM,Joseph R. Biden,17,93,0,110
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,President,,DEM,Bernie Sanders,12,17,0,29
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,President,,DEM,Tulsi Gabbard,3,0,0,3
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,President,,DEM,Write-in,1,3,0,4
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Attorney General,,DEM,Josh Shapiro,28,105,0,133
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,6,25,0,31
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,DEM,Christina M. Hartman,5,25,0,30
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,DEM,Nina Ahmad,7,21,0,28
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,DEM,H Scott Conklin,7,11,0,18
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,DEM,Michael Lamb,3,7,0,10
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,DEM,Tracie Fountain,2,7,0,9
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,State Treasurer,,DEM,Joe Torsella,26,104,0,130
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,U.S. House,7,DEM,Susan Wild,29,109,0,138
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,General Assembly,135,DEM,Steve Samuelson,27,101,0,128
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,President,,REP,Donald J Trump,34,31,0,65
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,President,,REP,Bill Weld,1,8,0,9
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Attorney General,,REP,Heather Heidelbaugh,32,33,0,65
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,REP,Timothy Defoor,32,33,0,65
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,State Treasurer,,REP,Stacy L. Garrity,31,33,0,64
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,U.S. House,7,REP,Dean N. Browning,23,17,0,40
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,U.S. House,7,REP,Lisa Scheller,13,20,0,33
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,General Assembly,135,REP,Scott J Hough,34,35,0,69
+Northampton,BETHLEHEM TWSP 3RD WARD 1ST DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Registered Voters,,,,,,,763
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Registered Voters,,DEM,,,,,328
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Registered Voters,,REP,,,,,295
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Registered Voters,,NPA,,,,,140
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Ballots Cast,,,,91,179,2,272
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Ballots Cast,,DEM,,38,136,1,175
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Ballots Cast,,REP,,53,43,1,97
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,President,,DEM,Joseph R. Biden,24,126,1,151
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,President,,DEM,Bernie Sanders,9,6,0,15
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,President,,DEM,Tulsi Gabbard,1,1,0,2
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,President,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Attorney General,,DEM,Josh Shapiro,25,122,1,148
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Nina Ahmad,10,46,1,57
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Christina M. Hartman,1,24,0,25
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Michael Lamb,7,17,0,24
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Tracie Fountain,0,17,0,17
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,4,11,0,15
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,DEM,H Scott Conklin,3,6,0,9
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,State Treasurer,,DEM,Joe Torsella,20,113,1,134
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,U.S. House,7,DEM,Susan Wild,27,128,1,156
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,General Assembly,135,DEM,Steve Samuelson,26,127,1,154
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,General Assembly,135,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,President,,REP,Donald J Trump,47,39,1,87
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,President,,REP,Bill Weld,3,4,0,7
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,President,,REP,Write-in,1,0,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Attorney General,,REP,Heather Heidelbaugh,47,39,0,86
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,REP,Timothy Defoor,46,38,0,84
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,State Treasurer,,REP,Stacy L. Garrity,46,39,0,85
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,U.S. House,7,REP,Lisa Scheller,25,26,0,51
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,U.S. House,7,REP,Dean N. Browning,27,15,1,43
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,General Assembly,135,REP,Scott J Hough,46,39,0,85
+Northampton,BETHLEHEM TWSP 3RD WARD 2ND DISTRICT,General Assembly,135,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Registered Voters,,,,,,,966
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Registered Voters,,DEM,,,,,458
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Registered Voters,,REP,,,,,353
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Registered Voters,,NPA,,,,,155
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Ballots Cast,,,,163,191,3,357
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Ballots Cast,,DEM,,80,131,3,214
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Ballots Cast,,REP,,83,60,0,143
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,President,,DEM,Joseph R. Biden,49,109,2,160
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,President,,DEM,Bernie Sanders,21,14,1,36
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,President,,DEM,Tulsi Gabbard,5,4,0,9
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,President,,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Attorney General,,DEM,Josh Shapiro,64,110,3,177
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Nina Ahmad,24,32,2,58
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Christina M. Hartman,6,24,0,30
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,13,16,0,29
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Tracie Fountain,5,22,0,27
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Michael Lamb,12,9,1,22
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,DEM,H Scott Conklin,11,10,0,21
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,State Treasurer,,DEM,Joe Torsella,58,110,3,171
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,U.S. House,7,DEM,Susan Wild,69,120,3,192
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,U.S. House,7,DEM,Write-in,1,2,0,3
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,General Assembly,135,DEM,Steve Samuelson,70,115,2,187
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,General Assembly,135,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,President,,REP,Donald J Trump,79,44,0,123
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,President,,REP,Bill Weld,0,10,0,10
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,President,,REP,Write-in,1,1,0,2
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Attorney General,,REP,Heather Heidelbaugh,68,51,0,119
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,REP,Timothy Defoor,68,50,0,118
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,State Treasurer,,REP,Stacy L. Garrity,70,50,0,120
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,U.S. House,7,REP,Lisa Scheller,38,31,0,69
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,U.S. House,7,REP,Dean N. Browning,43,25,0,68
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,General Assembly,135,REP,Scott J Hough,71,47,0,118
+Northampton,BETHLEHEM TWSP 3RD WARD 3RD DISTRICT,General Assembly,135,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Registered Voters,,,,,,,924
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Registered Voters,,DEM,,,,,431
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Registered Voters,,REP,,,,,317
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Registered Voters,,NPA,,,,,176
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Ballots Cast,,,,106,188,5,299
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Ballots Cast,,DEM,,44,140,1,185
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Ballots Cast,,REP,,62,48,4,114
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,President,,DEM,Joseph R. Biden,33,121,1,155
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,President,,DEM,Bernie Sanders,10,14,0,24
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,President,,DEM,Tulsi Gabbard,0,2,0,2
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,President,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Attorney General,,DEM,Josh Shapiro,30,128,0,158
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Nina Ahmad,11,31,0,42
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Michael Lamb,12,16,0,28
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,0,28,0,28
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Tracie Fountain,6,20,0,26
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,4,11,0,15
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,DEM,H Scott Conklin,5,9,0,14
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,State Treasurer,,DEM,Joe Torsella,34,127,0,161
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,U.S. House,7,DEM,Susan Wild,37,137,0,174
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,General Assembly,138,DEM,Tara Zrinski,36,133,0,169
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,President,,REP,Donald J Trump,56,33,4,93
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,President,,REP,Bill Weld,2,9,0,11
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,President,,REP,Write-in,1,4,0,5
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,48,43,4,95
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,REP,Timothy Defoor,48,42,4,94
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,48,43,4,95
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,U.S. House,7,REP,Lisa Scheller,31,28,4,63
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,U.S. House,7,REP,Dean N. Browning,28,14,0,42
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,General Assembly,138,REP,Ann Flood,31,19,4,54
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,General Assembly,138,REP,Tony Tarsi,24,23,0,47
+Northampton,BETHLEHEM TWSP 3RD WARD 4TH DISTRICT,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Registered Voters,,,,,,,1075
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Registered Voters,,DEM,,,,,413
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Registered Voters,,REP,,,,,420
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Registered Voters,,NPA,,,,,242
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Ballots Cast,,,,103,174,5,282
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Ballots Cast,,DEM,,33,110,1,144
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Ballots Cast,,REP,,70,64,4,138
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,President,,DEM,Joseph R. Biden,28,94,1,123
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,President,,DEM,Bernie Sanders,4,11,0,15
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,President,,DEM,Tulsi Gabbard,0,1,0,1
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,President,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Attorney General,,DEM,Josh Shapiro,22,100,1,123
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,DEM,Nina Ahmad,8,28,1,37
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,2,17,0,19
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,DEM,Michael Lamb,7,11,0,18
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,2,13,0,15
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,DEM,Tracie Fountain,2,10,0,12
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,DEM,H Scott Conklin,7,4,0,11
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,State Treasurer,,DEM,Joe Torsella,22,97,1,120
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,U.S. House,7,DEM,Susan Wild,27,101,1,129
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,General Assembly,138,DEM,Tara Zrinski,25,93,1,119
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,President,,REP,Donald J Trump,65,48,3,116
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,President,,REP,Bill Weld,3,7,0,10
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,President,,REP,Roque Rocky De La Fuente,1,6,0,7
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,President,,REP,Write-in,0,1,1,2
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,58,60,4,122
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,REP,Timothy Defoor,58,60,4,122
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,58,60,4,122
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,U.S. House,7,REP,Lisa Scheller,36,33,1,70
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,U.S. House,7,REP,Dean N. Browning,32,29,3,64
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,General Assembly,138,REP,Tony Tarsi,45,27,2,74
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,General Assembly,138,REP,Ann Flood,21,36,2,59
+Northampton,BETHLEHEM TWSP 3RD WARD 5TH DISTRICT,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Registered Voters,,,,,,,1750
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Registered Voters,,DEM,,,,,729
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Registered Voters,,REP,,,,,646
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Registered Voters,,NPA,,,,,375
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Ballots Cast,,,,166,361,4,531
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Ballots Cast,,DEM,,74,263,2,339
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Ballots Cast,,REP,,92,98,2,192
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,President,,DEM,Joseph R. Biden,52,205,2,259
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,President,,DEM,Bernie Sanders,18,52,0,70
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,President,,DEM,Tulsi Gabbard,3,4,0,7
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,President,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Attorney General,,DEM,Josh Shapiro,54,231,2,287
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,DEM,Nina Ahmad,30,86,2,118
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,DEM,Christina M. Hartman,3,48,0,51
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,9,32,0,41
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,DEM,Michael Lamb,10,28,0,38
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,DEM,Tracie Fountain,9,25,0,34
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,DEM,H Scott Conklin,9,9,0,18
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,State Treasurer,,DEM,Joe Torsella,58,232,2,292
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,U.S. House,7,DEM,Susan Wild,62,245,2,309
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,U.S. House,7,DEM,Write-in,0,3,0,3
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,General Assembly,138,DEM,Tara Zrinski,58,234,2,294
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,President,,REP,Donald J Trump,81,80,2,163
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,President,,REP,Bill Weld,7,11,0,18
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,President,,REP,Roque Rocky De La Fuente,3,0,0,3
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,President,,REP,Write-in,1,4,0,5
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Attorney General,,REP,Heather Heidelbaugh,80,82,2,164
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,REP,Timothy Defoor,80,77,2,159
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,State Treasurer,,REP,Stacy L. Garrity,79,81,1,161
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,U.S. House,7,REP,Lisa Scheller,46,49,2,97
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,U.S. House,7,REP,Dean N. Browning,42,40,0,82
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,General Assembly,138,REP,Tony Tarsi,68,40,2,110
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,General Assembly,138,REP,Ann Flood,17,46,0,63
+Northampton,BETHLEHEM TWSP 4TH WARD 1ST DISTRICT,General Assembly,138,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Registered Voters,,,,,,,1236
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Registered Voters,,DEM,,,,,470
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Registered Voters,,REP,,,,,502
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Registered Voters,,NPA,,,,,264
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Ballots Cast,,,,117,228,4,349
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Ballots Cast,,DEM,,27,145,0,172
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Ballots Cast,,REP,,90,83,4,177
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,President,,DEM,Joseph R. Biden,19,121,0,140
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,President,,DEM,Bernie Sanders,8,21,0,29
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,President,,DEM,Tulsi Gabbard,0,2,0,2
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,President,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Attorney General,,DEM,Josh Shapiro,17,129,0,146
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,DEM,Nina Ahmad,9,34,0,43
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,DEM,Christina M. Hartman,3,22,0,25
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,1,22,0,23
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,DEM,Tracie Fountain,0,17,0,17
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,DEM,H Scott Conklin,4,12,0,16
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,DEM,Michael Lamb,2,13,0,15
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,State Treasurer,,DEM,Joe Torsella,17,127,0,144
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,U.S. House,7,DEM,Susan Wild,24,133,0,157
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,General Assembly,138,DEM,Tara Zrinski,21,128,0,149
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,President,,REP,Donald J Trump,88,62,4,154
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,President,,REP,Bill Weld,1,12,0,13
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,President,,REP,Roque Rocky De La Fuente,0,3,0,3
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,President,,REP,Write-in,0,3,0,3
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Attorney General,,REP,Heather Heidelbaugh,78,75,4,157
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,REP,Timothy Defoor,77,75,4,156
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,State Treasurer,,REP,Stacy L. Garrity,80,75,4,159
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,U.S. House,7,REP,Lisa Scheller,49,39,1,89
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,U.S. House,7,REP,Dean N. Browning,40,39,3,82
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,General Assembly,138,REP,Ann Flood,32,55,2,89
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,General Assembly,138,REP,Tony Tarsi,55,23,2,80
+Northampton,BETHLEHEM TWSP 4TH WARD 2ND DISTRICT,General Assembly,138,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Registered Voters,,,,,,,1194
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Registered Voters,,DEM,,,,,500
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Registered Voters,,REP,,,,,469
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Registered Voters,,NPA,,,,,225
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Ballots Cast,,,,157,211,7,375
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Ballots Cast,,DEM,,64,142,4,210
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Ballots Cast,,REP,,93,69,3,165
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,President,,DEM,Joseph R. Biden,43,124,3,170
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,President,,DEM,Bernie Sanders,16,15,1,32
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,President,,DEM,Tulsi Gabbard,3,0,0,3
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,President,,DEM,Write-in,1,1,0,2
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Attorney General,,DEM,Josh Shapiro,50,129,2,181
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,DEM,Nina Ahmad,20,39,2,61
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,DEM,Christina M. Hartman,2,33,0,35
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,DEM,Michael Lamb,10,16,0,26
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,12,14,0,26
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,DEM,H Scott Conklin,6,13,0,19
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,DEM,Tracie Fountain,3,12,0,15
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,State Treasurer,,DEM,Joe Torsella,51,130,2,183
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,U.S. House,7,DEM,Susan Wild,54,136,4,194
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,U.S. House,7,DEM,Write-in,2,0,0,2
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,General Assembly,138,DEM,Tara Zrinski,56,128,4,188
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,General Assembly,138,DEM,Write-in,1,0,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,President,,REP,Donald J Trump,84,57,3,144
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,President,,REP,Bill Weld,6,6,0,12
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,President,,REP,Roque Rocky De La Fuente,0,3,0,3
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,President,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Attorney General,,REP,Heather Heidelbaugh,71,58,3,132
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,REP,Timothy Defoor,71,57,3,131
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,State Treasurer,,REP,Stacy L. Garrity,71,57,3,131
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,U.S. House,7,REP,Lisa Scheller,48,37,1,86
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,U.S. House,7,REP,Dean N. Browning,42,29,2,73
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,General Assembly,138,REP,Tony Tarsi,69,32,1,102
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,General Assembly,138,REP,Ann Flood,23,35,2,60
+Northampton,BETHLEHEM TWSP 4TH WARD 3RD DISTRICT,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Registered Voters,,,,,,,1169
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Registered Voters,,DEM,,,,,532
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Registered Voters,,REP,,,,,414
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Registered Voters,,NPA,,,,,223
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Ballots Cast,,,,118,257,4,379
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Ballots Cast,,DEM,,47,186,2,235
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Ballots Cast,,REP,,71,71,2,144
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,President,,DEM,Joseph R. Biden,29,150,2,181
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,President,,DEM,Bernie Sanders,13,24,0,37
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,President,,DEM,Tulsi Gabbard,3,5,0,8
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,President,,DEM,Write-in,1,2,0,3
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Attorney General,,DEM,Josh Shapiro,30,167,1,198
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,DEM,Nina Ahmad,11,43,2,56
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,5,42,0,47
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,5,29,0,34
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,DEM,Tracie Fountain,7,18,0,25
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,DEM,Michael Lamb,7,16,0,23
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,DEM,H Scott Conklin,4,10,0,14
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,State Treasurer,,DEM,Joe Torsella,31,168,1,200
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,U.S. House,7,DEM,Susan Wild,36,172,2,210
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,General Assembly,138,DEM,Tara Zrinski,31,168,1,200
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,President,,REP,Donald J Trump,65,62,1,128
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,President,,REP,Bill Weld,0,6,0,6
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,President,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,61,58,0,119
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,REP,Timothy Defoor,58,59,0,117
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,58,59,0,117
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,U.S. House,7,REP,Dean N. Browning,37,37,2,76
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,U.S. House,7,REP,Lisa Scheller,30,24,0,54
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,U.S. House,7,REP,Write-in,0,3,0,3
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,General Assembly,138,REP,Tony Tarsi,49,28,2,79
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,General Assembly,138,REP,Ann Flood,17,37,0,54
+Northampton,BETHLEHEM TWSP 4TH WARD 4TH DISTRICT,General Assembly,138,REP,Write-in,0,1,0,1
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Registered Voters,,,,,,,2684
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Registered Voters,,DEM,,,,,880
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Registered Voters,,REP,,,,,1338
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Registered Voters,,NPA,,,,,466
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Ballots Cast,,,,347,550,19,916
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Ballots Cast,,DEM,,87,304,1,392
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Ballots Cast,,REP,,260,246,18,524
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,President,,DEM,Joseph R. Biden,52,233,0,285
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,President,,DEM,Bernie Sanders,21,47,1,69
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,President,,DEM,Tulsi Gabbard,7,9,0,16
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,President,,DEM,Write-in,1,8,0,9
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Attorney General,,DEM,Josh Shapiro,56,274,1,331
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,DEM,Rose Rosie Marie Davis,21,69,0,90
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,DEM,Nina Ahmad,20,58,1,79
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,DEM,Christina M. Hartman,7,55,0,62
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,DEM,Michael Lamb,14,24,0,38
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,DEM,Tracie Fountain,6,25,0,31
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,DEM,H Scott Conklin,7,23,0,30
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,State Treasurer,,DEM,Joe Torsella,55,258,1,314
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,State Treasurer,,DEM,Write-in,1,2,0,3
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,U.S. House,7,DEM,Susan Wild,64,286,1,351
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,U.S. House,7,DEM,Write-in,2,3,0,5
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,General Assembly,138,DEM,Tara Zrinski,69,267,1,337
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,General Assembly,138,DEM,Write-in,1,3,0,4
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,President,,REP,Donald J Trump,230,217,16,463
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,President,,REP,Bill Weld,16,14,0,30
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,President,,REP,Roque Rocky De La Fuente,5,3,1,9
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,President,,REP,Write-in,4,6,1,11
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Attorney General,,REP,Heather Heidelbaugh,206,214,13,433
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Attorney General,,REP,Write-in,0,3,0,3
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,REP,Timothy Defoor,205,210,13,428
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,Auditor General,,REP,Write-in,0,3,0,3
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,State Treasurer,,REP,Stacy L. Garrity,201,215,13,429
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,State Treasurer,,REP,Write-in,0,3,0,3
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,U.S. House,7,REP,Lisa Scheller,135,122,9,266
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,U.S. House,7,REP,Dean N. Browning,114,109,8,231
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,General Assembly,138,REP,Ann Flood,156,158,7,321
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,General Assembly,138,REP,Tony Tarsi,96,82,9,187
+Northampton,BUSHKILL TWSP BUSHKILL CENTER,General Assembly,138,REP,Write-in,0,1,0,1
+Northampton,BUSHKILL TWSP CHERRY HILL,Registered Voters,,,,,,,2201
+Northampton,BUSHKILL TWSP CHERRY HILL,Registered Voters,,DEM,,,,,814
+Northampton,BUSHKILL TWSP CHERRY HILL,Registered Voters,,REP,,,,,1020
+Northampton,BUSHKILL TWSP CHERRY HILL,Registered Voters,,NPA,,,,,367
+Northampton,BUSHKILL TWSP CHERRY HILL,Ballots Cast,,,,253,504,9,766
+Northampton,BUSHKILL TWSP CHERRY HILL,Ballots Cast,,DEM,,48,304,3,355
+Northampton,BUSHKILL TWSP CHERRY HILL,Ballots Cast,,REP,,205,200,6,411
+Northampton,BUSHKILL TWSP CHERRY HILL,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BUSHKILL TWSP CHERRY HILL,President,,DEM,Joseph R. Biden,28,244,3,275
+Northampton,BUSHKILL TWSP CHERRY HILL,President,,DEM,Bernie Sanders,14,34,0,48
+Northampton,BUSHKILL TWSP CHERRY HILL,President,,DEM,Tulsi Gabbard,4,11,0,15
+Northampton,BUSHKILL TWSP CHERRY HILL,President,,DEM,Write-in,1,6,0,7
+Northampton,BUSHKILL TWSP CHERRY HILL,Attorney General,,DEM,Josh Shapiro,38,277,2,317
+Northampton,BUSHKILL TWSP CHERRY HILL,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,DEM,Nina Ahmad,12,72,1,85
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,DEM,Rose Rosie Marie Davis,12,63,2,77
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,DEM,Christina M. Hartman,3,56,0,59
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,DEM,Michael Lamb,7,37,0,44
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,DEM,H Scott Conklin,7,19,0,26
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,DEM,Tracie Fountain,1,23,0,24
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,BUSHKILL TWSP CHERRY HILL,State Treasurer,,DEM,Joe Torsella,39,274,3,316
+Northampton,BUSHKILL TWSP CHERRY HILL,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,BUSHKILL TWSP CHERRY HILL,U.S. House,7,DEM,Susan Wild,40,285,3,328
+Northampton,BUSHKILL TWSP CHERRY HILL,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,BUSHKILL TWSP CHERRY HILL,General Assembly,138,DEM,Tara Zrinski,39,277,3,319
+Northampton,BUSHKILL TWSP CHERRY HILL,General Assembly,138,DEM,Write-in,0,2,0,2
+Northampton,BUSHKILL TWSP CHERRY HILL,President,,REP,Donald J Trump,195,157,4,356
+Northampton,BUSHKILL TWSP CHERRY HILL,President,,REP,Bill Weld,5,23,0,28
+Northampton,BUSHKILL TWSP CHERRY HILL,President,,REP,Roque Rocky De La Fuente,0,3,0,3
+Northampton,BUSHKILL TWSP CHERRY HILL,President,,REP,Write-in,2,4,0,6
+Northampton,BUSHKILL TWSP CHERRY HILL,Attorney General,,REP,Heather Heidelbaugh,159,173,5,337
+Northampton,BUSHKILL TWSP CHERRY HILL,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,REP,Timothy Defoor,160,165,5,330
+Northampton,BUSHKILL TWSP CHERRY HILL,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,BUSHKILL TWSP CHERRY HILL,State Treasurer,,REP,Stacy L. Garrity,160,170,5,335
+Northampton,BUSHKILL TWSP CHERRY HILL,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BUSHKILL TWSP CHERRY HILL,U.S. House,7,REP,Lisa Scheller,103,105,4,212
+Northampton,BUSHKILL TWSP CHERRY HILL,U.S. House,7,REP,Dean N. Browning,93,77,1,171
+Northampton,BUSHKILL TWSP CHERRY HILL,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BUSHKILL TWSP CHERRY HILL,General Assembly,138,REP,Ann Flood,119,225,4,348
+Northampton,BUSHKILL TWSP CHERRY HILL,General Assembly,138,REP,Tony Tarsi,82,141,2,225
+Northampton,BUSHKILL TWSP CHERRY HILL,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,BUSHKILL TWSP CLEARFIELD,Registered Voters,,,,,,,1321
+Northampton,BUSHKILL TWSP CLEARFIELD,Registered Voters,,DEM,,,,,429
+Northampton,BUSHKILL TWSP CLEARFIELD,Registered Voters,,REP,,,,,649
+Northampton,BUSHKILL TWSP CLEARFIELD,Registered Voters,,NPA,,,,,243
+Northampton,BUSHKILL TWSP CLEARFIELD,Ballots Cast,,,,216,191,0,407
+Northampton,BUSHKILL TWSP CLEARFIELD,Ballots Cast,,DEM,,44,124,0,168
+Northampton,BUSHKILL TWSP CLEARFIELD,Ballots Cast,,REP,,172,67,0,239
+Northampton,BUSHKILL TWSP CLEARFIELD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,BUSHKILL TWSP CLEARFIELD,President,,DEM,Joseph R. Biden,24,96,0,120
+Northampton,BUSHKILL TWSP CLEARFIELD,President,,DEM,Bernie Sanders,10,21,0,31
+Northampton,BUSHKILL TWSP CLEARFIELD,President,,DEM,Tulsi Gabbard,8,3,0,11
+Northampton,BUSHKILL TWSP CLEARFIELD,President,,DEM,Write-in,2,1,0,3
+Northampton,BUSHKILL TWSP CLEARFIELD,Attorney General,,DEM,Josh Shapiro,32,112,0,144
+Northampton,BUSHKILL TWSP CLEARFIELD,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,DEM,Rose Rosie Marie Davis,14,40,0,54
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,DEM,Nina Ahmad,5,24,0,29
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,DEM,Michael Lamb,1,24,0,25
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,DEM,H Scott Conklin,8,7,0,15
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,DEM,Christina M. Hartman,6,8,0,14
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,DEM,Tracie Fountain,1,8,0,9
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,BUSHKILL TWSP CLEARFIELD,State Treasurer,,DEM,Joe Torsella,35,112,0,147
+Northampton,BUSHKILL TWSP CLEARFIELD,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,BUSHKILL TWSP CLEARFIELD,U.S. House,7,DEM,Susan Wild,37,114,0,151
+Northampton,BUSHKILL TWSP CLEARFIELD,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,BUSHKILL TWSP CLEARFIELD,General Assembly,138,DEM,Tara Zrinski,36,114,0,150
+Northampton,BUSHKILL TWSP CLEARFIELD,General Assembly,138,DEM,Write-in,1,0,0,1
+Northampton,BUSHKILL TWSP CLEARFIELD,President,,REP,Donald J Trump,164,55,0,219
+Northampton,BUSHKILL TWSP CLEARFIELD,President,,REP,Bill Weld,3,4,0,7
+Northampton,BUSHKILL TWSP CLEARFIELD,President,,REP,Roque Rocky De La Fuente,1,5,0,6
+Northampton,BUSHKILL TWSP CLEARFIELD,President,,REP,Write-in,0,1,0,1
+Northampton,BUSHKILL TWSP CLEARFIELD,Attorney General,,REP,Heather Heidelbaugh,134,64,0,198
+Northampton,BUSHKILL TWSP CLEARFIELD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,REP,Timothy Defoor,134,64,0,198
+Northampton,BUSHKILL TWSP CLEARFIELD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,BUSHKILL TWSP CLEARFIELD,State Treasurer,,REP,Stacy L. Garrity,138,63,0,201
+Northampton,BUSHKILL TWSP CLEARFIELD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,BUSHKILL TWSP CLEARFIELD,U.S. House,7,REP,Dean N. Browning,84,30,0,114
+Northampton,BUSHKILL TWSP CLEARFIELD,U.S. House,7,REP,Lisa Scheller,75,35,0,110
+Northampton,BUSHKILL TWSP CLEARFIELD,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,BUSHKILL TWSP CLEARFIELD,General Assembly,138,REP,Ann Flood,108,41,0,149
+Northampton,BUSHKILL TWSP CLEARFIELD,General Assembly,138,REP,Tony Tarsi,63,25,0,88
+Northampton,BUSHKILL TWSP CLEARFIELD,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,CHAPMAN,Registered Voters,,,,,,,134
+Northampton,CHAPMAN,Registered Voters,,DEM,,,,,53
+Northampton,CHAPMAN,Registered Voters,,REP,,,,,58
+Northampton,CHAPMAN,Registered Voters,,NPA,,,,,23
+Northampton,CHAPMAN,Ballots Cast,,,,36,14,0,50
+Northampton,CHAPMAN,Ballots Cast,,DEM,,14,10,0,24
+Northampton,CHAPMAN,Ballots Cast,,REP,,22,4,0,26
+Northampton,CHAPMAN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,CHAPMAN,President,,DEM,Joseph R. Biden,9,7,0,16
+Northampton,CHAPMAN,President,,DEM,Tulsi Gabbard,3,1,0,4
+Northampton,CHAPMAN,President,,DEM,Bernie Sanders,1,2,0,3
+Northampton,CHAPMAN,President,,DEM,Write-in,0,0,0,0
+Northampton,CHAPMAN,Attorney General,,DEM,Josh Shapiro,11,9,0,20
+Northampton,CHAPMAN,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,CHAPMAN,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,0,6
+Northampton,CHAPMAN,Auditor General,,DEM,Nina Ahmad,4,1,0,5
+Northampton,CHAPMAN,Auditor General,,DEM,Michael Lamb,4,0,0,4
+Northampton,CHAPMAN,Auditor General,,DEM,Christina M. Hartman,0,4,0,4
+Northampton,CHAPMAN,Auditor General,,DEM,H Scott Conklin,1,1,0,2
+Northampton,CHAPMAN,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Northampton,CHAPMAN,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,CHAPMAN,State Treasurer,,DEM,Joe Torsella,11,9,0,20
+Northampton,CHAPMAN,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,CHAPMAN,U.S. House,7,DEM,Susan Wild,10,10,0,20
+Northampton,CHAPMAN,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,CHAPMAN,General Assembly,138,DEM,Tara Zrinski,10,10,0,20
+Northampton,CHAPMAN,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,CHAPMAN,President,,REP,Donald J Trump,22,2,0,24
+Northampton,CHAPMAN,President,,REP,Bill Weld,0,2,0,2
+Northampton,CHAPMAN,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,CHAPMAN,President,,REP,Write-in,0,0,0,0
+Northampton,CHAPMAN,Attorney General,,REP,Heather Heidelbaugh,16,4,0,20
+Northampton,CHAPMAN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,CHAPMAN,Auditor General,,REP,Timothy Defoor,16,4,0,20
+Northampton,CHAPMAN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,CHAPMAN,State Treasurer,,REP,Stacy L. Garrity,15,3,0,18
+Northampton,CHAPMAN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,CHAPMAN,U.S. House,7,REP,Dean N. Browning,12,2,0,14
+Northampton,CHAPMAN,U.S. House,7,REP,Lisa Scheller,9,1,0,10
+Northampton,CHAPMAN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,CHAPMAN,General Assembly,138,REP,Ann Flood,15,2,0,17
+Northampton,CHAPMAN,General Assembly,138,REP,Tony Tarsi,6,1,0,7
+Northampton,CHAPMAN,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,EAST ALLEN TWSP EASTERN,Registered Voters,,,,,,,1710
+Northampton,EAST ALLEN TWSP EASTERN,Registered Voters,,DEM,,,,,649
+Northampton,EAST ALLEN TWSP EASTERN,Registered Voters,,REP,,,,,757
+Northampton,EAST ALLEN TWSP EASTERN,Registered Voters,,NPA,,,,,304
+Northampton,EAST ALLEN TWSP EASTERN,Ballots Cast,,,,259,285,12,556
+Northampton,EAST ALLEN TWSP EASTERN,Ballots Cast,,DEM,,66,166,4,236
+Northampton,EAST ALLEN TWSP EASTERN,Ballots Cast,,REP,,193,119,8,320
+Northampton,EAST ALLEN TWSP EASTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EAST ALLEN TWSP EASTERN,President,,DEM,Joseph R. Biden,48,140,0,188
+Northampton,EAST ALLEN TWSP EASTERN,President,,DEM,Bernie Sanders,13,19,2,34
+Northampton,EAST ALLEN TWSP EASTERN,President,,DEM,Tulsi Gabbard,3,2,1,6
+Northampton,EAST ALLEN TWSP EASTERN,President,,DEM,Write-in,1,3,0,4
+Northampton,EAST ALLEN TWSP EASTERN,Attorney General,,DEM,Josh Shapiro,53,149,4,206
+Northampton,EAST ALLEN TWSP EASTERN,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,DEM,Nina Ahmad,18,37,0,55
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,DEM,Christina M. Hartman,10,36,0,46
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,DEM,Rose Rosie Marie Davis,6,24,0,30
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,DEM,Michael Lamb,9,16,1,26
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,DEM,Tracie Fountain,3,17,0,20
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,DEM,H Scott Conklin,10,7,1,18
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP EASTERN,State Treasurer,,DEM,Joe Torsella,52,146,1,199
+Northampton,EAST ALLEN TWSP EASTERN,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP EASTERN,U.S. House,7,DEM,Susan Wild,57,157,1,215
+Northampton,EAST ALLEN TWSP EASTERN,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP EASTERN,General Assembly,138,DEM,Tara Zrinski,52,151,1,204
+Northampton,EAST ALLEN TWSP EASTERN,General Assembly,138,DEM,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP EASTERN,President,,REP,Donald J Trump,184,101,7,292
+Northampton,EAST ALLEN TWSP EASTERN,President,,REP,Bill Weld,3,9,1,13
+Northampton,EAST ALLEN TWSP EASTERN,President,,REP,Roque Rocky De La Fuente,1,3,0,4
+Northampton,EAST ALLEN TWSP EASTERN,President,,REP,Write-in,1,2,0,3
+Northampton,EAST ALLEN TWSP EASTERN,Attorney General,,REP,Heather Heidelbaugh,153,98,6,257
+Northampton,EAST ALLEN TWSP EASTERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,REP,Timothy Defoor,151,99,5,255
+Northampton,EAST ALLEN TWSP EASTERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EAST ALLEN TWSP EASTERN,State Treasurer,,REP,Stacy L. Garrity,153,100,6,259
+Northampton,EAST ALLEN TWSP EASTERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EAST ALLEN TWSP EASTERN,U.S. House,7,REP,Lisa Scheller,88,64,2,154
+Northampton,EAST ALLEN TWSP EASTERN,U.S. House,7,REP,Dean N. Browning,99,46,5,150
+Northampton,EAST ALLEN TWSP EASTERN,U.S. House,7,REP,Write-in,0,1,1,2
+Northampton,EAST ALLEN TWSP EASTERN,General Assembly,138,REP,Ann Flood,87,64,6,157
+Northampton,EAST ALLEN TWSP EASTERN,General Assembly,138,REP,Tony Tarsi,95,45,1,141
+Northampton,EAST ALLEN TWSP EASTERN,General Assembly,138,REP,Write-in,0,0,1,1
+Northampton,EAST ALLEN TWSP WESTERN,Registered Voters,,,,,,,1831
+Northampton,EAST ALLEN TWSP WESTERN,Registered Voters,,DEM,,,,,730
+Northampton,EAST ALLEN TWSP WESTERN,Registered Voters,,REP,,,,,812
+Northampton,EAST ALLEN TWSP WESTERN,Registered Voters,,NPA,,,,,289
+Northampton,EAST ALLEN TWSP WESTERN,Ballots Cast,,,,260,356,6,622
+Northampton,EAST ALLEN TWSP WESTERN,Ballots Cast,,DEM,,71,233,4,308
+Northampton,EAST ALLEN TWSP WESTERN,Ballots Cast,,REP,,189,123,2,314
+Northampton,EAST ALLEN TWSP WESTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EAST ALLEN TWSP WESTERN,President,,DEM,Joseph R. Biden,45,198,2,245
+Northampton,EAST ALLEN TWSP WESTERN,President,,DEM,Bernie Sanders,15,25,2,42
+Northampton,EAST ALLEN TWSP WESTERN,President,,DEM,Tulsi Gabbard,3,4,0,7
+Northampton,EAST ALLEN TWSP WESTERN,President,,DEM,Write-in,5,3,0,8
+Northampton,EAST ALLEN TWSP WESTERN,Attorney General,,DEM,Josh Shapiro,51,205,4,260
+Northampton,EAST ALLEN TWSP WESTERN,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,DEM,Nina Ahmad,16,52,1,69
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,DEM,Rose Rosie Marie Davis,10,36,1,47
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,DEM,Christina M. Hartman,10,36,0,46
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,DEM,Michael Lamb,14,26,0,40
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,DEM,Tracie Fountain,5,31,1,37
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,DEM,H Scott Conklin,6,17,0,23
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP WESTERN,State Treasurer,,DEM,Joe Torsella,48,206,2,256
+Northampton,EAST ALLEN TWSP WESTERN,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EAST ALLEN TWSP WESTERN,U.S. House,7,DEM,Susan Wild,56,217,3,276
+Northampton,EAST ALLEN TWSP WESTERN,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EAST ALLEN TWSP WESTERN,General Assembly,138,DEM,Tara Zrinski,54,210,3,267
+Northampton,EAST ALLEN TWSP WESTERN,General Assembly,138,DEM,Write-in,1,1,0,2
+Northampton,EAST ALLEN TWSP WESTERN,President,,REP,Donald J Trump,172,98,2,272
+Northampton,EAST ALLEN TWSP WESTERN,President,,REP,Bill Weld,6,9,0,15
+Northampton,EAST ALLEN TWSP WESTERN,President,,REP,Roque Rocky De La Fuente,3,4,0,7
+Northampton,EAST ALLEN TWSP WESTERN,President,,REP,Write-in,1,5,0,6
+Northampton,EAST ALLEN TWSP WESTERN,Attorney General,,REP,Heather Heidelbaugh,148,102,0,250
+Northampton,EAST ALLEN TWSP WESTERN,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,REP,Timothy Defoor,146,102,0,248
+Northampton,EAST ALLEN TWSP WESTERN,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP WESTERN,State Treasurer,,REP,Stacy L. Garrity,148,103,0,251
+Northampton,EAST ALLEN TWSP WESTERN,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,EAST ALLEN TWSP WESTERN,U.S. House,7,REP,Lisa Scheller,94,63,1,158
+Northampton,EAST ALLEN TWSP WESTERN,U.S. House,7,REP,Dean N. Browning,90,51,1,142
+Northampton,EAST ALLEN TWSP WESTERN,U.S. House,7,REP,Write-in,1,2,0,3
+Northampton,EAST ALLEN TWSP WESTERN,General Assembly,138,REP,Ann Flood,97,82,0,179
+Northampton,EAST ALLEN TWSP WESTERN,General Assembly,138,REP,Tony Tarsi,81,31,2,114
+Northampton,EAST ALLEN TWSP WESTERN,General Assembly,138,REP,Write-in,1,2,0,3
+Northampton,EAST BANGOR,Registered Voters,,,,,,,665
+Northampton,EAST BANGOR,Registered Voters,,DEM,,,,,226
+Northampton,EAST BANGOR,Registered Voters,,REP,,,,,280
+Northampton,EAST BANGOR,Registered Voters,,NPA,,,,,159
+Northampton,EAST BANGOR,Ballots Cast,,,,88,72,0,160
+Northampton,EAST BANGOR,Ballots Cast,,DEM,,23,49,0,72
+Northampton,EAST BANGOR,Ballots Cast,,REP,,65,23,0,88
+Northampton,EAST BANGOR,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EAST BANGOR,President,,DEM,Joseph R. Biden,16,34,0,50
+Northampton,EAST BANGOR,President,,DEM,Bernie Sanders,3,12,0,15
+Northampton,EAST BANGOR,President,,DEM,Tulsi Gabbard,1,0,0,1
+Northampton,EAST BANGOR,President,,DEM,Write-in,1,1,0,2
+Northampton,EAST BANGOR,Attorney General,,DEM,Josh Shapiro,17,40,0,57
+Northampton,EAST BANGOR,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EAST BANGOR,Auditor General,,DEM,Rose Rosie Marie Davis,8,21,0,29
+Northampton,EAST BANGOR,Auditor General,,DEM,Christina M. Hartman,2,8,0,10
+Northampton,EAST BANGOR,Auditor General,,DEM,Nina Ahmad,2,7,0,9
+Northampton,EAST BANGOR,Auditor General,,DEM,Michael Lamb,3,2,0,5
+Northampton,EAST BANGOR,Auditor General,,DEM,H Scott Conklin,1,1,0,2
+Northampton,EAST BANGOR,Auditor General,,DEM,Tracie Fountain,2,0,0,2
+Northampton,EAST BANGOR,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EAST BANGOR,State Treasurer,,DEM,Joe Torsella,16,39,0,55
+Northampton,EAST BANGOR,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EAST BANGOR,U.S. House,7,DEM,Susan Wild,20,44,0,64
+Northampton,EAST BANGOR,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EAST BANGOR,General Assembly,137,DEM,Katelind Brennan,15,37,0,52
+Northampton,EAST BANGOR,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,EAST BANGOR,President,,REP,Donald J Trump,60,17,0,77
+Northampton,EAST BANGOR,President,,REP,Bill Weld,1,4,0,5
+Northampton,EAST BANGOR,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,EAST BANGOR,President,,REP,Write-in,2,0,0,2
+Northampton,EAST BANGOR,Attorney General,,REP,Heather Heidelbaugh,47,16,0,63
+Northampton,EAST BANGOR,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EAST BANGOR,Auditor General,,REP,Timothy Defoor,48,15,0,63
+Northampton,EAST BANGOR,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EAST BANGOR,State Treasurer,,REP,Stacy L. Garrity,47,15,0,62
+Northampton,EAST BANGOR,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EAST BANGOR,U.S. House,7,REP,Lisa Scheller,34,10,0,44
+Northampton,EAST BANGOR,U.S. House,7,REP,Dean N. Browning,28,6,0,34
+Northampton,EAST BANGOR,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EAST BANGOR,General Assembly,137,REP,Joe Emrick,61,22,0,83
+Northampton,EAST BANGOR,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,EASTON 2ND WARD,Registered Voters,,,,,,,1030
+Northampton,EASTON 2ND WARD,Registered Voters,,DEM,,,,,578
+Northampton,EASTON 2ND WARD,Registered Voters,,REP,,,,,213
+Northampton,EASTON 2ND WARD,Registered Voters,,NPA,,,,,239
+Northampton,EASTON 2ND WARD,Ballots Cast,,,,95,152,3,250
+Northampton,EASTON 2ND WARD,Ballots Cast,,DEM,,72,136,3,211
+Northampton,EASTON 2ND WARD,Ballots Cast,,REP,,23,16,0,39
+Northampton,EASTON 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 2ND WARD,President,,DEM,Joseph R. Biden,43,87,2,132
+Northampton,EASTON 2ND WARD,President,,DEM,Bernie Sanders,27,46,0,73
+Northampton,EASTON 2ND WARD,President,,DEM,Tulsi Gabbard,1,0,1,2
+Northampton,EASTON 2ND WARD,President,,DEM,Write-in,0,1,0,1
+Northampton,EASTON 2ND WARD,Attorney General,,DEM,Josh Shapiro,52,112,2,166
+Northampton,EASTON 2ND WARD,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,EASTON 2ND WARD,Auditor General,,DEM,Nina Ahmad,21,48,2,71
+Northampton,EASTON 2ND WARD,Auditor General,,DEM,Michael Lamb,17,13,0,30
+Northampton,EASTON 2ND WARD,Auditor General,,DEM,Christina M. Hartman,3,19,1,23
+Northampton,EASTON 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,2,16,0,18
+Northampton,EASTON 2ND WARD,Auditor General,,DEM,H Scott Conklin,12,4,0,16
+Northampton,EASTON 2ND WARD,Auditor General,,DEM,Tracie Fountain,4,9,0,13
+Northampton,EASTON 2ND WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 2ND WARD,State Treasurer,,DEM,Joe Torsella,52,112,2,166
+Northampton,EASTON 2ND WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 2ND WARD,U.S. House,7,DEM,Susan Wild,60,127,3,190
+Northampton,EASTON 2ND WARD,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,EASTON 2ND WARD,General Assembly,136,DEM,Robert Freeman,66,129,3,198
+Northampton,EASTON 2ND WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 2ND WARD,President,,REP,Donald J Trump,20,12,0,32
+Northampton,EASTON 2ND WARD,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,EASTON 2ND WARD,President,,REP,Bill Weld,0,2,0,2
+Northampton,EASTON 2ND WARD,President,,REP,Write-in,1,1,0,2
+Northampton,EASTON 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,22,12,0,34
+Northampton,EASTON 2ND WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 2ND WARD,Auditor General,,REP,Timothy Defoor,21,12,0,33
+Northampton,EASTON 2ND WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,22,12,0,34
+Northampton,EASTON 2ND WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 2ND WARD,U.S. House,7,REP,Dean N. Browning,16,7,0,23
+Northampton,EASTON 2ND WARD,U.S. House,7,REP,Lisa Scheller,6,5,0,11
+Northampton,EASTON 2ND WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 2ND WARD,General Assembly,136,REP,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Registered Voters,,,,,,,1285
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Registered Voters,,DEM,,,,,743
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Registered Voters,,REP,,,,,308
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Registered Voters,,NPA,,,,,234
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Ballots Cast,,,,143,385,4,532
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Ballots Cast,,DEM,,86,352,4,442
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Ballots Cast,,REP,,57,33,0,90
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 3RD WARD 2ND DISTRICT,President,,DEM,Joseph R. Biden,59,259,2,320
+Northampton,EASTON 3RD WARD 2ND DISTRICT,President,,DEM,Bernie Sanders,22,67,1,90
+Northampton,EASTON 3RD WARD 2ND DISTRICT,President,,DEM,Tulsi Gabbard,0,4,0,4
+Northampton,EASTON 3RD WARD 2ND DISTRICT,President,,DEM,Write-in,2,17,0,19
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Attorney General,,DEM,Josh Shapiro,64,304,4,372
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Attorney General,,DEM,Write-in,0,5,0,5
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Nina Ahmad,27,107,3,137
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Michael Lamb,19,81,1,101
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,5,33,0,38
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Tracie Fountain,7,29,0,36
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Christina M. Hartman,5,31,0,36
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,DEM,H Scott Conklin,9,12,0,21
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 2ND DISTRICT,State Treasurer,,DEM,Joe Torsella,63,294,4,361
+Northampton,EASTON 3RD WARD 2ND DISTRICT,State Treasurer,,DEM,Write-in,0,4,0,4
+Northampton,EASTON 3RD WARD 2ND DISTRICT,U.S. House,7,DEM,Susan Wild,78,341,4,423
+Northampton,EASTON 3RD WARD 2ND DISTRICT,U.S. House,7,DEM,Write-in,0,5,0,5
+Northampton,EASTON 3RD WARD 2ND DISTRICT,General Assembly,136,DEM,Robert Freeman,76,323,4,403
+Northampton,EASTON 3RD WARD 2ND DISTRICT,General Assembly,136,DEM,Write-in,0,6,0,6
+Northampton,EASTON 3RD WARD 2ND DISTRICT,President,,REP,Donald J Trump,52,22,0,74
+Northampton,EASTON 3RD WARD 2ND DISTRICT,President,,REP,Bill Weld,3,3,0,6
+Northampton,EASTON 3RD WARD 2ND DISTRICT,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,EASTON 3RD WARD 2ND DISTRICT,President,,REP,Write-in,1,3,0,4
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Attorney General,,REP,Heather Heidelbaugh,47,24,0,71
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Attorney General,,REP,Write-in,1,2,0,3
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,REP,Timothy Defoor,47,28,0,75
+Northampton,EASTON 3RD WARD 2ND DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 2ND DISTRICT,State Treasurer,,REP,Stacy L. Garrity,47,26,0,73
+Northampton,EASTON 3RD WARD 2ND DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 2ND DISTRICT,U.S. House,7,REP,Lisa Scheller,32,16,0,48
+Northampton,EASTON 3RD WARD 2ND DISTRICT,U.S. House,7,REP,Dean N. Browning,21,11,0,32
+Northampton,EASTON 3RD WARD 2ND DISTRICT,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 2ND DISTRICT,General Assembly,136,REP,Write-in,2,3,0,5
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Registered Voters,,,,,,,1802
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Registered Voters,,DEM,,,,,1026
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Registered Voters,,REP,,,,,309
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Registered Voters,,NPA,,,,,467
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Ballots Cast,,,,47,102,0,149
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Ballots Cast,,DEM,,35,95,0,130
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Ballots Cast,,REP,,12,7,0,19
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,President,,DEM,Joseph R. Biden,23,65,0,88
+Northampton,EASTON 3RD WARD 3RD DISTRICT,President,,DEM,Bernie Sanders,12,28,0,40
+Northampton,EASTON 3RD WARD 3RD DISTRICT,President,,DEM,Tulsi Gabbard,0,1,0,1
+Northampton,EASTON 3RD WARD 3RD DISTRICT,President,,DEM,Write-in,0,1,0,1
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Attorney General,,DEM,Josh Shapiro,31,91,0,122
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Nina Ahmad,14,32,0,46
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Tracie Fountain,5,15,0,20
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Michael Lamb,2,12,0,14
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,2,12,0,14
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Christina M. Hartman,0,11,0,11
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,DEM,H Scott Conklin,7,3,0,10
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,State Treasurer,,DEM,Joe Torsella,31,85,0,116
+Northampton,EASTON 3RD WARD 3RD DISTRICT,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 3RD DISTRICT,U.S. House,7,DEM,Susan Wild,34,92,0,126
+Northampton,EASTON 3RD WARD 3RD DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,General Assembly,136,DEM,Robert Freeman,35,91,0,126
+Northampton,EASTON 3RD WARD 3RD DISTRICT,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,President,,REP,Donald J Trump,8,5,0,13
+Northampton,EASTON 3RD WARD 3RD DISTRICT,President,,REP,Bill Weld,0,2,0,2
+Northampton,EASTON 3RD WARD 3RD DISTRICT,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,EASTON 3RD WARD 3RD DISTRICT,President,,REP,Write-in,1,0,0,1
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Attorney General,,REP,Heather Heidelbaugh,9,5,0,14
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,REP,Timothy Defoor,8,5,0,13
+Northampton,EASTON 3RD WARD 3RD DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,State Treasurer,,REP,Stacy L. Garrity,8,5,0,13
+Northampton,EASTON 3RD WARD 3RD DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,U.S. House,7,REP,Dean N. Browning,9,2,0,11
+Northampton,EASTON 3RD WARD 3RD DISTRICT,U.S. House,7,REP,Lisa Scheller,2,5,0,7
+Northampton,EASTON 3RD WARD 3RD DISTRICT,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 3RD DISTRICT,General Assembly,136,REP,Write-in,0,1,0,1
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Registered Voters,,,,,,,1041
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Registered Voters,,DEM,,,,,594
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Registered Voters,,REP,,,,,245
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Registered Voters,,NPA,,,,,202
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Ballots Cast,,,,118,250,3,371
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Ballots Cast,,DEM,,83,218,3,304
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Ballots Cast,,REP,,35,32,0,67
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 3RD WARD 4TH DISTRICT,President,,DEM,Joseph R. Biden,51,166,2,219
+Northampton,EASTON 3RD WARD 4TH DISTRICT,President,,DEM,Bernie Sanders,27,48,1,76
+Northampton,EASTON 3RD WARD 4TH DISTRICT,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,EASTON 3RD WARD 4TH DISTRICT,President,,DEM,Write-in,0,1,0,1
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Attorney General,,DEM,Josh Shapiro,60,193,1,254
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Nina Ahmad,22,79,0,101
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Michael Lamb,15,26,0,41
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Rose Rosie Marie Davis,6,29,1,36
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Christina M. Hartman,7,26,0,33
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Tracie Fountain,5,20,0,25
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,DEM,H Scott Conklin,11,9,0,20
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 4TH DISTRICT,State Treasurer,,DEM,Joe Torsella,62,181,1,244
+Northampton,EASTON 3RD WARD 4TH DISTRICT,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 4TH DISTRICT,U.S. House,7,DEM,Susan Wild,75,213,3,291
+Northampton,EASTON 3RD WARD 4TH DISTRICT,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 4TH DISTRICT,General Assembly,136,DEM,Robert Freeman,76,209,1,286
+Northampton,EASTON 3RD WARD 4TH DISTRICT,General Assembly,136,DEM,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 4TH DISTRICT,President,,REP,Donald J Trump,31,22,0,53
+Northampton,EASTON 3RD WARD 4TH DISTRICT,President,,REP,Roque Rocky De La Fuente,1,4,0,5
+Northampton,EASTON 3RD WARD 4TH DISTRICT,President,,REP,Bill Weld,1,2,0,3
+Northampton,EASTON 3RD WARD 4TH DISTRICT,President,,REP,Write-in,1,2,0,3
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Attorney General,,REP,Heather Heidelbaugh,26,27,0,53
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,REP,Timothy Defoor,25,27,0,52
+Northampton,EASTON 3RD WARD 4TH DISTRICT,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 4TH DISTRICT,State Treasurer,,REP,Stacy L. Garrity,26,26,0,52
+Northampton,EASTON 3RD WARD 4TH DISTRICT,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 3RD WARD 4TH DISTRICT,U.S. House,7,REP,Lisa Scheller,17,19,0,36
+Northampton,EASTON 3RD WARD 4TH DISTRICT,U.S. House,7,REP,Dean N. Browning,16,6,0,22
+Northampton,EASTON 3RD WARD 4TH DISTRICT,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,EASTON 3RD WARD 4TH DISTRICT,General Assembly,136,REP,Write-in,0,1,0,1
+Northampton,EASTON 4TH WARD,Registered Voters,,,,,,,1332
+Northampton,EASTON 4TH WARD,Registered Voters,,DEM,,,,,772
+Northampton,EASTON 4TH WARD,Registered Voters,,REP,,,,,264
+Northampton,EASTON 4TH WARD,Registered Voters,,NPA,,,,,296
+Northampton,EASTON 4TH WARD,Ballots Cast,,,,141,115,3,259
+Northampton,EASTON 4TH WARD,Ballots Cast,,DEM,,100,89,3,192
+Northampton,EASTON 4TH WARD,Ballots Cast,,REP,,41,26,0,67
+Northampton,EASTON 4TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 4TH WARD,President,,DEM,Joseph R. Biden,69,57,1,127
+Northampton,EASTON 4TH WARD,President,,DEM,Bernie Sanders,25,29,2,56
+Northampton,EASTON 4TH WARD,President,,DEM,Tulsi Gabbard,3,0,0,3
+Northampton,EASTON 4TH WARD,President,,DEM,Write-in,1,1,0,2
+Northampton,EASTON 4TH WARD,Attorney General,,DEM,Josh Shapiro,65,84,3,152
+Northampton,EASTON 4TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 4TH WARD,Auditor General,,DEM,Nina Ahmad,25,36,2,63
+Northampton,EASTON 4TH WARD,Auditor General,,DEM,Michael Lamb,21,8,0,29
+Northampton,EASTON 4TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,8,14,0,22
+Northampton,EASTON 4TH WARD,Auditor General,,DEM,H Scott Conklin,18,2,1,21
+Northampton,EASTON 4TH WARD,Auditor General,,DEM,Tracie Fountain,4,13,0,17
+Northampton,EASTON 4TH WARD,Auditor General,,DEM,Christina M. Hartman,6,8,0,14
+Northampton,EASTON 4TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 4TH WARD,State Treasurer,,DEM,Joe Torsella,68,82,2,152
+Northampton,EASTON 4TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 4TH WARD,U.S. House,7,DEM,Susan Wild,79,87,3,169
+Northampton,EASTON 4TH WARD,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,EASTON 4TH WARD,General Assembly,136,DEM,Robert Freeman,79,89,3,171
+Northampton,EASTON 4TH WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 4TH WARD,President,,REP,Donald J Trump,34,24,0,58
+Northampton,EASTON 4TH WARD,President,,REP,Roque Rocky De La Fuente,3,1,0,4
+Northampton,EASTON 4TH WARD,President,,REP,Bill Weld,3,0,0,3
+Northampton,EASTON 4TH WARD,President,,REP,Write-in,0,1,0,1
+Northampton,EASTON 4TH WARD,Attorney General,,REP,Heather Heidelbaugh,31,25,0,56
+Northampton,EASTON 4TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 4TH WARD,Auditor General,,REP,Timothy Defoor,30,24,0,54
+Northampton,EASTON 4TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 4TH WARD,State Treasurer,,REP,Stacy L. Garrity,29,25,0,54
+Northampton,EASTON 4TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 4TH WARD,U.S. House,7,REP,Dean N. Browning,20,14,0,34
+Northampton,EASTON 4TH WARD,U.S. House,7,REP,Lisa Scheller,20,12,0,32
+Northampton,EASTON 4TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 4TH WARD,General Assembly,136,REP,Write-in,0,1,0,1
+Northampton,EASTON 5TH WARD,Registered Voters,,,,,,,576
+Northampton,EASTON 5TH WARD,Registered Voters,,DEM,,,,,383
+Northampton,EASTON 5TH WARD,Registered Voters,,REP,,,,,101
+Northampton,EASTON 5TH WARD,Registered Voters,,NPA,,,,,92
+Northampton,EASTON 5TH WARD,Ballots Cast,,,,50,50,7,107
+Northampton,EASTON 5TH WARD,Ballots Cast,,DEM,,41,44,6,91
+Northampton,EASTON 5TH WARD,Ballots Cast,,REP,,9,6,1,16
+Northampton,EASTON 5TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 5TH WARD,President,,DEM,Joseph R. Biden,27,32,5,64
+Northampton,EASTON 5TH WARD,President,,DEM,Bernie Sanders,9,11,1,21
+Northampton,EASTON 5TH WARD,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,EASTON 5TH WARD,President,,DEM,Write-in,1,0,0,1
+Northampton,EASTON 5TH WARD,Attorney General,,DEM,Josh Shapiro,28,39,4,71
+Northampton,EASTON 5TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,Auditor General,,DEM,Nina Ahmad,10,16,2,28
+Northampton,EASTON 5TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,4,12,0,16
+Northampton,EASTON 5TH WARD,Auditor General,,DEM,H Scott Conklin,7,3,0,10
+Northampton,EASTON 5TH WARD,Auditor General,,DEM,Christina M. Hartman,4,4,0,8
+Northampton,EASTON 5TH WARD,Auditor General,,DEM,Michael Lamb,4,1,2,7
+Northampton,EASTON 5TH WARD,Auditor General,,DEM,Tracie Fountain,1,3,0,4
+Northampton,EASTON 5TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,State Treasurer,,DEM,Joe Torsella,26,40,3,69
+Northampton,EASTON 5TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,U.S. House,7,DEM,Susan Wild,28,42,4,74
+Northampton,EASTON 5TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,General Assembly,136,DEM,Robert Freeman,34,42,4,80
+Northampton,EASTON 5TH WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,President,,REP,Donald J Trump,7,5,0,12
+Northampton,EASTON 5TH WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,EASTON 5TH WARD,President,,REP,Bill Weld,1,0,0,1
+Northampton,EASTON 5TH WARD,President,,REP,Write-in,0,0,1,1
+Northampton,EASTON 5TH WARD,Attorney General,,REP,Heather Heidelbaugh,5,6,0,11
+Northampton,EASTON 5TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,Auditor General,,REP,Timothy Defoor,5,6,0,11
+Northampton,EASTON 5TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,State Treasurer,,REP,Stacy L. Garrity,5,5,0,10
+Northampton,EASTON 5TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,U.S. House,7,REP,Lisa Scheller,6,3,1,10
+Northampton,EASTON 5TH WARD,U.S. House,7,REP,Dean N. Browning,3,3,0,6
+Northampton,EASTON 5TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 5TH WARD,General Assembly,136,REP,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,Registered Voters,,,,,,,956
+Northampton,EASTON 6TH WARD,Registered Voters,,DEM,,,,,601
+Northampton,EASTON 6TH WARD,Registered Voters,,REP,,,,,141
+Northampton,EASTON 6TH WARD,Registered Voters,,NPA,,,,,214
+Northampton,EASTON 6TH WARD,Ballots Cast,,,,80,80,0,160
+Northampton,EASTON 6TH WARD,Ballots Cast,,DEM,,63,73,0,136
+Northampton,EASTON 6TH WARD,Ballots Cast,,REP,,17,7,0,24
+Northampton,EASTON 6TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 6TH WARD,President,,DEM,Joseph R. Biden,44,46,0,90
+Northampton,EASTON 6TH WARD,President,,DEM,Bernie Sanders,17,25,0,42
+Northampton,EASTON 6TH WARD,President,,DEM,Tulsi Gabbard,1,0,0,1
+Northampton,EASTON 6TH WARD,President,,DEM,Write-in,1,1,0,2
+Northampton,EASTON 6TH WARD,Attorney General,,DEM,Josh Shapiro,49,67,0,116
+Northampton,EASTON 6TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,Auditor General,,DEM,Nina Ahmad,18,31,0,49
+Northampton,EASTON 6TH WARD,Auditor General,,DEM,Michael Lamb,9,7,0,16
+Northampton,EASTON 6TH WARD,Auditor General,,DEM,Christina M. Hartman,4,11,0,15
+Northampton,EASTON 6TH WARD,Auditor General,,DEM,H Scott Conklin,11,2,0,13
+Northampton,EASTON 6TH WARD,Auditor General,,DEM,Tracie Fountain,3,8,0,11
+Northampton,EASTON 6TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,5,6,0,11
+Northampton,EASTON 6TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,State Treasurer,,DEM,Joe Torsella,41,65,0,106
+Northampton,EASTON 6TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,U.S. House,7,DEM,Susan Wild,51,70,0,121
+Northampton,EASTON 6TH WARD,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,EASTON 6TH WARD,General Assembly,136,DEM,Robert Freeman,55,71,0,126
+Northampton,EASTON 6TH WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,President,,REP,Donald J Trump,15,7,0,22
+Northampton,EASTON 6TH WARD,President,,REP,Bill Weld,1,0,0,1
+Northampton,EASTON 6TH WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,EASTON 6TH WARD,President,,REP,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,Attorney General,,REP,Heather Heidelbaugh,15,5,0,20
+Northampton,EASTON 6TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,Auditor General,,REP,Timothy Defoor,15,5,0,20
+Northampton,EASTON 6TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,State Treasurer,,REP,Stacy L. Garrity,15,5,0,20
+Northampton,EASTON 6TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,U.S. House,7,REP,Lisa Scheller,9,5,0,14
+Northampton,EASTON 6TH WARD,U.S. House,7,REP,Dean N. Browning,7,2,0,9
+Northampton,EASTON 6TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 6TH WARD,General Assembly,136,REP,Write-in,2,0,0,2
+Northampton,EASTON 7TH WARD,Registered Voters,,,,,,,1072
+Northampton,EASTON 7TH WARD,Registered Voters,,DEM,,,,,680
+Northampton,EASTON 7TH WARD,Registered Voters,,REP,,,,,140
+Northampton,EASTON 7TH WARD,Registered Voters,,NPA,,,,,252
+Northampton,EASTON 7TH WARD,Ballots Cast,,,,83,82,5,170
+Northampton,EASTON 7TH WARD,Ballots Cast,,DEM,,60,78,4,142
+Northampton,EASTON 7TH WARD,Ballots Cast,,REP,,23,4,1,28
+Northampton,EASTON 7TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 7TH WARD,President,,DEM,Joseph R. Biden,43,53,3,99
+Northampton,EASTON 7TH WARD,President,,DEM,Bernie Sanders,13,19,1,33
+Northampton,EASTON 7TH WARD,President,,DEM,Tulsi Gabbard,2,3,0,5
+Northampton,EASTON 7TH WARD,President,,DEM,Write-in,0,2,0,2
+Northampton,EASTON 7TH WARD,Attorney General,,DEM,Josh Shapiro,39,69,3,111
+Northampton,EASTON 7TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,Auditor General,,DEM,Nina Ahmad,15,27,1,43
+Northampton,EASTON 7TH WARD,Auditor General,,DEM,Michael Lamb,14,10,1,25
+Northampton,EASTON 7TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,3,13,1,17
+Northampton,EASTON 7TH WARD,Auditor General,,DEM,H Scott Conklin,12,3,0,15
+Northampton,EASTON 7TH WARD,Auditor General,,DEM,Christina M. Hartman,3,11,0,14
+Northampton,EASTON 7TH WARD,Auditor General,,DEM,Tracie Fountain,3,2,0,5
+Northampton,EASTON 7TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,State Treasurer,,DEM,Joe Torsella,36,71,3,110
+Northampton,EASTON 7TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,U.S. House,7,DEM,Susan Wild,45,74,4,123
+Northampton,EASTON 7TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,General Assembly,136,DEM,Robert Freeman,47,74,4,125
+Northampton,EASTON 7TH WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,President,,REP,Donald J Trump,21,3,1,25
+Northampton,EASTON 7TH WARD,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,EASTON 7TH WARD,President,,REP,Bill Weld,0,0,0,0
+Northampton,EASTON 7TH WARD,President,,REP,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,Attorney General,,REP,Heather Heidelbaugh,17,4,0,21
+Northampton,EASTON 7TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,Auditor General,,REP,Timothy Defoor,19,4,1,24
+Northampton,EASTON 7TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,State Treasurer,,REP,Stacy L. Garrity,19,4,1,24
+Northampton,EASTON 7TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 7TH WARD,U.S. House,7,REP,Dean N. Browning,10,3,1,14
+Northampton,EASTON 7TH WARD,U.S. House,7,REP,Lisa Scheller,12,0,0,12
+Northampton,EASTON 7TH WARD,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,EASTON 7TH WARD,General Assembly,136,REP,Write-in,1,1,1,3
+Northampton,EASTON 8TH WARD EASTERN,Registered Voters,,,,,,,939
+Northampton,EASTON 8TH WARD EASTERN,Registered Voters,,DEM,,,,,540
+Northampton,EASTON 8TH WARD EASTERN,Registered Voters,,REP,,,,,189
+Northampton,EASTON 8TH WARD EASTERN,Registered Voters,,NPA,,,,,210
+Northampton,EASTON 8TH WARD EASTERN,Ballots Cast,,,,80,76,3,159
+Northampton,EASTON 8TH WARD EASTERN,Ballots Cast,,DEM,,47,68,3,118
+Northampton,EASTON 8TH WARD EASTERN,Ballots Cast,,REP,,33,8,0,41
+Northampton,EASTON 8TH WARD EASTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 8TH WARD EASTERN,President,,DEM,Joseph R. Biden,33,56,2,91
+Northampton,EASTON 8TH WARD EASTERN,President,,DEM,Bernie Sanders,12,8,1,21
+Northampton,EASTON 8TH WARD EASTERN,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,EASTON 8TH WARD EASTERN,President,,DEM,Write-in,0,1,0,1
+Northampton,EASTON 8TH WARD EASTERN,Attorney General,,DEM,Josh Shapiro,33,53,2,88
+Northampton,EASTON 8TH WARD EASTERN,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,DEM,Nina Ahmad,14,16,2,32
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,DEM,Michael Lamb,8,9,0,17
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,DEM,Rose Rosie Marie Davis,3,11,1,15
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,DEM,H Scott Conklin,4,6,0,10
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,DEM,Christina M. Hartman,4,6,0,10
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,DEM,Tracie Fountain,0,4,0,4
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,EASTON 8TH WARD EASTERN,State Treasurer,,DEM,Joe Torsella,28,53,2,83
+Northampton,EASTON 8TH WARD EASTERN,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,EASTON 8TH WARD EASTERN,U.S. House,7,DEM,Susan Wild,35,61,2,98
+Northampton,EASTON 8TH WARD EASTERN,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,EASTON 8TH WARD EASTERN,General Assembly,136,DEM,Robert Freeman,36,64,3,103
+Northampton,EASTON 8TH WARD EASTERN,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD EASTERN,President,,REP,Donald J Trump,29,7,0,36
+Northampton,EASTON 8TH WARD EASTERN,President,,REP,Bill Weld,3,0,0,3
+Northampton,EASTON 8TH WARD EASTERN,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,EASTON 8TH WARD EASTERN,President,,REP,Write-in,0,1,0,1
+Northampton,EASTON 8TH WARD EASTERN,Attorney General,,REP,Heather Heidelbaugh,29,5,0,34
+Northampton,EASTON 8TH WARD EASTERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,REP,Timothy Defoor,28,5,0,33
+Northampton,EASTON 8TH WARD EASTERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD EASTERN,State Treasurer,,REP,Stacy L. Garrity,28,5,0,33
+Northampton,EASTON 8TH WARD EASTERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD EASTERN,U.S. House,7,REP,Lisa Scheller,17,5,0,22
+Northampton,EASTON 8TH WARD EASTERN,U.S. House,7,REP,Dean N. Browning,14,2,0,16
+Northampton,EASTON 8TH WARD EASTERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD EASTERN,General Assembly,136,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,Registered Voters,,,,,,,1160
+Northampton,EASTON 8TH WARD WESTERN,Registered Voters,,DEM,,,,,685
+Northampton,EASTON 8TH WARD WESTERN,Registered Voters,,REP,,,,,219
+Northampton,EASTON 8TH WARD WESTERN,Registered Voters,,NPA,,,,,256
+Northampton,EASTON 8TH WARD WESTERN,Ballots Cast,,,,124,93,4,221
+Northampton,EASTON 8TH WARD WESTERN,Ballots Cast,,DEM,,76,81,2,159
+Northampton,EASTON 8TH WARD WESTERN,Ballots Cast,,REP,,48,12,2,62
+Northampton,EASTON 8TH WARD WESTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,President,,DEM,Joseph R. Biden,51,59,2,112
+Northampton,EASTON 8TH WARD WESTERN,President,,DEM,Bernie Sanders,15,20,0,35
+Northampton,EASTON 8TH WARD WESTERN,President,,DEM,Tulsi Gabbard,4,1,0,5
+Northampton,EASTON 8TH WARD WESTERN,President,,DEM,Write-in,1,0,0,1
+Northampton,EASTON 8TH WARD WESTERN,Attorney General,,DEM,Josh Shapiro,45,78,1,124
+Northampton,EASTON 8TH WARD WESTERN,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,DEM,Nina Ahmad,23,22,0,45
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,DEM,Michael Lamb,22,10,0,32
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,DEM,Christina M. Hartman,3,13,0,16
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,DEM,Tracie Fountain,3,10,0,13
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,DEM,Rose Rosie Marie Davis,2,10,0,12
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,DEM,H Scott Conklin,4,5,0,9
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,EASTON 8TH WARD WESTERN,State Treasurer,,DEM,Joe Torsella,43,74,1,118
+Northampton,EASTON 8TH WARD WESTERN,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,U.S. House,7,DEM,Susan Wild,56,77,2,135
+Northampton,EASTON 8TH WARD WESTERN,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,General Assembly,136,DEM,Robert Freeman,64,79,2,145
+Northampton,EASTON 8TH WARD WESTERN,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,President,,REP,Donald J Trump,46,10,2,58
+Northampton,EASTON 8TH WARD WESTERN,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,EASTON 8TH WARD WESTERN,President,,REP,Bill Weld,1,0,0,1
+Northampton,EASTON 8TH WARD WESTERN,President,,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,Attorney General,,REP,Heather Heidelbaugh,37,8,2,47
+Northampton,EASTON 8TH WARD WESTERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,REP,Timothy Defoor,38,9,2,49
+Northampton,EASTON 8TH WARD WESTERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,State Treasurer,,REP,Stacy L. Garrity,38,9,2,49
+Northampton,EASTON 8TH WARD WESTERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,U.S. House,7,REP,Dean N. Browning,22,5,2,29
+Northampton,EASTON 8TH WARD WESTERN,U.S. House,7,REP,Lisa Scheller,22,7,0,29
+Northampton,EASTON 8TH WARD WESTERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 8TH WARD WESTERN,General Assembly,136,REP,Write-in,4,1,0,5
+Northampton,EASTON 9TH WARD,Registered Voters,,,,,,,2056
+Northampton,EASTON 9TH WARD,Registered Voters,,DEM,,,,,1296
+Northampton,EASTON 9TH WARD,Registered Voters,,REP,,,,,342
+Northampton,EASTON 9TH WARD,Registered Voters,,NPA,,,,,418
+Northampton,EASTON 9TH WARD,Ballots Cast,,,,194,249,0,443
+Northampton,EASTON 9TH WARD,Ballots Cast,,DEM,,147,225,0,372
+Northampton,EASTON 9TH WARD,Ballots Cast,,REP,,47,24,0,71
+Northampton,EASTON 9TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 9TH WARD,President,,DEM,Joseph R. Biden,103,187,0,290
+Northampton,EASTON 9TH WARD,President,,DEM,Bernie Sanders,36,28,0,64
+Northampton,EASTON 9TH WARD,President,,DEM,Tulsi Gabbard,1,2,0,3
+Northampton,EASTON 9TH WARD,President,,DEM,Write-in,2,3,0,5
+Northampton,EASTON 9TH WARD,Attorney General,,DEM,Josh Shapiro,87,195,0,282
+Northampton,EASTON 9TH WARD,Attorney General,,DEM,Write-in,1,1,0,2
+Northampton,EASTON 9TH WARD,Auditor General,,DEM,Nina Ahmad,42,73,0,115
+Northampton,EASTON 9TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,11,41,0,52
+Northampton,EASTON 9TH WARD,Auditor General,,DEM,Michael Lamb,28,16,0,44
+Northampton,EASTON 9TH WARD,Auditor General,,DEM,H Scott Conklin,20,19,0,39
+Northampton,EASTON 9TH WARD,Auditor General,,DEM,Tracie Fountain,8,20,0,28
+Northampton,EASTON 9TH WARD,Auditor General,,DEM,Christina M. Hartman,5,23,0,28
+Northampton,EASTON 9TH WARD,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,EASTON 9TH WARD,State Treasurer,,DEM,Joe Torsella,87,189,0,276
+Northampton,EASTON 9TH WARD,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,EASTON 9TH WARD,U.S. House,7,DEM,Susan Wild,110,213,0,323
+Northampton,EASTON 9TH WARD,U.S. House,7,DEM,Write-in,1,2,0,3
+Northampton,EASTON 9TH WARD,General Assembly,136,DEM,Robert Freeman,113,215,0,328
+Northampton,EASTON 9TH WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 9TH WARD,President,,REP,Donald J Trump,42,21,0,63
+Northampton,EASTON 9TH WARD,President,,REP,Bill Weld,4,2,0,6
+Northampton,EASTON 9TH WARD,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,EASTON 9TH WARD,President,,REP,Write-in,0,0,0,0
+Northampton,EASTON 9TH WARD,Attorney General,,REP,Heather Heidelbaugh,36,19,0,55
+Northampton,EASTON 9TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 9TH WARD,Auditor General,,REP,Timothy Defoor,37,18,0,55
+Northampton,EASTON 9TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 9TH WARD,State Treasurer,,REP,Stacy L. Garrity,36,18,0,54
+Northampton,EASTON 9TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 9TH WARD,U.S. House,7,REP,Dean N. Browning,26,9,0,35
+Northampton,EASTON 9TH WARD,U.S. House,7,REP,Lisa Scheller,19,14,0,33
+Northampton,EASTON 9TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 9TH WARD,General Assembly,136,REP,Write-in,1,1,0,2
+Northampton,EASTON 10TH WARD EASTERN,Registered Voters,,,,,,,606
+Northampton,EASTON 10TH WARD EASTERN,Registered Voters,,DEM,,,,,387
+Northampton,EASTON 10TH WARD EASTERN,Registered Voters,,REP,,,,,111
+Northampton,EASTON 10TH WARD EASTERN,Registered Voters,,NPA,,,,,108
+Northampton,EASTON 10TH WARD EASTERN,Ballots Cast,,,,83,65,0,148
+Northampton,EASTON 10TH WARD EASTERN,Ballots Cast,,DEM,,56,53,0,109
+Northampton,EASTON 10TH WARD EASTERN,Ballots Cast,,REP,,27,12,0,39
+Northampton,EASTON 10TH WARD EASTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,President,,DEM,Joseph R. Biden,36,41,0,77
+Northampton,EASTON 10TH WARD EASTERN,President,,DEM,Bernie Sanders,17,9,0,26
+Northampton,EASTON 10TH WARD EASTERN,President,,DEM,Tulsi Gabbard,1,0,0,1
+Northampton,EASTON 10TH WARD EASTERN,President,,DEM,Write-in,2,0,0,2
+Northampton,EASTON 10TH WARD EASTERN,Attorney General,,DEM,Josh Shapiro,39,45,0,84
+Northampton,EASTON 10TH WARD EASTERN,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,DEM,Nina Ahmad,19,16,0,35
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,DEM,Rose Rosie Marie Davis,8,12,0,20
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,DEM,Michael Lamb,11,6,0,17
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,DEM,H Scott Conklin,6,3,0,9
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,DEM,Christina M. Hartman,3,5,0,8
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,DEM,Tracie Fountain,2,2,0,4
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,State Treasurer,,DEM,Joe Torsella,37,40,0,77
+Northampton,EASTON 10TH WARD EASTERN,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,U.S. House,7,DEM,Susan Wild,40,49,0,89
+Northampton,EASTON 10TH WARD EASTERN,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,General Assembly,136,DEM,Robert Freeman,44,48,0,92
+Northampton,EASTON 10TH WARD EASTERN,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,President,,REP,Donald J Trump,26,11,0,37
+Northampton,EASTON 10TH WARD EASTERN,President,,REP,Bill Weld,0,1,0,1
+Northampton,EASTON 10TH WARD EASTERN,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,President,,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,Attorney General,,REP,Heather Heidelbaugh,22,9,0,31
+Northampton,EASTON 10TH WARD EASTERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,REP,Timothy Defoor,22,10,0,32
+Northampton,EASTON 10TH WARD EASTERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,State Treasurer,,REP,Stacy L. Garrity,21,10,0,31
+Northampton,EASTON 10TH WARD EASTERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,U.S. House,7,REP,Dean N. Browning,16,7,0,23
+Northampton,EASTON 10TH WARD EASTERN,U.S. House,7,REP,Lisa Scheller,10,5,0,15
+Northampton,EASTON 10TH WARD EASTERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD EASTERN,General Assembly,136,REP,Write-in,1,0,0,1
+Northampton,EASTON 10TH WARD WESTERN,Registered Voters,,,,,,,916
+Northampton,EASTON 10TH WARD WESTERN,Registered Voters,,DEM,,,,,562
+Northampton,EASTON 10TH WARD WESTERN,Registered Voters,,REP,,,,,184
+Northampton,EASTON 10TH WARD WESTERN,Registered Voters,,NPA,,,,,170
+Northampton,EASTON 10TH WARD WESTERN,Ballots Cast,,,,94,138,1,233
+Northampton,EASTON 10TH WARD WESTERN,Ballots Cast,,DEM,,59,119,1,179
+Northampton,EASTON 10TH WARD WESTERN,Ballots Cast,,REP,,35,19,0,54
+Northampton,EASTON 10TH WARD WESTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,President,,DEM,Joseph R. Biden,38,90,1,129
+Northampton,EASTON 10TH WARD WESTERN,President,,DEM,Bernie Sanders,17,22,0,39
+Northampton,EASTON 10TH WARD WESTERN,President,,DEM,Tulsi Gabbard,1,3,0,4
+Northampton,EASTON 10TH WARD WESTERN,President,,DEM,Write-in,0,1,0,1
+Northampton,EASTON 10TH WARD WESTERN,Attorney General,,DEM,Josh Shapiro,42,107,0,149
+Northampton,EASTON 10TH WARD WESTERN,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,DEM,Nina Ahmad,14,30,0,44
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,DEM,Rose Rosie Marie Davis,8,28,0,36
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,DEM,Michael Lamb,11,16,0,27
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,DEM,Christina M. Hartman,3,14,0,17
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,DEM,H Scott Conklin,8,8,0,16
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,DEM,Tracie Fountain,3,7,0,10
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,State Treasurer,,DEM,Joe Torsella,39,101,0,140
+Northampton,EASTON 10TH WARD WESTERN,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,U.S. House,7,DEM,Susan Wild,47,110,1,158
+Northampton,EASTON 10TH WARD WESTERN,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,EASTON 10TH WARD WESTERN,General Assembly,136,DEM,Robert Freeman,48,113,1,162
+Northampton,EASTON 10TH WARD WESTERN,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,President,,REP,Donald J Trump,31,16,0,47
+Northampton,EASTON 10TH WARD WESTERN,President,,REP,Bill Weld,3,0,0,3
+Northampton,EASTON 10TH WARD WESTERN,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,President,,REP,Write-in,0,2,0,2
+Northampton,EASTON 10TH WARD WESTERN,Attorney General,,REP,Heather Heidelbaugh,27,16,0,43
+Northampton,EASTON 10TH WARD WESTERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,REP,Timothy Defoor,25,16,0,41
+Northampton,EASTON 10TH WARD WESTERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,State Treasurer,,REP,Stacy L. Garrity,25,15,0,40
+Northampton,EASTON 10TH WARD WESTERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,U.S. House,7,REP,Dean N. Browning,18,9,0,27
+Northampton,EASTON 10TH WARD WESTERN,U.S. House,7,REP,Lisa Scheller,14,8,0,22
+Northampton,EASTON 10TH WARD WESTERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 10TH WARD WESTERN,General Assembly,136,REP,Write-in,2,1,0,3
+Northampton,EASTON 11TH WARD,Registered Voters,,,,,,,1090
+Northampton,EASTON 11TH WARD,Registered Voters,,DEM,,,,,691
+Northampton,EASTON 11TH WARD,Registered Voters,,REP,,,,,192
+Northampton,EASTON 11TH WARD,Registered Voters,,NPA,,,,,207
+Northampton,EASTON 11TH WARD,Ballots Cast,,,,124,130,8,262
+Northampton,EASTON 11TH WARD,Ballots Cast,,DEM,,93,117,6,216
+Northampton,EASTON 11TH WARD,Ballots Cast,,REP,,31,13,2,46
+Northampton,EASTON 11TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 11TH WARD,President,,DEM,Joseph R. Biden,70,85,5,160
+Northampton,EASTON 11TH WARD,President,,DEM,Bernie Sanders,22,20,0,42
+Northampton,EASTON 11TH WARD,President,,DEM,Tulsi Gabbard,0,6,0,6
+Northampton,EASTON 11TH WARD,President,,DEM,Write-in,0,4,0,4
+Northampton,EASTON 11TH WARD,Attorney General,,DEM,Josh Shapiro,62,95,5,162
+Northampton,EASTON 11TH WARD,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,EASTON 11TH WARD,Auditor General,,DEM,Nina Ahmad,26,33,1,60
+Northampton,EASTON 11TH WARD,Auditor General,,DEM,Michael Lamb,24,10,0,34
+Northampton,EASTON 11TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,10,23,0,33
+Northampton,EASTON 11TH WARD,Auditor General,,DEM,Christina M. Hartman,6,17,1,24
+Northampton,EASTON 11TH WARD,Auditor General,,DEM,H Scott Conklin,9,6,1,16
+Northampton,EASTON 11TH WARD,Auditor General,,DEM,Tracie Fountain,3,9,0,12
+Northampton,EASTON 11TH WARD,Auditor General,,DEM,Write-in,0,0,1,1
+Northampton,EASTON 11TH WARD,State Treasurer,,DEM,Joe Torsella,60,96,3,159
+Northampton,EASTON 11TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 11TH WARD,U.S. House,7,DEM,Susan Wild,73,106,6,185
+Northampton,EASTON 11TH WARD,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,EASTON 11TH WARD,General Assembly,136,DEM,Robert Freeman,75,108,5,188
+Northampton,EASTON 11TH WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 11TH WARD,President,,REP,Donald J Trump,30,12,2,44
+Northampton,EASTON 11TH WARD,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Northampton,EASTON 11TH WARD,President,,REP,Bill Weld,1,0,0,1
+Northampton,EASTON 11TH WARD,President,,REP,Write-in,0,0,0,0
+Northampton,EASTON 11TH WARD,Attorney General,,REP,Heather Heidelbaugh,29,13,1,43
+Northampton,EASTON 11TH WARD,Attorney General,,REP,Write-in,1,0,0,1
+Northampton,EASTON 11TH WARD,Auditor General,,REP,Timothy Defoor,30,13,1,44
+Northampton,EASTON 11TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 11TH WARD,State Treasurer,,REP,Stacy L. Garrity,30,13,1,44
+Northampton,EASTON 11TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 11TH WARD,U.S. House,7,REP,Dean N. Browning,17,8,2,27
+Northampton,EASTON 11TH WARD,U.S. House,7,REP,Lisa Scheller,14,5,0,19
+Northampton,EASTON 11TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 11TH WARD,General Assembly,136,REP,Write-in,0,1,0,1
+Northampton,EASTON 12TH WARD,Registered Voters,,,,,,,681
+Northampton,EASTON 12TH WARD,Registered Voters,,DEM,,,,,431
+Northampton,EASTON 12TH WARD,Registered Voters,,REP,,,,,112
+Northampton,EASTON 12TH WARD,Registered Voters,,NPA,,,,,138
+Northampton,EASTON 12TH WARD,Ballots Cast,,,,100,44,2,146
+Northampton,EASTON 12TH WARD,Ballots Cast,,DEM,,86,39,1,126
+Northampton,EASTON 12TH WARD,Ballots Cast,,REP,,14,5,1,20
+Northampton,EASTON 12TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,EASTON 12TH WARD,President,,DEM,Joseph R. Biden,68,30,1,99
+Northampton,EASTON 12TH WARD,President,,DEM,Bernie Sanders,16,8,0,24
+Northampton,EASTON 12TH WARD,President,,DEM,Tulsi Gabbard,0,0,0,0
+Northampton,EASTON 12TH WARD,President,,DEM,Write-in,1,0,0,1
+Northampton,EASTON 12TH WARD,Attorney General,,DEM,Josh Shapiro,48,35,1,84
+Northampton,EASTON 12TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,Auditor General,,DEM,Nina Ahmad,21,9,0,30
+Northampton,EASTON 12TH WARD,Auditor General,,DEM,Michael Lamb,21,6,0,27
+Northampton,EASTON 12TH WARD,Auditor General,,DEM,H Scott Conklin,13,5,0,18
+Northampton,EASTON 12TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,7,7,1,15
+Northampton,EASTON 12TH WARD,Auditor General,,DEM,Christina M. Hartman,3,2,0,5
+Northampton,EASTON 12TH WARD,Auditor General,,DEM,Tracie Fountain,1,3,0,4
+Northampton,EASTON 12TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,State Treasurer,,DEM,Joe Torsella,53,35,1,89
+Northampton,EASTON 12TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,U.S. House,7,DEM,Susan Wild,64,37,1,102
+Northampton,EASTON 12TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,General Assembly,136,DEM,Robert Freeman,68,37,1,106
+Northampton,EASTON 12TH WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,President,,REP,Donald J Trump,11,5,1,17
+Northampton,EASTON 12TH WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,EASTON 12TH WARD,President,,REP,Bill Weld,1,0,0,1
+Northampton,EASTON 12TH WARD,President,,REP,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,Attorney General,,REP,Heather Heidelbaugh,9,4,0,13
+Northampton,EASTON 12TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,Auditor General,,REP,Timothy Defoor,10,4,1,15
+Northampton,EASTON 12TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,State Treasurer,,REP,Stacy L. Garrity,9,5,1,15
+Northampton,EASTON 12TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,U.S. House,7,REP,Dean N. Browning,8,3,0,11
+Northampton,EASTON 12TH WARD,U.S. House,7,REP,Lisa Scheller,3,2,1,6
+Northampton,EASTON 12TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,EASTON 12TH WARD,General Assembly,136,REP,Write-in,0,0,0,0
+Northampton,FORKS EASTERN #1,Registered Voters,,,,,,,3066
+Northampton,FORKS EASTERN #1,Registered Voters,,DEM,,,,,1211
+Northampton,FORKS EASTERN #1,Registered Voters,,REP,,,,,1250
+Northampton,FORKS EASTERN #1,Registered Voters,,NPA,,,,,605
+Northampton,FORKS EASTERN #1,Ballots Cast,,,,338,708,13,1059
+Northampton,FORKS EASTERN #1,Ballots Cast,,DEM,,129,460,6,595
+Northampton,FORKS EASTERN #1,Ballots Cast,,REP,,209,248,7,464
+Northampton,FORKS EASTERN #1,Ballots Cast,,NPA,,0,0,0,0
+Northampton,FORKS EASTERN #1,President,,DEM,Joseph R. Biden,92,396,2,490
+Northampton,FORKS EASTERN #1,President,,DEM,Bernie Sanders,29,47,3,79
+Northampton,FORKS EASTERN #1,President,,DEM,Tulsi Gabbard,6,4,0,10
+Northampton,FORKS EASTERN #1,President,,DEM,Write-in,0,6,1,7
+Northampton,FORKS EASTERN #1,Attorney General,,DEM,Josh Shapiro,96,403,6,505
+Northampton,FORKS EASTERN #1,Attorney General,,DEM,Write-in,0,5,0,5
+Northampton,FORKS EASTERN #1,Auditor General,,DEM,Nina Ahmad,36,133,3,172
+Northampton,FORKS EASTERN #1,Auditor General,,DEM,Rose Rosie Marie Davis,9,88,0,97
+Northampton,FORKS EASTERN #1,Auditor General,,DEM,Christina M. Hartman,11,72,0,83
+Northampton,FORKS EASTERN #1,Auditor General,,DEM,Michael Lamb,26,36,1,63
+Northampton,FORKS EASTERN #1,Auditor General,,DEM,Tracie Fountain,14,41,0,55
+Northampton,FORKS EASTERN #1,Auditor General,,DEM,H Scott Conklin,14,16,1,31
+Northampton,FORKS EASTERN #1,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,FORKS EASTERN #1,State Treasurer,,DEM,Joe Torsella,90,402,5,497
+Northampton,FORKS EASTERN #1,State Treasurer,,DEM,Write-in,0,4,0,4
+Northampton,FORKS EASTERN #1,U.S. House,7,DEM,Susan Wild,103,425,6,534
+Northampton,FORKS EASTERN #1,U.S. House,7,DEM,Write-in,0,3,0,3
+Northampton,FORKS EASTERN #1,General Assembly,137,DEM,Katelind Brennan,89,401,4,494
+Northampton,FORKS EASTERN #1,General Assembly,137,DEM,Write-in,0,5,0,5
+Northampton,FORKS EASTERN #1,President,,REP,Donald J Trump,200,195,7,402
+Northampton,FORKS EASTERN #1,President,,REP,Bill Weld,3,22,0,25
+Northampton,FORKS EASTERN #1,President,,REP,Roque Rocky De La Fuente,3,7,0,10
+Northampton,FORKS EASTERN #1,President,,REP,Write-in,3,10,0,13
+Northampton,FORKS EASTERN #1,Attorney General,,REP,Heather Heidelbaugh,178,201,4,383
+Northampton,FORKS EASTERN #1,Attorney General,,REP,Write-in,1,5,0,6
+Northampton,FORKS EASTERN #1,Auditor General,,REP,Timothy Defoor,173,205,3,381
+Northampton,FORKS EASTERN #1,Auditor General,,REP,Write-in,1,2,0,3
+Northampton,FORKS EASTERN #1,State Treasurer,,REP,Stacy L. Garrity,173,208,4,385
+Northampton,FORKS EASTERN #1,State Treasurer,,REP,Write-in,1,2,0,3
+Northampton,FORKS EASTERN #1,U.S. House,7,REP,Lisa Scheller,106,127,5,238
+Northampton,FORKS EASTERN #1,U.S. House,7,REP,Dean N. Browning,97,105,2,204
+Northampton,FORKS EASTERN #1,U.S. House,7,REP,Write-in,1,4,0,5
+Northampton,FORKS EASTERN #1,General Assembly,137,REP,Joe Emrick,194,238,6,438
+Northampton,FORKS EASTERN #1,General Assembly,137,REP,Write-in,1,4,0,5
+Northampton,FORKS EASTERN #2,Registered Voters,,,,,,,3473
+Northampton,FORKS EASTERN #2,Registered Voters,,DEM,,,,,1484
+Northampton,FORKS EASTERN #2,Registered Voters,,REP,,,,,1311
+Northampton,FORKS EASTERN #2,Registered Voters,,NPA,,,,,678
+Northampton,FORKS EASTERN #2,Ballots Cast,,,,284,743,17,1044
+Northampton,FORKS EASTERN #2,Ballots Cast,,DEM,,116,526,8,650
+Northampton,FORKS EASTERN #2,Ballots Cast,,REP,,168,217,9,394
+Northampton,FORKS EASTERN #2,Ballots Cast,,NPA,,0,0,0,0
+Northampton,FORKS EASTERN #2,President,,DEM,Joseph R. Biden,78,429,5,512
+Northampton,FORKS EASTERN #2,President,,DEM,Bernie Sanders,28,75,2,105
+Northampton,FORKS EASTERN #2,President,,DEM,Tulsi Gabbard,6,8,0,14
+Northampton,FORKS EASTERN #2,President,,DEM,Write-in,3,6,0,9
+Northampton,FORKS EASTERN #2,Attorney General,,DEM,Josh Shapiro,90,476,5,571
+Northampton,FORKS EASTERN #2,Attorney General,,DEM,Write-in,1,2,0,3
+Northampton,FORKS EASTERN #2,Auditor General,,DEM,Nina Ahmad,32,177,2,211
+Northampton,FORKS EASTERN #2,Auditor General,,DEM,Rose Rosie Marie Davis,16,73,3,92
+Northampton,FORKS EASTERN #2,Auditor General,,DEM,Michael Lamb,27,46,0,73
+Northampton,FORKS EASTERN #2,Auditor General,,DEM,Christina M. Hartman,3,67,0,70
+Northampton,FORKS EASTERN #2,Auditor General,,DEM,Tracie Fountain,9,47,0,56
+Northampton,FORKS EASTERN #2,Auditor General,,DEM,H Scott Conklin,13,24,1,38
+Northampton,FORKS EASTERN #2,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,FORKS EASTERN #2,State Treasurer,,DEM,Joe Torsella,88,462,5,555
+Northampton,FORKS EASTERN #2,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,FORKS EASTERN #2,U.S. House,7,DEM,Susan Wild,95,501,6,602
+Northampton,FORKS EASTERN #2,U.S. House,7,DEM,Write-in,2,4,0,6
+Northampton,FORKS EASTERN #2,General Assembly,137,DEM,Katelind Brennan,94,462,6,562
+Northampton,FORKS EASTERN #2,General Assembly,137,DEM,Write-in,0,2,0,2
+Northampton,FORKS EASTERN #2,President,,REP,Donald J Trump,159,173,8,340
+Northampton,FORKS EASTERN #2,President,,REP,Bill Weld,5,21,0,26
+Northampton,FORKS EASTERN #2,President,,REP,Roque Rocky De La Fuente,1,9,0,10
+Northampton,FORKS EASTERN #2,President,,REP,Write-in,3,8,0,11
+Northampton,FORKS EASTERN #2,Attorney General,,REP,Heather Heidelbaugh,151,191,7,349
+Northampton,FORKS EASTERN #2,Attorney General,,REP,Write-in,1,5,0,6
+Northampton,FORKS EASTERN #2,Auditor General,,REP,Timothy Defoor,147,193,7,347
+Northampton,FORKS EASTERN #2,Auditor General,,REP,Write-in,1,2,0,3
+Northampton,FORKS EASTERN #2,State Treasurer,,REP,Stacy L. Garrity,149,194,6,349
+Northampton,FORKS EASTERN #2,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,FORKS EASTERN #2,U.S. House,7,REP,Lisa Scheller,90,128,5,223
+Northampton,FORKS EASTERN #2,U.S. House,7,REP,Dean N. Browning,76,73,4,153
+Northampton,FORKS EASTERN #2,U.S. House,7,REP,Write-in,0,4,0,4
+Northampton,FORKS EASTERN #2,General Assembly,137,REP,Joe Emrick,158,207,7,372
+Northampton,FORKS EASTERN #2,General Assembly,137,REP,Write-in,0,3,0,3
+Northampton,FORKS WESTERN #1,Registered Voters,,,,,,,2337
+Northampton,FORKS WESTERN #1,Registered Voters,,DEM,,,,,1128
+Northampton,FORKS WESTERN #1,Registered Voters,,REP,,,,,803
+Northampton,FORKS WESTERN #1,Registered Voters,,NPA,,,,,406
+Northampton,FORKS WESTERN #1,Ballots Cast,,,,233,467,3,703
+Northampton,FORKS WESTERN #1,Ballots Cast,,DEM,,111,339,1,451
+Northampton,FORKS WESTERN #1,Ballots Cast,,REP,,122,128,2,252
+Northampton,FORKS WESTERN #1,Ballots Cast,,NPA,,0,0,0,0
+Northampton,FORKS WESTERN #1,President,,DEM,Joseph R. Biden,87,282,1,370
+Northampton,FORKS WESTERN #1,President,,DEM,Bernie Sanders,17,45,0,62
+Northampton,FORKS WESTERN #1,President,,DEM,Tulsi Gabbard,1,3,0,4
+Northampton,FORKS WESTERN #1,President,,DEM,Write-in,2,7,0,9
+Northampton,FORKS WESTERN #1,Attorney General,,DEM,Josh Shapiro,81,306,1,388
+Northampton,FORKS WESTERN #1,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,FORKS WESTERN #1,Auditor General,,DEM,Nina Ahmad,28,121,0,149
+Northampton,FORKS WESTERN #1,Auditor General,,DEM,Rose Rosie Marie Davis,10,54,1,65
+Northampton,FORKS WESTERN #1,Auditor General,,DEM,Christina M. Hartman,10,45,0,55
+Northampton,FORKS WESTERN #1,Auditor General,,DEM,Michael Lamb,24,30,0,54
+Northampton,FORKS WESTERN #1,Auditor General,,DEM,H Scott Conklin,13,22,0,35
+Northampton,FORKS WESTERN #1,Auditor General,,DEM,Tracie Fountain,8,17,0,25
+Northampton,FORKS WESTERN #1,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,FORKS WESTERN #1,State Treasurer,,DEM,Joe Torsella,77,302,1,380
+Northampton,FORKS WESTERN #1,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,FORKS WESTERN #1,U.S. House,7,DEM,Susan Wild,91,321,1,413
+Northampton,FORKS WESTERN #1,U.S. House,7,DEM,Write-in,2,2,0,4
+Northampton,FORKS WESTERN #1,General Assembly,137,DEM,Katelind Brennan,84,298,1,383
+Northampton,FORKS WESTERN #1,General Assembly,137,DEM,Write-in,0,4,0,4
+Northampton,FORKS WESTERN #1,President,,REP,Donald J Trump,111,99,2,212
+Northampton,FORKS WESTERN #1,President,,REP,Bill Weld,6,15,0,21
+Northampton,FORKS WESTERN #1,President,,REP,Roque Rocky De La Fuente,1,4,0,5
+Northampton,FORKS WESTERN #1,President,,REP,Write-in,2,7,0,9
+Northampton,FORKS WESTERN #1,Attorney General,,REP,Heather Heidelbaugh,92,109,2,203
+Northampton,FORKS WESTERN #1,Attorney General,,REP,Write-in,1,1,0,2
+Northampton,FORKS WESTERN #1,Auditor General,,REP,Timothy Defoor,92,107,2,201
+Northampton,FORKS WESTERN #1,Auditor General,,REP,Write-in,1,1,0,2
+Northampton,FORKS WESTERN #1,State Treasurer,,REP,Stacy L. Garrity,92,111,2,205
+Northampton,FORKS WESTERN #1,State Treasurer,,REP,Write-in,1,0,0,1
+Northampton,FORKS WESTERN #1,U.S. House,7,REP,Lisa Scheller,56,65,1,122
+Northampton,FORKS WESTERN #1,U.S. House,7,REP,Dean N. Browning,60,53,1,114
+Northampton,FORKS WESTERN #1,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,FORKS WESTERN #1,General Assembly,137,REP,Joe Emrick,111,122,2,235
+Northampton,FORKS WESTERN #1,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,FORKS WESTERN #2,Registered Voters,,,,,,,3065
+Northampton,FORKS WESTERN #2,Registered Voters,,DEM,,,,,1323
+Northampton,FORKS WESTERN #2,Registered Voters,,REP,,,,,1116
+Northampton,FORKS WESTERN #2,Registered Voters,,NPA,,,,,626
+Northampton,FORKS WESTERN #2,Ballots Cast,,,,291,526,4,821
+Northampton,FORKS WESTERN #2,Ballots Cast,,DEM,,120,370,2,492
+Northampton,FORKS WESTERN #2,Ballots Cast,,REP,,171,156,2,329
+Northampton,FORKS WESTERN #2,Ballots Cast,,NPA,,0,0,0,0
+Northampton,FORKS WESTERN #2,President,,DEM,Joseph R. Biden,90,314,1,405
+Northampton,FORKS WESTERN #2,President,,DEM,Bernie Sanders,21,37,1,59
+Northampton,FORKS WESTERN #2,President,,DEM,Tulsi Gabbard,6,5,0,11
+Northampton,FORKS WESTERN #2,President,,DEM,Write-in,2,9,0,11
+Northampton,FORKS WESTERN #2,Attorney General,,DEM,Josh Shapiro,81,331,2,414
+Northampton,FORKS WESTERN #2,Attorney General,,DEM,Write-in,2,3,0,5
+Northampton,FORKS WESTERN #2,Auditor General,,DEM,Nina Ahmad,32,116,2,150
+Northampton,FORKS WESTERN #2,Auditor General,,DEM,Michael Lamb,31,41,0,72
+Northampton,FORKS WESTERN #2,Auditor General,,DEM,Christina M. Hartman,10,49,0,59
+Northampton,FORKS WESTERN #2,Auditor General,,DEM,Rose Rosie Marie Davis,9,48,0,57
+Northampton,FORKS WESTERN #2,Auditor General,,DEM,Tracie Fountain,12,40,0,52
+Northampton,FORKS WESTERN #2,Auditor General,,DEM,H Scott Conklin,11,20,0,31
+Northampton,FORKS WESTERN #2,Auditor General,,DEM,Write-in,1,2,0,3
+Northampton,FORKS WESTERN #2,State Treasurer,,DEM,Joe Torsella,84,326,2,412
+Northampton,FORKS WESTERN #2,State Treasurer,,DEM,Write-in,2,4,0,6
+Northampton,FORKS WESTERN #2,U.S. House,7,DEM,Susan Wild,91,347,2,440
+Northampton,FORKS WESTERN #2,U.S. House,7,DEM,Write-in,3,2,0,5
+Northampton,FORKS WESTERN #2,General Assembly,137,DEM,Katelind Brennan,82,332,2,416
+Northampton,FORKS WESTERN #2,General Assembly,137,DEM,Write-in,3,3,0,6
+Northampton,FORKS WESTERN #2,President,,REP,Donald J Trump,161,115,2,278
+Northampton,FORKS WESTERN #2,President,,REP,Bill Weld,3,18,0,21
+Northampton,FORKS WESTERN #2,President,,REP,Roque Rocky De La Fuente,3,7,0,10
+Northampton,FORKS WESTERN #2,President,,REP,Write-in,1,9,0,10
+Northampton,FORKS WESTERN #2,Attorney General,,REP,Heather Heidelbaugh,149,140,1,290
+Northampton,FORKS WESTERN #2,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,FORKS WESTERN #2,Auditor General,,REP,Timothy Defoor,149,140,1,290
+Northampton,FORKS WESTERN #2,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,FORKS WESTERN #2,State Treasurer,,REP,Stacy L. Garrity,149,137,1,287
+Northampton,FORKS WESTERN #2,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,FORKS WESTERN #2,U.S. House,7,REP,Dean N. Browning,94,67,1,162
+Northampton,FORKS WESTERN #2,U.S. House,7,REP,Lisa Scheller,73,77,1,151
+Northampton,FORKS WESTERN #2,U.S. House,7,REP,Write-in,0,4,0,4
+Northampton,FORKS WESTERN #2,General Assembly,137,REP,Joe Emrick,162,147,2,311
+Northampton,FORKS WESTERN #2,General Assembly,137,REP,Write-in,0,1,0,1
+Northampton,FREEMANSBURG,Registered Voters,,,,,,,1788
+Northampton,FREEMANSBURG,Registered Voters,,DEM,,,,,1061
+Northampton,FREEMANSBURG,Registered Voters,,REP,,,,,375
+Northampton,FREEMANSBURG,Registered Voters,,NPA,,,,,352
+Northampton,FREEMANSBURG,Ballots Cast,,,,184,167,7,358
+Northampton,FREEMANSBURG,Ballots Cast,,DEM,,113,137,7,257
+Northampton,FREEMANSBURG,Ballots Cast,,REP,,71,30,0,101
+Northampton,FREEMANSBURG,Ballots Cast,,NPA,,0,0,0,0
+Northampton,FREEMANSBURG,President,,DEM,Joseph R. Biden,69,107,4,180
+Northampton,FREEMANSBURG,President,,DEM,Bernie Sanders,25,27,2,54
+Northampton,FREEMANSBURG,President,,DEM,Tulsi Gabbard,11,0,1,12
+Northampton,FREEMANSBURG,President,,DEM,Write-in,2,3,0,5
+Northampton,FREEMANSBURG,Attorney General,,DEM,Josh Shapiro,83,126,7,216
+Northampton,FREEMANSBURG,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,FREEMANSBURG,Auditor General,,DEM,Nina Ahmad,23,41,2,66
+Northampton,FREEMANSBURG,Auditor General,,DEM,Christina M. Hartman,15,22,2,39
+Northampton,FREEMANSBURG,Auditor General,,DEM,Rose Rosie Marie Davis,17,20,0,37
+Northampton,FREEMANSBURG,Auditor General,,DEM,Michael Lamb,13,14,1,28
+Northampton,FREEMANSBURG,Auditor General,,DEM,H Scott Conklin,17,5,0,22
+Northampton,FREEMANSBURG,Auditor General,,DEM,Tracie Fountain,6,15,0,21
+Northampton,FREEMANSBURG,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,FREEMANSBURG,State Treasurer,,DEM,Joe Torsella,81,121,6,208
+Northampton,FREEMANSBURG,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,FREEMANSBURG,U.S. House,7,DEM,Susan Wild,94,131,6,231
+Northampton,FREEMANSBURG,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,FREEMANSBURG,General Assembly,136,DEM,Robert Freeman,90,130,7,227
+Northampton,FREEMANSBURG,General Assembly,136,DEM,Write-in,0,3,0,3
+Northampton,FREEMANSBURG,President,,REP,Donald J Trump,63,28,0,91
+Northampton,FREEMANSBURG,President,,REP,Bill Weld,3,0,0,3
+Northampton,FREEMANSBURG,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,FREEMANSBURG,President,,REP,Write-in,3,2,0,5
+Northampton,FREEMANSBURG,Attorney General,,REP,Heather Heidelbaugh,62,25,0,87
+Northampton,FREEMANSBURG,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,FREEMANSBURG,Auditor General,,REP,Timothy Defoor,61,25,0,86
+Northampton,FREEMANSBURG,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,FREEMANSBURG,State Treasurer,,REP,Stacy L. Garrity,61,22,0,83
+Northampton,FREEMANSBURG,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,FREEMANSBURG,U.S. House,7,REP,Dean N. Browning,38,15,0,53
+Northampton,FREEMANSBURG,U.S. House,7,REP,Lisa Scheller,29,9,0,38
+Northampton,FREEMANSBURG,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,FREEMANSBURG,General Assembly,136,REP,Write-in,0,5,0,5
+Northampton,GLENDON,Registered Voters,,,,,,,242
+Northampton,GLENDON,Registered Voters,,DEM,,,,,123
+Northampton,GLENDON,Registered Voters,,REP,,,,,74
+Northampton,GLENDON,Registered Voters,,NPA,,,,,45
+Northampton,GLENDON,Ballots Cast,,,,33,27,0,60
+Northampton,GLENDON,Ballots Cast,,DEM,,21,23,0,44
+Northampton,GLENDON,Ballots Cast,,REP,,12,4,0,16
+Northampton,GLENDON,Ballots Cast,,NPA,,0,0,0,0
+Northampton,GLENDON,President,,DEM,Joseph R. Biden,18,17,0,35
+Northampton,GLENDON,President,,DEM,Bernie Sanders,2,3,0,5
+Northampton,GLENDON,President,,DEM,Tulsi Gabbard,1,0,0,1
+Northampton,GLENDON,President,,DEM,Write-in,0,2,0,2
+Northampton,GLENDON,Attorney General,,DEM,Josh Shapiro,18,19,0,37
+Northampton,GLENDON,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,GLENDON,Auditor General,,DEM,Nina Ahmad,6,7,0,13
+Northampton,GLENDON,Auditor General,,DEM,Michael Lamb,4,3,0,7
+Northampton,GLENDON,Auditor General,,DEM,H Scott Conklin,2,3,0,5
+Northampton,GLENDON,Auditor General,,DEM,Tracie Fountain,2,3,0,5
+Northampton,GLENDON,Auditor General,,DEM,Christina M. Hartman,2,3,0,5
+Northampton,GLENDON,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,0,4
+Northampton,GLENDON,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,GLENDON,State Treasurer,,DEM,Joe Torsella,15,19,0,34
+Northampton,GLENDON,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,GLENDON,U.S. House,7,DEM,Susan Wild,18,23,0,41
+Northampton,GLENDON,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,GLENDON,General Assembly,136,DEM,Robert Freeman,18,23,0,41
+Northampton,GLENDON,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,GLENDON,President,,REP,Donald J Trump,12,3,0,15
+Northampton,GLENDON,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,GLENDON,President,,REP,Bill Weld,0,0,0,0
+Northampton,GLENDON,President,,REP,Write-in,0,1,0,1
+Northampton,GLENDON,Attorney General,,REP,Heather Heidelbaugh,8,4,0,12
+Northampton,GLENDON,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,GLENDON,Auditor General,,REP,Timothy Defoor,9,3,0,12
+Northampton,GLENDON,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,GLENDON,State Treasurer,,REP,Stacy L. Garrity,9,4,0,13
+Northampton,GLENDON,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,GLENDON,U.S. House,7,REP,Lisa Scheller,8,4,0,12
+Northampton,GLENDON,U.S. House,7,REP,Dean N. Browning,3,0,0,3
+Northampton,GLENDON,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,GLENDON,General Assembly,136,REP,Write-in,0,0,0,0
+Northampton,HANOVER #1,Registered Voters,,,,,,,1925
+Northampton,HANOVER #1,Registered Voters,,DEM,,,,,936
+Northampton,HANOVER #1,Registered Voters,,REP,,,,,682
+Northampton,HANOVER #1,Registered Voters,,NPA,,,,,307
+Northampton,HANOVER #1,Ballots Cast,,,,192,564,5,761
+Northampton,HANOVER #1,Ballots Cast,,DEM,,67,398,1,466
+Northampton,HANOVER #1,Ballots Cast,,REP,,125,166,4,295
+Northampton,HANOVER #1,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HANOVER #1,President,,DEM,Joseph R. Biden,45,357,0,402
+Northampton,HANOVER #1,President,,DEM,Bernie Sanders,13,29,1,43
+Northampton,HANOVER #1,President,,DEM,Tulsi Gabbard,5,5,0,10
+Northampton,HANOVER #1,President,,DEM,Write-in,0,4,0,4
+Northampton,HANOVER #1,Attorney General,,DEM,Josh Shapiro,44,363,0,407
+Northampton,HANOVER #1,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,HANOVER #1,Auditor General,,DEM,Nina Ahmad,13,116,0,129
+Northampton,HANOVER #1,Auditor General,,DEM,Christina M. Hartman,8,70,0,78
+Northampton,HANOVER #1,Auditor General,,DEM,Rose Rosie Marie Davis,5,55,0,60
+Northampton,HANOVER #1,Auditor General,,DEM,Michael Lamb,12,37,0,49
+Northampton,HANOVER #1,Auditor General,,DEM,Tracie Fountain,4,35,1,40
+Northampton,HANOVER #1,Auditor General,,DEM,H Scott Conklin,11,20,0,31
+Northampton,HANOVER #1,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #1,State Treasurer,,DEM,Joe Torsella,47,356,0,403
+Northampton,HANOVER #1,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,HANOVER #1,U.S. House,7,DEM,Susan Wild,56,383,0,439
+Northampton,HANOVER #1,U.S. House,7,DEM,Write-in,0,3,0,3
+Northampton,HANOVER #1,General Assembly,138,DEM,Tara Zrinski,55,359,1,415
+Northampton,HANOVER #1,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #1,President,,REP,Donald J Trump,120,127,4,251
+Northampton,HANOVER #1,President,,REP,Bill Weld,2,17,0,19
+Northampton,HANOVER #1,President,,REP,Roque Rocky De La Fuente,1,3,0,4
+Northampton,HANOVER #1,President,,REP,Write-in,0,4,0,4
+Northampton,HANOVER #1,Attorney General,,REP,Heather Heidelbaugh,96,136,1,233
+Northampton,HANOVER #1,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,HANOVER #1,Auditor General,,REP,Timothy Defoor,96,136,1,233
+Northampton,HANOVER #1,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,HANOVER #1,State Treasurer,,REP,Stacy L. Garrity,99,135,3,237
+Northampton,HANOVER #1,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,HANOVER #1,U.S. House,7,REP,Lisa Scheller,71,91,4,166
+Northampton,HANOVER #1,U.S. House,7,REP,Dean N. Browning,52,66,0,118
+Northampton,HANOVER #1,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,HANOVER #1,General Assembly,138,REP,Ann Flood,46,86,4,136
+Northampton,HANOVER #1,General Assembly,138,REP,Tony Tarsi,75,59,0,134
+Northampton,HANOVER #1,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,HANOVER #2,Registered Voters,,,,,,,1956
+Northampton,HANOVER #2,Registered Voters,,DEM,,,,,961
+Northampton,HANOVER #2,Registered Voters,,REP,,,,,719
+Northampton,HANOVER #2,Registered Voters,,NPA,,,,,276
+Northampton,HANOVER #2,Ballots Cast,,,,260,468,13,741
+Northampton,HANOVER #2,Ballots Cast,,DEM,,107,338,8,453
+Northampton,HANOVER #2,Ballots Cast,,REP,,153,130,5,288
+Northampton,HANOVER #2,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HANOVER #2,President,,DEM,Joseph R. Biden,68,286,7,361
+Northampton,HANOVER #2,President,,DEM,Bernie Sanders,25,40,1,66
+Northampton,HANOVER #2,President,,DEM,Tulsi Gabbard,7,3,0,10
+Northampton,HANOVER #2,President,,DEM,Write-in,3,5,0,8
+Northampton,HANOVER #2,Attorney General,,DEM,Josh Shapiro,67,303,8,378
+Northampton,HANOVER #2,Attorney General,,DEM,Write-in,1,1,0,2
+Northampton,HANOVER #2,Auditor General,,DEM,Nina Ahmad,28,97,3,128
+Northampton,HANOVER #2,Auditor General,,DEM,Michael Lamb,23,44,2,69
+Northampton,HANOVER #2,Auditor General,,DEM,Christina M. Hartman,8,56,0,64
+Northampton,HANOVER #2,Auditor General,,DEM,Rose Rosie Marie Davis,11,47,0,58
+Northampton,HANOVER #2,Auditor General,,DEM,Tracie Fountain,6,34,0,40
+Northampton,HANOVER #2,Auditor General,,DEM,H Scott Conklin,12,22,1,35
+Northampton,HANOVER #2,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,HANOVER #2,State Treasurer,,DEM,Joe Torsella,75,290,8,373
+Northampton,HANOVER #2,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #2,U.S. House,7,DEM,Susan Wild,79,320,8,407
+Northampton,HANOVER #2,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,HANOVER #2,General Assembly,138,DEM,Tara Zrinski,81,297,8,386
+Northampton,HANOVER #2,General Assembly,138,DEM,Write-in,0,2,0,2
+Northampton,HANOVER #2,President,,REP,Donald J Trump,138,106,5,249
+Northampton,HANOVER #2,President,,REP,Bill Weld,6,4,0,10
+Northampton,HANOVER #2,President,,REP,Roque Rocky De La Fuente,4,2,0,6
+Northampton,HANOVER #2,President,,REP,Write-in,0,7,0,7
+Northampton,HANOVER #2,Attorney General,,REP,Heather Heidelbaugh,123,113,4,240
+Northampton,HANOVER #2,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,HANOVER #2,Auditor General,,REP,Timothy Defoor,120,110,4,234
+Northampton,HANOVER #2,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,HANOVER #2,State Treasurer,,REP,Stacy L. Garrity,121,110,4,235
+Northampton,HANOVER #2,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,HANOVER #2,U.S. House,7,REP,Lisa Scheller,97,67,3,167
+Northampton,HANOVER #2,U.S. House,7,REP,Dean N. Browning,55,54,2,111
+Northampton,HANOVER #2,U.S. House,7,REP,Write-in,0,4,0,4
+Northampton,HANOVER #2,General Assembly,138,REP,Ann Flood,68,65,2,135
+Northampton,HANOVER #2,General Assembly,138,REP,Tony Tarsi,76,54,3,133
+Northampton,HANOVER #2,General Assembly,138,REP,Write-in,0,2,0,2
+Northampton,HANOVER #3,Registered Voters,,,,,,,952
+Northampton,HANOVER #3,Registered Voters,,DEM,,,,,405
+Northampton,HANOVER #3,Registered Voters,,REP,,,,,394
+Northampton,HANOVER #3,Registered Voters,,NPA,,,,,153
+Northampton,HANOVER #3,Ballots Cast,,,,161,203,5,369
+Northampton,HANOVER #3,Ballots Cast,,DEM,,40,138,5,183
+Northampton,HANOVER #3,Ballots Cast,,REP,,121,65,0,186
+Northampton,HANOVER #3,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HANOVER #3,President,,DEM,Joseph R. Biden,31,108,2,141
+Northampton,HANOVER #3,President,,DEM,Bernie Sanders,8,25,3,36
+Northampton,HANOVER #3,President,,DEM,Tulsi Gabbard,1,2,0,3
+Northampton,HANOVER #3,President,,DEM,Write-in,0,3,0,3
+Northampton,HANOVER #3,Attorney General,,DEM,Josh Shapiro,28,124,5,157
+Northampton,HANOVER #3,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #3,Auditor General,,DEM,Nina Ahmad,7,38,1,46
+Northampton,HANOVER #3,Auditor General,,DEM,Michael Lamb,9,16,1,26
+Northampton,HANOVER #3,Auditor General,,DEM,Christina M. Hartman,5,18,1,24
+Northampton,HANOVER #3,Auditor General,,DEM,Tracie Fountain,2,18,1,21
+Northampton,HANOVER #3,Auditor General,,DEM,Rose Rosie Marie Davis,2,17,0,19
+Northampton,HANOVER #3,Auditor General,,DEM,H Scott Conklin,5,9,0,14
+Northampton,HANOVER #3,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #3,State Treasurer,,DEM,Joe Torsella,28,119,4,151
+Northampton,HANOVER #3,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #3,U.S. House,7,DEM,Susan Wild,33,133,5,171
+Northampton,HANOVER #3,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #3,General Assembly,138,DEM,Tara Zrinski,34,125,5,164
+Northampton,HANOVER #3,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #3,President,,REP,Donald J Trump,113,49,0,162
+Northampton,HANOVER #3,President,,REP,Bill Weld,5,9,0,14
+Northampton,HANOVER #3,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,HANOVER #3,President,,REP,Write-in,0,4,0,4
+Northampton,HANOVER #3,Attorney General,,REP,Heather Heidelbaugh,104,46,0,150
+Northampton,HANOVER #3,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,HANOVER #3,Auditor General,,REP,Timothy Defoor,107,45,0,152
+Northampton,HANOVER #3,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,HANOVER #3,State Treasurer,,REP,Stacy L. Garrity,107,46,0,153
+Northampton,HANOVER #3,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,HANOVER #3,U.S. House,7,REP,Lisa Scheller,59,42,0,101
+Northampton,HANOVER #3,U.S. House,7,REP,Dean N. Browning,60,17,0,77
+Northampton,HANOVER #3,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,HANOVER #3,General Assembly,138,REP,Tony Tarsi,77,24,0,101
+Northampton,HANOVER #3,General Assembly,138,REP,Ann Flood,40,28,0,68
+Northampton,HANOVER #3,General Assembly,138,REP,Write-in,0,2,0,2
+Northampton,HANOVER #4,Registered Voters,,,,,,,1682
+Northampton,HANOVER #4,Registered Voters,,DEM,,,,,757
+Northampton,HANOVER #4,Registered Voters,,REP,,,,,689
+Northampton,HANOVER #4,Registered Voters,,NPA,,,,,236
+Northampton,HANOVER #4,Ballots Cast,,,,191,429,7,627
+Northampton,HANOVER #4,Ballots Cast,,DEM,,65,293,3,361
+Northampton,HANOVER #4,Ballots Cast,,REP,,126,136,4,266
+Northampton,HANOVER #4,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HANOVER #4,President,,DEM,Joseph R. Biden,46,248,2,296
+Northampton,HANOVER #4,President,,DEM,Bernie Sanders,15,33,1,49
+Northampton,HANOVER #4,President,,DEM,Tulsi Gabbard,2,6,0,8
+Northampton,HANOVER #4,President,,DEM,Write-in,0,3,0,3
+Northampton,HANOVER #4,Attorney General,,DEM,Josh Shapiro,45,257,1,303
+Northampton,HANOVER #4,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,HANOVER #4,Auditor General,,DEM,Nina Ahmad,18,85,0,103
+Northampton,HANOVER #4,Auditor General,,DEM,Christina M. Hartman,4,54,0,58
+Northampton,HANOVER #4,Auditor General,,DEM,Michael Lamb,10,32,1,43
+Northampton,HANOVER #4,Auditor General,,DEM,Rose Rosie Marie Davis,9,28,0,37
+Northampton,HANOVER #4,Auditor General,,DEM,Tracie Fountain,3,29,0,32
+Northampton,HANOVER #4,Auditor General,,DEM,H Scott Conklin,6,17,0,23
+Northampton,HANOVER #4,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #4,State Treasurer,,DEM,Joe Torsella,46,255,1,302
+Northampton,HANOVER #4,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #4,U.S. House,7,DEM,Susan Wild,54,275,3,332
+Northampton,HANOVER #4,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,HANOVER #4,General Assembly,138,DEM,Tara Zrinski,51,248,1,300
+Northampton,HANOVER #4,General Assembly,138,DEM,Write-in,0,6,0,6
+Northampton,HANOVER #4,President,,REP,Donald J Trump,117,104,3,224
+Northampton,HANOVER #4,President,,REP,Bill Weld,3,21,0,24
+Northampton,HANOVER #4,President,,REP,Roque Rocky De La Fuente,0,3,0,3
+Northampton,HANOVER #4,President,,REP,Write-in,1,2,0,3
+Northampton,HANOVER #4,Attorney General,,REP,Heather Heidelbaugh,106,107,4,217
+Northampton,HANOVER #4,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,HANOVER #4,Auditor General,,REP,Timothy Defoor,105,105,3,213
+Northampton,HANOVER #4,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,HANOVER #4,State Treasurer,,REP,Stacy L. Garrity,105,108,4,217
+Northampton,HANOVER #4,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,HANOVER #4,U.S. House,7,REP,Lisa Scheller,52,83,1,136
+Northampton,HANOVER #4,U.S. House,7,REP,Dean N. Browning,68,46,3,117
+Northampton,HANOVER #4,U.S. House,7,REP,Write-in,0,3,0,3
+Northampton,HANOVER #4,General Assembly,138,REP,Ann Flood,42,83,2,127
+Northampton,HANOVER #4,General Assembly,138,REP,Tony Tarsi,78,43,2,123
+Northampton,HANOVER #4,General Assembly,138,REP,Write-in,1,1,0,2
+Northampton,HANOVER #5,Registered Voters,,,,,,,1604
+Northampton,HANOVER #5,Registered Voters,,DEM,,,,,682
+Northampton,HANOVER #5,Registered Voters,,REP,,,,,592
+Northampton,HANOVER #5,Registered Voters,,NPA,,,,,330
+Northampton,HANOVER #5,Ballots Cast,,,,188,404,13,605
+Northampton,HANOVER #5,Ballots Cast,,DEM,,75,276,11,362
+Northampton,HANOVER #5,Ballots Cast,,REP,,113,128,2,243
+Northampton,HANOVER #5,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HANOVER #5,President,,DEM,Joseph R. Biden,57,240,6,303
+Northampton,HANOVER #5,President,,DEM,Bernie Sanders,11,25,2,38
+Northampton,HANOVER #5,President,,DEM,Tulsi Gabbard,3,4,0,7
+Northampton,HANOVER #5,President,,DEM,Write-in,2,4,0,6
+Northampton,HANOVER #5,Attorney General,,DEM,Josh Shapiro,59,256,11,326
+Northampton,HANOVER #5,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #5,Auditor General,,DEM,Nina Ahmad,27,86,5,118
+Northampton,HANOVER #5,Auditor General,,DEM,Christina M. Hartman,6,56,0,62
+Northampton,HANOVER #5,Auditor General,,DEM,Rose Rosie Marie Davis,9,22,2,33
+Northampton,HANOVER #5,Auditor General,,DEM,H Scott Conklin,11,19,2,32
+Northampton,HANOVER #5,Auditor General,,DEM,Michael Lamb,7,22,0,29
+Northampton,HANOVER #5,Auditor General,,DEM,Tracie Fountain,5,23,1,29
+Northampton,HANOVER #5,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #5,State Treasurer,,DEM,Joe Torsella,56,252,10,318
+Northampton,HANOVER #5,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #5,U.S. House,7,DEM,Susan Wild,65,265,9,339
+Northampton,HANOVER #5,U.S. House,7,DEM,Write-in,0,3,0,3
+Northampton,HANOVER #5,General Assembly,138,DEM,Tara Zrinski,63,254,10,327
+Northampton,HANOVER #5,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #5,President,,REP,Donald J Trump,107,104,2,213
+Northampton,HANOVER #5,President,,REP,Bill Weld,3,12,0,15
+Northampton,HANOVER #5,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Northampton,HANOVER #5,President,,REP,Write-in,0,4,0,4
+Northampton,HANOVER #5,Attorney General,,REP,Heather Heidelbaugh,92,107,2,201
+Northampton,HANOVER #5,Attorney General,,REP,Write-in,0,4,0,4
+Northampton,HANOVER #5,Auditor General,,REP,Timothy Defoor,90,105,2,197
+Northampton,HANOVER #5,Auditor General,,REP,Write-in,0,2,0,2
+Northampton,HANOVER #5,State Treasurer,,REP,Stacy L. Garrity,90,103,2,195
+Northampton,HANOVER #5,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,HANOVER #5,U.S. House,7,REP,Lisa Scheller,54,72,1,127
+Northampton,HANOVER #5,U.S. House,7,REP,Dean N. Browning,55,45,1,101
+Northampton,HANOVER #5,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,HANOVER #5,General Assembly,138,REP,Tony Tarsi,73,53,2,128
+Northampton,HANOVER #5,General Assembly,138,REP,Ann Flood,37,56,0,93
+Northampton,HANOVER #5,General Assembly,138,REP,Write-in,0,2,0,2
+Northampton,HANOVER #6,Registered Voters,,,,,,,1155
+Northampton,HANOVER #6,Registered Voters,,DEM,,,,,475
+Northampton,HANOVER #6,Registered Voters,,REP,,,,,489
+Northampton,HANOVER #6,Registered Voters,,NPA,,,,,191
+Northampton,HANOVER #6,Ballots Cast,,,,183,258,5,446
+Northampton,HANOVER #6,Ballots Cast,,DEM,,57,187,1,245
+Northampton,HANOVER #6,Ballots Cast,,REP,,126,71,4,201
+Northampton,HANOVER #6,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HANOVER #6,President,,DEM,Joseph R. Biden,31,150,0,181
+Northampton,HANOVER #6,President,,DEM,Bernie Sanders,24,29,1,54
+Northampton,HANOVER #6,President,,DEM,Tulsi Gabbard,1,5,0,6
+Northampton,HANOVER #6,President,,DEM,Write-in,1,1,0,2
+Northampton,HANOVER #6,Attorney General,,DEM,Josh Shapiro,39,169,1,209
+Northampton,HANOVER #6,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #6,Auditor General,,DEM,Nina Ahmad,18,64,1,83
+Northampton,HANOVER #6,Auditor General,,DEM,Christina M. Hartman,2,31,0,33
+Northampton,HANOVER #6,Auditor General,,DEM,H Scott Conklin,11,15,0,26
+Northampton,HANOVER #6,Auditor General,,DEM,Rose Rosie Marie Davis,4,20,0,24
+Northampton,HANOVER #6,Auditor General,,DEM,Tracie Fountain,4,19,0,23
+Northampton,HANOVER #6,Auditor General,,DEM,Michael Lamb,13,9,0,22
+Northampton,HANOVER #6,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,HANOVER #6,State Treasurer,,DEM,Joe Torsella,41,162,1,204
+Northampton,HANOVER #6,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,HANOVER #6,U.S. House,7,DEM,Susan Wild,44,179,1,224
+Northampton,HANOVER #6,U.S. House,7,DEM,Write-in,0,4,0,4
+Northampton,HANOVER #6,General Assembly,138,DEM,Tara Zrinski,44,161,1,206
+Northampton,HANOVER #6,General Assembly,138,DEM,Write-in,0,1,0,1
+Northampton,HANOVER #6,President,,REP,Donald J Trump,111,57,4,172
+Northampton,HANOVER #6,President,,REP,Bill Weld,10,6,0,16
+Northampton,HANOVER #6,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,HANOVER #6,President,,REP,Write-in,2,3,0,5
+Northampton,HANOVER #6,Attorney General,,REP,Heather Heidelbaugh,96,64,4,164
+Northampton,HANOVER #6,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,HANOVER #6,Auditor General,,REP,Timothy Defoor,100,64,4,168
+Northampton,HANOVER #6,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,HANOVER #6,State Treasurer,,REP,Stacy L. Garrity,97,65,3,165
+Northampton,HANOVER #6,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,HANOVER #6,U.S. House,7,REP,Lisa Scheller,63,40,3,106
+Northampton,HANOVER #6,U.S. House,7,REP,Dean N. Browning,57,27,1,85
+Northampton,HANOVER #6,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,HANOVER #6,General Assembly,138,REP,Tony Tarsi,86,41,2,129
+Northampton,HANOVER #6,General Assembly,138,REP,Ann Flood,38,28,2,68
+Northampton,HANOVER #6,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 1ST WARD,Registered Voters,,,,,,,1331
+Northampton,HELLERTOWN BORO 1ST WARD,Registered Voters,,DEM,,,,,634
+Northampton,HELLERTOWN BORO 1ST WARD,Registered Voters,,REP,,,,,456
+Northampton,HELLERTOWN BORO 1ST WARD,Registered Voters,,NPA,,,,,241
+Northampton,HELLERTOWN BORO 1ST WARD,Ballots Cast,,,,203,222,0,425
+Northampton,HELLERTOWN BORO 1ST WARD,Ballots Cast,,DEM,,85,175,0,260
+Northampton,HELLERTOWN BORO 1ST WARD,Ballots Cast,,REP,,118,47,0,165
+Northampton,HELLERTOWN BORO 1ST WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HELLERTOWN BORO 1ST WARD,President,,DEM,Joseph R. Biden,45,138,0,183
+Northampton,HELLERTOWN BORO 1ST WARD,President,,DEM,Bernie Sanders,27,32,0,59
+Northampton,HELLERTOWN BORO 1ST WARD,President,,DEM,Tulsi Gabbard,6,3,0,9
+Northampton,HELLERTOWN BORO 1ST WARD,President,,DEM,Write-in,3,2,0,5
+Northampton,HELLERTOWN BORO 1ST WARD,Attorney General,,DEM,Josh Shapiro,58,148,0,206
+Northampton,HELLERTOWN BORO 1ST WARD,Attorney General,,DEM,Write-in,0,4,0,4
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,DEM,Nina Ahmad,18,49,0,67
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,DEM,Christina M. Hartman,11,35,0,46
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,DEM,H Scott Conklin,15,13,0,28
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,DEM,Tracie Fountain,4,24,0,28
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,DEM,Michael Lamb,12,10,0,22
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,6,15,0,21
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 1ST WARD,State Treasurer,,DEM,Joe Torsella,56,148,0,204
+Northampton,HELLERTOWN BORO 1ST WARD,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 1ST WARD,U.S. House,7,DEM,Susan Wild,68,161,0,229
+Northampton,HELLERTOWN BORO 1ST WARD,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,HELLERTOWN BORO 1ST WARD,General Assembly,136,DEM,Robert Freeman,72,160,0,232
+Northampton,HELLERTOWN BORO 1ST WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 1ST WARD,President,,REP,Donald J Trump,105,41,0,146
+Northampton,HELLERTOWN BORO 1ST WARD,President,,REP,Bill Weld,4,3,0,7
+Northampton,HELLERTOWN BORO 1ST WARD,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,HELLERTOWN BORO 1ST WARD,President,,REP,Write-in,1,0,0,1
+Northampton,HELLERTOWN BORO 1ST WARD,Attorney General,,REP,Heather Heidelbaugh,74,41,0,115
+Northampton,HELLERTOWN BORO 1ST WARD,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,REP,Timothy Defoor,74,42,0,116
+Northampton,HELLERTOWN BORO 1ST WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 1ST WARD,State Treasurer,,REP,Stacy L. Garrity,77,41,0,118
+Northampton,HELLERTOWN BORO 1ST WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 1ST WARD,U.S. House,7,REP,Dean N. Browning,60,23,0,83
+Northampton,HELLERTOWN BORO 1ST WARD,U.S. House,7,REP,Lisa Scheller,54,22,0,76
+Northampton,HELLERTOWN BORO 1ST WARD,U.S. House,7,REP,Write-in,2,0,0,2
+Northampton,HELLERTOWN BORO 1ST WARD,General Assembly,136,REP,Write-in,1,1,0,2
+Northampton,HELLERTOWN BORO 2ND WARD,Registered Voters,,,,,,,1120
+Northampton,HELLERTOWN BORO 2ND WARD,Registered Voters,,DEM,,,,,554
+Northampton,HELLERTOWN BORO 2ND WARD,Registered Voters,,REP,,,,,370
+Northampton,HELLERTOWN BORO 2ND WARD,Registered Voters,,NPA,,,,,196
+Northampton,HELLERTOWN BORO 2ND WARD,Ballots Cast,,,,166,191,1,358
+Northampton,HELLERTOWN BORO 2ND WARD,Ballots Cast,,DEM,,73,150,1,224
+Northampton,HELLERTOWN BORO 2ND WARD,Ballots Cast,,REP,,93,41,0,134
+Northampton,HELLERTOWN BORO 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HELLERTOWN BORO 2ND WARD,President,,DEM,Joseph R. Biden,44,104,0,148
+Northampton,HELLERTOWN BORO 2ND WARD,President,,DEM,Bernie Sanders,17,34,0,51
+Northampton,HELLERTOWN BORO 2ND WARD,President,,DEM,Tulsi Gabbard,5,3,1,9
+Northampton,HELLERTOWN BORO 2ND WARD,President,,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 2ND WARD,Attorney General,,DEM,Josh Shapiro,53,136,1,190
+Northampton,HELLERTOWN BORO 2ND WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,DEM,Nina Ahmad,16,49,0,65
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,DEM,Christina M. Hartman,6,26,0,32
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,DEM,Michael Lamb,11,14,0,25
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,9,16,0,25
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,DEM,H Scott Conklin,8,10,0,18
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,DEM,Tracie Fountain,4,14,0,18
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 2ND WARD,State Treasurer,,DEM,Joe Torsella,48,138,1,187
+Northampton,HELLERTOWN BORO 2ND WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 2ND WARD,U.S. House,7,DEM,Susan Wild,54,141,1,196
+Northampton,HELLERTOWN BORO 2ND WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 2ND WARD,General Assembly,136,DEM,Robert Freeman,59,142,1,202
+Northampton,HELLERTOWN BORO 2ND WARD,General Assembly,136,DEM,Write-in,0,2,0,2
+Northampton,HELLERTOWN BORO 2ND WARD,President,,REP,Donald J Trump,86,29,0,115
+Northampton,HELLERTOWN BORO 2ND WARD,President,,REP,Bill Weld,3,6,0,9
+Northampton,HELLERTOWN BORO 2ND WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,HELLERTOWN BORO 2ND WARD,President,,REP,Write-in,0,5,0,5
+Northampton,HELLERTOWN BORO 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,75,34,0,109
+Northampton,HELLERTOWN BORO 2ND WARD,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,REP,Timothy Defoor,70,36,0,106
+Northampton,HELLERTOWN BORO 2ND WARD,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,71,34,0,105
+Northampton,HELLERTOWN BORO 2ND WARD,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 2ND WARD,U.S. House,7,REP,Dean N. Browning,52,20,0,72
+Northampton,HELLERTOWN BORO 2ND WARD,U.S. House,7,REP,Lisa Scheller,39,18,0,57
+Northampton,HELLERTOWN BORO 2ND WARD,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 2ND WARD,General Assembly,136,REP,Write-in,0,9,0,9
+Northampton,HELLERTOWN BORO 3RD WARD,Registered Voters,,,,,,,1546
+Northampton,HELLERTOWN BORO 3RD WARD,Registered Voters,,DEM,,,,,747
+Northampton,HELLERTOWN BORO 3RD WARD,Registered Voters,,REP,,,,,522
+Northampton,HELLERTOWN BORO 3RD WARD,Registered Voters,,NPA,,,,,277
+Northampton,HELLERTOWN BORO 3RD WARD,Ballots Cast,,,,219,263,8,490
+Northampton,HELLERTOWN BORO 3RD WARD,Ballots Cast,,DEM,,104,217,4,325
+Northampton,HELLERTOWN BORO 3RD WARD,Ballots Cast,,REP,,115,46,4,165
+Northampton,HELLERTOWN BORO 3RD WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,HELLERTOWN BORO 3RD WARD,President,,DEM,Joseph R. Biden,66,170,3,239
+Northampton,HELLERTOWN BORO 3RD WARD,President,,DEM,Bernie Sanders,28,34,1,63
+Northampton,HELLERTOWN BORO 3RD WARD,President,,DEM,Tulsi Gabbard,5,6,0,11
+Northampton,HELLERTOWN BORO 3RD WARD,President,,DEM,Write-in,2,3,0,5
+Northampton,HELLERTOWN BORO 3RD WARD,Attorney General,,DEM,Josh Shapiro,83,192,4,279
+Northampton,HELLERTOWN BORO 3RD WARD,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,DEM,Nina Ahmad,25,48,3,76
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,DEM,Christina M. Hartman,13,47,0,60
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,DEM,Tracie Fountain,10,31,0,41
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,DEM,Rose Rosie Marie Davis,8,28,0,36
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,DEM,Michael Lamb,14,20,0,34
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,DEM,H Scott Conklin,15,11,1,27
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 3RD WARD,State Treasurer,,DEM,Joe Torsella,75,191,4,270
+Northampton,HELLERTOWN BORO 3RD WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 3RD WARD,U.S. House,7,DEM,Susan Wild,88,204,4,296
+Northampton,HELLERTOWN BORO 3RD WARD,U.S. House,7,DEM,Write-in,2,1,0,3
+Northampton,HELLERTOWN BORO 3RD WARD,General Assembly,136,DEM,Robert Freeman,94,200,4,298
+Northampton,HELLERTOWN BORO 3RD WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,HELLERTOWN BORO 3RD WARD,President,,REP,Donald J Trump,101,37,4,142
+Northampton,HELLERTOWN BORO 3RD WARD,President,,REP,Bill Weld,6,6,0,12
+Northampton,HELLERTOWN BORO 3RD WARD,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,HELLERTOWN BORO 3RD WARD,President,,REP,Write-in,1,2,0,3
+Northampton,HELLERTOWN BORO 3RD WARD,Attorney General,,REP,Heather Heidelbaugh,100,42,3,145
+Northampton,HELLERTOWN BORO 3RD WARD,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,REP,Timothy Defoor,98,42,3,143
+Northampton,HELLERTOWN BORO 3RD WARD,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 3RD WARD,State Treasurer,,REP,Stacy L. Garrity,101,42,3,146
+Northampton,HELLERTOWN BORO 3RD WARD,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,HELLERTOWN BORO 3RD WARD,U.S. House,7,REP,Dean N. Browning,72,14,3,89
+Northampton,HELLERTOWN BORO 3RD WARD,U.S. House,7,REP,Lisa Scheller,42,28,1,71
+Northampton,HELLERTOWN BORO 3RD WARD,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,HELLERTOWN BORO 3RD WARD,General Assembly,136,REP,Write-in,0,5,0,5
+Northampton,LEHIGH TWSP CENTRAL,Registered Voters,,,,,,,1772
+Northampton,LEHIGH TWSP CENTRAL,Registered Voters,,DEM,,,,,624
+Northampton,LEHIGH TWSP CENTRAL,Registered Voters,,REP,,,,,881
+Northampton,LEHIGH TWSP CENTRAL,Registered Voters,,NPA,,,,,267
+Northampton,LEHIGH TWSP CENTRAL,Ballots Cast,,,,291,343,7,641
+Northampton,LEHIGH TWSP CENTRAL,Ballots Cast,,DEM,,56,210,1,267
+Northampton,LEHIGH TWSP CENTRAL,Ballots Cast,,REP,,235,133,6,374
+Northampton,LEHIGH TWSP CENTRAL,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LEHIGH TWSP CENTRAL,President,,DEM,Joseph R. Biden,33,176,1,210
+Northampton,LEHIGH TWSP CENTRAL,President,,DEM,Bernie Sanders,16,26,0,42
+Northampton,LEHIGH TWSP CENTRAL,President,,DEM,Tulsi Gabbard,0,4,0,4
+Northampton,LEHIGH TWSP CENTRAL,President,,DEM,Write-in,2,3,0,5
+Northampton,LEHIGH TWSP CENTRAL,Attorney General,,DEM,Josh Shapiro,37,196,1,234
+Northampton,LEHIGH TWSP CENTRAL,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,DEM,Nina Ahmad,10,55,1,66
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,DEM,Christina M. Hartman,5,45,0,50
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,DEM,Rose Rosie Marie Davis,12,36,0,48
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,DEM,Michael Lamb,8,21,0,29
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,DEM,Tracie Fountain,3,22,0,25
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,DEM,H Scott Conklin,4,12,0,16
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP CENTRAL,State Treasurer,,DEM,Joe Torsella,38,191,1,230
+Northampton,LEHIGH TWSP CENTRAL,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP CENTRAL,U.S. House,7,DEM,Susan Wild,44,199,1,244
+Northampton,LEHIGH TWSP CENTRAL,U.S. House,7,DEM,Write-in,2,0,0,2
+Northampton,LEHIGH TWSP CENTRAL,General Assembly,183,DEM,Jason Ruff,43,195,1,239
+Northampton,LEHIGH TWSP CENTRAL,General Assembly,183,DEM,Write-in,2,0,0,2
+Northampton,LEHIGH TWSP CENTRAL,President,,REP,Donald J Trump,229,112,6,347
+Northampton,LEHIGH TWSP CENTRAL,President,,REP,Bill Weld,1,8,0,9
+Northampton,LEHIGH TWSP CENTRAL,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,LEHIGH TWSP CENTRAL,President,,REP,Write-in,0,6,0,6
+Northampton,LEHIGH TWSP CENTRAL,Attorney General,,REP,Heather Heidelbaugh,196,110,5,311
+Northampton,LEHIGH TWSP CENTRAL,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,REP,Timothy Defoor,194,107,5,306
+Northampton,LEHIGH TWSP CENTRAL,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP CENTRAL,State Treasurer,,REP,Stacy L. Garrity,197,107,5,309
+Northampton,LEHIGH TWSP CENTRAL,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP CENTRAL,U.S. House,7,REP,Dean N. Browning,161,60,4,225
+Northampton,LEHIGH TWSP CENTRAL,U.S. House,7,REP,Lisa Scheller,70,65,2,137
+Northampton,LEHIGH TWSP CENTRAL,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP CENTRAL,General Assembly,183,REP,Zach Mako,214,121,6,341
+Northampton,LEHIGH TWSP CENTRAL,General Assembly,183,REP,Write-in,5,2,0,7
+Northampton,LEHIGH TWSP DANIELSVILLE,Registered Voters,,,,,,,2038
+Northampton,LEHIGH TWSP DANIELSVILLE,Registered Voters,,DEM,,,,,832
+Northampton,LEHIGH TWSP DANIELSVILLE,Registered Voters,,REP,,,,,899
+Northampton,LEHIGH TWSP DANIELSVILLE,Registered Voters,,NPA,,,,,307
+Northampton,LEHIGH TWSP DANIELSVILLE,Ballots Cast,,,,386,347,0,733
+Northampton,LEHIGH TWSP DANIELSVILLE,Ballots Cast,,DEM,,104,234,0,338
+Northampton,LEHIGH TWSP DANIELSVILLE,Ballots Cast,,REP,,282,113,0,395
+Northampton,LEHIGH TWSP DANIELSVILLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LEHIGH TWSP DANIELSVILLE,President,,DEM,Joseph R. Biden,66,185,0,251
+Northampton,LEHIGH TWSP DANIELSVILLE,President,,DEM,Bernie Sanders,23,37,0,60
+Northampton,LEHIGH TWSP DANIELSVILLE,President,,DEM,Tulsi Gabbard,4,6,0,10
+Northampton,LEHIGH TWSP DANIELSVILLE,President,,DEM,Write-in,4,4,0,8
+Northampton,LEHIGH TWSP DANIELSVILLE,Attorney General,,DEM,Josh Shapiro,70,206,0,276
+Northampton,LEHIGH TWSP DANIELSVILLE,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,DEM,Nina Ahmad,18,57,0,75
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,DEM,Rose Rosie Marie Davis,17,51,0,68
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,DEM,Christina M. Hartman,12,36,0,48
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,DEM,Michael Lamb,17,28,0,45
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,DEM,H Scott Conklin,15,14,0,29
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,DEM,Tracie Fountain,6,17,0,23
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP DANIELSVILLE,State Treasurer,,DEM,Joe Torsella,70,201,0,271
+Northampton,LEHIGH TWSP DANIELSVILLE,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP DANIELSVILLE,U.S. House,7,DEM,Susan Wild,76,217,0,293
+Northampton,LEHIGH TWSP DANIELSVILLE,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,LEHIGH TWSP DANIELSVILLE,General Assembly,183,DEM,Jason Ruff,74,205,0,279
+Northampton,LEHIGH TWSP DANIELSVILLE,General Assembly,183,DEM,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP DANIELSVILLE,President,,REP,Donald J Trump,263,100,0,363
+Northampton,LEHIGH TWSP DANIELSVILLE,President,,REP,Bill Weld,3,5,0,8
+Northampton,LEHIGH TWSP DANIELSVILLE,President,,REP,Roque Rocky De La Fuente,3,0,0,3
+Northampton,LEHIGH TWSP DANIELSVILLE,President,,REP,Write-in,2,6,0,8
+Northampton,LEHIGH TWSP DANIELSVILLE,Attorney General,,REP,Heather Heidelbaugh,214,100,0,314
+Northampton,LEHIGH TWSP DANIELSVILLE,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,REP,Timothy Defoor,213,99,0,312
+Northampton,LEHIGH TWSP DANIELSVILLE,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP DANIELSVILLE,State Treasurer,,REP,Stacy L. Garrity,220,101,0,321
+Northampton,LEHIGH TWSP DANIELSVILLE,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP DANIELSVILLE,U.S. House,7,REP,Dean N. Browning,173,50,0,223
+Northampton,LEHIGH TWSP DANIELSVILLE,U.S. House,7,REP,Lisa Scheller,100,56,0,156
+Northampton,LEHIGH TWSP DANIELSVILLE,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,LEHIGH TWSP DANIELSVILLE,General Assembly,183,REP,Zach Mako,258,106,0,364
+Northampton,LEHIGH TWSP DANIELSVILLE,General Assembly,183,REP,Write-in,1,1,0,2
+Northampton,LEHIGH TWSP PENNSVILLE,Registered Voters,,,,,,,1554
+Northampton,LEHIGH TWSP PENNSVILLE,Registered Voters,,DEM,,,,,546
+Northampton,LEHIGH TWSP PENNSVILLE,Registered Voters,,REP,,,,,754
+Northampton,LEHIGH TWSP PENNSVILLE,Registered Voters,,NPA,,,,,254
+Northampton,LEHIGH TWSP PENNSVILLE,Ballots Cast,,,,232,289,12,533
+Northampton,LEHIGH TWSP PENNSVILLE,Ballots Cast,,DEM,,52,182,6,240
+Northampton,LEHIGH TWSP PENNSVILLE,Ballots Cast,,REP,,180,107,6,293
+Northampton,LEHIGH TWSP PENNSVILLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LEHIGH TWSP PENNSVILLE,President,,DEM,Joseph R. Biden,31,148,4,183
+Northampton,LEHIGH TWSP PENNSVILLE,President,,DEM,Bernie Sanders,15,22,1,38
+Northampton,LEHIGH TWSP PENNSVILLE,President,,DEM,Tulsi Gabbard,1,3,1,5
+Northampton,LEHIGH TWSP PENNSVILLE,President,,DEM,Write-in,2,5,0,7
+Northampton,LEHIGH TWSP PENNSVILLE,Attorney General,,DEM,Josh Shapiro,38,162,4,204
+Northampton,LEHIGH TWSP PENNSVILLE,Attorney General,,DEM,Write-in,0,2,1,3
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,DEM,Nina Ahmad,13,42,1,56
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,DEM,Rose Rosie Marie Davis,6,41,1,48
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,DEM,Christina M. Hartman,5,37,0,42
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,DEM,Michael Lamb,9,17,1,27
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,DEM,H Scott Conklin,7,10,0,17
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,DEM,Tracie Fountain,1,9,0,10
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP PENNSVILLE,State Treasurer,,DEM,Joe Torsella,40,157,4,201
+Northampton,LEHIGH TWSP PENNSVILLE,State Treasurer,,DEM,Write-in,0,1,1,2
+Northampton,LEHIGH TWSP PENNSVILLE,U.S. House,7,DEM,Susan Wild,47,166,5,218
+Northampton,LEHIGH TWSP PENNSVILLE,U.S. House,7,DEM,Write-in,0,3,1,4
+Northampton,LEHIGH TWSP PENNSVILLE,General Assembly,183,DEM,Jason Ruff,44,159,5,208
+Northampton,LEHIGH TWSP PENNSVILLE,General Assembly,183,DEM,Write-in,0,2,1,3
+Northampton,LEHIGH TWSP PENNSVILLE,President,,REP,Donald J Trump,170,97,6,273
+Northampton,LEHIGH TWSP PENNSVILLE,President,,REP,Bill Weld,4,5,0,9
+Northampton,LEHIGH TWSP PENNSVILLE,President,,REP,Roque Rocky De La Fuente,2,4,0,6
+Northampton,LEHIGH TWSP PENNSVILLE,President,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP PENNSVILLE,Attorney General,,REP,Heather Heidelbaugh,143,85,5,233
+Northampton,LEHIGH TWSP PENNSVILLE,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,REP,Timothy Defoor,146,83,4,233
+Northampton,LEHIGH TWSP PENNSVILLE,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP PENNSVILLE,State Treasurer,,REP,Stacy L. Garrity,143,85,5,233
+Northampton,LEHIGH TWSP PENNSVILLE,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP PENNSVILLE,U.S. House,7,REP,Dean N. Browning,112,45,4,161
+Northampton,LEHIGH TWSP PENNSVILLE,U.S. House,7,REP,Lisa Scheller,64,55,1,120
+Northampton,LEHIGH TWSP PENNSVILLE,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,LEHIGH TWSP PENNSVILLE,General Assembly,183,REP,Zach Mako,163,96,5,264
+Northampton,LEHIGH TWSP PENNSVILLE,General Assembly,183,REP,Write-in,0,2,0,2
+Northampton,LEHIGH TWSP TREICHLERS,Registered Voters,,,,,,,1114
+Northampton,LEHIGH TWSP TREICHLERS,Registered Voters,,DEM,,,,,401
+Northampton,LEHIGH TWSP TREICHLERS,Registered Voters,,REP,,,,,548
+Northampton,LEHIGH TWSP TREICHLERS,Registered Voters,,NPA,,,,,165
+Northampton,LEHIGH TWSP TREICHLERS,Ballots Cast,,,,195,197,6,398
+Northampton,LEHIGH TWSP TREICHLERS,Ballots Cast,,DEM,,33,114,0,147
+Northampton,LEHIGH TWSP TREICHLERS,Ballots Cast,,REP,,162,83,6,251
+Northampton,LEHIGH TWSP TREICHLERS,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LEHIGH TWSP TREICHLERS,President,,DEM,Joseph R. Biden,24,90,0,114
+Northampton,LEHIGH TWSP TREICHLERS,President,,DEM,Bernie Sanders,4,19,0,23
+Northampton,LEHIGH TWSP TREICHLERS,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,LEHIGH TWSP TREICHLERS,President,,DEM,Write-in,2,3,0,5
+Northampton,LEHIGH TWSP TREICHLERS,Attorney General,,DEM,Josh Shapiro,26,107,0,133
+Northampton,LEHIGH TWSP TREICHLERS,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,DEM,Nina Ahmad,10,26,0,36
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,DEM,Christina M. Hartman,2,24,0,26
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,DEM,Michael Lamb,7,12,0,19
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,DEM,Tracie Fountain,3,14,0,17
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,DEM,Rose Rosie Marie Davis,3,12,0,15
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,DEM,H Scott Conklin,5,9,0,14
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP TREICHLERS,State Treasurer,,DEM,Joe Torsella,24,104,0,128
+Northampton,LEHIGH TWSP TREICHLERS,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP TREICHLERS,U.S. House,7,DEM,Susan Wild,27,107,0,134
+Northampton,LEHIGH TWSP TREICHLERS,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP TREICHLERS,General Assembly,183,DEM,Jason Ruff,25,106,0,131
+Northampton,LEHIGH TWSP TREICHLERS,General Assembly,183,DEM,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP TREICHLERS,President,,REP,Donald J Trump,152,70,5,227
+Northampton,LEHIGH TWSP TREICHLERS,President,,REP,Bill Weld,2,6,0,8
+Northampton,LEHIGH TWSP TREICHLERS,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,LEHIGH TWSP TREICHLERS,President,,REP,Write-in,1,2,0,3
+Northampton,LEHIGH TWSP TREICHLERS,Attorney General,,REP,Heather Heidelbaugh,137,66,3,206
+Northampton,LEHIGH TWSP TREICHLERS,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,REP,Timothy Defoor,136,65,3,204
+Northampton,LEHIGH TWSP TREICHLERS,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP TREICHLERS,State Treasurer,,REP,Stacy L. Garrity,133,65,3,201
+Northampton,LEHIGH TWSP TREICHLERS,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP TREICHLERS,U.S. House,7,REP,Dean N. Browning,111,44,2,157
+Northampton,LEHIGH TWSP TREICHLERS,U.S. House,7,REP,Lisa Scheller,48,34,3,85
+Northampton,LEHIGH TWSP TREICHLERS,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP TREICHLERS,General Assembly,183,REP,Zach Mako,140,73,5,218
+Northampton,LEHIGH TWSP TREICHLERS,General Assembly,183,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP NORTHWESTERN,Registered Voters,,,,,,,838
+Northampton,LEHIGH TWSP NORTHWESTERN,Registered Voters,,DEM,,,,,295
+Northampton,LEHIGH TWSP NORTHWESTERN,Registered Voters,,REP,,,,,395
+Northampton,LEHIGH TWSP NORTHWESTERN,Registered Voters,,NPA,,,,,148
+Northampton,LEHIGH TWSP NORTHWESTERN,Ballots Cast,,,,153,104,2,259
+Northampton,LEHIGH TWSP NORTHWESTERN,Ballots Cast,,DEM,,42,76,0,118
+Northampton,LEHIGH TWSP NORTHWESTERN,Ballots Cast,,REP,,111,28,2,141
+Northampton,LEHIGH TWSP NORTHWESTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LEHIGH TWSP NORTHWESTERN,President,,DEM,Joseph R. Biden,25,61,0,86
+Northampton,LEHIGH TWSP NORTHWESTERN,President,,DEM,Bernie Sanders,10,10,0,20
+Northampton,LEHIGH TWSP NORTHWESTERN,President,,DEM,Tulsi Gabbard,0,3,0,3
+Northampton,LEHIGH TWSP NORTHWESTERN,President,,DEM,Write-in,6,2,0,8
+Northampton,LEHIGH TWSP NORTHWESTERN,Attorney General,,DEM,Josh Shapiro,28,69,0,97
+Northampton,LEHIGH TWSP NORTHWESTERN,Attorney General,,DEM,Write-in,5,0,0,5
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,DEM,Nina Ahmad,8,21,0,29
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,DEM,Rose Rosie Marie Davis,6,17,0,23
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,DEM,Michael Lamb,6,6,0,12
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,DEM,Tracie Fountain,1,10,0,11
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,DEM,Christina M. Hartman,2,9,0,11
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,DEM,H Scott Conklin,7,2,0,9
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,DEM,Write-in,4,0,0,4
+Northampton,LEHIGH TWSP NORTHWESTERN,State Treasurer,,DEM,Joe Torsella,29,68,0,97
+Northampton,LEHIGH TWSP NORTHWESTERN,State Treasurer,,DEM,Write-in,3,0,0,3
+Northampton,LEHIGH TWSP NORTHWESTERN,U.S. House,7,DEM,Susan Wild,36,69,0,105
+Northampton,LEHIGH TWSP NORTHWESTERN,U.S. House,7,DEM,Write-in,2,1,0,3
+Northampton,LEHIGH TWSP NORTHWESTERN,General Assembly,183,DEM,Jason Ruff,32,65,0,97
+Northampton,LEHIGH TWSP NORTHWESTERN,General Assembly,183,DEM,Write-in,2,1,0,3
+Northampton,LEHIGH TWSP NORTHWESTERN,President,,REP,Donald J Trump,107,25,1,133
+Northampton,LEHIGH TWSP NORTHWESTERN,President,,REP,Bill Weld,3,1,1,5
+Northampton,LEHIGH TWSP NORTHWESTERN,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,LEHIGH TWSP NORTHWESTERN,President,,REP,Write-in,0,1,0,1
+Northampton,LEHIGH TWSP NORTHWESTERN,Attorney General,,REP,Heather Heidelbaugh,96,23,2,121
+Northampton,LEHIGH TWSP NORTHWESTERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,REP,Timothy Defoor,95,22,2,119
+Northampton,LEHIGH TWSP NORTHWESTERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP NORTHWESTERN,State Treasurer,,REP,Stacy L. Garrity,96,23,2,121
+Northampton,LEHIGH TWSP NORTHWESTERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP NORTHWESTERN,U.S. House,7,REP,Dean N. Browning,92,11,1,104
+Northampton,LEHIGH TWSP NORTHWESTERN,U.S. House,7,REP,Lisa Scheller,18,11,1,30
+Northampton,LEHIGH TWSP NORTHWESTERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,LEHIGH TWSP NORTHWESTERN,General Assembly,183,REP,Zach Mako,98,26,2,126
+Northampton,LEHIGH TWSP NORTHWESTERN,General Assembly,183,REP,Write-in,2,0,0,2
+Northampton,LOWER MT BETHEL LOWER,Registered Voters,,,,,,,798
+Northampton,LOWER MT BETHEL LOWER,Registered Voters,,DEM,,,,,334
+Northampton,LOWER MT BETHEL LOWER,Registered Voters,,REP,,,,,321
+Northampton,LOWER MT BETHEL LOWER,Registered Voters,,NPA,,,,,143
+Northampton,LOWER MT BETHEL LOWER,Ballots Cast,,,,121,132,5,258
+Northampton,LOWER MT BETHEL LOWER,Ballots Cast,,DEM,,35,98,0,133
+Northampton,LOWER MT BETHEL LOWER,Ballots Cast,,REP,,86,34,5,125
+Northampton,LOWER MT BETHEL LOWER,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER MT BETHEL LOWER,President,,DEM,Joseph R. Biden,20,77,0,97
+Northampton,LOWER MT BETHEL LOWER,President,,DEM,Bernie Sanders,8,11,0,19
+Northampton,LOWER MT BETHEL LOWER,President,,DEM,Tulsi Gabbard,4,7,0,11
+Northampton,LOWER MT BETHEL LOWER,President,,DEM,Write-in,0,2,0,2
+Northampton,LOWER MT BETHEL LOWER,Attorney General,,DEM,Josh Shapiro,26,76,0,102
+Northampton,LOWER MT BETHEL LOWER,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,DEM,Nina Ahmad,8,26,0,34
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,DEM,Rose Rosie Marie Davis,9,23,0,32
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,DEM,Christina M. Hartman,2,14,0,16
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,DEM,H Scott Conklin,5,5,0,10
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,DEM,Michael Lamb,3,5,0,8
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,DEM,Tracie Fountain,1,4,0,5
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,LOWER MT BETHEL LOWER,State Treasurer,,DEM,Joe Torsella,22,78,0,100
+Northampton,LOWER MT BETHEL LOWER,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,LOWER MT BETHEL LOWER,U.S. House,7,DEM,Susan Wild,27,87,0,114
+Northampton,LOWER MT BETHEL LOWER,U.S. House,7,DEM,Write-in,0,3,0,3
+Northampton,LOWER MT BETHEL LOWER,General Assembly,137,DEM,Katelind Brennan,23,77,0,100
+Northampton,LOWER MT BETHEL LOWER,General Assembly,137,DEM,Write-in,0,2,0,2
+Northampton,LOWER MT BETHEL LOWER,President,,REP,Donald J Trump,78,28,5,111
+Northampton,LOWER MT BETHEL LOWER,President,,REP,Bill Weld,5,2,0,7
+Northampton,LOWER MT BETHEL LOWER,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Northampton,LOWER MT BETHEL LOWER,President,,REP,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL LOWER,Attorney General,,REP,Heather Heidelbaugh,65,26,3,94
+Northampton,LOWER MT BETHEL LOWER,Attorney General,,REP,Write-in,2,0,0,2
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,REP,Timothy Defoor,67,26,2,95
+Northampton,LOWER MT BETHEL LOWER,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL LOWER,State Treasurer,,REP,Stacy L. Garrity,71,26,3,100
+Northampton,LOWER MT BETHEL LOWER,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL LOWER,U.S. House,7,REP,Lisa Scheller,53,15,4,72
+Northampton,LOWER MT BETHEL LOWER,U.S. House,7,REP,Dean N. Browning,33,15,1,49
+Northampton,LOWER MT BETHEL LOWER,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL LOWER,General Assembly,137,REP,Joe Emrick,75,30,5,110
+Northampton,LOWER MT BETHEL LOWER,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,Registered Voters,,,,,,,1350
+Northampton,LOWER MT BETHEL UPPER,Registered Voters,,DEM,,,,,433
+Northampton,LOWER MT BETHEL UPPER,Registered Voters,,REP,,,,,653
+Northampton,LOWER MT BETHEL UPPER,Registered Voters,,NPA,,,,,264
+Northampton,LOWER MT BETHEL UPPER,Ballots Cast,,,,140,190,5,335
+Northampton,LOWER MT BETHEL UPPER,Ballots Cast,,DEM,,26,101,2,129
+Northampton,LOWER MT BETHEL UPPER,Ballots Cast,,REP,,114,89,3,206
+Northampton,LOWER MT BETHEL UPPER,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,President,,DEM,Joseph R. Biden,12,76,0,88
+Northampton,LOWER MT BETHEL UPPER,President,,DEM,Bernie Sanders,11,18,2,31
+Northampton,LOWER MT BETHEL UPPER,President,,DEM,Tulsi Gabbard,1,1,0,2
+Northampton,LOWER MT BETHEL UPPER,President,,DEM,Write-in,0,4,0,4
+Northampton,LOWER MT BETHEL UPPER,Attorney General,,DEM,Josh Shapiro,19,90,2,111
+Northampton,LOWER MT BETHEL UPPER,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,DEM,Rose Rosie Marie Davis,3,30,2,35
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,DEM,Nina Ahmad,7,22,0,29
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,DEM,Christina M. Hartman,2,18,0,20
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,DEM,H Scott Conklin,7,7,0,14
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,DEM,Michael Lamb,3,8,0,11
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,DEM,Tracie Fountain,1,4,0,5
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,State Treasurer,,DEM,Joe Torsella,18,89,2,109
+Northampton,LOWER MT BETHEL UPPER,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,U.S. House,7,DEM,Susan Wild,20,97,2,119
+Northampton,LOWER MT BETHEL UPPER,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,General Assembly,137,DEM,Katelind Brennan,20,90,1,111
+Northampton,LOWER MT BETHEL UPPER,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,President,,REP,Donald J Trump,109,77,3,189
+Northampton,LOWER MT BETHEL UPPER,President,,REP,Bill Weld,3,7,0,10
+Northampton,LOWER MT BETHEL UPPER,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,LOWER MT BETHEL UPPER,President,,REP,Write-in,0,1,0,1
+Northampton,LOWER MT BETHEL UPPER,Attorney General,,REP,Heather Heidelbaugh,87,76,3,166
+Northampton,LOWER MT BETHEL UPPER,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,REP,Timothy Defoor,88,75,3,166
+Northampton,LOWER MT BETHEL UPPER,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,State Treasurer,,REP,Stacy L. Garrity,86,75,1,162
+Northampton,LOWER MT BETHEL UPPER,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LOWER MT BETHEL UPPER,U.S. House,7,REP,Lisa Scheller,52,50,0,102
+Northampton,LOWER MT BETHEL UPPER,U.S. House,7,REP,Dean N. Browning,57,28,3,88
+Northampton,LOWER MT BETHEL UPPER,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,LOWER MT BETHEL UPPER,General Assembly,137,REP,Joe Emrick,107,85,3,195
+Northampton,LOWER MT BETHEL UPPER,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #1,Registered Voters,,,,,,,3357
+Northampton,LOWER NAZARETH #1,Registered Voters,,DEM,,,,,1262
+Northampton,LOWER NAZARETH #1,Registered Voters,,REP,,,,,1487
+Northampton,LOWER NAZARETH #1,Registered Voters,,NPA,,,,,608
+Northampton,LOWER NAZARETH #1,Ballots Cast,,,,404,737,9,1150
+Northampton,LOWER NAZARETH #1,Ballots Cast,,DEM,,91,490,0,581
+Northampton,LOWER NAZARETH #1,Ballots Cast,,REP,,313,247,9,569
+Northampton,LOWER NAZARETH #1,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER NAZARETH #1,President,,DEM,Joseph R. Biden,59,413,0,472
+Northampton,LOWER NAZARETH #1,President,,DEM,Bernie Sanders,18,47,0,65
+Northampton,LOWER NAZARETH #1,President,,DEM,Tulsi Gabbard,8,10,0,18
+Northampton,LOWER NAZARETH #1,President,,DEM,Write-in,2,11,0,13
+Northampton,LOWER NAZARETH #1,Attorney General,,DEM,Josh Shapiro,57,442,0,499
+Northampton,LOWER NAZARETH #1,Attorney General,,DEM,Write-in,0,4,0,4
+Northampton,LOWER NAZARETH #1,Auditor General,,DEM,Nina Ahmad,16,122,0,138
+Northampton,LOWER NAZARETH #1,Auditor General,,DEM,Rose Rosie Marie Davis,11,77,0,88
+Northampton,LOWER NAZARETH #1,Auditor General,,DEM,Christina M. Hartman,6,80,0,86
+Northampton,LOWER NAZARETH #1,Auditor General,,DEM,Michael Lamb,20,49,0,69
+Northampton,LOWER NAZARETH #1,Auditor General,,DEM,Tracie Fountain,5,58,0,63
+Northampton,LOWER NAZARETH #1,Auditor General,,DEM,H Scott Conklin,11,30,0,41
+Northampton,LOWER NAZARETH #1,Auditor General,,DEM,Write-in,0,3,0,3
+Northampton,LOWER NAZARETH #1,State Treasurer,,DEM,Joe Torsella,58,439,0,497
+Northampton,LOWER NAZARETH #1,State Treasurer,,DEM,Write-in,0,3,0,3
+Northampton,LOWER NAZARETH #1,U.S. House,7,DEM,Susan Wild,73,460,0,533
+Northampton,LOWER NAZARETH #1,U.S. House,7,DEM,Write-in,1,3,0,4
+Northampton,LOWER NAZARETH #1,General Assembly,138,DEM,Tara Zrinski,66,438,0,504
+Northampton,LOWER NAZARETH #1,General Assembly,138,DEM,Write-in,2,4,0,6
+Northampton,LOWER NAZARETH #1,President,,REP,Donald J Trump,294,206,7,507
+Northampton,LOWER NAZARETH #1,President,,REP,Bill Weld,3,23,1,27
+Northampton,LOWER NAZARETH #1,President,,REP,Roque Rocky De La Fuente,3,7,0,10
+Northampton,LOWER NAZARETH #1,President,,REP,Write-in,2,6,0,8
+Northampton,LOWER NAZARETH #1,Attorney General,,REP,Heather Heidelbaugh,260,215,7,482
+Northampton,LOWER NAZARETH #1,Attorney General,,REP,Write-in,1,2,0,3
+Northampton,LOWER NAZARETH #1,Auditor General,,REP,Timothy Defoor,264,213,8,485
+Northampton,LOWER NAZARETH #1,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,LOWER NAZARETH #1,State Treasurer,,REP,Stacy L. Garrity,267,213,7,487
+Northampton,LOWER NAZARETH #1,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,LOWER NAZARETH #1,U.S. House,7,REP,Lisa Scheller,162,117,8,287
+Northampton,LOWER NAZARETH #1,U.S. House,7,REP,Dean N. Browning,143,119,0,262
+Northampton,LOWER NAZARETH #1,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,LOWER NAZARETH #1,General Assembly,138,REP,Tony Tarsi,196,125,6,327
+Northampton,LOWER NAZARETH #1,General Assembly,138,REP,Ann Flood,111,106,3,220
+Northampton,LOWER NAZARETH #1,General Assembly,138,REP,Write-in,0,2,0,2
+Northampton,LOWER NAZARETH #2,Registered Voters,,,,,,,1632
+Northampton,LOWER NAZARETH #2,Registered Voters,,DEM,,,,,612
+Northampton,LOWER NAZARETH #2,Registered Voters,,REP,,,,,754
+Northampton,LOWER NAZARETH #2,Registered Voters,,NPA,,,,,266
+Northampton,LOWER NAZARETH #2,Ballots Cast,,,,277,281,5,563
+Northampton,LOWER NAZARETH #2,Ballots Cast,,DEM,,77,180,0,257
+Northampton,LOWER NAZARETH #2,Ballots Cast,,REP,,200,101,5,306
+Northampton,LOWER NAZARETH #2,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER NAZARETH #2,President,,DEM,Joseph R. Biden,49,150,0,199
+Northampton,LOWER NAZARETH #2,President,,DEM,Bernie Sanders,20,19,0,39
+Northampton,LOWER NAZARETH #2,President,,DEM,Tulsi Gabbard,7,4,0,11
+Northampton,LOWER NAZARETH #2,President,,DEM,Write-in,0,3,0,3
+Northampton,LOWER NAZARETH #2,Attorney General,,DEM,Josh Shapiro,57,170,0,227
+Northampton,LOWER NAZARETH #2,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #2,Auditor General,,DEM,Nina Ahmad,12,40,0,52
+Northampton,LOWER NAZARETH #2,Auditor General,,DEM,Rose Rosie Marie Davis,8,40,0,48
+Northampton,LOWER NAZARETH #2,Auditor General,,DEM,Christina M. Hartman,11,36,0,47
+Northampton,LOWER NAZARETH #2,Auditor General,,DEM,Michael Lamb,15,22,0,37
+Northampton,LOWER NAZARETH #2,Auditor General,,DEM,H Scott Conklin,12,9,0,21
+Northampton,LOWER NAZARETH #2,Auditor General,,DEM,Tracie Fountain,5,14,0,19
+Northampton,LOWER NAZARETH #2,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #2,State Treasurer,,DEM,Joe Torsella,52,169,0,221
+Northampton,LOWER NAZARETH #2,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #2,U.S. House,7,DEM,Susan Wild,61,175,0,236
+Northampton,LOWER NAZARETH #2,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,LOWER NAZARETH #2,General Assembly,138,DEM,Tara Zrinski,61,166,0,227
+Northampton,LOWER NAZARETH #2,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #2,President,,REP,Donald J Trump,176,81,5,262
+Northampton,LOWER NAZARETH #2,President,,REP,Bill Weld,7,11,0,18
+Northampton,LOWER NAZARETH #2,President,,REP,Roque Rocky De La Fuente,5,2,0,7
+Northampton,LOWER NAZARETH #2,President,,REP,Write-in,2,2,0,4
+Northampton,LOWER NAZARETH #2,Attorney General,,REP,Heather Heidelbaugh,163,86,3,252
+Northampton,LOWER NAZARETH #2,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #2,Auditor General,,REP,Timothy Defoor,159,85,3,247
+Northampton,LOWER NAZARETH #2,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #2,State Treasurer,,REP,Stacy L. Garrity,158,87,3,248
+Northampton,LOWER NAZARETH #2,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #2,U.S. House,7,REP,Lisa Scheller,93,55,3,151
+Northampton,LOWER NAZARETH #2,U.S. House,7,REP,Dean N. Browning,97,39,2,138
+Northampton,LOWER NAZARETH #2,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,LOWER NAZARETH #2,General Assembly,138,REP,Tony Tarsi,132,53,1,186
+Northampton,LOWER NAZARETH #2,General Assembly,138,REP,Ann Flood,63,44,4,111
+Northampton,LOWER NAZARETH #2,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 1,Registered Voters,,,,,,,1327
+Northampton,LOWER SAUCON TWSP 1,Registered Voters,,DEM,,,,,524
+Northampton,LOWER SAUCON TWSP 1,Registered Voters,,REP,,,,,582
+Northampton,LOWER SAUCON TWSP 1,Registered Voters,,NPA,,,,,221
+Northampton,LOWER SAUCON TWSP 1,Ballots Cast,,,,153,343,4,500
+Northampton,LOWER SAUCON TWSP 1,Ballots Cast,,DEM,,42,237,3,282
+Northampton,LOWER SAUCON TWSP 1,Ballots Cast,,REP,,111,106,1,218
+Northampton,LOWER SAUCON TWSP 1,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER SAUCON TWSP 1,President,,DEM,Joseph R. Biden,30,209,1,240
+Northampton,LOWER SAUCON TWSP 1,President,,DEM,Bernie Sanders,6,22,2,30
+Northampton,LOWER SAUCON TWSP 1,President,,DEM,Tulsi Gabbard,5,0,0,5
+Northampton,LOWER SAUCON TWSP 1,President,,DEM,Write-in,0,3,0,3
+Northampton,LOWER SAUCON TWSP 1,Attorney General,,DEM,Josh Shapiro,31,198,3,232
+Northampton,LOWER SAUCON TWSP 1,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,DEM,Nina Ahmad,7,65,0,72
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,DEM,Christina M. Hartman,3,42,2,47
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,DEM,Rose Rosie Marie Davis,2,33,0,35
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,DEM,Michael Lamb,10,20,0,30
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,DEM,Tracie Fountain,2,22,1,25
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,DEM,H Scott Conklin,11,9,0,20
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 1,State Treasurer,,DEM,Joe Torsella,27,197,3,227
+Northampton,LOWER SAUCON TWSP 1,State Treasurer,,DEM,Write-in,0,2,0,2
+Northampton,LOWER SAUCON TWSP 1,U.S. House,7,DEM,Susan Wild,37,224,3,264
+Northampton,LOWER SAUCON TWSP 1,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 1,General Assembly,131,DEM,Kevin Branco,35,200,3,238
+Northampton,LOWER SAUCON TWSP 1,General Assembly,131,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 1,President,,REP,Donald J Trump,96,79,1,176
+Northampton,LOWER SAUCON TWSP 1,President,,REP,Bill Weld,2,12,0,14
+Northampton,LOWER SAUCON TWSP 1,President,,REP,Roque Rocky De La Fuente,0,6,0,6
+Northampton,LOWER SAUCON TWSP 1,President,,REP,Write-in,2,5,0,7
+Northampton,LOWER SAUCON TWSP 1,Attorney General,,REP,Heather Heidelbaugh,84,89,1,174
+Northampton,LOWER SAUCON TWSP 1,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,REP,Timothy Defoor,87,88,1,176
+Northampton,LOWER SAUCON TWSP 1,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 1,State Treasurer,,REP,Stacy L. Garrity,87,87,1,175
+Northampton,LOWER SAUCON TWSP 1,State Treasurer,,REP,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 1,U.S. House,7,REP,Lisa Scheller,45,61,0,106
+Northampton,LOWER SAUCON TWSP 1,U.S. House,7,REP,Dean N. Browning,62,36,1,99
+Northampton,LOWER SAUCON TWSP 1,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,LOWER SAUCON TWSP 1,General Assembly,131,REP,Milou Mackenzie,78,42,0,120
+Northampton,LOWER SAUCON TWSP 1,General Assembly,131,REP,Nathan Brown,14,18,1,33
+Northampton,LOWER SAUCON TWSP 1,General Assembly,131,REP,Vicki Lightcap,5,23,0,28
+Northampton,LOWER SAUCON TWSP 1,General Assembly,131,REP,Joe Ellenberger,5,8,0,13
+Northampton,LOWER SAUCON TWSP 1,General Assembly,131,REP,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 2,Registered Voters,,,,,,,1746
+Northampton,LOWER SAUCON TWSP 2,Registered Voters,,DEM,,,,,661
+Northampton,LOWER SAUCON TWSP 2,Registered Voters,,REP,,,,,771
+Northampton,LOWER SAUCON TWSP 2,Registered Voters,,NPA,,,,,314
+Northampton,LOWER SAUCON TWSP 2,Ballots Cast,,,,225,311,5,541
+Northampton,LOWER SAUCON TWSP 2,Ballots Cast,,DEM,,60,216,2,278
+Northampton,LOWER SAUCON TWSP 2,Ballots Cast,,REP,,165,95,3,263
+Northampton,LOWER SAUCON TWSP 2,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,President,,DEM,Joseph R. Biden,47,183,2,232
+Northampton,LOWER SAUCON TWSP 2,President,,DEM,Bernie Sanders,8,28,0,36
+Northampton,LOWER SAUCON TWSP 2,President,,DEM,Tulsi Gabbard,3,1,0,4
+Northampton,LOWER SAUCON TWSP 2,President,,DEM,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 2,Attorney General,,DEM,Josh Shapiro,47,183,1,231
+Northampton,LOWER SAUCON TWSP 2,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,DEM,Nina Ahmad,17,55,2,74
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,DEM,Christina M. Hartman,3,48,0,51
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,DEM,Michael Lamb,16,21,0,37
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,DEM,Rose Rosie Marie Davis,7,20,0,27
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,DEM,H Scott Conklin,5,20,0,25
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,DEM,Tracie Fountain,3,15,0,18
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,State Treasurer,,DEM,Joe Torsella,49,180,2,231
+Northampton,LOWER SAUCON TWSP 2,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,U.S. House,7,DEM,Susan Wild,52,196,2,250
+Northampton,LOWER SAUCON TWSP 2,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,General Assembly,131,DEM,Kevin Branco,52,191,2,245
+Northampton,LOWER SAUCON TWSP 2,General Assembly,131,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 2,President,,REP,Donald J Trump,149,84,2,235
+Northampton,LOWER SAUCON TWSP 2,President,,REP,Bill Weld,7,8,1,16
+Northampton,LOWER SAUCON TWSP 2,President,,REP,Roque Rocky De La Fuente,5,1,0,6
+Northampton,LOWER SAUCON TWSP 2,President,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,Attorney General,,REP,Heather Heidelbaugh,131,85,3,219
+Northampton,LOWER SAUCON TWSP 2,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,REP,Timothy Defoor,127,82,3,212
+Northampton,LOWER SAUCON TWSP 2,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,State Treasurer,,REP,Stacy L. Garrity,132,82,3,217
+Northampton,LOWER SAUCON TWSP 2,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,U.S. House,7,REP,Lisa Scheller,79,55,1,135
+Northampton,LOWER SAUCON TWSP 2,U.S. House,7,REP,Dean N. Browning,77,31,2,110
+Northampton,LOWER SAUCON TWSP 2,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 2,General Assembly,131,REP,Milou Mackenzie,106,46,1,153
+Northampton,LOWER SAUCON TWSP 2,General Assembly,131,REP,Vicki Lightcap,20,15,1,36
+Northampton,LOWER SAUCON TWSP 2,General Assembly,131,REP,Nathan Brown,20,7,0,27
+Northampton,LOWER SAUCON TWSP 2,General Assembly,131,REP,Joe Ellenberger,10,12,1,23
+Northampton,LOWER SAUCON TWSP 2,General Assembly,131,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,Registered Voters,,,,,,,614
+Northampton,LOWER SAUCON TWSP 3,Registered Voters,,DEM,,,,,247
+Northampton,LOWER SAUCON TWSP 3,Registered Voters,,REP,,,,,272
+Northampton,LOWER SAUCON TWSP 3,Registered Voters,,NPA,,,,,95
+Northampton,LOWER SAUCON TWSP 3,Ballots Cast,,,,94,114,0,208
+Northampton,LOWER SAUCON TWSP 3,Ballots Cast,,DEM,,21,86,0,107
+Northampton,LOWER SAUCON TWSP 3,Ballots Cast,,REP,,73,28,0,101
+Northampton,LOWER SAUCON TWSP 3,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,President,,DEM,Joseph R. Biden,10,73,0,83
+Northampton,LOWER SAUCON TWSP 3,President,,DEM,Bernie Sanders,5,6,0,11
+Northampton,LOWER SAUCON TWSP 3,President,,DEM,Tulsi Gabbard,4,6,0,10
+Northampton,LOWER SAUCON TWSP 3,President,,DEM,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 3,Attorney General,,DEM,Josh Shapiro,16,79,0,95
+Northampton,LOWER SAUCON TWSP 3,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,DEM,Christina M. Hartman,2,24,0,26
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,DEM,Nina Ahmad,6,18,0,24
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,DEM,Tracie Fountain,0,17,0,17
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,DEM,H Scott Conklin,2,9,0,11
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,DEM,Michael Lamb,5,6,0,11
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,DEM,Rose Rosie Marie Davis,0,3,0,3
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,State Treasurer,,DEM,Joe Torsella,17,77,0,94
+Northampton,LOWER SAUCON TWSP 3,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,U.S. House,7,DEM,Susan Wild,19,79,0,98
+Northampton,LOWER SAUCON TWSP 3,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 3,General Assembly,136,DEM,Robert Freeman,19,80,0,99
+Northampton,LOWER SAUCON TWSP 3,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,President,,REP,Donald J Trump,67,20,0,87
+Northampton,LOWER SAUCON TWSP 3,President,,REP,Bill Weld,4,6,0,10
+Northampton,LOWER SAUCON TWSP 3,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,President,,REP,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 3,Attorney General,,REP,Heather Heidelbaugh,54,19,0,73
+Northampton,LOWER SAUCON TWSP 3,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,REP,Timothy Defoor,56,22,0,78
+Northampton,LOWER SAUCON TWSP 3,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,State Treasurer,,REP,Stacy L. Garrity,55,20,0,75
+Northampton,LOWER SAUCON TWSP 3,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 3,U.S. House,7,REP,Dean N. Browning,40,10,0,50
+Northampton,LOWER SAUCON TWSP 3,U.S. House,7,REP,Lisa Scheller,29,15,0,44
+Northampton,LOWER SAUCON TWSP 3,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 3,General Assembly,136,REP,Write-in,1,3,0,4
+Northampton,LOWER SAUCON TWSP 4,Registered Voters,,,,,,,1163
+Northampton,LOWER SAUCON TWSP 4,Registered Voters,,DEM,,,,,500
+Northampton,LOWER SAUCON TWSP 4,Registered Voters,,REP,,,,,460
+Northampton,LOWER SAUCON TWSP 4,Registered Voters,,NPA,,,,,203
+Northampton,LOWER SAUCON TWSP 4,Ballots Cast,,,,155,190,4,349
+Northampton,LOWER SAUCON TWSP 4,Ballots Cast,,DEM,,54,139,1,194
+Northampton,LOWER SAUCON TWSP 4,Ballots Cast,,REP,,101,51,3,155
+Northampton,LOWER SAUCON TWSP 4,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER SAUCON TWSP 4,President,,DEM,Joseph R. Biden,39,103,1,143
+Northampton,LOWER SAUCON TWSP 4,President,,DEM,Bernie Sanders,10,30,0,40
+Northampton,LOWER SAUCON TWSP 4,President,,DEM,Tulsi Gabbard,3,4,0,7
+Northampton,LOWER SAUCON TWSP 4,President,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 4,Attorney General,,DEM,Josh Shapiro,42,124,1,167
+Northampton,LOWER SAUCON TWSP 4,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,DEM,Nina Ahmad,16,44,1,61
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,DEM,Christina M. Hartman,5,22,0,27
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,DEM,Tracie Fountain,5,21,0,26
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,DEM,Rose Rosie Marie Davis,8,16,0,24
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,DEM,H Scott Conklin,7,4,0,11
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,DEM,Michael Lamb,4,5,0,9
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 4,State Treasurer,,DEM,Joe Torsella,40,115,1,156
+Northampton,LOWER SAUCON TWSP 4,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 4,U.S. House,7,DEM,Susan Wild,49,127,1,177
+Northampton,LOWER SAUCON TWSP 4,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 4,General Assembly,131,DEM,Kevin Branco,44,115,0,159
+Northampton,LOWER SAUCON TWSP 4,General Assembly,131,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 4,President,,REP,Donald J Trump,92,41,3,136
+Northampton,LOWER SAUCON TWSP 4,President,,REP,Bill Weld,2,7,0,9
+Northampton,LOWER SAUCON TWSP 4,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Northampton,LOWER SAUCON TWSP 4,President,,REP,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 4,Attorney General,,REP,Heather Heidelbaugh,74,44,3,121
+Northampton,LOWER SAUCON TWSP 4,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,REP,Timothy Defoor,77,44,3,124
+Northampton,LOWER SAUCON TWSP 4,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 4,State Treasurer,,REP,Stacy L. Garrity,75,44,3,122
+Northampton,LOWER SAUCON TWSP 4,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 4,U.S. House,7,REP,Lisa Scheller,60,30,1,91
+Northampton,LOWER SAUCON TWSP 4,U.S. House,7,REP,Dean N. Browning,39,19,2,60
+Northampton,LOWER SAUCON TWSP 4,U.S. House,7,REP,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 4,General Assembly,131,REP,Milou Mackenzie,66,26,2,94
+Northampton,LOWER SAUCON TWSP 4,General Assembly,131,REP,Vicki Lightcap,10,11,0,21
+Northampton,LOWER SAUCON TWSP 4,General Assembly,131,REP,Nathan Brown,8,7,1,16
+Northampton,LOWER SAUCON TWSP 4,General Assembly,131,REP,Joe Ellenberger,4,2,0,6
+Northampton,LOWER SAUCON TWSP 4,General Assembly,131,REP,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 5,Registered Voters,,,,,,,482
+Northampton,LOWER SAUCON TWSP 5,Registered Voters,,DEM,,,,,204
+Northampton,LOWER SAUCON TWSP 5,Registered Voters,,REP,,,,,195
+Northampton,LOWER SAUCON TWSP 5,Registered Voters,,NPA,,,,,83
+Northampton,LOWER SAUCON TWSP 5,Ballots Cast,,,,103,54,0,157
+Northampton,LOWER SAUCON TWSP 5,Ballots Cast,,DEM,,42,47,0,89
+Northampton,LOWER SAUCON TWSP 5,Ballots Cast,,REP,,61,7,0,68
+Northampton,LOWER SAUCON TWSP 5,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER SAUCON TWSP 5,President,,DEM,Joseph R. Biden,25,37,0,62
+Northampton,LOWER SAUCON TWSP 5,President,,DEM,Bernie Sanders,12,8,0,20
+Northampton,LOWER SAUCON TWSP 5,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,LOWER SAUCON TWSP 5,President,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 5,Attorney General,,DEM,Josh Shapiro,30,43,0,73
+Northampton,LOWER SAUCON TWSP 5,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,DEM,Nina Ahmad,10,10,0,20
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,DEM,Michael Lamb,5,7,0,12
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,DEM,Christina M. Hartman,4,7,0,11
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,DEM,H Scott Conklin,8,2,0,10
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,DEM,Tracie Fountain,1,9,0,10
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,DEM,Rose Rosie Marie Davis,5,4,0,9
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 5,State Treasurer,,DEM,Joe Torsella,28,42,0,70
+Northampton,LOWER SAUCON TWSP 5,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 5,U.S. House,7,DEM,Susan Wild,32,46,0,78
+Northampton,LOWER SAUCON TWSP 5,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 5,General Assembly,136,DEM,Robert Freeman,31,47,0,78
+Northampton,LOWER SAUCON TWSP 5,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 5,President,,REP,Donald J Trump,58,4,0,62
+Northampton,LOWER SAUCON TWSP 5,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,LOWER SAUCON TWSP 5,President,,REP,Bill Weld,1,1,0,2
+Northampton,LOWER SAUCON TWSP 5,President,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 5,Attorney General,,REP,Heather Heidelbaugh,46,5,0,51
+Northampton,LOWER SAUCON TWSP 5,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,REP,Timothy Defoor,47,5,0,52
+Northampton,LOWER SAUCON TWSP 5,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 5,State Treasurer,,REP,Stacy L. Garrity,47,5,0,52
+Northampton,LOWER SAUCON TWSP 5,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 5,U.S. House,7,REP,Dean N. Browning,29,5,0,34
+Northampton,LOWER SAUCON TWSP 5,U.S. House,7,REP,Lisa Scheller,26,1,0,27
+Northampton,LOWER SAUCON TWSP 5,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 5,General Assembly,136,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 6,Registered Voters,,,,,,,1100
+Northampton,LOWER SAUCON TWSP 6,Registered Voters,,DEM,,,,,435
+Northampton,LOWER SAUCON TWSP 6,Registered Voters,,REP,,,,,481
+Northampton,LOWER SAUCON TWSP 6,Registered Voters,,NPA,,,,,184
+Northampton,LOWER SAUCON TWSP 6,Ballots Cast,,,,195,194,8,397
+Northampton,LOWER SAUCON TWSP 6,Ballots Cast,,DEM,,62,145,3,210
+Northampton,LOWER SAUCON TWSP 6,Ballots Cast,,REP,,133,49,5,187
+Northampton,LOWER SAUCON TWSP 6,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER SAUCON TWSP 6,President,,DEM,Joseph R. Biden,40,123,1,164
+Northampton,LOWER SAUCON TWSP 6,President,,DEM,Bernie Sanders,14,12,1,27
+Northampton,LOWER SAUCON TWSP 6,President,,DEM,Tulsi Gabbard,3,6,0,9
+Northampton,LOWER SAUCON TWSP 6,President,,DEM,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 6,Attorney General,,DEM,Josh Shapiro,38,125,2,165
+Northampton,LOWER SAUCON TWSP 6,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,DEM,Nina Ahmad,12,45,1,58
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,DEM,Christina M. Hartman,2,31,0,33
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,DEM,Michael Lamb,9,16,0,25
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,DEM,Tracie Fountain,7,17,0,24
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,DEM,Rose Rosie Marie Davis,6,15,0,21
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,DEM,H Scott Conklin,6,4,0,10
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 6,State Treasurer,,DEM,Joe Torsella,37,125,2,164
+Northampton,LOWER SAUCON TWSP 6,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 6,U.S. House,7,DEM,Susan Wild,44,132,2,178
+Northampton,LOWER SAUCON TWSP 6,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 6,General Assembly,136,DEM,Robert Freeman,49,129,2,180
+Northampton,LOWER SAUCON TWSP 6,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 6,President,,REP,Donald J Trump,124,43,5,172
+Northampton,LOWER SAUCON TWSP 6,President,,REP,Bill Weld,5,2,0,7
+Northampton,LOWER SAUCON TWSP 6,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Northampton,LOWER SAUCON TWSP 6,President,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 6,Attorney General,,REP,Heather Heidelbaugh,103,35,4,142
+Northampton,LOWER SAUCON TWSP 6,Attorney General,,REP,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,REP,Timothy Defoor,101,35,4,140
+Northampton,LOWER SAUCON TWSP 6,Auditor General,,REP,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 6,State Treasurer,,REP,Stacy L. Garrity,104,35,4,143
+Northampton,LOWER SAUCON TWSP 6,State Treasurer,,REP,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 6,U.S. House,7,REP,Lisa Scheller,70,25,4,99
+Northampton,LOWER SAUCON TWSP 6,U.S. House,7,REP,Dean N. Browning,59,21,1,81
+Northampton,LOWER SAUCON TWSP 6,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 6,General Assembly,136,REP,Write-in,2,5,2,9
+Northampton,LOWER SAUCON TWSP 7,Registered Voters,,,,,,,792
+Northampton,LOWER SAUCON TWSP 7,Registered Voters,,DEM,,,,,307
+Northampton,LOWER SAUCON TWSP 7,Registered Voters,,REP,,,,,334
+Northampton,LOWER SAUCON TWSP 7,Registered Voters,,NPA,,,,,151
+Northampton,LOWER SAUCON TWSP 7,Ballots Cast,,,,138,123,8,269
+Northampton,LOWER SAUCON TWSP 7,Ballots Cast,,DEM,,43,86,4,133
+Northampton,LOWER SAUCON TWSP 7,Ballots Cast,,REP,,95,37,4,136
+Northampton,LOWER SAUCON TWSP 7,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,President,,DEM,Joseph R. Biden,32,74,3,109
+Northampton,LOWER SAUCON TWSP 7,President,,DEM,Bernie Sanders,10,7,0,17
+Northampton,LOWER SAUCON TWSP 7,President,,DEM,Tulsi Gabbard,1,0,1,2
+Northampton,LOWER SAUCON TWSP 7,President,,DEM,Write-in,0,4,0,4
+Northampton,LOWER SAUCON TWSP 7,Attorney General,,DEM,Josh Shapiro,22,79,4,105
+Northampton,LOWER SAUCON TWSP 7,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,DEM,Nina Ahmad,14,26,1,41
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,DEM,Tracie Fountain,4,13,1,18
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,DEM,Christina M. Hartman,3,14,1,18
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,DEM,Michael Lamb,8,7,0,15
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,DEM,Rose Rosie Marie Davis,3,10,0,13
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,DEM,H Scott Conklin,3,4,1,8
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,State Treasurer,,DEM,Joe Torsella,23,78,4,105
+Northampton,LOWER SAUCON TWSP 7,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,U.S. House,7,DEM,Susan Wild,34,81,4,119
+Northampton,LOWER SAUCON TWSP 7,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 7,General Assembly,131,DEM,Kevin Branco,28,75,3,106
+Northampton,LOWER SAUCON TWSP 7,General Assembly,131,DEM,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,President,,REP,Donald J Trump,82,28,3,113
+Northampton,LOWER SAUCON TWSP 7,President,,REP,Bill Weld,7,3,1,11
+Northampton,LOWER SAUCON TWSP 7,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,President,,REP,Write-in,1,3,0,4
+Northampton,LOWER SAUCON TWSP 7,Attorney General,,REP,Heather Heidelbaugh,76,33,4,113
+Northampton,LOWER SAUCON TWSP 7,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,REP,Timothy Defoor,72,33,4,109
+Northampton,LOWER SAUCON TWSP 7,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,State Treasurer,,REP,Stacy L. Garrity,71,33,4,108
+Northampton,LOWER SAUCON TWSP 7,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,U.S. House,7,REP,Lisa Scheller,43,22,2,67
+Northampton,LOWER SAUCON TWSP 7,U.S. House,7,REP,Dean N. Browning,47,12,2,61
+Northampton,LOWER SAUCON TWSP 7,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 7,General Assembly,131,REP,Milou Mackenzie,64,20,4,88
+Northampton,LOWER SAUCON TWSP 7,General Assembly,131,REP,Nathan Brown,12,7,0,19
+Northampton,LOWER SAUCON TWSP 7,General Assembly,131,REP,Vicki Lightcap,6,2,0,8
+Northampton,LOWER SAUCON TWSP 7,General Assembly,131,REP,Joe Ellenberger,3,4,0,7
+Northampton,LOWER SAUCON TWSP 7,General Assembly,131,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 8,Registered Voters,,,,,,,1169
+Northampton,LOWER SAUCON TWSP 8,Registered Voters,,DEM,,,,,489
+Northampton,LOWER SAUCON TWSP 8,Registered Voters,,REP,,,,,485
+Northampton,LOWER SAUCON TWSP 8,Registered Voters,,NPA,,,,,195
+Northampton,LOWER SAUCON TWSP 8,Ballots Cast,,,,183,271,11,465
+Northampton,LOWER SAUCON TWSP 8,Ballots Cast,,DEM,,57,198,7,262
+Northampton,LOWER SAUCON TWSP 8,Ballots Cast,,REP,,126,73,4,203
+Northampton,LOWER SAUCON TWSP 8,Ballots Cast,,NPA,,0,0,0,0
+Northampton,LOWER SAUCON TWSP 8,President,,DEM,Joseph R. Biden,38,165,6,209
+Northampton,LOWER SAUCON TWSP 8,President,,DEM,Bernie Sanders,12,27,1,40
+Northampton,LOWER SAUCON TWSP 8,President,,DEM,Tulsi Gabbard,5,2,0,7
+Northampton,LOWER SAUCON TWSP 8,President,,DEM,Write-in,1,2,0,3
+Northampton,LOWER SAUCON TWSP 8,Attorney General,,DEM,Josh Shapiro,44,174,7,225
+Northampton,LOWER SAUCON TWSP 8,Attorney General,,DEM,Write-in,1,3,0,4
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,DEM,Nina Ahmad,19,74,1,94
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,DEM,Tracie Fountain,7,22,1,30
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,DEM,Rose Rosie Marie Davis,2,25,0,27
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,DEM,Christina M. Hartman,2,19,2,23
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,DEM,H Scott Conklin,13,8,1,22
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,DEM,Michael Lamb,5,13,0,18
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,DEM,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 8,State Treasurer,,DEM,Joe Torsella,43,170,6,219
+Northampton,LOWER SAUCON TWSP 8,State Treasurer,,DEM,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 8,U.S. House,7,DEM,Susan Wild,45,192,7,244
+Northampton,LOWER SAUCON TWSP 8,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,LOWER SAUCON TWSP 8,General Assembly,131,DEM,Kevin Branco,45,175,6,226
+Northampton,LOWER SAUCON TWSP 8,General Assembly,131,DEM,Write-in,1,1,0,2
+Northampton,LOWER SAUCON TWSP 8,President,,REP,Donald J Trump,110,49,4,163
+Northampton,LOWER SAUCON TWSP 8,President,,REP,Bill Weld,5,11,0,16
+Northampton,LOWER SAUCON TWSP 8,President,,REP,Roque Rocky De La Fuente,4,3,0,7
+Northampton,LOWER SAUCON TWSP 8,President,,REP,Write-in,4,2,0,6
+Northampton,LOWER SAUCON TWSP 8,Attorney General,,REP,Heather Heidelbaugh,99,60,4,163
+Northampton,LOWER SAUCON TWSP 8,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,REP,Timothy Defoor,95,60,3,158
+Northampton,LOWER SAUCON TWSP 8,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,LOWER SAUCON TWSP 8,State Treasurer,,REP,Stacy L. Garrity,96,57,3,156
+Northampton,LOWER SAUCON TWSP 8,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 8,U.S. House,7,REP,Lisa Scheller,63,49,1,113
+Northampton,LOWER SAUCON TWSP 8,U.S. House,7,REP,Dean N. Browning,60,20,3,83
+Northampton,LOWER SAUCON TWSP 8,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,LOWER SAUCON TWSP 8,General Assembly,131,REP,Milou Mackenzie,93,38,4,135
+Northampton,LOWER SAUCON TWSP 8,General Assembly,131,REP,Vicki Lightcap,12,13,0,25
+Northampton,LOWER SAUCON TWSP 8,General Assembly,131,REP,Nathan Brown,12,6,0,18
+Northampton,LOWER SAUCON TWSP 8,General Assembly,131,REP,Joe Ellenberger,7,7,0,14
+Northampton,LOWER SAUCON TWSP 8,General Assembly,131,REP,Write-in,0,2,0,2
+Northampton,MOORE TWSP BEERSVILLE,Registered Voters,,,,,,,1294
+Northampton,MOORE TWSP BEERSVILLE,Registered Voters,,DEM,,,,,456
+Northampton,MOORE TWSP BEERSVILLE,Registered Voters,,REP,,,,,647
+Northampton,MOORE TWSP BEERSVILLE,Registered Voters,,NPA,,,,,191
+Northampton,MOORE TWSP BEERSVILLE,Ballots Cast,,,,240,228,10,478
+Northampton,MOORE TWSP BEERSVILLE,Ballots Cast,,DEM,,55,133,3,191
+Northampton,MOORE TWSP BEERSVILLE,Ballots Cast,,REP,,185,95,7,287
+Northampton,MOORE TWSP BEERSVILLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,MOORE TWSP BEERSVILLE,President,,DEM,Joseph R. Biden,33,111,0,144
+Northampton,MOORE TWSP BEERSVILLE,President,,DEM,Bernie Sanders,10,16,2,28
+Northampton,MOORE TWSP BEERSVILLE,President,,DEM,Tulsi Gabbard,6,2,0,8
+Northampton,MOORE TWSP BEERSVILLE,President,,DEM,Write-in,0,4,0,4
+Northampton,MOORE TWSP BEERSVILLE,Attorney General,,DEM,Josh Shapiro,37,124,3,164
+Northampton,MOORE TWSP BEERSVILLE,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,DEM,Christina M. Hartman,12,26,0,38
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,DEM,Rose Rosie Marie Davis,10,24,1,35
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,DEM,Michael Lamb,10,19,0,29
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,DEM,Nina Ahmad,5,22,2,29
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,DEM,H Scott Conklin,9,11,0,20
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,DEM,Tracie Fountain,2,18,0,20
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP BEERSVILLE,State Treasurer,,DEM,Joe Torsella,34,121,3,158
+Northampton,MOORE TWSP BEERSVILLE,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP BEERSVILLE,U.S. House,7,DEM,Susan Wild,39,124,3,166
+Northampton,MOORE TWSP BEERSVILLE,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP BEERSVILLE,General Assembly,183,DEM,Jason Ruff,38,120,3,161
+Northampton,MOORE TWSP BEERSVILLE,General Assembly,183,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP BEERSVILLE,President,,REP,Donald J Trump,176,83,3,262
+Northampton,MOORE TWSP BEERSVILLE,President,,REP,Bill Weld,5,6,1,12
+Northampton,MOORE TWSP BEERSVILLE,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,MOORE TWSP BEERSVILLE,President,,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP BEERSVILLE,Attorney General,,REP,Heather Heidelbaugh,142,82,6,230
+Northampton,MOORE TWSP BEERSVILLE,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,REP,Timothy Defoor,140,79,6,225
+Northampton,MOORE TWSP BEERSVILLE,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP BEERSVILLE,State Treasurer,,REP,Stacy L. Garrity,138,82,6,226
+Northampton,MOORE TWSP BEERSVILLE,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP BEERSVILLE,U.S. House,7,REP,Dean N. Browning,90,52,4,146
+Northampton,MOORE TWSP BEERSVILLE,U.S. House,7,REP,Lisa Scheller,89,38,3,130
+Northampton,MOORE TWSP BEERSVILLE,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP BEERSVILLE,General Assembly,183,REP,Zach Mako,165,90,6,261
+Northampton,MOORE TWSP BEERSVILLE,General Assembly,183,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP EASTERN,Registered Voters,,,,,,,2665
+Northampton,MOORE TWSP EASTERN,Registered Voters,,DEM,,,,,930
+Northampton,MOORE TWSP EASTERN,Registered Voters,,REP,,,,,1258
+Northampton,MOORE TWSP EASTERN,Registered Voters,,NPA,,,,,477
+Northampton,MOORE TWSP EASTERN,Ballots Cast,,,,397,523,6,926
+Northampton,MOORE TWSP EASTERN,Ballots Cast,,DEM,,87,330,3,420
+Northampton,MOORE TWSP EASTERN,Ballots Cast,,REP,,310,193,3,506
+Northampton,MOORE TWSP EASTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,MOORE TWSP EASTERN,President,,DEM,Joseph R. Biden,60,272,2,334
+Northampton,MOORE TWSP EASTERN,President,,DEM,Bernie Sanders,16,39,0,55
+Northampton,MOORE TWSP EASTERN,President,,DEM,Tulsi Gabbard,4,9,0,13
+Northampton,MOORE TWSP EASTERN,President,,DEM,Write-in,1,7,1,9
+Northampton,MOORE TWSP EASTERN,Attorney General,,DEM,Josh Shapiro,64,297,2,363
+Northampton,MOORE TWSP EASTERN,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP EASTERN,Auditor General,,DEM,Rose Rosie Marie Davis,14,81,1,96
+Northampton,MOORE TWSP EASTERN,Auditor General,,DEM,Nina Ahmad,21,48,1,70
+Northampton,MOORE TWSP EASTERN,Auditor General,,DEM,Christina M. Hartman,7,55,0,62
+Northampton,MOORE TWSP EASTERN,Auditor General,,DEM,Michael Lamb,10,51,0,61
+Northampton,MOORE TWSP EASTERN,Auditor General,,DEM,H Scott Conklin,13,24,0,37
+Northampton,MOORE TWSP EASTERN,Auditor General,,DEM,Tracie Fountain,3,28,0,31
+Northampton,MOORE TWSP EASTERN,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,MOORE TWSP EASTERN,State Treasurer,,DEM,Joe Torsella,59,301,2,362
+Northampton,MOORE TWSP EASTERN,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,MOORE TWSP EASTERN,U.S. House,7,DEM,Susan Wild,71,313,3,387
+Northampton,MOORE TWSP EASTERN,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP EASTERN,General Assembly,138,DEM,Tara Zrinski,65,305,2,372
+Northampton,MOORE TWSP EASTERN,General Assembly,138,DEM,Write-in,0,2,0,2
+Northampton,MOORE TWSP EASTERN,President,,REP,Donald J Trump,291,161,3,455
+Northampton,MOORE TWSP EASTERN,President,,REP,Bill Weld,7,14,0,21
+Northampton,MOORE TWSP EASTERN,President,,REP,Roque Rocky De La Fuente,4,5,0,9
+Northampton,MOORE TWSP EASTERN,President,,REP,Write-in,0,5,0,5
+Northampton,MOORE TWSP EASTERN,Attorney General,,REP,Heather Heidelbaugh,253,163,3,419
+Northampton,MOORE TWSP EASTERN,Attorney General,,REP,Write-in,0,3,0,3
+Northampton,MOORE TWSP EASTERN,Auditor General,,REP,Timothy Defoor,251,162,2,415
+Northampton,MOORE TWSP EASTERN,Auditor General,,REP,Write-in,0,3,0,3
+Northampton,MOORE TWSP EASTERN,State Treasurer,,REP,Stacy L. Garrity,252,164,2,418
+Northampton,MOORE TWSP EASTERN,State Treasurer,,REP,Write-in,0,3,0,3
+Northampton,MOORE TWSP EASTERN,U.S. House,7,REP,Lisa Scheller,165,97,2,264
+Northampton,MOORE TWSP EASTERN,U.S. House,7,REP,Dean N. Browning,134,85,1,220
+Northampton,MOORE TWSP EASTERN,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,MOORE TWSP EASTERN,General Assembly,138,REP,Ann Flood,208,135,1,344
+Northampton,MOORE TWSP EASTERN,General Assembly,138,REP,Tony Tarsi,94,53,2,149
+Northampton,MOORE TWSP EASTERN,General Assembly,138,REP,Write-in,1,2,0,3
+Northampton,MOORE TWSP KLECKNERSVILLE,Registered Voters,,,,,,,1859
+Northampton,MOORE TWSP KLECKNERSVILLE,Registered Voters,,DEM,,,,,631
+Northampton,MOORE TWSP KLECKNERSVILLE,Registered Voters,,REP,,,,,962
+Northampton,MOORE TWSP KLECKNERSVILLE,Registered Voters,,NPA,,,,,266
+Northampton,MOORE TWSP KLECKNERSVILLE,Ballots Cast,,,,321,338,10,669
+Northampton,MOORE TWSP KLECKNERSVILLE,Ballots Cast,,DEM,,60,198,3,261
+Northampton,MOORE TWSP KLECKNERSVILLE,Ballots Cast,,REP,,261,140,7,408
+Northampton,MOORE TWSP KLECKNERSVILLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,MOORE TWSP KLECKNERSVILLE,President,,DEM,Joseph R. Biden,41,160,1,202
+Northampton,MOORE TWSP KLECKNERSVILLE,President,,DEM,Bernie Sanders,9,24,2,35
+Northampton,MOORE TWSP KLECKNERSVILLE,President,,DEM,Tulsi Gabbard,6,7,0,13
+Northampton,MOORE TWSP KLECKNERSVILLE,President,,DEM,Write-in,2,2,0,4
+Northampton,MOORE TWSP KLECKNERSVILLE,Attorney General,,DEM,Josh Shapiro,47,168,3,218
+Northampton,MOORE TWSP KLECKNERSVILLE,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,DEM,Rose Rosie Marie Davis,9,43,0,52
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,DEM,Nina Ahmad,13,33,2,48
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,DEM,Christina M. Hartman,8,36,1,45
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,DEM,Michael Lamb,13,17,0,30
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,DEM,H Scott Conklin,5,18,0,23
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,DEM,Tracie Fountain,4,14,0,18
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,MOORE TWSP KLECKNERSVILLE,State Treasurer,,DEM,Joe Torsella,47,164,3,214
+Northampton,MOORE TWSP KLECKNERSVILLE,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,MOORE TWSP KLECKNERSVILLE,U.S. House,7,DEM,Susan Wild,52,185,3,240
+Northampton,MOORE TWSP KLECKNERSVILLE,U.S. House,7,DEM,Write-in,0,3,0,3
+Northampton,MOORE TWSP KLECKNERSVILLE,General Assembly,183,DEM,Jason Ruff,44,173,2,219
+Northampton,MOORE TWSP KLECKNERSVILLE,General Assembly,183,DEM,Write-in,0,0,0,0
+Northampton,MOORE TWSP KLECKNERSVILLE,President,,REP,Donald J Trump,251,130,7,388
+Northampton,MOORE TWSP KLECKNERSVILLE,President,,REP,Bill Weld,3,6,0,9
+Northampton,MOORE TWSP KLECKNERSVILLE,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,MOORE TWSP KLECKNERSVILLE,President,,REP,Write-in,0,2,0,2
+Northampton,MOORE TWSP KLECKNERSVILLE,Attorney General,,REP,Heather Heidelbaugh,214,126,6,346
+Northampton,MOORE TWSP KLECKNERSVILLE,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,REP,Timothy Defoor,211,126,6,343
+Northampton,MOORE TWSP KLECKNERSVILLE,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,MOORE TWSP KLECKNERSVILLE,State Treasurer,,REP,Stacy L. Garrity,217,125,6,348
+Northampton,MOORE TWSP KLECKNERSVILLE,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,MOORE TWSP KLECKNERSVILLE,U.S. House,7,REP,Dean N. Browning,131,66,5,202
+Northampton,MOORE TWSP KLECKNERSVILLE,U.S. House,7,REP,Lisa Scheller,124,66,2,192
+Northampton,MOORE TWSP KLECKNERSVILLE,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP KLECKNERSVILLE,General Assembly,183,REP,Zach Mako,222,123,7,352
+Northampton,MOORE TWSP KLECKNERSVILLE,General Assembly,183,REP,Write-in,0,1,0,1
+Northampton,MOORE TWSP POINT PHILLIPS,Registered Voters,,,,,,,850
+Northampton,MOORE TWSP POINT PHILLIPS,Registered Voters,,DEM,,,,,294
+Northampton,MOORE TWSP POINT PHILLIPS,Registered Voters,,REP,,,,,424
+Northampton,MOORE TWSP POINT PHILLIPS,Registered Voters,,NPA,,,,,132
+Northampton,MOORE TWSP POINT PHILLIPS,Ballots Cast,,,,183,151,5,339
+Northampton,MOORE TWSP POINT PHILLIPS,Ballots Cast,,DEM,,40,89,2,131
+Northampton,MOORE TWSP POINT PHILLIPS,Ballots Cast,,REP,,143,62,3,208
+Northampton,MOORE TWSP POINT PHILLIPS,Ballots Cast,,NPA,,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,President,,DEM,Joseph R. Biden,29,73,2,104
+Northampton,MOORE TWSP POINT PHILLIPS,President,,DEM,Bernie Sanders,4,10,0,14
+Northampton,MOORE TWSP POINT PHILLIPS,President,,DEM,Tulsi Gabbard,3,3,0,6
+Northampton,MOORE TWSP POINT PHILLIPS,President,,DEM,Write-in,0,2,0,2
+Northampton,MOORE TWSP POINT PHILLIPS,Attorney General,,DEM,Josh Shapiro,30,81,2,113
+Northampton,MOORE TWSP POINT PHILLIPS,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,DEM,Rose Rosie Marie Davis,5,22,0,27
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,DEM,Christina M. Hartman,6,18,1,25
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,DEM,Nina Ahmad,6,14,1,21
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,DEM,Michael Lamb,9,7,0,16
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,DEM,Tracie Fountain,2,8,0,10
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,DEM,H Scott Conklin,3,3,0,6
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,State Treasurer,,DEM,Joe Torsella,29,79,2,110
+Northampton,MOORE TWSP POINT PHILLIPS,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,U.S. House,7,DEM,Susan Wild,34,85,2,121
+Northampton,MOORE TWSP POINT PHILLIPS,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,General Assembly,138,DEM,Tara Zrinski,26,82,2,110
+Northampton,MOORE TWSP POINT PHILLIPS,General Assembly,138,DEM,Write-in,1,0,0,1
+Northampton,MOORE TWSP POINT PHILLIPS,President,,REP,Donald J Trump,136,54,3,193
+Northampton,MOORE TWSP POINT PHILLIPS,President,,REP,Bill Weld,3,7,0,10
+Northampton,MOORE TWSP POINT PHILLIPS,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,MOORE TWSP POINT PHILLIPS,President,,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,Attorney General,,REP,Heather Heidelbaugh,108,48,2,158
+Northampton,MOORE TWSP POINT PHILLIPS,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,REP,Timothy Defoor,105,50,2,157
+Northampton,MOORE TWSP POINT PHILLIPS,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,State Treasurer,,REP,Stacy L. Garrity,106,48,2,156
+Northampton,MOORE TWSP POINT PHILLIPS,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,U.S. House,7,REP,Dean N. Browning,78,32,2,112
+Northampton,MOORE TWSP POINT PHILLIPS,U.S. House,7,REP,Lisa Scheller,60,26,1,87
+Northampton,MOORE TWSP POINT PHILLIPS,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,MOORE TWSP POINT PHILLIPS,General Assembly,138,REP,Ann Flood,104,45,3,152
+Northampton,MOORE TWSP POINT PHILLIPS,General Assembly,138,REP,Tony Tarsi,32,15,0,47
+Northampton,MOORE TWSP POINT PHILLIPS,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 1ST WARD,Registered Voters,,,,,,,1412
+Northampton,NAZARETH BORO 1ST WARD,Registered Voters,,DEM,,,,,595
+Northampton,NAZARETH BORO 1ST WARD,Registered Voters,,REP,,,,,598
+Northampton,NAZARETH BORO 1ST WARD,Registered Voters,,NPA,,,,,219
+Northampton,NAZARETH BORO 1ST WARD,Ballots Cast,,,,178,315,4,497
+Northampton,NAZARETH BORO 1ST WARD,Ballots Cast,,DEM,,73,202,2,277
+Northampton,NAZARETH BORO 1ST WARD,Ballots Cast,,REP,,105,113,2,220
+Northampton,NAZARETH BORO 1ST WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NAZARETH BORO 1ST WARD,President,,DEM,Joseph R. Biden,45,166,2,213
+Northampton,NAZARETH BORO 1ST WARD,President,,DEM,Bernie Sanders,20,25,0,45
+Northampton,NAZARETH BORO 1ST WARD,President,,DEM,Tulsi Gabbard,5,4,0,9
+Northampton,NAZARETH BORO 1ST WARD,President,,DEM,Write-in,0,4,0,4
+Northampton,NAZARETH BORO 1ST WARD,Attorney General,,DEM,Josh Shapiro,52,184,2,238
+Northampton,NAZARETH BORO 1ST WARD,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,DEM,Nina Ahmad,11,54,1,66
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,8,42,1,51
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,DEM,Christina M. Hartman,10,36,0,46
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,DEM,Michael Lamb,18,16,0,34
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,DEM,Tracie Fountain,5,18,0,23
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,DEM,H Scott Conklin,6,11,0,17
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 1ST WARD,State Treasurer,,DEM,Joe Torsella,48,176,1,225
+Northampton,NAZARETH BORO 1ST WARD,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 1ST WARD,U.S. House,7,DEM,Susan Wild,59,188,1,248
+Northampton,NAZARETH BORO 1ST WARD,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 1ST WARD,General Assembly,137,DEM,Katelind Brennan,57,176,2,235
+Northampton,NAZARETH BORO 1ST WARD,General Assembly,137,DEM,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 1ST WARD,President,,REP,Donald J Trump,104,93,2,199
+Northampton,NAZARETH BORO 1ST WARD,President,,REP,Bill Weld,0,9,0,9
+Northampton,NAZARETH BORO 1ST WARD,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Northampton,NAZARETH BORO 1ST WARD,President,,REP,Write-in,0,2,0,2
+Northampton,NAZARETH BORO 1ST WARD,Attorney General,,REP,Heather Heidelbaugh,88,96,2,186
+Northampton,NAZARETH BORO 1ST WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,REP,Timothy Defoor,84,92,2,178
+Northampton,NAZARETH BORO 1ST WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 1ST WARD,State Treasurer,,REP,Stacy L. Garrity,88,91,2,181
+Northampton,NAZARETH BORO 1ST WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 1ST WARD,U.S. House,7,REP,Dean N. Browning,64,53,2,119
+Northampton,NAZARETH BORO 1ST WARD,U.S. House,7,REP,Lisa Scheller,37,51,0,88
+Northampton,NAZARETH BORO 1ST WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 1ST WARD,General Assembly,137,REP,Joe Emrick,100,109,2,211
+Northampton,NAZARETH BORO 1ST WARD,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 2ND WARD,Registered Voters,,,,,,,1358
+Northampton,NAZARETH BORO 2ND WARD,Registered Voters,,DEM,,,,,619
+Northampton,NAZARETH BORO 2ND WARD,Registered Voters,,REP,,,,,463
+Northampton,NAZARETH BORO 2ND WARD,Registered Voters,,NPA,,,,,276
+Northampton,NAZARETH BORO 2ND WARD,Ballots Cast,,,,157,194,0,351
+Northampton,NAZARETH BORO 2ND WARD,Ballots Cast,,DEM,,76,141,0,217
+Northampton,NAZARETH BORO 2ND WARD,Ballots Cast,,REP,,81,53,0,134
+Northampton,NAZARETH BORO 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NAZARETH BORO 2ND WARD,President,,DEM,Joseph R. Biden,49,100,0,149
+Northampton,NAZARETH BORO 2ND WARD,President,,DEM,Bernie Sanders,19,35,0,54
+Northampton,NAZARETH BORO 2ND WARD,President,,DEM,Tulsi Gabbard,1,4,0,5
+Northampton,NAZARETH BORO 2ND WARD,President,,DEM,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 2ND WARD,Attorney General,,DEM,Josh Shapiro,54,127,0,181
+Northampton,NAZARETH BORO 2ND WARD,Attorney General,,DEM,Write-in,1,1,0,2
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,DEM,Nina Ahmad,24,33,0,57
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,13,37,0,50
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,DEM,Michael Lamb,9,20,0,29
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,DEM,Christina M. Hartman,6,18,0,24
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,DEM,H Scott Conklin,11,5,0,16
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,DEM,Tracie Fountain,2,10,0,12
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,NAZARETH BORO 2ND WARD,State Treasurer,,DEM,Joe Torsella,51,126,0,177
+Northampton,NAZARETH BORO 2ND WARD,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,NAZARETH BORO 2ND WARD,U.S. House,7,DEM,Susan Wild,65,135,0,200
+Northampton,NAZARETH BORO 2ND WARD,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,NAZARETH BORO 2ND WARD,General Assembly,137,DEM,Katelind Brennan,57,127,0,184
+Northampton,NAZARETH BORO 2ND WARD,General Assembly,137,DEM,Write-in,2,0,0,2
+Northampton,NAZARETH BORO 2ND WARD,President,,REP,Donald J Trump,77,49,0,126
+Northampton,NAZARETH BORO 2ND WARD,President,,REP,Bill Weld,3,2,0,5
+Northampton,NAZARETH BORO 2ND WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,NAZARETH BORO 2ND WARD,President,,REP,Write-in,0,2,0,2
+Northampton,NAZARETH BORO 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,63,46,0,109
+Northampton,NAZARETH BORO 2ND WARD,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,REP,Timothy Defoor,63,45,0,108
+Northampton,NAZARETH BORO 2ND WARD,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,62,45,0,107
+Northampton,NAZARETH BORO 2ND WARD,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 2ND WARD,U.S. House,7,REP,Lisa Scheller,42,23,0,65
+Northampton,NAZARETH BORO 2ND WARD,U.S. House,7,REP,Dean N. Browning,35,26,0,61
+Northampton,NAZARETH BORO 2ND WARD,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 2ND WARD,General Assembly,137,REP,Joe Emrick,76,51,0,127
+Northampton,NAZARETH BORO 2ND WARD,General Assembly,137,REP,Write-in,0,2,0,2
+Northampton,NAZARETH BORO 3RD WARD,Registered Voters,,,,,,,1212
+Northampton,NAZARETH BORO 3RD WARD,Registered Voters,,DEM,,,,,569
+Northampton,NAZARETH BORO 3RD WARD,Registered Voters,,REP,,,,,427
+Northampton,NAZARETH BORO 3RD WARD,Registered Voters,,NPA,,,,,216
+Northampton,NAZARETH BORO 3RD WARD,Ballots Cast,,,,173,177,3,353
+Northampton,NAZARETH BORO 3RD WARD,Ballots Cast,,DEM,,72,143,3,218
+Northampton,NAZARETH BORO 3RD WARD,Ballots Cast,,REP,,101,34,0,135
+Northampton,NAZARETH BORO 3RD WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NAZARETH BORO 3RD WARD,President,,DEM,Joseph R. Biden,47,111,2,160
+Northampton,NAZARETH BORO 3RD WARD,President,,DEM,Bernie Sanders,12,27,1,40
+Northampton,NAZARETH BORO 3RD WARD,President,,DEM,Tulsi Gabbard,4,3,0,7
+Northampton,NAZARETH BORO 3RD WARD,President,,DEM,Write-in,4,0,0,4
+Northampton,NAZARETH BORO 3RD WARD,Attorney General,,DEM,Josh Shapiro,53,134,2,189
+Northampton,NAZARETH BORO 3RD WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,DEM,Nina Ahmad,13,32,3,48
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,DEM,Rose Rosie Marie Davis,14,31,0,45
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,DEM,Christina M. Hartman,6,34,0,40
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,DEM,H Scott Conklin,9,9,0,18
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,DEM,Michael Lamb,8,7,0,15
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,DEM,Tracie Fountain,3,11,0,14
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 3RD WARD,State Treasurer,,DEM,Joe Torsella,51,131,2,184
+Northampton,NAZARETH BORO 3RD WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 3RD WARD,U.S. House,7,DEM,Susan Wild,57,138,2,197
+Northampton,NAZARETH BORO 3RD WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 3RD WARD,General Assembly,137,DEM,Katelind Brennan,52,131,2,185
+Northampton,NAZARETH BORO 3RD WARD,General Assembly,137,DEM,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 3RD WARD,President,,REP,Donald J Trump,92,26,0,118
+Northampton,NAZARETH BORO 3RD WARD,President,,REP,Bill Weld,6,3,0,9
+Northampton,NAZARETH BORO 3RD WARD,President,,REP,Roque Rocky De La Fuente,2,2,0,4
+Northampton,NAZARETH BORO 3RD WARD,President,,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 3RD WARD,Attorney General,,REP,Heather Heidelbaugh,88,25,0,113
+Northampton,NAZARETH BORO 3RD WARD,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,REP,Timothy Defoor,89,25,0,114
+Northampton,NAZARETH BORO 3RD WARD,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,NAZARETH BORO 3RD WARD,State Treasurer,,REP,Stacy L. Garrity,87,27,0,114
+Northampton,NAZARETH BORO 3RD WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 3RD WARD,U.S. House,7,REP,Lisa Scheller,51,16,0,67
+Northampton,NAZARETH BORO 3RD WARD,U.S. House,7,REP,Dean N. Browning,50,15,0,65
+Northampton,NAZARETH BORO 3RD WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,NAZARETH BORO 3RD WARD,General Assembly,137,REP,Joe Emrick,94,32,0,126
+Northampton,NAZARETH BORO 3RD WARD,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 1ST WARD,Registered Voters,,,,,,,1480
+Northampton,NORTHAMPTON BORO 1ST WARD,Registered Voters,,DEM,,,,,696
+Northampton,NORTHAMPTON BORO 1ST WARD,Registered Voters,,REP,,,,,534
+Northampton,NORTHAMPTON BORO 1ST WARD,Registered Voters,,NPA,,,,,250
+Northampton,NORTHAMPTON BORO 1ST WARD,Ballots Cast,,,,241,208,7,456
+Northampton,NORTHAMPTON BORO 1ST WARD,Ballots Cast,,DEM,,103,162,2,267
+Northampton,NORTHAMPTON BORO 1ST WARD,Ballots Cast,,REP,,138,46,5,189
+Northampton,NORTHAMPTON BORO 1ST WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NORTHAMPTON BORO 1ST WARD,President,,DEM,Joseph R. Biden,68,137,1,206
+Northampton,NORTHAMPTON BORO 1ST WARD,President,,DEM,Bernie Sanders,18,21,1,40
+Northampton,NORTHAMPTON BORO 1ST WARD,President,,DEM,Tulsi Gabbard,8,3,0,11
+Northampton,NORTHAMPTON BORO 1ST WARD,President,,DEM,Write-in,6,0,0,6
+Northampton,NORTHAMPTON BORO 1ST WARD,Attorney General,,DEM,Josh Shapiro,68,149,2,219
+Northampton,NORTHAMPTON BORO 1ST WARD,Attorney General,,DEM,Write-in,3,0,0,3
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,DEM,Nina Ahmad,23,44,2,69
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,DEM,Christina M. Hartman,11,38,0,49
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,DEM,Michael Lamb,22,23,0,45
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,10,21,0,31
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,DEM,H Scott Conklin,15,11,0,26
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,DEM,Tracie Fountain,5,12,0,17
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 1ST WARD,State Treasurer,,DEM,Joe Torsella,66,148,2,216
+Northampton,NORTHAMPTON BORO 1ST WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 1ST WARD,U.S. House,7,DEM,Susan Wild,80,156,2,238
+Northampton,NORTHAMPTON BORO 1ST WARD,U.S. House,7,DEM,Write-in,5,1,0,6
+Northampton,NORTHAMPTON BORO 1ST WARD,General Assembly,183,DEM,Jason Ruff,74,151,2,227
+Northampton,NORTHAMPTON BORO 1ST WARD,General Assembly,183,DEM,Write-in,3,0,0,3
+Northampton,NORTHAMPTON BORO 1ST WARD,President,,REP,Donald J Trump,129,41,5,175
+Northampton,NORTHAMPTON BORO 1ST WARD,President,,REP,Bill Weld,4,1,0,5
+Northampton,NORTHAMPTON BORO 1ST WARD,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,NORTHAMPTON BORO 1ST WARD,President,,REP,Write-in,1,1,0,2
+Northampton,NORTHAMPTON BORO 1ST WARD,Attorney General,,REP,Heather Heidelbaugh,114,39,5,158
+Northampton,NORTHAMPTON BORO 1ST WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,REP,Timothy Defoor,114,39,5,158
+Northampton,NORTHAMPTON BORO 1ST WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 1ST WARD,State Treasurer,,REP,Stacy L. Garrity,111,40,5,156
+Northampton,NORTHAMPTON BORO 1ST WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 1ST WARD,U.S. House,7,REP,Lisa Scheller,64,25,2,91
+Northampton,NORTHAMPTON BORO 1ST WARD,U.S. House,7,REP,Dean N. Browning,70,18,2,90
+Northampton,NORTHAMPTON BORO 1ST WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 1ST WARD,General Assembly,183,REP,Zach Mako,126,43,5,174
+Northampton,NORTHAMPTON BORO 1ST WARD,General Assembly,183,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 2ND WARD,Registered Voters,,,,,,,1489
+Northampton,NORTHAMPTON BORO 2ND WARD,Registered Voters,,DEM,,,,,694
+Northampton,NORTHAMPTON BORO 2ND WARD,Registered Voters,,REP,,,,,509
+Northampton,NORTHAMPTON BORO 2ND WARD,Registered Voters,,NPA,,,,,286
+Northampton,NORTHAMPTON BORO 2ND WARD,Ballots Cast,,,,212,195,4,411
+Northampton,NORTHAMPTON BORO 2ND WARD,Ballots Cast,,DEM,,97,148,0,245
+Northampton,NORTHAMPTON BORO 2ND WARD,Ballots Cast,,REP,,115,47,4,166
+Northampton,NORTHAMPTON BORO 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NORTHAMPTON BORO 2ND WARD,President,,DEM,Joseph R. Biden,68,114,0,182
+Northampton,NORTHAMPTON BORO 2ND WARD,President,,DEM,Bernie Sanders,18,28,0,46
+Northampton,NORTHAMPTON BORO 2ND WARD,President,,DEM,Tulsi Gabbard,6,5,0,11
+Northampton,NORTHAMPTON BORO 2ND WARD,President,,DEM,Write-in,3,0,0,3
+Northampton,NORTHAMPTON BORO 2ND WARD,Attorney General,,DEM,Josh Shapiro,70,136,0,206
+Northampton,NORTHAMPTON BORO 2ND WARD,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,DEM,Nina Ahmad,18,42,0,60
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,DEM,Christina M. Hartman,10,33,0,43
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,DEM,Michael Lamb,17,16,0,33
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,8,20,0,28
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,DEM,H Scott Conklin,21,5,0,26
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,DEM,Tracie Fountain,3,14,0,17
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,NORTHAMPTON BORO 2ND WARD,State Treasurer,,DEM,Joe Torsella,71,134,0,205
+Northampton,NORTHAMPTON BORO 2ND WARD,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,NORTHAMPTON BORO 2ND WARD,U.S. House,7,DEM,Susan Wild,82,145,0,227
+Northampton,NORTHAMPTON BORO 2ND WARD,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,NORTHAMPTON BORO 2ND WARD,General Assembly,183,DEM,Jason Ruff,81,142,0,223
+Northampton,NORTHAMPTON BORO 2ND WARD,General Assembly,183,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 2ND WARD,President,,REP,Donald J Trump,108,34,4,146
+Northampton,NORTHAMPTON BORO 2ND WARD,President,,REP,Bill Weld,5,6,0,11
+Northampton,NORTHAMPTON BORO 2ND WARD,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Northampton,NORTHAMPTON BORO 2ND WARD,President,,REP,Write-in,0,4,0,4
+Northampton,NORTHAMPTON BORO 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,88,43,3,134
+Northampton,NORTHAMPTON BORO 2ND WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,REP,Timothy Defoor,87,39,3,129
+Northampton,NORTHAMPTON BORO 2ND WARD,Auditor General,,REP,Write-in,0,2,0,2
+Northampton,NORTHAMPTON BORO 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,90,41,3,134
+Northampton,NORTHAMPTON BORO 2ND WARD,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,NORTHAMPTON BORO 2ND WARD,U.S. House,7,REP,Lisa Scheller,65,27,2,94
+Northampton,NORTHAMPTON BORO 2ND WARD,U.S. House,7,REP,Dean N. Browning,47,16,2,65
+Northampton,NORTHAMPTON BORO 2ND WARD,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,NORTHAMPTON BORO 2ND WARD,General Assembly,183,REP,Zach Mako,102,44,3,149
+Northampton,NORTHAMPTON BORO 2ND WARD,General Assembly,183,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 3RD WARD,Registered Voters,,,,,,,2635
+Northampton,NORTHAMPTON BORO 3RD WARD,Registered Voters,,DEM,,,,,1214
+Northampton,NORTHAMPTON BORO 3RD WARD,Registered Voters,,REP,,,,,986
+Northampton,NORTHAMPTON BORO 3RD WARD,Registered Voters,,NPA,,,,,435
+Northampton,NORTHAMPTON BORO 3RD WARD,Ballots Cast,,,,333,508,6,847
+Northampton,NORTHAMPTON BORO 3RD WARD,Ballots Cast,,DEM,,110,384,3,497
+Northampton,NORTHAMPTON BORO 3RD WARD,Ballots Cast,,REP,,223,124,3,350
+Northampton,NORTHAMPTON BORO 3RD WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NORTHAMPTON BORO 3RD WARD,President,,DEM,Joseph R. Biden,76,311,2,389
+Northampton,NORTHAMPTON BORO 3RD WARD,President,,DEM,Bernie Sanders,21,54,1,76
+Northampton,NORTHAMPTON BORO 3RD WARD,President,,DEM,Tulsi Gabbard,5,7,0,12
+Northampton,NORTHAMPTON BORO 3RD WARD,President,,DEM,Write-in,3,6,0,9
+Northampton,NORTHAMPTON BORO 3RD WARD,Attorney General,,DEM,Josh Shapiro,77,348,3,428
+Northampton,NORTHAMPTON BORO 3RD WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,DEM,Nina Ahmad,20,101,2,123
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,DEM,Christina M. Hartman,12,81,1,94
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,DEM,Michael Lamb,31,42,0,73
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,DEM,Rose Rosie Marie Davis,6,45,0,51
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,DEM,H Scott Conklin,16,31,0,47
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,DEM,Tracie Fountain,5,31,0,36
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 3RD WARD,State Treasurer,,DEM,Joe Torsella,72,341,3,416
+Northampton,NORTHAMPTON BORO 3RD WARD,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,NORTHAMPTON BORO 3RD WARD,U.S. House,7,DEM,Susan Wild,89,361,3,453
+Northampton,NORTHAMPTON BORO 3RD WARD,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,NORTHAMPTON BORO 3RD WARD,General Assembly,183,DEM,Jason Ruff,81,345,3,429
+Northampton,NORTHAMPTON BORO 3RD WARD,General Assembly,183,DEM,Write-in,0,2,0,2
+Northampton,NORTHAMPTON BORO 3RD WARD,President,,REP,Donald J Trump,216,107,3,326
+Northampton,NORTHAMPTON BORO 3RD WARD,President,,REP,Bill Weld,3,9,0,12
+Northampton,NORTHAMPTON BORO 3RD WARD,President,,REP,Roque Rocky De La Fuente,3,2,0,5
+Northampton,NORTHAMPTON BORO 3RD WARD,President,,REP,Write-in,0,2,0,2
+Northampton,NORTHAMPTON BORO 3RD WARD,Attorney General,,REP,Heather Heidelbaugh,188,102,3,293
+Northampton,NORTHAMPTON BORO 3RD WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,REP,Timothy Defoor,186,101,3,290
+Northampton,NORTHAMPTON BORO 3RD WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 3RD WARD,State Treasurer,,REP,Stacy L. Garrity,187,100,2,289
+Northampton,NORTHAMPTON BORO 3RD WARD,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,NORTHAMPTON BORO 3RD WARD,U.S. House,7,REP,Dean N. Browning,129,41,1,171
+Northampton,NORTHAMPTON BORO 3RD WARD,U.S. House,7,REP,Lisa Scheller,86,75,2,163
+Northampton,NORTHAMPTON BORO 3RD WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 3RD WARD,General Assembly,183,REP,Zach Mako,208,113,3,324
+Northampton,NORTHAMPTON BORO 3RD WARD,General Assembly,183,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,Registered Voters,,,,,,,744
+Northampton,NORTHAMPTON BORO 4TH WARD,Registered Voters,,DEM,,,,,358
+Northampton,NORTHAMPTON BORO 4TH WARD,Registered Voters,,REP,,,,,245
+Northampton,NORTHAMPTON BORO 4TH WARD,Registered Voters,,NPA,,,,,141
+Northampton,NORTHAMPTON BORO 4TH WARD,Ballots Cast,,,,118,64,6,188
+Northampton,NORTHAMPTON BORO 4TH WARD,Ballots Cast,,DEM,,53,44,2,99
+Northampton,NORTHAMPTON BORO 4TH WARD,Ballots Cast,,REP,,65,20,4,89
+Northampton,NORTHAMPTON BORO 4TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,President,,DEM,Joseph R. Biden,24,29,1,54
+Northampton,NORTHAMPTON BORO 4TH WARD,President,,DEM,Bernie Sanders,22,13,1,36
+Northampton,NORTHAMPTON BORO 4TH WARD,President,,DEM,Tulsi Gabbard,2,2,0,4
+Northampton,NORTHAMPTON BORO 4TH WARD,President,,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,Attorney General,,DEM,Josh Shapiro,39,40,2,81
+Northampton,NORTHAMPTON BORO 4TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,DEM,Nina Ahmad,13,13,2,28
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,DEM,Michael Lamb,8,5,0,13
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,DEM,Christina M. Hartman,4,8,0,12
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,DEM,H Scott Conklin,8,3,0,11
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,3,6,0,9
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,DEM,Tracie Fountain,6,2,0,8
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,State Treasurer,,DEM,Joe Torsella,42,38,2,82
+Northampton,NORTHAMPTON BORO 4TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,U.S. House,7,DEM,Susan Wild,44,41,2,87
+Northampton,NORTHAMPTON BORO 4TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,General Assembly,183,DEM,Jason Ruff,44,40,2,86
+Northampton,NORTHAMPTON BORO 4TH WARD,General Assembly,183,DEM,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,President,,REP,Donald J Trump,62,14,4,80
+Northampton,NORTHAMPTON BORO 4TH WARD,President,,REP,Bill Weld,2,5,0,7
+Northampton,NORTHAMPTON BORO 4TH WARD,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Northampton,NORTHAMPTON BORO 4TH WARD,President,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,Attorney General,,REP,Heather Heidelbaugh,51,16,3,70
+Northampton,NORTHAMPTON BORO 4TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,REP,Timothy Defoor,54,16,2,72
+Northampton,NORTHAMPTON BORO 4TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,State Treasurer,,REP,Stacy L. Garrity,54,16,2,72
+Northampton,NORTHAMPTON BORO 4TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,NORTHAMPTON BORO 4TH WARD,U.S. House,7,REP,Lisa Scheller,32,10,3,45
+Northampton,NORTHAMPTON BORO 4TH WARD,U.S. House,7,REP,Dean N. Browning,28,7,1,36
+Northampton,NORTHAMPTON BORO 4TH WARD,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,NORTHAMPTON BORO 4TH WARD,General Assembly,183,REP,Zach Mako,56,19,3,78
+Northampton,NORTHAMPTON BORO 4TH WARD,General Assembly,183,REP,Write-in,1,0,0,1
+Northampton,NORTH CATASAUQUA 1ST WARD,Registered Voters,,,,,,,622
+Northampton,NORTH CATASAUQUA 1ST WARD,Registered Voters,,DEM,,,,,276
+Northampton,NORTH CATASAUQUA 1ST WARD,Registered Voters,,REP,,,,,223
+Northampton,NORTH CATASAUQUA 1ST WARD,Registered Voters,,NPA,,,,,123
+Northampton,NORTH CATASAUQUA 1ST WARD,Ballots Cast,,,,105,69,4,178
+Northampton,NORTH CATASAUQUA 1ST WARD,Ballots Cast,,DEM,,45,42,4,91
+Northampton,NORTH CATASAUQUA 1ST WARD,Ballots Cast,,REP,,60,27,0,87
+Northampton,NORTH CATASAUQUA 1ST WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,President,,DEM,Joseph R. Biden,27,37,2,66
+Northampton,NORTH CATASAUQUA 1ST WARD,President,,DEM,Bernie Sanders,13,4,2,19
+Northampton,NORTH CATASAUQUA 1ST WARD,President,,DEM,Tulsi Gabbard,1,0,0,1
+Northampton,NORTH CATASAUQUA 1ST WARD,President,,DEM,Write-in,1,1,0,2
+Northampton,NORTH CATASAUQUA 1ST WARD,Attorney General,,DEM,Josh Shapiro,33,42,4,79
+Northampton,NORTH CATASAUQUA 1ST WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,DEM,Nina Ahmad,8,14,1,23
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,DEM,Michael Lamb,9,9,0,18
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,DEM,Christina M. Hartman,3,11,1,15
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,5,4,1,10
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,DEM,H Scott Conklin,9,0,0,9
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,DEM,Tracie Fountain,4,2,0,6
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,State Treasurer,,DEM,Joe Torsella,34,42,4,80
+Northampton,NORTH CATASAUQUA 1ST WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,U.S. House,7,DEM,Susan Wild,39,39,4,82
+Northampton,NORTH CATASAUQUA 1ST WARD,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,NORTH CATASAUQUA 1ST WARD,General Assembly,183,DEM,Jason Ruff,34,42,4,80
+Northampton,NORTH CATASAUQUA 1ST WARD,General Assembly,183,DEM,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,President,,REP,Donald J Trump,58,24,0,82
+Northampton,NORTH CATASAUQUA 1ST WARD,President,,REP,Bill Weld,1,1,0,2
+Northampton,NORTH CATASAUQUA 1ST WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,President,,REP,Write-in,0,1,0,1
+Northampton,NORTH CATASAUQUA 1ST WARD,Attorney General,,REP,Heather Heidelbaugh,51,21,0,72
+Northampton,NORTH CATASAUQUA 1ST WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,REP,Timothy Defoor,52,21,0,73
+Northampton,NORTH CATASAUQUA 1ST WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,State Treasurer,,REP,Stacy L. Garrity,51,21,0,72
+Northampton,NORTH CATASAUQUA 1ST WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,U.S. House,7,REP,Dean N. Browning,33,11,0,44
+Northampton,NORTH CATASAUQUA 1ST WARD,U.S. House,7,REP,Lisa Scheller,27,15,0,42
+Northampton,NORTH CATASAUQUA 1ST WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 1ST WARD,General Assembly,183,REP,Zach Mako,55,23,0,78
+Northampton,NORTH CATASAUQUA 1ST WARD,General Assembly,183,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,Registered Voters,,,,,,,1275
+Northampton,NORTH CATASAUQUA 2ND WARD,Registered Voters,,DEM,,,,,629
+Northampton,NORTH CATASAUQUA 2ND WARD,Registered Voters,,REP,,,,,456
+Northampton,NORTH CATASAUQUA 2ND WARD,Registered Voters,,NPA,,,,,190
+Northampton,NORTH CATASAUQUA 2ND WARD,Ballots Cast,,,,202,242,4,448
+Northampton,NORTH CATASAUQUA 2ND WARD,Ballots Cast,,DEM,,95,184,2,281
+Northampton,NORTH CATASAUQUA 2ND WARD,Ballots Cast,,REP,,107,58,2,167
+Northampton,NORTH CATASAUQUA 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,President,,DEM,Joseph R. Biden,57,148,2,207
+Northampton,NORTH CATASAUQUA 2ND WARD,President,,DEM,Bernie Sanders,21,23,0,44
+Northampton,NORTH CATASAUQUA 2ND WARD,President,,DEM,Tulsi Gabbard,7,3,0,10
+Northampton,NORTH CATASAUQUA 2ND WARD,President,,DEM,Write-in,0,5,0,5
+Northampton,NORTH CATASAUQUA 2ND WARD,Attorney General,,DEM,Josh Shapiro,66,159,2,227
+Northampton,NORTH CATASAUQUA 2ND WARD,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,DEM,Nina Ahmad,23,54,1,78
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,DEM,Christina M. Hartman,12,46,1,59
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,DEM,Michael Lamb,18,15,0,33
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,5,23,0,28
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,DEM,H Scott Conklin,13,9,0,22
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,DEM,Tracie Fountain,3,15,0,18
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,State Treasurer,,DEM,Joe Torsella,71,160,2,233
+Northampton,NORTH CATASAUQUA 2ND WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,U.S. House,7,DEM,Susan Wild,78,174,2,254
+Northampton,NORTH CATASAUQUA 2ND WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,General Assembly,183,DEM,Jason Ruff,77,156,2,235
+Northampton,NORTH CATASAUQUA 2ND WARD,General Assembly,183,DEM,Write-in,0,1,0,1
+Northampton,NORTH CATASAUQUA 2ND WARD,President,,REP,Donald J Trump,103,47,2,152
+Northampton,NORTH CATASAUQUA 2ND WARD,President,,REP,Bill Weld,0,6,0,6
+Northampton,NORTH CATASAUQUA 2ND WARD,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,NORTH CATASAUQUA 2ND WARD,President,,REP,Write-in,0,2,0,2
+Northampton,NORTH CATASAUQUA 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,81,50,2,133
+Northampton,NORTH CATASAUQUA 2ND WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,REP,Timothy Defoor,78,48,2,128
+Northampton,NORTH CATASAUQUA 2ND WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,79,50,2,131
+Northampton,NORTH CATASAUQUA 2ND WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,U.S. House,7,REP,Dean N. Browning,51,29,1,81
+Northampton,NORTH CATASAUQUA 2ND WARD,U.S. House,7,REP,Lisa Scheller,53,25,1,79
+Northampton,NORTH CATASAUQUA 2ND WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,NORTH CATASAUQUA 2ND WARD,General Assembly,183,REP,Zach Mako,96,53,2,151
+Northampton,NORTH CATASAUQUA 2ND WARD,General Assembly,183,REP,Write-in,0,0,0,0
+Northampton,PALMER EASTERN,Registered Voters,,,,,,,3156
+Northampton,PALMER EASTERN,Registered Voters,,DEM,,,,,1582
+Northampton,PALMER EASTERN,Registered Voters,,REP,,,,,984
+Northampton,PALMER EASTERN,Registered Voters,,NPA,,,,,590
+Northampton,PALMER EASTERN,Ballots Cast,,,,296,542,4,842
+Northampton,PALMER EASTERN,Ballots Cast,,DEM,,139,421,4,564
+Northampton,PALMER EASTERN,Ballots Cast,,REP,,157,121,0,278
+Northampton,PALMER EASTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PALMER EASTERN,President,,DEM,Joseph R. Biden,97,341,1,439
+Northampton,PALMER EASTERN,President,,DEM,Bernie Sanders,31,61,2,94
+Northampton,PALMER EASTERN,President,,DEM,Tulsi Gabbard,5,7,0,12
+Northampton,PALMER EASTERN,President,,DEM,Write-in,0,7,0,7
+Northampton,PALMER EASTERN,Attorney General,,DEM,Josh Shapiro,95,382,3,480
+Northampton,PALMER EASTERN,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,PALMER EASTERN,Auditor General,,DEM,Nina Ahmad,32,129,1,162
+Northampton,PALMER EASTERN,Auditor General,,DEM,Rose Rosie Marie Davis,12,79,0,91
+Northampton,PALMER EASTERN,Auditor General,,DEM,Christina M. Hartman,10,67,2,79
+Northampton,PALMER EASTERN,Auditor General,,DEM,Tracie Fountain,8,41,0,49
+Northampton,PALMER EASTERN,Auditor General,,DEM,Michael Lamb,23,25,0,48
+Northampton,PALMER EASTERN,Auditor General,,DEM,H Scott Conklin,18,15,0,33
+Northampton,PALMER EASTERN,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PALMER EASTERN,State Treasurer,,DEM,Joe Torsella,84,371,3,458
+Northampton,PALMER EASTERN,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,PALMER EASTERN,U.S. House,7,DEM,Susan Wild,117,399,3,519
+Northampton,PALMER EASTERN,U.S. House,7,DEM,Write-in,0,4,0,4
+Northampton,PALMER EASTERN,General Assembly,136,DEM,Robert Freeman,109,392,4,505
+Northampton,PALMER EASTERN,General Assembly,136,DEM,Write-in,0,2,0,2
+Northampton,PALMER EASTERN,President,,REP,Donald J Trump,142,108,0,250
+Northampton,PALMER EASTERN,President,,REP,Roque Rocky De La Fuente,9,0,0,9
+Northampton,PALMER EASTERN,President,,REP,Bill Weld,1,7,0,8
+Northampton,PALMER EASTERN,President,,REP,Write-in,3,1,0,4
+Northampton,PALMER EASTERN,Attorney General,,REP,Heather Heidelbaugh,135,111,0,246
+Northampton,PALMER EASTERN,Attorney General,,REP,Write-in,2,0,0,2
+Northampton,PALMER EASTERN,Auditor General,,REP,Timothy Defoor,136,112,0,248
+Northampton,PALMER EASTERN,Auditor General,,REP,Write-in,2,0,0,2
+Northampton,PALMER EASTERN,State Treasurer,,REP,Stacy L. Garrity,137,110,0,247
+Northampton,PALMER EASTERN,State Treasurer,,REP,Write-in,1,0,0,1
+Northampton,PALMER EASTERN,U.S. House,7,REP,Lisa Scheller,59,74,0,133
+Northampton,PALMER EASTERN,U.S. House,7,REP,Dean N. Browning,87,41,0,128
+Northampton,PALMER EASTERN,U.S. House,7,REP,Write-in,2,0,0,2
+Northampton,PALMER EASTERN,General Assembly,136,REP,Write-in,3,4,0,7
+Northampton,PALMER MIDDLE #1,Registered Voters,,,,,,,1572
+Northampton,PALMER MIDDLE #1,Registered Voters,,DEM,,,,,716
+Northampton,PALMER MIDDLE #1,Registered Voters,,REP,,,,,612
+Northampton,PALMER MIDDLE #1,Registered Voters,,NPA,,,,,244
+Northampton,PALMER MIDDLE #1,Ballots Cast,,,,229,313,2,544
+Northampton,PALMER MIDDLE #1,Ballots Cast,,DEM,,103,220,0,323
+Northampton,PALMER MIDDLE #1,Ballots Cast,,REP,,126,93,2,221
+Northampton,PALMER MIDDLE #1,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PALMER MIDDLE #1,President,,DEM,Joseph R. Biden,77,172,0,249
+Northampton,PALMER MIDDLE #1,President,,DEM,Bernie Sanders,18,35,0,53
+Northampton,PALMER MIDDLE #1,President,,DEM,Tulsi Gabbard,0,6,0,6
+Northampton,PALMER MIDDLE #1,President,,DEM,Write-in,1,4,0,5
+Northampton,PALMER MIDDLE #1,Attorney General,,DEM,Josh Shapiro,64,188,0,252
+Northampton,PALMER MIDDLE #1,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,PALMER MIDDLE #1,Auditor General,,DEM,Nina Ahmad,27,45,0,72
+Northampton,PALMER MIDDLE #1,Auditor General,,DEM,Michael Lamb,33,28,0,61
+Northampton,PALMER MIDDLE #1,Auditor General,,DEM,Christina M. Hartman,5,46,0,51
+Northampton,PALMER MIDDLE #1,Auditor General,,DEM,Rose Rosie Marie Davis,11,33,0,44
+Northampton,PALMER MIDDLE #1,Auditor General,,DEM,H Scott Conklin,9,9,0,18
+Northampton,PALMER MIDDLE #1,Auditor General,,DEM,Tracie Fountain,3,15,0,18
+Northampton,PALMER MIDDLE #1,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,PALMER MIDDLE #1,State Treasurer,,DEM,Joe Torsella,66,189,0,255
+Northampton,PALMER MIDDLE #1,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,PALMER MIDDLE #1,U.S. House,7,DEM,Susan Wild,81,198,0,279
+Northampton,PALMER MIDDLE #1,U.S. House,7,DEM,Write-in,0,4,0,4
+Northampton,PALMER MIDDLE #1,General Assembly,137,DEM,Katelind Brennan,70,181,0,251
+Northampton,PALMER MIDDLE #1,General Assembly,137,DEM,Write-in,0,3,0,3
+Northampton,PALMER MIDDLE #1,President,,REP,Donald J Trump,117,73,2,192
+Northampton,PALMER MIDDLE #1,President,,REP,Bill Weld,2,10,0,12
+Northampton,PALMER MIDDLE #1,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,PALMER MIDDLE #1,President,,REP,Write-in,1,2,0,3
+Northampton,PALMER MIDDLE #1,Attorney General,,REP,Heather Heidelbaugh,99,73,2,174
+Northampton,PALMER MIDDLE #1,Attorney General,,REP,Write-in,0,3,0,3
+Northampton,PALMER MIDDLE #1,Auditor General,,REP,Timothy Defoor,102,72,2,176
+Northampton,PALMER MIDDLE #1,Auditor General,,REP,Write-in,0,4,0,4
+Northampton,PALMER MIDDLE #1,State Treasurer,,REP,Stacy L. Garrity,101,72,2,175
+Northampton,PALMER MIDDLE #1,State Treasurer,,REP,Write-in,0,3,0,3
+Northampton,PALMER MIDDLE #1,U.S. House,7,REP,Dean N. Browning,68,40,1,109
+Northampton,PALMER MIDDLE #1,U.S. House,7,REP,Lisa Scheller,53,40,1,94
+Northampton,PALMER MIDDLE #1,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,PALMER MIDDLE #1,General Assembly,137,REP,Joe Emrick,108,86,2,196
+Northampton,PALMER MIDDLE #1,General Assembly,137,REP,Write-in,1,2,0,3
+Northampton,PALMER MIDDLE #2,Registered Voters,,,,,,,1787
+Northampton,PALMER MIDDLE #2,Registered Voters,,DEM,,,,,857
+Northampton,PALMER MIDDLE #2,Registered Voters,,REP,,,,,637
+Northampton,PALMER MIDDLE #2,Registered Voters,,NPA,,,,,293
+Northampton,PALMER MIDDLE #2,Ballots Cast,,,,179,400,2,581
+Northampton,PALMER MIDDLE #2,Ballots Cast,,DEM,,60,275,1,336
+Northampton,PALMER MIDDLE #2,Ballots Cast,,REP,,119,125,1,245
+Northampton,PALMER MIDDLE #2,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PALMER MIDDLE #2,President,,DEM,Joseph R. Biden,39,219,1,259
+Northampton,PALMER MIDDLE #2,President,,DEM,Bernie Sanders,18,43,0,61
+Northampton,PALMER MIDDLE #2,President,,DEM,Tulsi Gabbard,1,3,0,4
+Northampton,PALMER MIDDLE #2,President,,DEM,Write-in,1,6,0,7
+Northampton,PALMER MIDDLE #2,Attorney General,,DEM,Josh Shapiro,43,247,1,291
+Northampton,PALMER MIDDLE #2,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,PALMER MIDDLE #2,Auditor General,,DEM,Nina Ahmad,18,90,1,109
+Northampton,PALMER MIDDLE #2,Auditor General,,DEM,Rose Rosie Marie Davis,13,52,0,65
+Northampton,PALMER MIDDLE #2,Auditor General,,DEM,Christina M. Hartman,2,44,0,46
+Northampton,PALMER MIDDLE #2,Auditor General,,DEM,Michael Lamb,10,24,0,34
+Northampton,PALMER MIDDLE #2,Auditor General,,DEM,H Scott Conklin,8,14,0,22
+Northampton,PALMER MIDDLE #2,Auditor General,,DEM,Tracie Fountain,2,13,0,15
+Northampton,PALMER MIDDLE #2,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PALMER MIDDLE #2,State Treasurer,,DEM,Joe Torsella,43,246,1,290
+Northampton,PALMER MIDDLE #2,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PALMER MIDDLE #2,U.S. House,7,DEM,Susan Wild,48,262,1,311
+Northampton,PALMER MIDDLE #2,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,PALMER MIDDLE #2,General Assembly,136,DEM,Robert Freeman,51,258,1,310
+Northampton,PALMER MIDDLE #2,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,PALMER MIDDLE #2,President,,REP,Donald J Trump,105,112,1,218
+Northampton,PALMER MIDDLE #2,President,,REP,Bill Weld,7,9,0,16
+Northampton,PALMER MIDDLE #2,President,,REP,Roque Rocky De La Fuente,4,0,0,4
+Northampton,PALMER MIDDLE #2,President,,REP,Write-in,1,2,0,3
+Northampton,PALMER MIDDLE #2,Attorney General,,REP,Heather Heidelbaugh,98,101,0,199
+Northampton,PALMER MIDDLE #2,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,PALMER MIDDLE #2,Auditor General,,REP,Timothy Defoor,97,102,1,200
+Northampton,PALMER MIDDLE #2,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,PALMER MIDDLE #2,State Treasurer,,REP,Stacy L. Garrity,96,103,0,199
+Northampton,PALMER MIDDLE #2,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,PALMER MIDDLE #2,U.S. House,7,REP,Lisa Scheller,63,61,0,124
+Northampton,PALMER MIDDLE #2,U.S. House,7,REP,Dean N. Browning,54,54,1,109
+Northampton,PALMER MIDDLE #2,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,PALMER MIDDLE #2,General Assembly,136,REP,Write-in,0,12,0,12
+Northampton,PALMER UPPER EASTERN,Registered Voters,,,,,,,2852
+Northampton,PALMER UPPER EASTERN,Registered Voters,,DEM,,,,,1186
+Northampton,PALMER UPPER EASTERN,Registered Voters,,REP,,,,,1127
+Northampton,PALMER UPPER EASTERN,Registered Voters,,NPA,,,,,539
+Northampton,PALMER UPPER EASTERN,Ballots Cast,,,,271,534,3,808
+Northampton,PALMER UPPER EASTERN,Ballots Cast,,DEM,,94,377,2,473
+Northampton,PALMER UPPER EASTERN,Ballots Cast,,REP,,177,157,1,335
+Northampton,PALMER UPPER EASTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PALMER UPPER EASTERN,President,,DEM,Joseph R. Biden,56,314,1,371
+Northampton,PALMER UPPER EASTERN,President,,DEM,Bernie Sanders,28,44,1,73
+Northampton,PALMER UPPER EASTERN,President,,DEM,Tulsi Gabbard,8,6,0,14
+Northampton,PALMER UPPER EASTERN,President,,DEM,Write-in,1,8,0,9
+Northampton,PALMER UPPER EASTERN,Attorney General,,DEM,Josh Shapiro,63,344,1,408
+Northampton,PALMER UPPER EASTERN,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,PALMER UPPER EASTERN,Auditor General,,DEM,Nina Ahmad,27,114,0,141
+Northampton,PALMER UPPER EASTERN,Auditor General,,DEM,Christina M. Hartman,4,61,0,65
+Northampton,PALMER UPPER EASTERN,Auditor General,,DEM,Rose Rosie Marie Davis,9,52,0,61
+Northampton,PALMER UPPER EASTERN,Auditor General,,DEM,Michael Lamb,22,37,1,60
+Northampton,PALMER UPPER EASTERN,Auditor General,,DEM,Tracie Fountain,1,54,0,55
+Northampton,PALMER UPPER EASTERN,Auditor General,,DEM,H Scott Conklin,8,11,0,19
+Northampton,PALMER UPPER EASTERN,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PALMER UPPER EASTERN,State Treasurer,,DEM,Joe Torsella,59,338,1,398
+Northampton,PALMER UPPER EASTERN,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,PALMER UPPER EASTERN,U.S. House,7,DEM,Susan Wild,75,362,1,438
+Northampton,PALMER UPPER EASTERN,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PALMER UPPER EASTERN,General Assembly,137,DEM,Katelind Brennan,68,331,1,400
+Northampton,PALMER UPPER EASTERN,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,PALMER UPPER EASTERN,President,,REP,Donald J Trump,166,127,1,294
+Northampton,PALMER UPPER EASTERN,President,,REP,Bill Weld,6,15,0,21
+Northampton,PALMER UPPER EASTERN,President,,REP,Roque Rocky De La Fuente,2,2,0,4
+Northampton,PALMER UPPER EASTERN,President,,REP,Write-in,0,5,0,5
+Northampton,PALMER UPPER EASTERN,Attorney General,,REP,Heather Heidelbaugh,141,140,1,282
+Northampton,PALMER UPPER EASTERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,PALMER UPPER EASTERN,Auditor General,,REP,Timothy Defoor,142,138,1,281
+Northampton,PALMER UPPER EASTERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,PALMER UPPER EASTERN,State Treasurer,,REP,Stacy L. Garrity,143,138,1,282
+Northampton,PALMER UPPER EASTERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,PALMER UPPER EASTERN,U.S. House,7,REP,Lisa Scheller,90,81,0,171
+Northampton,PALMER UPPER EASTERN,U.S. House,7,REP,Dean N. Browning,83,60,1,144
+Northampton,PALMER UPPER EASTERN,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,PALMER UPPER EASTERN,General Assembly,137,REP,Joe Emrick,159,148,1,308
+Northampton,PALMER UPPER EASTERN,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,PALMER UPPER WESTERN,Registered Voters,,,,,,,3943
+Northampton,PALMER UPPER WESTERN,Registered Voters,,DEM,,,,,1764
+Northampton,PALMER UPPER WESTERN,Registered Voters,,REP,,,,,1411
+Northampton,PALMER UPPER WESTERN,Registered Voters,,NPA,,,,,768
+Northampton,PALMER UPPER WESTERN,Ballots Cast,,,,271,1033,17,1321
+Northampton,PALMER UPPER WESTERN,Ballots Cast,,DEM,,115,690,10,815
+Northampton,PALMER UPPER WESTERN,Ballots Cast,,REP,,156,343,7,506
+Northampton,PALMER UPPER WESTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PALMER UPPER WESTERN,President,,DEM,Joseph R. Biden,76,582,4,662
+Northampton,PALMER UPPER WESTERN,President,,DEM,Bernie Sanders,30,68,6,104
+Northampton,PALMER UPPER WESTERN,President,,DEM,Tulsi Gabbard,6,13,0,19
+Northampton,PALMER UPPER WESTERN,President,,DEM,Write-in,1,18,0,19
+Northampton,PALMER UPPER WESTERN,Attorney General,,DEM,Josh Shapiro,85,631,8,724
+Northampton,PALMER UPPER WESTERN,Attorney General,,DEM,Write-in,0,3,0,3
+Northampton,PALMER UPPER WESTERN,Auditor General,,DEM,Nina Ahmad,27,171,4,202
+Northampton,PALMER UPPER WESTERN,Auditor General,,DEM,Christina M. Hartman,3,139,2,144
+Northampton,PALMER UPPER WESTERN,Auditor General,,DEM,Rose Rosie Marie Davis,11,118,1,130
+Northampton,PALMER UPPER WESTERN,Auditor General,,DEM,Michael Lamb,24,58,1,83
+Northampton,PALMER UPPER WESTERN,Auditor General,,DEM,H Scott Conklin,24,44,0,68
+Northampton,PALMER UPPER WESTERN,Auditor General,,DEM,Tracie Fountain,6,52,1,59
+Northampton,PALMER UPPER WESTERN,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,PALMER UPPER WESTERN,State Treasurer,,DEM,Joe Torsella,83,620,8,711
+Northampton,PALMER UPPER WESTERN,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PALMER UPPER WESTERN,U.S. House,7,DEM,Susan Wild,93,654,9,756
+Northampton,PALMER UPPER WESTERN,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,PALMER UPPER WESTERN,General Assembly,137,DEM,Katelind Brennan,87,617,9,713
+Northampton,PALMER UPPER WESTERN,General Assembly,137,DEM,Write-in,1,0,0,1
+Northampton,PALMER UPPER WESTERN,President,,REP,Donald J Trump,142,276,7,425
+Northampton,PALMER UPPER WESTERN,President,,REP,Bill Weld,3,32,0,35
+Northampton,PALMER UPPER WESTERN,President,,REP,Roque Rocky De La Fuente,1,10,0,11
+Northampton,PALMER UPPER WESTERN,President,,REP,Write-in,0,9,0,9
+Northampton,PALMER UPPER WESTERN,Attorney General,,REP,Heather Heidelbaugh,116,295,6,417
+Northampton,PALMER UPPER WESTERN,Attorney General,,REP,Write-in,1,0,0,1
+Northampton,PALMER UPPER WESTERN,Auditor General,,REP,Timothy Defoor,120,289,5,414
+Northampton,PALMER UPPER WESTERN,Auditor General,,REP,Write-in,1,1,0,2
+Northampton,PALMER UPPER WESTERN,State Treasurer,,REP,Stacy L. Garrity,114,288,5,407
+Northampton,PALMER UPPER WESTERN,State Treasurer,,REP,Write-in,1,1,0,2
+Northampton,PALMER UPPER WESTERN,U.S. House,7,REP,Lisa Scheller,87,177,5,269
+Northampton,PALMER UPPER WESTERN,U.S. House,7,REP,Dean N. Browning,62,141,2,205
+Northampton,PALMER UPPER WESTERN,U.S. House,7,REP,Write-in,1,2,0,3
+Northampton,PALMER UPPER WESTERN,General Assembly,137,REP,Joe Emrick,137,319,6,462
+Northampton,PALMER UPPER WESTERN,General Assembly,137,REP,Write-in,1,0,0,1
+Northampton,PALMER WESTERN #1,Registered Voters,,,,,,,1800
+Northampton,PALMER WESTERN #1,Registered Voters,,DEM,,,,,737
+Northampton,PALMER WESTERN #1,Registered Voters,,REP,,,,,753
+Northampton,PALMER WESTERN #1,Registered Voters,,NPA,,,,,310
+Northampton,PALMER WESTERN #1,Ballots Cast,,,,232,404,4,640
+Northampton,PALMER WESTERN #1,Ballots Cast,,DEM,,59,281,1,341
+Northampton,PALMER WESTERN #1,Ballots Cast,,REP,,173,123,3,299
+Northampton,PALMER WESTERN #1,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PALMER WESTERN #1,President,,DEM,Joseph R. Biden,40,231,1,272
+Northampton,PALMER WESTERN #1,President,,DEM,Bernie Sanders,12,40,0,52
+Northampton,PALMER WESTERN #1,President,,DEM,Tulsi Gabbard,2,7,0,9
+Northampton,PALMER WESTERN #1,President,,DEM,Write-in,2,3,0,5
+Northampton,PALMER WESTERN #1,Attorney General,,DEM,Josh Shapiro,38,244,1,283
+Northampton,PALMER WESTERN #1,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #1,Auditor General,,DEM,Nina Ahmad,12,84,0,96
+Northampton,PALMER WESTERN #1,Auditor General,,DEM,Christina M. Hartman,8,50,0,58
+Northampton,PALMER WESTERN #1,Auditor General,,DEM,Rose Rosie Marie Davis,8,36,0,44
+Northampton,PALMER WESTERN #1,Auditor General,,DEM,Michael Lamb,8,29,0,37
+Northampton,PALMER WESTERN #1,Auditor General,,DEM,H Scott Conklin,8,15,0,23
+Northampton,PALMER WESTERN #1,Auditor General,,DEM,Tracie Fountain,0,20,0,20
+Northampton,PALMER WESTERN #1,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #1,State Treasurer,,DEM,Joe Torsella,37,242,1,280
+Northampton,PALMER WESTERN #1,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #1,U.S. House,7,DEM,Susan Wild,45,264,1,310
+Northampton,PALMER WESTERN #1,U.S. House,7,DEM,Write-in,0,5,0,5
+Northampton,PALMER WESTERN #1,General Assembly,136,DEM,Robert Freeman,49,258,1,308
+Northampton,PALMER WESTERN #1,General Assembly,136,DEM,Write-in,0,2,0,2
+Northampton,PALMER WESTERN #1,President,,REP,Donald J Trump,163,103,3,269
+Northampton,PALMER WESTERN #1,President,,REP,Bill Weld,3,8,0,11
+Northampton,PALMER WESTERN #1,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Northampton,PALMER WESTERN #1,President,,REP,Write-in,1,3,0,4
+Northampton,PALMER WESTERN #1,Attorney General,,REP,Heather Heidelbaugh,144,102,2,248
+Northampton,PALMER WESTERN #1,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,PALMER WESTERN #1,Auditor General,,REP,Timothy Defoor,145,101,2,248
+Northampton,PALMER WESTERN #1,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,PALMER WESTERN #1,State Treasurer,,REP,Stacy L. Garrity,143,99,2,244
+Northampton,PALMER WESTERN #1,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,PALMER WESTERN #1,U.S. House,7,REP,Lisa Scheller,80,66,1,147
+Northampton,PALMER WESTERN #1,U.S. House,7,REP,Dean N. Browning,89,49,2,140
+Northampton,PALMER WESTERN #1,U.S. House,7,REP,Write-in,1,2,0,3
+Northampton,PALMER WESTERN #1,General Assembly,136,REP,Write-in,0,5,0,5
+Northampton,PALMER WESTERN #2,Registered Voters,,,,,,,960
+Northampton,PALMER WESTERN #2,Registered Voters,,DEM,,,,,428
+Northampton,PALMER WESTERN #2,Registered Voters,,REP,,,,,338
+Northampton,PALMER WESTERN #2,Registered Voters,,NPA,,,,,194
+Northampton,PALMER WESTERN #2,Ballots Cast,,,,121,172,0,293
+Northampton,PALMER WESTERN #2,Ballots Cast,,DEM,,53,130,0,183
+Northampton,PALMER WESTERN #2,Ballots Cast,,REP,,68,42,0,110
+Northampton,PALMER WESTERN #2,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PALMER WESTERN #2,President,,DEM,Joseph R. Biden,38,114,0,152
+Northampton,PALMER WESTERN #2,President,,DEM,Bernie Sanders,11,9,0,20
+Northampton,PALMER WESTERN #2,President,,DEM,Tulsi Gabbard,1,3,0,4
+Northampton,PALMER WESTERN #2,President,,DEM,Write-in,1,2,0,3
+Northampton,PALMER WESTERN #2,Attorney General,,DEM,Josh Shapiro,36,121,0,157
+Northampton,PALMER WESTERN #2,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,Auditor General,,DEM,Nina Ahmad,8,38,0,46
+Northampton,PALMER WESTERN #2,Auditor General,,DEM,Christina M. Hartman,5,32,0,37
+Northampton,PALMER WESTERN #2,Auditor General,,DEM,Michael Lamb,13,14,0,27
+Northampton,PALMER WESTERN #2,Auditor General,,DEM,Rose Rosie Marie Davis,5,14,0,19
+Northampton,PALMER WESTERN #2,Auditor General,,DEM,H Scott Conklin,9,7,0,16
+Northampton,PALMER WESTERN #2,Auditor General,,DEM,Tracie Fountain,4,9,0,13
+Northampton,PALMER WESTERN #2,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,State Treasurer,,DEM,Joe Torsella,35,120,0,155
+Northampton,PALMER WESTERN #2,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,U.S. House,7,DEM,Susan Wild,40,125,0,165
+Northampton,PALMER WESTERN #2,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,General Assembly,136,DEM,Robert Freeman,41,127,0,168
+Northampton,PALMER WESTERN #2,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,President,,REP,Donald J Trump,61,36,0,97
+Northampton,PALMER WESTERN #2,President,,REP,Roque Rocky De La Fuente,3,1,0,4
+Northampton,PALMER WESTERN #2,President,,REP,Bill Weld,3,1,0,4
+Northampton,PALMER WESTERN #2,President,,REP,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,Attorney General,,REP,Heather Heidelbaugh,53,33,0,86
+Northampton,PALMER WESTERN #2,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,Auditor General,,REP,Timothy Defoor,54,33,0,87
+Northampton,PALMER WESTERN #2,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,State Treasurer,,REP,Stacy L. Garrity,54,32,0,86
+Northampton,PALMER WESTERN #2,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,U.S. House,7,REP,Dean N. Browning,38,21,0,59
+Northampton,PALMER WESTERN #2,U.S. House,7,REP,Lisa Scheller,29,18,0,47
+Northampton,PALMER WESTERN #2,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,PALMER WESTERN #2,General Assembly,136,REP,Write-in,1,5,0,6
+Northampton,PEN ARGYL BORO 1ST WARD,Registered Voters,,,,,,,364
+Northampton,PEN ARGYL BORO 1ST WARD,Registered Voters,,DEM,,,,,146
+Northampton,PEN ARGYL BORO 1ST WARD,Registered Voters,,REP,,,,,154
+Northampton,PEN ARGYL BORO 1ST WARD,Registered Voters,,NPA,,,,,64
+Northampton,PEN ARGYL BORO 1ST WARD,Ballots Cast,,,,60,36,1,97
+Northampton,PEN ARGYL BORO 1ST WARD,Ballots Cast,,DEM,,16,26,0,42
+Northampton,PEN ARGYL BORO 1ST WARD,Ballots Cast,,REP,,44,10,1,55
+Northampton,PEN ARGYL BORO 1ST WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,President,,DEM,Joseph R. Biden,9,20,0,29
+Northampton,PEN ARGYL BORO 1ST WARD,President,,DEM,Bernie Sanders,4,4,0,8
+Northampton,PEN ARGYL BORO 1ST WARD,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,PEN ARGYL BORO 1ST WARD,President,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,Attorney General,,DEM,Josh Shapiro,12,23,0,35
+Northampton,PEN ARGYL BORO 1ST WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,DEM,Christina M. Hartman,5,6,0,11
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,DEM,Michael Lamb,2,6,0,8
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,4,4,0,8
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,DEM,Nina Ahmad,2,3,0,5
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,DEM,H Scott Conklin,1,1,0,2
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,State Treasurer,,DEM,Joe Torsella,13,22,0,35
+Northampton,PEN ARGYL BORO 1ST WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,U.S. House,7,DEM,Susan Wild,13,23,0,36
+Northampton,PEN ARGYL BORO 1ST WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,General Assembly,138,DEM,Tara Zrinski,13,22,0,35
+Northampton,PEN ARGYL BORO 1ST WARD,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,President,,REP,Donald J Trump,43,8,1,52
+Northampton,PEN ARGYL BORO 1ST WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,President,,REP,Bill Weld,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,President,,REP,Write-in,0,2,0,2
+Northampton,PEN ARGYL BORO 1ST WARD,Attorney General,,REP,Heather Heidelbaugh,39,8,0,47
+Northampton,PEN ARGYL BORO 1ST WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,REP,Timothy Defoor,38,7,1,46
+Northampton,PEN ARGYL BORO 1ST WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,State Treasurer,,REP,Stacy L. Garrity,38,7,1,46
+Northampton,PEN ARGYL BORO 1ST WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,U.S. House,7,REP,Lisa Scheller,23,4,0,27
+Northampton,PEN ARGYL BORO 1ST WARD,U.S. House,7,REP,Dean N. Browning,21,3,0,24
+Northampton,PEN ARGYL BORO 1ST WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 1ST WARD,General Assembly,138,REP,Ann Flood,35,6,0,41
+Northampton,PEN ARGYL BORO 1ST WARD,General Assembly,138,REP,Tony Tarsi,9,2,1,12
+Northampton,PEN ARGYL BORO 1ST WARD,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,Registered Voters,,,,,,,863
+Northampton,PEN ARGYL BORO 2ND WARD,Registered Voters,,DEM,,,,,297
+Northampton,PEN ARGYL BORO 2ND WARD,Registered Voters,,REP,,,,,445
+Northampton,PEN ARGYL BORO 2ND WARD,Registered Voters,,NPA,,,,,121
+Northampton,PEN ARGYL BORO 2ND WARD,Ballots Cast,,,,185,122,4,311
+Northampton,PEN ARGYL BORO 2ND WARD,Ballots Cast,,DEM,,43,64,1,108
+Northampton,PEN ARGYL BORO 2ND WARD,Ballots Cast,,REP,,142,58,3,203
+Northampton,PEN ARGYL BORO 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,President,,DEM,Joseph R. Biden,20,51,1,72
+Northampton,PEN ARGYL BORO 2ND WARD,President,,DEM,Bernie Sanders,11,8,0,19
+Northampton,PEN ARGYL BORO 2ND WARD,President,,DEM,Tulsi Gabbard,3,1,0,4
+Northampton,PEN ARGYL BORO 2ND WARD,President,,DEM,Write-in,3,2,0,5
+Northampton,PEN ARGYL BORO 2ND WARD,Attorney General,,DEM,Josh Shapiro,25,53,1,79
+Northampton,PEN ARGYL BORO 2ND WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,11,29,0,40
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,DEM,Nina Ahmad,3,13,0,16
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,DEM,Michael Lamb,8,4,0,12
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,DEM,H Scott Conklin,7,1,1,9
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,DEM,Christina M. Hartman,2,5,0,7
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,State Treasurer,,DEM,Joe Torsella,24,54,1,79
+Northampton,PEN ARGYL BORO 2ND WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,U.S. House,7,DEM,Susan Wild,29,58,1,88
+Northampton,PEN ARGYL BORO 2ND WARD,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,PEN ARGYL BORO 2ND WARD,General Assembly,138,DEM,Tara Zrinski,31,54,1,86
+Northampton,PEN ARGYL BORO 2ND WARD,General Assembly,138,DEM,Write-in,2,0,0,2
+Northampton,PEN ARGYL BORO 2ND WARD,President,,REP,Donald J Trump,133,45,3,181
+Northampton,PEN ARGYL BORO 2ND WARD,President,,REP,Bill Weld,3,4,0,7
+Northampton,PEN ARGYL BORO 2ND WARD,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,PEN ARGYL BORO 2ND WARD,President,,REP,Write-in,0,2,0,2
+Northampton,PEN ARGYL BORO 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,113,51,3,167
+Northampton,PEN ARGYL BORO 2ND WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,REP,Timothy Defoor,110,51,3,164
+Northampton,PEN ARGYL BORO 2ND WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,108,51,3,162
+Northampton,PEN ARGYL BORO 2ND WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,U.S. House,7,REP,Dean N. Browning,83,28,3,114
+Northampton,PEN ARGYL BORO 2ND WARD,U.S. House,7,REP,Lisa Scheller,54,24,0,78
+Northampton,PEN ARGYL BORO 2ND WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 2ND WARD,General Assembly,138,REP,Ann Flood,86,41,1,128
+Northampton,PEN ARGYL BORO 2ND WARD,General Assembly,138,REP,Tony Tarsi,52,14,2,68
+Northampton,PEN ARGYL BORO 2ND WARD,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,Registered Voters,,,,,,,611
+Northampton,PEN ARGYL BORO 3RD WARD,Registered Voters,,DEM,,,,,248
+Northampton,PEN ARGYL BORO 3RD WARD,Registered Voters,,REP,,,,,260
+Northampton,PEN ARGYL BORO 3RD WARD,Registered Voters,,NPA,,,,,103
+Northampton,PEN ARGYL BORO 3RD WARD,Ballots Cast,,,,131,85,2,218
+Northampton,PEN ARGYL BORO 3RD WARD,Ballots Cast,,DEM,,42,65,2,109
+Northampton,PEN ARGYL BORO 3RD WARD,Ballots Cast,,REP,,89,20,0,109
+Northampton,PEN ARGYL BORO 3RD WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,President,,DEM,Joseph R. Biden,28,53,1,82
+Northampton,PEN ARGYL BORO 3RD WARD,President,,DEM,Bernie Sanders,11,11,0,22
+Northampton,PEN ARGYL BORO 3RD WARD,President,,DEM,Tulsi Gabbard,1,0,0,1
+Northampton,PEN ARGYL BORO 3RD WARD,President,,DEM,Write-in,0,0,1,1
+Northampton,PEN ARGYL BORO 3RD WARD,Attorney General,,DEM,Josh Shapiro,31,58,2,91
+Northampton,PEN ARGYL BORO 3RD WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,DEM,Rose Rosie Marie Davis,15,29,0,44
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,DEM,Nina Ahmad,4,11,1,16
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,DEM,Christina M. Hartman,5,9,1,15
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,DEM,Michael Lamb,8,5,0,13
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,DEM,H Scott Conklin,7,5,0,12
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,State Treasurer,,DEM,Joe Torsella,33,59,2,94
+Northampton,PEN ARGYL BORO 3RD WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,U.S. House,7,DEM,Susan Wild,34,64,2,100
+Northampton,PEN ARGYL BORO 3RD WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,General Assembly,138,DEM,Tara Zrinski,34,58,2,94
+Northampton,PEN ARGYL BORO 3RD WARD,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,President,,REP,Donald J Trump,87,18,0,105
+Northampton,PEN ARGYL BORO 3RD WARD,President,,REP,Bill Weld,2,2,0,4
+Northampton,PEN ARGYL BORO 3RD WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,President,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,Attorney General,,REP,Heather Heidelbaugh,80,16,0,96
+Northampton,PEN ARGYL BORO 3RD WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,REP,Timothy Defoor,79,15,0,94
+Northampton,PEN ARGYL BORO 3RD WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,State Treasurer,,REP,Stacy L. Garrity,81,16,0,97
+Northampton,PEN ARGYL BORO 3RD WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,U.S. House,7,REP,Lisa Scheller,49,10,0,59
+Northampton,PEN ARGYL BORO 3RD WARD,U.S. House,7,REP,Dean N. Browning,38,8,0,46
+Northampton,PEN ARGYL BORO 3RD WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 3RD WARD,General Assembly,138,REP,Ann Flood,63,17,0,80
+Northampton,PEN ARGYL BORO 3RD WARD,General Assembly,138,REP,Tony Tarsi,24,2,0,26
+Northampton,PEN ARGYL BORO 3RD WARD,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,Registered Voters,,,,,,,408
+Northampton,PEN ARGYL BORO 4TH WARD,Registered Voters,,DEM,,,,,175
+Northampton,PEN ARGYL BORO 4TH WARD,Registered Voters,,REP,,,,,142
+Northampton,PEN ARGYL BORO 4TH WARD,Registered Voters,,NPA,,,,,91
+Northampton,PEN ARGYL BORO 4TH WARD,Ballots Cast,,,,43,47,4,94
+Northampton,PEN ARGYL BORO 4TH WARD,Ballots Cast,,DEM,,14,34,2,50
+Northampton,PEN ARGYL BORO 4TH WARD,Ballots Cast,,REP,,29,13,2,44
+Northampton,PEN ARGYL BORO 4TH WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,President,,DEM,Joseph R. Biden,9,22,1,32
+Northampton,PEN ARGYL BORO 4TH WARD,President,,DEM,Bernie Sanders,3,10,1,14
+Northampton,PEN ARGYL BORO 4TH WARD,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,PEN ARGYL BORO 4TH WARD,President,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,Attorney General,,DEM,Josh Shapiro,8,33,2,43
+Northampton,PEN ARGYL BORO 4TH WARD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,6,17,2,25
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,DEM,Nina Ahmad,3,10,0,13
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,DEM,Michael Lamb,2,1,0,3
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,DEM,Tracie Fountain,0,2,0,2
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,DEM,Christina M. Hartman,0,2,0,2
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,DEM,H Scott Conklin,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,State Treasurer,,DEM,Joe Torsella,8,33,2,43
+Northampton,PEN ARGYL BORO 4TH WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,U.S. House,7,DEM,Susan Wild,11,33,2,46
+Northampton,PEN ARGYL BORO 4TH WARD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,General Assembly,138,DEM,Tara Zrinski,10,33,2,45
+Northampton,PEN ARGYL BORO 4TH WARD,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,President,,REP,Donald J Trump,26,11,1,38
+Northampton,PEN ARGYL BORO 4TH WARD,President,,REP,Bill Weld,2,1,0,3
+Northampton,PEN ARGYL BORO 4TH WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,PEN ARGYL BORO 4TH WARD,President,,REP,Write-in,0,1,0,1
+Northampton,PEN ARGYL BORO 4TH WARD,Attorney General,,REP,Heather Heidelbaugh,23,12,1,36
+Northampton,PEN ARGYL BORO 4TH WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,REP,Timothy Defoor,23,10,1,34
+Northampton,PEN ARGYL BORO 4TH WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,State Treasurer,,REP,Stacy L. Garrity,25,9,1,35
+Northampton,PEN ARGYL BORO 4TH WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,U.S. House,7,REP,Dean N. Browning,14,6,1,21
+Northampton,PEN ARGYL BORO 4TH WARD,U.S. House,7,REP,Lisa Scheller,14,7,0,21
+Northampton,PEN ARGYL BORO 4TH WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,PEN ARGYL BORO 4TH WARD,General Assembly,138,REP,Ann Flood,19,7,0,26
+Northampton,PEN ARGYL BORO 4TH WARD,General Assembly,138,REP,Tony Tarsi,7,5,1,13
+Northampton,PEN ARGYL BORO 4TH WARD,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP BELFAST,Registered Voters,,,,,,,1377
+Northampton,PLAINFIELD TWSP BELFAST,Registered Voters,,DEM,,,,,498
+Northampton,PLAINFIELD TWSP BELFAST,Registered Voters,,REP,,,,,622
+Northampton,PLAINFIELD TWSP BELFAST,Registered Voters,,NPA,,,,,257
+Northampton,PLAINFIELD TWSP BELFAST,Ballots Cast,,,,264,205,5,474
+Northampton,PLAINFIELD TWSP BELFAST,Ballots Cast,,DEM,,70,131,2,203
+Northampton,PLAINFIELD TWSP BELFAST,Ballots Cast,,REP,,194,74,3,271
+Northampton,PLAINFIELD TWSP BELFAST,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PLAINFIELD TWSP BELFAST,President,,DEM,Joseph R. Biden,43,101,0,144
+Northampton,PLAINFIELD TWSP BELFAST,President,,DEM,Bernie Sanders,15,17,2,34
+Northampton,PLAINFIELD TWSP BELFAST,President,,DEM,Tulsi Gabbard,5,4,0,9
+Northampton,PLAINFIELD TWSP BELFAST,President,,DEM,Write-in,2,6,0,8
+Northampton,PLAINFIELD TWSP BELFAST,Attorney General,,DEM,Josh Shapiro,53,122,2,177
+Northampton,PLAINFIELD TWSP BELFAST,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,DEM,Rose Rosie Marie Davis,16,52,0,68
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,DEM,Nina Ahmad,14,18,0,32
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,DEM,Christina M. Hartman,9,19,1,29
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,DEM,H Scott Conklin,11,10,0,21
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,DEM,Tracie Fountain,4,12,1,17
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,DEM,Michael Lamb,9,5,0,14
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP BELFAST,State Treasurer,,DEM,Joe Torsella,52,121,2,175
+Northampton,PLAINFIELD TWSP BELFAST,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP BELFAST,U.S. House,7,DEM,Susan Wild,58,121,2,181
+Northampton,PLAINFIELD TWSP BELFAST,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP BELFAST,General Assembly,138,DEM,Tara Zrinski,51,120,2,173
+Northampton,PLAINFIELD TWSP BELFAST,General Assembly,138,DEM,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP BELFAST,President,,REP,Donald J Trump,184,69,2,255
+Northampton,PLAINFIELD TWSP BELFAST,President,,REP,Bill Weld,7,0,0,7
+Northampton,PLAINFIELD TWSP BELFAST,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,PLAINFIELD TWSP BELFAST,President,,REP,Write-in,1,1,1,3
+Northampton,PLAINFIELD TWSP BELFAST,Attorney General,,REP,Heather Heidelbaugh,150,60,3,213
+Northampton,PLAINFIELD TWSP BELFAST,Attorney General,,REP,Write-in,1,0,0,1
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,REP,Timothy Defoor,151,60,3,214
+Northampton,PLAINFIELD TWSP BELFAST,Auditor General,,REP,Write-in,1,0,0,1
+Northampton,PLAINFIELD TWSP BELFAST,State Treasurer,,REP,Stacy L. Garrity,150,61,3,214
+Northampton,PLAINFIELD TWSP BELFAST,State Treasurer,,REP,Write-in,1,0,0,1
+Northampton,PLAINFIELD TWSP BELFAST,U.S. House,7,REP,Dean N. Browning,110,37,1,148
+Northampton,PLAINFIELD TWSP BELFAST,U.S. House,7,REP,Lisa Scheller,70,35,2,107
+Northampton,PLAINFIELD TWSP BELFAST,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP BELFAST,General Assembly,138,REP,Ann Flood,117,47,0,164
+Northampton,PLAINFIELD TWSP BELFAST,General Assembly,138,REP,Tony Tarsi,71,26,3,100
+Northampton,PLAINFIELD TWSP BELFAST,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP DELABOLE,Registered Voters,,,,,,,1101
+Northampton,PLAINFIELD TWSP DELABOLE,Registered Voters,,DEM,,,,,402
+Northampton,PLAINFIELD TWSP DELABOLE,Registered Voters,,REP,,,,,534
+Northampton,PLAINFIELD TWSP DELABOLE,Registered Voters,,NPA,,,,,165
+Northampton,PLAINFIELD TWSP DELABOLE,Ballots Cast,,,,170,197,1,368
+Northampton,PLAINFIELD TWSP DELABOLE,Ballots Cast,,DEM,,44,116,1,161
+Northampton,PLAINFIELD TWSP DELABOLE,Ballots Cast,,REP,,126,81,0,207
+Northampton,PLAINFIELD TWSP DELABOLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PLAINFIELD TWSP DELABOLE,President,,DEM,Joseph R. Biden,28,99,0,127
+Northampton,PLAINFIELD TWSP DELABOLE,President,,DEM,Bernie Sanders,12,11,1,24
+Northampton,PLAINFIELD TWSP DELABOLE,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,PLAINFIELD TWSP DELABOLE,President,,DEM,Write-in,1,4,0,5
+Northampton,PLAINFIELD TWSP DELABOLE,Attorney General,,DEM,Josh Shapiro,32,104,1,137
+Northampton,PLAINFIELD TWSP DELABOLE,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,DEM,Rose Rosie Marie Davis,16,30,0,46
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,DEM,Nina Ahmad,12,18,0,30
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,DEM,Christina M. Hartman,4,18,0,22
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,DEM,Tracie Fountain,1,15,0,16
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,DEM,H Scott Conklin,2,10,0,12
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,DEM,Michael Lamb,3,6,1,10
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP DELABOLE,State Treasurer,,DEM,Joe Torsella,34,105,1,140
+Northampton,PLAINFIELD TWSP DELABOLE,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP DELABOLE,U.S. House,7,DEM,Susan Wild,41,111,1,153
+Northampton,PLAINFIELD TWSP DELABOLE,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP DELABOLE,General Assembly,138,DEM,Tara Zrinski,37,110,1,148
+Northampton,PLAINFIELD TWSP DELABOLE,General Assembly,138,DEM,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP DELABOLE,President,,REP,Donald J Trump,113,68,0,181
+Northampton,PLAINFIELD TWSP DELABOLE,President,,REP,Bill Weld,3,6,0,9
+Northampton,PLAINFIELD TWSP DELABOLE,President,,REP,Roque Rocky De La Fuente,3,0,0,3
+Northampton,PLAINFIELD TWSP DELABOLE,President,,REP,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP DELABOLE,Attorney General,,REP,Heather Heidelbaugh,104,56,0,160
+Northampton,PLAINFIELD TWSP DELABOLE,Attorney General,,REP,Write-in,0,3,0,3
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,REP,Timothy Defoor,102,56,0,158
+Northampton,PLAINFIELD TWSP DELABOLE,Auditor General,,REP,Write-in,0,3,0,3
+Northampton,PLAINFIELD TWSP DELABOLE,State Treasurer,,REP,Stacy L. Garrity,104,60,0,164
+Northampton,PLAINFIELD TWSP DELABOLE,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP DELABOLE,U.S. House,7,REP,Dean N. Browning,68,34,0,102
+Northampton,PLAINFIELD TWSP DELABOLE,U.S. House,7,REP,Lisa Scheller,56,37,0,93
+Northampton,PLAINFIELD TWSP DELABOLE,U.S. House,7,REP,Write-in,0,3,0,3
+Northampton,PLAINFIELD TWSP DELABOLE,General Assembly,138,REP,Ann Flood,83,60,0,143
+Northampton,PLAINFIELD TWSP DELABOLE,General Assembly,138,REP,Tony Tarsi,41,17,0,58
+Northampton,PLAINFIELD TWSP DELABOLE,General Assembly,138,REP,Write-in,0,3,0,3
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Registered Voters,,,,,,,941
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Registered Voters,,DEM,,,,,301
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Registered Voters,,REP,,,,,479
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Registered Voters,,NPA,,,,,161
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Ballots Cast,,,,190,152,4,346
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Ballots Cast,,DEM,,47,87,1,135
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Ballots Cast,,REP,,143,65,3,211
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,President,,DEM,Joseph R. Biden,29,74,1,104
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,President,,DEM,Bernie Sanders,11,12,0,23
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,President,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Attorney General,,DEM,Josh Shapiro,31,80,0,111
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,DEM,Nina Ahmad,13,29,0,42
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,DEM,Rose Rosie Marie Davis,5,22,1,28
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,DEM,Christina M. Hartman,4,12,0,16
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,DEM,Michael Lamb,6,7,0,13
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,DEM,Tracie Fountain,2,8,0,10
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,DEM,H Scott Conklin,6,3,0,9
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,State Treasurer,,DEM,Joe Torsella,29,78,1,108
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,U.S. House,7,DEM,Susan Wild,33,87,1,121
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,General Assembly,138,DEM,Tara Zrinski,31,78,1,110
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,General Assembly,138,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,President,,REP,Donald J Trump,132,51,3,186
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,President,,REP,Bill Weld,2,7,0,9
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,President,,REP,Roque Rocky De La Fuente,3,2,0,5
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,President,,REP,Write-in,1,1,0,2
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Attorney General,,REP,Heather Heidelbaugh,115,52,3,170
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Attorney General,,REP,Write-in,0,3,0,3
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,REP,Timothy Defoor,117,55,3,175
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,State Treasurer,,REP,Stacy L. Garrity,118,54,2,174
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,U.S. House,7,REP,Dean N. Browning,79,25,0,104
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,U.S. House,7,REP,Lisa Scheller,60,34,3,97
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,General Assembly,138,REP,Ann Flood,84,50,3,137
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,General Assembly,138,REP,Tony Tarsi,48,13,0,61
+Northampton,PLAINFIELD TWSP KESSLERSVILLE,General Assembly,138,REP,Write-in,0,1,0,1
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Registered Voters,,,,,,,1049
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Registered Voters,,DEM,,,,,366
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Registered Voters,,REP,,,,,512
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Registered Voters,,NPA,,,,,171
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Ballots Cast,,,,151,208,6,365
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Ballots Cast,,DEM,,37,118,2,157
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Ballots Cast,,REP,,114,90,4,208
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,President,,DEM,Joseph R. Biden,22,100,2,124
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,President,,DEM,Bernie Sanders,8,11,0,19
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,President,,DEM,Tulsi Gabbard,3,4,0,7
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,President,,DEM,Write-in,1,3,0,4
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Attorney General,,DEM,Josh Shapiro,29,102,2,133
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,DEM,Rose Rosie Marie Davis,9,41,1,51
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,DEM,Christina M. Hartman,5,18,0,23
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,DEM,Michael Lamb,5,13,1,19
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,DEM,Nina Ahmad,3,15,0,18
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,DEM,H Scott Conklin,7,7,0,14
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,DEM,Tracie Fountain,1,4,0,5
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,State Treasurer,,DEM,Joe Torsella,28,102,2,132
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,U.S. House,7,DEM,Susan Wild,28,109,2,139
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,General Assembly,138,DEM,Tara Zrinski,26,101,2,129
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,General Assembly,138,DEM,Write-in,1,1,0,2
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,President,,REP,Donald J Trump,111,80,4,195
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,President,,REP,Bill Weld,2,4,0,6
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,President,,REP,Write-in,0,2,0,2
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Attorney General,,REP,Heather Heidelbaugh,86,81,1,168
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,REP,Timothy Defoor,87,78,2,167
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,State Treasurer,,REP,Stacy L. Garrity,88,84,2,174
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,U.S. House,7,REP,Dean N. Browning,67,47,3,117
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,U.S. House,7,REP,Lisa Scheller,42,38,1,81
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,General Assembly,138,REP,Ann Flood,79,61,3,143
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,General Assembly,138,REP,Tony Tarsi,34,27,1,62
+Northampton,PLAINFIELD TWSP PLAINFIELD CHURCH,General Assembly,138,REP,Write-in,0,0,0,0
+Northampton,PORTLAND BORO,Registered Voters,,,,,,,349
+Northampton,PORTLAND BORO,Registered Voters,,DEM,,,,,109
+Northampton,PORTLAND BORO,Registered Voters,,REP,,,,,164
+Northampton,PORTLAND BORO,Registered Voters,,NPA,,,,,76
+Northampton,PORTLAND BORO,Ballots Cast,,,,58,27,5,90
+Northampton,PORTLAND BORO,Ballots Cast,,DEM,,15,17,1,33
+Northampton,PORTLAND BORO,Ballots Cast,,REP,,43,10,4,57
+Northampton,PORTLAND BORO,Ballots Cast,,NPA,,0,0,0,0
+Northampton,PORTLAND BORO,President,,DEM,Joseph R. Biden,5,14,1,20
+Northampton,PORTLAND BORO,President,,DEM,Bernie Sanders,6,2,0,8
+Northampton,PORTLAND BORO,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,PORTLAND BORO,President,,DEM,Write-in,1,0,0,1
+Northampton,PORTLAND BORO,Attorney General,,DEM,Josh Shapiro,12,15,1,28
+Northampton,PORTLAND BORO,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,PORTLAND BORO,Auditor General,,DEM,Rose Rosie Marie Davis,8,11,1,20
+Northampton,PORTLAND BORO,Auditor General,,DEM,H Scott Conklin,4,1,0,5
+Northampton,PORTLAND BORO,Auditor General,,DEM,Nina Ahmad,0,3,0,3
+Northampton,PORTLAND BORO,Auditor General,,DEM,Michael Lamb,0,1,0,1
+Northampton,PORTLAND BORO,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Northampton,PORTLAND BORO,Auditor General,,DEM,Christina M. Hartman,0,0,0,0
+Northampton,PORTLAND BORO,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,PORTLAND BORO,State Treasurer,,DEM,Joe Torsella,11,16,1,28
+Northampton,PORTLAND BORO,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,PORTLAND BORO,U.S. House,7,DEM,Susan Wild,15,16,1,32
+Northampton,PORTLAND BORO,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,PORTLAND BORO,General Assembly,137,DEM,Katelind Brennan,12,16,1,29
+Northampton,PORTLAND BORO,General Assembly,137,DEM,Write-in,0,1,0,1
+Northampton,PORTLAND BORO,President,,REP,Donald J Trump,39,8,4,51
+Northampton,PORTLAND BORO,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,PORTLAND BORO,President,,REP,Bill Weld,0,0,0,0
+Northampton,PORTLAND BORO,President,,REP,Write-in,1,2,0,3
+Northampton,PORTLAND BORO,Attorney General,,REP,Heather Heidelbaugh,39,6,4,49
+Northampton,PORTLAND BORO,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,PORTLAND BORO,Auditor General,,REP,Timothy Defoor,38,6,4,48
+Northampton,PORTLAND BORO,Auditor General,,REP,Write-in,0,2,0,2
+Northampton,PORTLAND BORO,State Treasurer,,REP,Stacy L. Garrity,39,6,3,48
+Northampton,PORTLAND BORO,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,PORTLAND BORO,U.S. House,7,REP,Lisa Scheller,22,1,2,25
+Northampton,PORTLAND BORO,U.S. House,7,REP,Dean N. Browning,17,5,2,24
+Northampton,PORTLAND BORO,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,PORTLAND BORO,General Assembly,137,REP,Joe Emrick,40,10,4,54
+Northampton,PORTLAND BORO,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,ROSETO BORO,Registered Voters,,,,,,,1088
+Northampton,ROSETO BORO,Registered Voters,,DEM,,,,,419
+Northampton,ROSETO BORO,Registered Voters,,REP,,,,,476
+Northampton,ROSETO BORO,Registered Voters,,NPA,,,,,193
+Northampton,ROSETO BORO,Ballots Cast,,,,176,119,0,295
+Northampton,ROSETO BORO,Ballots Cast,,DEM,,60,76,0,136
+Northampton,ROSETO BORO,Ballots Cast,,REP,,116,43,0,159
+Northampton,ROSETO BORO,Ballots Cast,,NPA,,0,0,0,0
+Northampton,ROSETO BORO,President,,DEM,Joseph R. Biden,43,60,0,103
+Northampton,ROSETO BORO,President,,DEM,Bernie Sanders,5,9,0,14
+Northampton,ROSETO BORO,President,,DEM,Tulsi Gabbard,5,2,0,7
+Northampton,ROSETO BORO,President,,DEM,Write-in,1,0,0,1
+Northampton,ROSETO BORO,Attorney General,,DEM,Josh Shapiro,45,68,0,113
+Northampton,ROSETO BORO,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,ROSETO BORO,Auditor General,,DEM,Rose Rosie Marie Davis,19,43,0,62
+Northampton,ROSETO BORO,Auditor General,,DEM,Nina Ahmad,7,11,0,18
+Northampton,ROSETO BORO,Auditor General,,DEM,Christina M. Hartman,6,5,0,11
+Northampton,ROSETO BORO,Auditor General,,DEM,H Scott Conklin,9,1,0,10
+Northampton,ROSETO BORO,Auditor General,,DEM,Michael Lamb,6,4,0,10
+Northampton,ROSETO BORO,Auditor General,,DEM,Tracie Fountain,2,3,0,5
+Northampton,ROSETO BORO,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,ROSETO BORO,State Treasurer,,DEM,Joe Torsella,42,65,0,107
+Northampton,ROSETO BORO,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,ROSETO BORO,U.S. House,7,DEM,Susan Wild,50,72,0,122
+Northampton,ROSETO BORO,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,ROSETO BORO,General Assembly,137,DEM,Katelind Brennan,43,56,0,99
+Northampton,ROSETO BORO,General Assembly,137,DEM,Write-in,2,0,0,2
+Northampton,ROSETO BORO,President,,REP,Donald J Trump,111,37,0,148
+Northampton,ROSETO BORO,President,,REP,Bill Weld,2,2,0,4
+Northampton,ROSETO BORO,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,ROSETO BORO,President,,REP,Write-in,0,1,0,1
+Northampton,ROSETO BORO,Attorney General,,REP,Heather Heidelbaugh,96,37,0,133
+Northampton,ROSETO BORO,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,ROSETO BORO,Auditor General,,REP,Timothy Defoor,96,37,0,133
+Northampton,ROSETO BORO,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,ROSETO BORO,State Treasurer,,REP,Stacy L. Garrity,92,37,0,129
+Northampton,ROSETO BORO,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,ROSETO BORO,U.S. House,7,REP,Lisa Scheller,53,25,0,78
+Northampton,ROSETO BORO,U.S. House,7,REP,Dean N. Browning,55,16,0,71
+Northampton,ROSETO BORO,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,ROSETO BORO,General Assembly,137,REP,Joe Emrick,110,43,0,153
+Northampton,ROSETO BORO,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,Registered Voters,,,,,,,620
+Northampton,STOCKERTOWN BORO,Registered Voters,,DEM,,,,,255
+Northampton,STOCKERTOWN BORO,Registered Voters,,REP,,,,,243
+Northampton,STOCKERTOWN BORO,Registered Voters,,NPA,,,,,122
+Northampton,STOCKERTOWN BORO,Ballots Cast,,,,114,70,0,184
+Northampton,STOCKERTOWN BORO,Ballots Cast,,DEM,,38,51,0,89
+Northampton,STOCKERTOWN BORO,Ballots Cast,,REP,,76,19,0,95
+Northampton,STOCKERTOWN BORO,Ballots Cast,,NPA,,0,0,0,0
+Northampton,STOCKERTOWN BORO,President,,DEM,Joseph R. Biden,26,38,0,64
+Northampton,STOCKERTOWN BORO,President,,DEM,Bernie Sanders,5,11,0,16
+Northampton,STOCKERTOWN BORO,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,STOCKERTOWN BORO,President,,DEM,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,Attorney General,,DEM,Josh Shapiro,27,48,0,75
+Northampton,STOCKERTOWN BORO,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,Auditor General,,DEM,Rose Rosie Marie Davis,12,8,0,20
+Northampton,STOCKERTOWN BORO,Auditor General,,DEM,Nina Ahmad,5,10,0,15
+Northampton,STOCKERTOWN BORO,Auditor General,,DEM,Christina M. Hartman,2,13,0,15
+Northampton,STOCKERTOWN BORO,Auditor General,,DEM,Michael Lamb,8,3,0,11
+Northampton,STOCKERTOWN BORO,Auditor General,,DEM,H Scott Conklin,4,3,0,7
+Northampton,STOCKERTOWN BORO,Auditor General,,DEM,Tracie Fountain,0,7,0,7
+Northampton,STOCKERTOWN BORO,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,State Treasurer,,DEM,Joe Torsella,27,47,0,74
+Northampton,STOCKERTOWN BORO,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,U.S. House,7,DEM,Susan Wild,33,50,0,83
+Northampton,STOCKERTOWN BORO,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,General Assembly,137,DEM,Katelind Brennan,27,45,0,72
+Northampton,STOCKERTOWN BORO,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,President,,REP,Donald J Trump,72,14,0,86
+Northampton,STOCKERTOWN BORO,President,,REP,Bill Weld,0,4,0,4
+Northampton,STOCKERTOWN BORO,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Northampton,STOCKERTOWN BORO,President,,REP,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,Attorney General,,REP,Heather Heidelbaugh,62,17,0,79
+Northampton,STOCKERTOWN BORO,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,Auditor General,,REP,Timothy Defoor,62,18,0,80
+Northampton,STOCKERTOWN BORO,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,State Treasurer,,REP,Stacy L. Garrity,65,17,0,82
+Northampton,STOCKERTOWN BORO,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,U.S. House,7,REP,Lisa Scheller,32,13,0,45
+Northampton,STOCKERTOWN BORO,U.S. House,7,REP,Dean N. Browning,38,5,0,43
+Northampton,STOCKERTOWN BORO,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,STOCKERTOWN BORO,General Assembly,137,REP,Joe Emrick,66,19,0,85
+Northampton,STOCKERTOWN BORO,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,TATAMY BORO,Registered Voters,,,,,,,791
+Northampton,TATAMY BORO,Registered Voters,,DEM,,,,,296
+Northampton,TATAMY BORO,Registered Voters,,REP,,,,,353
+Northampton,TATAMY BORO,Registered Voters,,NPA,,,,,142
+Northampton,TATAMY BORO,Ballots Cast,,,,132,103,5,240
+Northampton,TATAMY BORO,Ballots Cast,,DEM,,50,66,0,116
+Northampton,TATAMY BORO,Ballots Cast,,REP,,82,37,5,124
+Northampton,TATAMY BORO,Ballots Cast,,NPA,,0,0,0,0
+Northampton,TATAMY BORO,President,,DEM,Joseph R. Biden,34,45,0,79
+Northampton,TATAMY BORO,President,,DEM,Bernie Sanders,9,19,0,28
+Northampton,TATAMY BORO,President,,DEM,Tulsi Gabbard,3,0,0,3
+Northampton,TATAMY BORO,President,,DEM,Write-in,0,0,0,0
+Northampton,TATAMY BORO,Attorney General,,DEM,Josh Shapiro,34,60,0,94
+Northampton,TATAMY BORO,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,TATAMY BORO,Auditor General,,DEM,Rose Rosie Marie Davis,10,21,0,31
+Northampton,TATAMY BORO,Auditor General,,DEM,Nina Ahmad,8,12,0,20
+Northampton,TATAMY BORO,Auditor General,,DEM,Christina M. Hartman,8,12,0,20
+Northampton,TATAMY BORO,Auditor General,,DEM,Michael Lamb,13,5,0,18
+Northampton,TATAMY BORO,Auditor General,,DEM,Tracie Fountain,1,7,0,8
+Northampton,TATAMY BORO,Auditor General,,DEM,H Scott Conklin,5,2,0,7
+Northampton,TATAMY BORO,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,TATAMY BORO,State Treasurer,,DEM,Joe Torsella,34,59,0,93
+Northampton,TATAMY BORO,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,TATAMY BORO,U.S. House,7,DEM,Susan Wild,38,62,0,100
+Northampton,TATAMY BORO,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,TATAMY BORO,General Assembly,137,DEM,Katelind Brennan,37,58,0,95
+Northampton,TATAMY BORO,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,TATAMY BORO,President,,REP,Donald J Trump,78,30,5,113
+Northampton,TATAMY BORO,President,,REP,Bill Weld,3,4,0,7
+Northampton,TATAMY BORO,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,TATAMY BORO,President,,REP,Write-in,0,1,0,1
+Northampton,TATAMY BORO,Attorney General,,REP,Heather Heidelbaugh,67,30,4,101
+Northampton,TATAMY BORO,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,TATAMY BORO,Auditor General,,REP,Timothy Defoor,67,30,5,102
+Northampton,TATAMY BORO,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,TATAMY BORO,State Treasurer,,REP,Stacy L. Garrity,67,28,5,100
+Northampton,TATAMY BORO,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,TATAMY BORO,U.S. House,7,REP,Dean N. Browning,46,21,2,69
+Northampton,TATAMY BORO,U.S. House,7,REP,Lisa Scheller,34,12,3,49
+Northampton,TATAMY BORO,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,TATAMY BORO,General Assembly,137,REP,Joe Emrick,75,35,5,115
+Northampton,TATAMY BORO,General Assembly,137,REP,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Registered Voters,,,,,,,1281
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Registered Voters,,DEM,,,,,331
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Registered Voters,,REP,,,,,668
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Registered Voters,,NPA,,,,,282
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Ballots Cast,,,,170,142,3,315
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Ballots Cast,,DEM,,35,73,2,110
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Ballots Cast,,REP,,135,69,1,205
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,President,,DEM,Joseph R. Biden,28,62,1,91
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,President,,DEM,Bernie Sanders,4,10,1,15
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,President,,DEM,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Attorney General,,DEM,Josh Shapiro,24,64,2,90
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,DEM,Rose Rosie Marie Davis,11,26,0,37
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,DEM,Nina Ahmad,2,14,1,17
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,DEM,Michael Lamb,3,5,1,9
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,DEM,Christina M. Hartman,2,6,0,8
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,DEM,Tracie Fountain,0,7,0,7
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,DEM,H Scott Conklin,2,1,0,3
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,State Treasurer,,DEM,Joe Torsella,19,61,2,82
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,U.S. House,7,DEM,Susan Wild,27,65,2,94
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,U.S. House,7,DEM,Write-in,2,0,0,2
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,General Assembly,137,DEM,Katelind Brennan,18,62,2,82
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,General Assembly,137,DEM,Write-in,1,0,0,1
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,President,,REP,Donald J Trump,127,57,1,185
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,President,,REP,Bill Weld,6,9,0,15
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,President,,REP,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Attorney General,,REP,Heather Heidelbaugh,116,50,1,167
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,REP,Timothy Defoor,116,51,1,168
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,State Treasurer,,REP,Stacy L. Garrity,115,50,1,166
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,U.S. House,7,REP,Dean N. Browning,76,27,0,103
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,U.S. House,7,REP,Lisa Scheller,52,36,1,89
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,General Assembly,137,REP,Joe Emrick,129,63,1,193
+Northampton,UPPER MT BETHEL TWSP CENTERVILLE,General Assembly,137,REP,Write-in,0,3,0,3
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Registered Voters,,,,,,,841
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Registered Voters,,DEM,,,,,268
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Registered Voters,,REP,,,,,422
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Registered Voters,,NPA,,,,,151
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Ballots Cast,,,,126,133,3,262
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Ballots Cast,,DEM,,23,80,2,105
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Ballots Cast,,REP,,103,53,1,157
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,President,,DEM,Joseph R. Biden,13,66,0,79
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,President,,DEM,Bernie Sanders,3,11,2,16
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,President,,DEM,Tulsi Gabbard,4,1,0,5
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,President,,DEM,Write-in,1,0,0,1
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Attorney General,,DEM,Josh Shapiro,11,73,2,86
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,DEM,Rose Rosie Marie Davis,10,35,1,46
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,DEM,Nina Ahmad,1,14,0,15
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,DEM,Michael Lamb,2,9,0,11
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,DEM,Tracie Fountain,0,8,1,9
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,DEM,Christina M. Hartman,1,6,0,7
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,DEM,H Scott Conklin,2,3,0,5
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,State Treasurer,,DEM,Joe Torsella,14,73,2,89
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,U.S. House,7,DEM,Susan Wild,15,74,2,91
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,General Assembly,137,DEM,Katelind Brennan,15,72,2,89
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,President,,REP,Donald J Trump,93,48,1,142
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,President,,REP,Bill Weld,4,2,0,6
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,President,,REP,Roque Rocky De La Fuente,2,2,0,4
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,President,,REP,Write-in,1,1,0,2
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Attorney General,,REP,Heather Heidelbaugh,86,41,1,128
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,REP,Timothy Defoor,86,40,1,127
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,State Treasurer,,REP,Stacy L. Garrity,87,42,1,130
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,U.S. House,7,REP,Dean N. Browning,45,30,0,75
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,U.S. House,7,REP,Lisa Scheller,53,18,1,72
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,General Assembly,137,REP,Joe Emrick,95,49,1,145
+Northampton,UPPER MT BETHEL TWSP JOHNSONVILLE,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Registered Voters,,,,,,,727
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Registered Voters,,DEM,,,,,238
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Registered Voters,,REP,,,,,379
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Registered Voters,,NPA,,,,,110
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Ballots Cast,,,,148,112,3,263
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Ballots Cast,,DEM,,33,67,0,100
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Ballots Cast,,REP,,115,45,3,163
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Ballots Cast,,NPA,,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,President,,DEM,Joseph R. Biden,21,55,0,76
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,President,,DEM,Bernie Sanders,7,10,0,17
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,President,,DEM,Tulsi Gabbard,3,1,0,4
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,President,,DEM,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Attorney General,,DEM,Josh Shapiro,27,58,0,85
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,DEM,Rose Rosie Marie Davis,12,31,0,43
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,DEM,Nina Ahmad,3,9,0,12
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,DEM,H Scott Conklin,6,4,0,10
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,DEM,Michael Lamb,5,5,0,10
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,DEM,Christina M. Hartman,3,5,0,8
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,DEM,Tracie Fountain,0,6,0,6
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,State Treasurer,,DEM,Joe Torsella,25,57,0,82
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,U.S. House,7,DEM,Susan Wild,28,63,0,91
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,General Assembly,137,DEM,Katelind Brennan,25,61,0,86
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,President,,REP,Donald J Trump,111,41,3,155
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,President,,REP,Bill Weld,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,President,,REP,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Attorney General,,REP,Heather Heidelbaugh,87,30,3,120
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,REP,Timothy Defoor,85,32,3,120
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,State Treasurer,,REP,Stacy L. Garrity,84,32,3,119
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,U.S. House,7,REP,Lisa Scheller,57,19,1,77
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,U.S. House,7,REP,Dean N. Browning,53,18,2,73
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,General Assembly,137,REP,Joe Emrick,104,43,3,150
+Northampton,UPPER MT BETHEL TWSP NORTH BANGOR,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Registered Voters,,,,,,,740
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Registered Voters,,DEM,,,,,201
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Registered Voters,,REP,,,,,377
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Registered Voters,,NPA,,,,,162
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Ballots Cast,,,,106,99,3,208
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Ballots Cast,,DEM,,16,64,0,80
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Ballots Cast,,REP,,90,35,3,128
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,President,,DEM,Joseph R. Biden,8,52,0,60
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,President,,DEM,Bernie Sanders,5,11,0,16
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,President,,DEM,Tulsi Gabbard,1,0,0,1
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,President,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Attorney General,,DEM,Josh Shapiro,13,53,0,66
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,DEM,Rose Rosie Marie Davis,9,16,0,25
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,DEM,Nina Ahmad,1,17,0,18
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,DEM,Michael Lamb,1,8,0,9
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,DEM,Christina M. Hartman,2,5,0,7
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,DEM,Tracie Fountain,0,6,0,6
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,DEM,H Scott Conklin,1,0,0,1
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,State Treasurer,,DEM,Joe Torsella,12,54,0,66
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,U.S. House,7,DEM,Susan Wild,14,57,0,71
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,General Assembly,137,DEM,Katelind Brennan,14,53,0,67
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,President,,REP,Donald J Trump,87,32,3,122
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,President,,REP,Bill Weld,1,1,0,2
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,President,,REP,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Attorney General,,REP,Heather Heidelbaugh,73,30,3,106
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,REP,Timothy Defoor,73,28,3,104
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,State Treasurer,,REP,Stacy L. Garrity,73,28,3,104
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,U.S. House,7,REP,Dean N. Browning,43,18,1,62
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,U.S. House,7,REP,Lisa Scheller,42,13,2,57
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,General Assembly,137,REP,Joe Emrick,86,33,2,121
+Northampton,UPPER MT BETHEL TWSP SLATEFORD,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Registered Voters,,,,,,,1198
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Registered Voters,,DEM,,,,,409
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Registered Voters,,REP,,,,,533
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Registered Voters,,NPA,,,,,256
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Ballots Cast,,,,192,128,9,329
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Ballots Cast,,DEM,,66,72,4,142
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Ballots Cast,,REP,,126,56,5,187
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Ballots Cast,,NPA,,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,President,,DEM,Joseph R. Biden,45,56,2,103
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,President,,DEM,Bernie Sanders,17,8,2,27
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,President,,DEM,Tulsi Gabbard,1,1,0,2
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,President,,DEM,Write-in,1,5,0,6
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Attorney General,,DEM,Josh Shapiro,48,61,4,113
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,DEM,Rose Rosie Marie Davis,21,30,1,52
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,DEM,Nina Ahmad,8,12,3,23
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,DEM,Michael Lamb,11,5,0,16
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,DEM,H Scott Conklin,10,4,0,14
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,DEM,Tracie Fountain,5,5,0,10
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,DEM,Christina M. Hartman,1,5,0,6
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,State Treasurer,,DEM,Joe Torsella,44,59,4,107
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,U.S. House,7,DEM,Susan Wild,48,64,4,116
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,General Assembly,137,DEM,Katelind Brennan,46,61,4,111
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,General Assembly,137,DEM,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,President,,REP,Donald J Trump,118,41,5,164
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,President,,REP,Bill Weld,3,4,0,7
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,President,,REP,Roque Rocky De La Fuente,1,3,0,4
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,President,,REP,Write-in,2,2,0,4
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Attorney General,,REP,Heather Heidelbaugh,98,44,4,146
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,REP,Timothy Defoor,102,43,4,149
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,State Treasurer,,REP,Stacy L. Garrity,104,46,4,154
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,U.S. House,7,REP,Lisa Scheller,62,31,1,94
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,U.S. House,7,REP,Dean N. Browning,59,16,4,79
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,General Assembly,137,REP,Joe Emrick,116,54,5,175
+Northampton,UPPER MT BETHEL TWSP WILLIAMSBURG,General Assembly,137,REP,Write-in,1,0,0,1
+Northampton,UPPER NAZARETH EASTERN,Registered Voters,,,,,,,2513
+Northampton,UPPER NAZARETH EASTERN,Registered Voters,,DEM,,,,,1062
+Northampton,UPPER NAZARETH EASTERN,Registered Voters,,REP,,,,,1046
+Northampton,UPPER NAZARETH EASTERN,Registered Voters,,NPA,,,,,405
+Northampton,UPPER NAZARETH EASTERN,Ballots Cast,,,,283,632,8,923
+Northampton,UPPER NAZARETH EASTERN,Ballots Cast,,DEM,,83,427,3,513
+Northampton,UPPER NAZARETH EASTERN,Ballots Cast,,REP,,191,185,5,381
+Northampton,UPPER NAZARETH EASTERN,Ballots Cast,,NPA,,9,20,0,29
+Northampton,UPPER NAZARETH EASTERN,President,,DEM,Joseph R. Biden,49,349,2,400
+Northampton,UPPER NAZARETH EASTERN,President,,DEM,Bernie Sanders,22,52,0,74
+Northampton,UPPER NAZARETH EASTERN,President,,DEM,Tulsi Gabbard,5,8,0,13
+Northampton,UPPER NAZARETH EASTERN,President,,DEM,Write-in,0,7,0,7
+Northampton,UPPER NAZARETH EASTERN,Attorney General,,DEM,Josh Shapiro,58,390,3,451
+Northampton,UPPER NAZARETH EASTERN,Attorney General,,DEM,Write-in,0,4,0,4
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,DEM,Nina Ahmad,20,93,1,114
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,DEM,Rose Rosie Marie Davis,8,85,2,95
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,DEM,Christina M. Hartman,10,83,0,93
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,DEM,Michael Lamb,11,49,0,60
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,DEM,H Scott Conklin,12,31,0,43
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,DEM,Tracie Fountain,5,35,0,40
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,UPPER NAZARETH EASTERN,State Treasurer,,DEM,Joe Torsella,57,384,3,444
+Northampton,UPPER NAZARETH EASTERN,State Treasurer,,DEM,Write-in,0,3,0,3
+Northampton,UPPER NAZARETH EASTERN,U.S. House,7,DEM,Susan Wild,66,405,3,474
+Northampton,UPPER NAZARETH EASTERN,U.S. House,7,DEM,Write-in,0,3,0,3
+Northampton,UPPER NAZARETH EASTERN,General Assembly,137,DEM,Katelind Brennan,61,385,3,449
+Northampton,UPPER NAZARETH EASTERN,General Assembly,137,DEM,Write-in,0,5,0,5
+Northampton,UPPER NAZARETH EASTERN,President,,REP,Donald J Trump,173,160,7,340
+Northampton,UPPER NAZARETH EASTERN,President,,REP,Bill Weld,8,12,0,20
+Northampton,UPPER NAZARETH EASTERN,President,,REP,Roque Rocky De La Fuente,2,7,0,9
+Northampton,UPPER NAZARETH EASTERN,President,,REP,Write-in,4,4,0,8
+Northampton,UPPER NAZARETH EASTERN,Attorney General,,REP,Heather Heidelbaugh,151,158,7,316
+Northampton,UPPER NAZARETH EASTERN,Attorney General,,REP,Write-in,0,3,0,3
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,REP,Timothy Defoor,153,157,7,317
+Northampton,UPPER NAZARETH EASTERN,Auditor General,,REP,Write-in,0,3,0,3
+Northampton,UPPER NAZARETH EASTERN,State Treasurer,,REP,Stacy L. Garrity,151,161,7,319
+Northampton,UPPER NAZARETH EASTERN,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,UPPER NAZARETH EASTERN,U.S. House,7,REP,Lisa Scheller,78,107,2,187
+Northampton,UPPER NAZARETH EASTERN,U.S. House,7,REP,Dean N. Browning,107,67,5,179
+Northampton,UPPER NAZARETH EASTERN,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,UPPER NAZARETH EASTERN,General Assembly,137,REP,Joe Emrick,175,174,7,356
+Northampton,UPPER NAZARETH EASTERN,General Assembly,137,REP,Write-in,1,3,0,4
+Northampton,UPPER NAZARETH WESTERN,Registered Voters,,,,,,,2171
+Northampton,UPPER NAZARETH WESTERN,Registered Voters,,DEM,,,,,812
+Northampton,UPPER NAZARETH WESTERN,Registered Voters,,REP,,,,,882
+Northampton,UPPER NAZARETH WESTERN,Registered Voters,,NPA,,,,,477
+Northampton,UPPER NAZARETH WESTERN,Ballots Cast,,,,186,481,0,667
+Northampton,UPPER NAZARETH WESTERN,Ballots Cast,,DEM,,47,310,0,357
+Northampton,UPPER NAZARETH WESTERN,Ballots Cast,,REP,,120,149,0,269
+Northampton,UPPER NAZARETH WESTERN,Ballots Cast,,NPA,,19,22,0,41
+Northampton,UPPER NAZARETH WESTERN,President,,DEM,Joseph R. Biden,26,247,0,273
+Northampton,UPPER NAZARETH WESTERN,President,,DEM,Bernie Sanders,12,44,0,56
+Northampton,UPPER NAZARETH WESTERN,President,,DEM,Tulsi Gabbard,6,5,0,11
+Northampton,UPPER NAZARETH WESTERN,President,,DEM,Write-in,0,9,0,9
+Northampton,UPPER NAZARETH WESTERN,Attorney General,,DEM,Josh Shapiro,37,273,0,310
+Northampton,UPPER NAZARETH WESTERN,Attorney General,,DEM,Write-in,0,3,0,3
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,DEM,Nina Ahmad,14,71,0,85
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,DEM,Rose Rosie Marie Davis,4,55,0,59
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,DEM,Christina M. Hartman,5,35,0,40
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,DEM,Tracie Fountain,8,29,0,37
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,DEM,Michael Lamb,4,30,0,34
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,DEM,H Scott Conklin,7,20,0,27
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,DEM,Write-in,0,1,0,1
+Northampton,UPPER NAZARETH WESTERN,State Treasurer,,DEM,Joe Torsella,37,267,0,304
+Northampton,UPPER NAZARETH WESTERN,State Treasurer,,DEM,Write-in,0,1,0,1
+Northampton,UPPER NAZARETH WESTERN,U.S. House,7,DEM,Susan Wild,37,278,0,315
+Northampton,UPPER NAZARETH WESTERN,U.S. House,7,DEM,Write-in,0,4,0,4
+Northampton,UPPER NAZARETH WESTERN,General Assembly,137,DEM,Katelind Brennan,36,263,0,299
+Northampton,UPPER NAZARETH WESTERN,General Assembly,137,DEM,Write-in,0,4,0,4
+Northampton,UPPER NAZARETH WESTERN,President,,REP,Donald J Trump,113,116,0,229
+Northampton,UPPER NAZARETH WESTERN,President,,REP,Bill Weld,4,13,0,17
+Northampton,UPPER NAZARETH WESTERN,President,,REP,Roque Rocky De La Fuente,0,4,0,4
+Northampton,UPPER NAZARETH WESTERN,President,,REP,Write-in,0,6,0,6
+Northampton,UPPER NAZARETH WESTERN,Attorney General,,REP,Heather Heidelbaugh,102,116,0,218
+Northampton,UPPER NAZARETH WESTERN,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,REP,Timothy Defoor,101,115,0,216
+Northampton,UPPER NAZARETH WESTERN,Auditor General,,REP,Write-in,0,2,0,2
+Northampton,UPPER NAZARETH WESTERN,State Treasurer,,REP,Stacy L. Garrity,103,120,0,223
+Northampton,UPPER NAZARETH WESTERN,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,UPPER NAZARETH WESTERN,U.S. House,7,REP,Lisa Scheller,57,80,0,137
+Northampton,UPPER NAZARETH WESTERN,U.S. House,7,REP,Dean N. Browning,60,52,0,112
+Northampton,UPPER NAZARETH WESTERN,U.S. House,7,REP,Write-in,0,4,0,4
+Northampton,UPPER NAZARETH WESTERN,General Assembly,137,REP,Joe Emrick,114,139,0,253
+Northampton,UPPER NAZARETH WESTERN,General Assembly,137,REP,Write-in,0,1,0,1
+Northampton,WALNUTPORT BORO,Registered Voters,,,,,,,1229
+Northampton,WALNUTPORT BORO,Registered Voters,,DEM,,,,,520
+Northampton,WALNUTPORT BORO,Registered Voters,,REP,,,,,479
+Northampton,WALNUTPORT BORO,Registered Voters,,NPA,,,,,230
+Northampton,WALNUTPORT BORO,Ballots Cast,,,,187,155,11,353
+Northampton,WALNUTPORT BORO,Ballots Cast,,DEM,,54,115,2,171
+Northampton,WALNUTPORT BORO,Ballots Cast,,REP,,133,40,9,182
+Northampton,WALNUTPORT BORO,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WALNUTPORT BORO,President,,DEM,Joseph R. Biden,33,80,2,115
+Northampton,WALNUTPORT BORO,President,,DEM,Bernie Sanders,12,31,0,43
+Northampton,WALNUTPORT BORO,President,,DEM,Tulsi Gabbard,5,0,0,5
+Northampton,WALNUTPORT BORO,President,,DEM,Write-in,0,2,0,2
+Northampton,WALNUTPORT BORO,Attorney General,,DEM,Josh Shapiro,34,109,2,145
+Northampton,WALNUTPORT BORO,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,WALNUTPORT BORO,Auditor General,,DEM,Nina Ahmad,13,25,0,38
+Northampton,WALNUTPORT BORO,Auditor General,,DEM,Christina M. Hartman,7,27,1,35
+Northampton,WALNUTPORT BORO,Auditor General,,DEM,Rose Rosie Marie Davis,11,21,0,32
+Northampton,WALNUTPORT BORO,Auditor General,,DEM,H Scott Conklin,8,9,0,17
+Northampton,WALNUTPORT BORO,Auditor General,,DEM,Michael Lamb,6,11,0,17
+Northampton,WALNUTPORT BORO,Auditor General,,DEM,Tracie Fountain,0,10,1,11
+Northampton,WALNUTPORT BORO,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,WALNUTPORT BORO,State Treasurer,,DEM,Joe Torsella,36,106,2,144
+Northampton,WALNUTPORT BORO,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WALNUTPORT BORO,U.S. House,7,DEM,Susan Wild,45,113,2,160
+Northampton,WALNUTPORT BORO,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,WALNUTPORT BORO,General Assembly,183,DEM,Jason Ruff,39,110,1,150
+Northampton,WALNUTPORT BORO,General Assembly,183,DEM,Write-in,0,0,0,0
+Northampton,WALNUTPORT BORO,President,,REP,Donald J Trump,129,23,7,159
+Northampton,WALNUTPORT BORO,President,,REP,Bill Weld,2,6,1,9
+Northampton,WALNUTPORT BORO,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Northampton,WALNUTPORT BORO,President,,REP,Write-in,0,5,0,5
+Northampton,WALNUTPORT BORO,Attorney General,,REP,Heather Heidelbaugh,114,36,6,156
+Northampton,WALNUTPORT BORO,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,WALNUTPORT BORO,Auditor General,,REP,Timothy Defoor,114,35,4,153
+Northampton,WALNUTPORT BORO,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,WALNUTPORT BORO,State Treasurer,,REP,Stacy L. Garrity,116,36,5,157
+Northampton,WALNUTPORT BORO,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,WALNUTPORT BORO,U.S. House,7,REP,Dean N. Browning,74,14,4,92
+Northampton,WALNUTPORT BORO,U.S. House,7,REP,Lisa Scheller,55,22,4,81
+Northampton,WALNUTPORT BORO,U.S. House,7,REP,Write-in,0,2,0,2
+Northampton,WALNUTPORT BORO,General Assembly,183,REP,Zach Mako,120,36,6,162
+Northampton,WALNUTPORT BORO,General Assembly,183,REP,Write-in,0,1,0,1
+Northampton,WASHINGTON TWSP LOWER,Registered Voters,,,,,,,2730
+Northampton,WASHINGTON TWSP LOWER,Registered Voters,,DEM,,,,,916
+Northampton,WASHINGTON TWSP LOWER,Registered Voters,,REP,,,,,1291
+Northampton,WASHINGTON TWSP LOWER,Registered Voters,,NPA,,,,,523
+Northampton,WASHINGTON TWSP LOWER,Ballots Cast,,,,292,457,12,761
+Northampton,WASHINGTON TWSP LOWER,Ballots Cast,,DEM,,70,281,3,354
+Northampton,WASHINGTON TWSP LOWER,Ballots Cast,,REP,,222,176,9,407
+Northampton,WASHINGTON TWSP LOWER,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WASHINGTON TWSP LOWER,President,,DEM,Joseph R. Biden,43,226,1,270
+Northampton,WASHINGTON TWSP LOWER,President,,DEM,Bernie Sanders,12,34,2,48
+Northampton,WASHINGTON TWSP LOWER,President,,DEM,Tulsi Gabbard,4,9,0,13
+Northampton,WASHINGTON TWSP LOWER,President,,DEM,Write-in,4,2,0,6
+Northampton,WASHINGTON TWSP LOWER,Attorney General,,DEM,Josh Shapiro,51,253,3,307
+Northampton,WASHINGTON TWSP LOWER,Attorney General,,DEM,Write-in,3,1,0,4
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,DEM,Rose Rosie Marie Davis,16,107,2,125
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,DEM,Nina Ahmad,13,47,0,60
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,DEM,Michael Lamb,10,27,0,37
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,DEM,Christina M. Hartman,3,32,1,36
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,DEM,H Scott Conklin,13,19,0,32
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,DEM,Tracie Fountain,0,16,0,16
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,DEM,Write-in,2,0,0,2
+Northampton,WASHINGTON TWSP LOWER,State Treasurer,,DEM,Joe Torsella,47,255,3,305
+Northampton,WASHINGTON TWSP LOWER,State Treasurer,,DEM,Write-in,2,0,0,2
+Northampton,WASHINGTON TWSP LOWER,U.S. House,7,DEM,Susan Wild,52,269,3,324
+Northampton,WASHINGTON TWSP LOWER,U.S. House,7,DEM,Write-in,3,1,0,4
+Northampton,WASHINGTON TWSP LOWER,General Assembly,137,DEM,Katelind Brennan,51,256,3,310
+Northampton,WASHINGTON TWSP LOWER,General Assembly,137,DEM,Write-in,2,2,0,4
+Northampton,WASHINGTON TWSP LOWER,President,,REP,Donald J Trump,214,149,8,371
+Northampton,WASHINGTON TWSP LOWER,President,,REP,Bill Weld,5,13,0,18
+Northampton,WASHINGTON TWSP LOWER,President,,REP,Roque Rocky De La Fuente,3,5,0,8
+Northampton,WASHINGTON TWSP LOWER,President,,REP,Write-in,0,1,0,1
+Northampton,WASHINGTON TWSP LOWER,Attorney General,,REP,Heather Heidelbaugh,191,141,8,340
+Northampton,WASHINGTON TWSP LOWER,Attorney General,,REP,Write-in,1,1,0,2
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,REP,Timothy Defoor,192,142,6,340
+Northampton,WASHINGTON TWSP LOWER,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP LOWER,State Treasurer,,REP,Stacy L. Garrity,194,143,7,344
+Northampton,WASHINGTON TWSP LOWER,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP LOWER,U.S. House,7,REP,Lisa Scheller,103,86,6,195
+Northampton,WASHINGTON TWSP LOWER,U.S. House,7,REP,Dean N. Browning,113,67,3,183
+Northampton,WASHINGTON TWSP LOWER,U.S. House,7,REP,Write-in,1,2,0,3
+Northampton,WASHINGTON TWSP LOWER,General Assembly,137,REP,Joe Emrick,214,167,9,390
+Northampton,WASHINGTON TWSP LOWER,General Assembly,137,REP,Write-in,1,0,0,1
+Northampton,WASHINGTON TWSP UPPER,Registered Voters,,,,,,,819
+Northampton,WASHINGTON TWSP UPPER,Registered Voters,,DEM,,,,,315
+Northampton,WASHINGTON TWSP UPPER,Registered Voters,,REP,,,,,349
+Northampton,WASHINGTON TWSP UPPER,Registered Voters,,NPA,,,,,155
+Northampton,WASHINGTON TWSP UPPER,Ballots Cast,,,,129,110,2,241
+Northampton,WASHINGTON TWSP UPPER,Ballots Cast,,DEM,,46,76,2,124
+Northampton,WASHINGTON TWSP UPPER,Ballots Cast,,REP,,83,34,0,117
+Northampton,WASHINGTON TWSP UPPER,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,President,,DEM,Joseph R. Biden,32,60,1,93
+Northampton,WASHINGTON TWSP UPPER,President,,DEM,Bernie Sanders,3,12,1,16
+Northampton,WASHINGTON TWSP UPPER,President,,DEM,Tulsi Gabbard,6,1,0,7
+Northampton,WASHINGTON TWSP UPPER,President,,DEM,Write-in,1,3,0,4
+Northampton,WASHINGTON TWSP UPPER,Attorney General,,DEM,Josh Shapiro,29,68,2,99
+Northampton,WASHINGTON TWSP UPPER,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,DEM,Rose Rosie Marie Davis,17,30,1,48
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,DEM,Michael Lamb,8,10,0,18
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,DEM,Nina Ahmad,6,8,1,15
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,DEM,Tracie Fountain,3,8,0,11
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,DEM,Christina M. Hartman,4,7,0,11
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,DEM,H Scott Conklin,3,4,0,7
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,State Treasurer,,DEM,Joe Torsella,31,69,1,101
+Northampton,WASHINGTON TWSP UPPER,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,U.S. House,7,DEM,Susan Wild,35,70,1,106
+Northampton,WASHINGTON TWSP UPPER,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,General Assembly,137,DEM,Katelind Brennan,31,65,2,98
+Northampton,WASHINGTON TWSP UPPER,General Assembly,137,DEM,Write-in,0,2,0,2
+Northampton,WASHINGTON TWSP UPPER,President,,REP,Donald J Trump,77,28,0,105
+Northampton,WASHINGTON TWSP UPPER,President,,REP,Bill Weld,1,4,0,5
+Northampton,WASHINGTON TWSP UPPER,President,,REP,Roque Rocky De La Fuente,3,0,0,3
+Northampton,WASHINGTON TWSP UPPER,President,,REP,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,Attorney General,,REP,Heather Heidelbaugh,63,24,0,87
+Northampton,WASHINGTON TWSP UPPER,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,REP,Timothy Defoor,61,23,0,84
+Northampton,WASHINGTON TWSP UPPER,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,State Treasurer,,REP,Stacy L. Garrity,67,23,0,90
+Northampton,WASHINGTON TWSP UPPER,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,U.S. House,7,REP,Lisa Scheller,38,19,0,57
+Northampton,WASHINGTON TWSP UPPER,U.S. House,7,REP,Dean N. Browning,42,13,0,55
+Northampton,WASHINGTON TWSP UPPER,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,WASHINGTON TWSP UPPER,General Assembly,137,REP,Joe Emrick,77,30,0,107
+Northampton,WASHINGTON TWSP UPPER,General Assembly,137,REP,Write-in,0,0,0,0
+Northampton,WEST EASTON,Registered Voters,,,,,,,779
+Northampton,WEST EASTON,Registered Voters,,DEM,,,,,366
+Northampton,WEST EASTON,Registered Voters,,REP,,,,,271
+Northampton,WEST EASTON,Registered Voters,,NPA,,,,,142
+Northampton,WEST EASTON,Ballots Cast,,,,119,72,0,191
+Northampton,WEST EASTON,Ballots Cast,,DEM,,54,54,0,108
+Northampton,WEST EASTON,Ballots Cast,,REP,,65,18,0,83
+Northampton,WEST EASTON,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WEST EASTON,President,,DEM,Joseph R. Biden,34,37,0,71
+Northampton,WEST EASTON,President,,DEM,Bernie Sanders,10,13,0,23
+Northampton,WEST EASTON,President,,DEM,Tulsi Gabbard,2,1,0,3
+Northampton,WEST EASTON,President,,DEM,Write-in,1,0,0,1
+Northampton,WEST EASTON,Attorney General,,DEM,Josh Shapiro,34,49,0,83
+Northampton,WEST EASTON,Attorney General,,DEM,Write-in,0,2,0,2
+Northampton,WEST EASTON,Auditor General,,DEM,Nina Ahmad,13,12,0,25
+Northampton,WEST EASTON,Auditor General,,DEM,Christina M. Hartman,7,12,0,19
+Northampton,WEST EASTON,Auditor General,,DEM,Michael Lamb,9,5,0,14
+Northampton,WEST EASTON,Auditor General,,DEM,Rose Rosie Marie Davis,4,9,0,13
+Northampton,WEST EASTON,Auditor General,,DEM,H Scott Conklin,7,3,0,10
+Northampton,WEST EASTON,Auditor General,,DEM,Tracie Fountain,1,7,0,8
+Northampton,WEST EASTON,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,WEST EASTON,State Treasurer,,DEM,Joe Torsella,34,48,0,82
+Northampton,WEST EASTON,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WEST EASTON,U.S. House,7,DEM,Susan Wild,37,51,0,88
+Northampton,WEST EASTON,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,WEST EASTON,General Assembly,136,DEM,Robert Freeman,45,52,0,97
+Northampton,WEST EASTON,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,WEST EASTON,President,,REP,Donald J Trump,57,14,0,71
+Northampton,WEST EASTON,President,,REP,Bill Weld,3,2,0,5
+Northampton,WEST EASTON,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,WEST EASTON,President,,REP,Write-in,1,0,0,1
+Northampton,WEST EASTON,Attorney General,,REP,Heather Heidelbaugh,54,16,0,70
+Northampton,WEST EASTON,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,WEST EASTON,Auditor General,,REP,Timothy Defoor,52,15,0,67
+Northampton,WEST EASTON,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,WEST EASTON,State Treasurer,,REP,Stacy L. Garrity,54,16,0,70
+Northampton,WEST EASTON,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,WEST EASTON,U.S. House,7,REP,Dean N. Browning,33,9,0,42
+Northampton,WEST EASTON,U.S. House,7,REP,Lisa Scheller,27,8,0,35
+Northampton,WEST EASTON,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,WEST EASTON,General Assembly,136,REP,Write-in,0,1,0,1
+Northampton,WILLIAMS TWSP EASTERN,Registered Voters,,,,,,,1357
+Northampton,WILLIAMS TWSP EASTERN,Registered Voters,,DEM,,,,,446
+Northampton,WILLIAMS TWSP EASTERN,Registered Voters,,REP,,,,,621
+Northampton,WILLIAMS TWSP EASTERN,Registered Voters,,NPA,,,,,290
+Northampton,WILLIAMS TWSP EASTERN,Ballots Cast,,,,223,208,9,440
+Northampton,WILLIAMS TWSP EASTERN,Ballots Cast,,DEM,,61,144,6,211
+Northampton,WILLIAMS TWSP EASTERN,Ballots Cast,,REP,,162,64,3,229
+Northampton,WILLIAMS TWSP EASTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WILLIAMS TWSP EASTERN,President,,DEM,Joseph R. Biden,38,118,4,160
+Northampton,WILLIAMS TWSP EASTERN,President,,DEM,Bernie Sanders,12,24,2,38
+Northampton,WILLIAMS TWSP EASTERN,President,,DEM,Tulsi Gabbard,7,0,0,7
+Northampton,WILLIAMS TWSP EASTERN,President,,DEM,Write-in,3,0,0,3
+Northampton,WILLIAMS TWSP EASTERN,Attorney General,,DEM,Josh Shapiro,44,129,6,179
+Northampton,WILLIAMS TWSP EASTERN,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,DEM,Nina Ahmad,12,38,2,52
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,DEM,Christina M. Hartman,8,24,0,32
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,DEM,Tracie Fountain,5,24,1,30
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,DEM,Rose Rosie Marie Davis,9,13,2,24
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,DEM,Michael Lamb,10,10,1,21
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,DEM,H Scott Conklin,7,8,0,15
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,WILLIAMS TWSP EASTERN,State Treasurer,,DEM,Joe Torsella,45,125,5,175
+Northampton,WILLIAMS TWSP EASTERN,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP EASTERN,U.S. House,7,DEM,Susan Wild,50,129,5,184
+Northampton,WILLIAMS TWSP EASTERN,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP EASTERN,General Assembly,136,DEM,Robert Freeman,54,135,5,194
+Northampton,WILLIAMS TWSP EASTERN,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP EASTERN,President,,REP,Donald J Trump,151,49,3,203
+Northampton,WILLIAMS TWSP EASTERN,President,,REP,Bill Weld,6,6,0,12
+Northampton,WILLIAMS TWSP EASTERN,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Northampton,WILLIAMS TWSP EASTERN,President,,REP,Write-in,2,4,0,6
+Northampton,WILLIAMS TWSP EASTERN,Attorney General,,REP,Heather Heidelbaugh,118,53,3,174
+Northampton,WILLIAMS TWSP EASTERN,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,REP,Timothy Defoor,119,53,3,175
+Northampton,WILLIAMS TWSP EASTERN,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,WILLIAMS TWSP EASTERN,State Treasurer,,REP,Stacy L. Garrity,120,53,3,176
+Northampton,WILLIAMS TWSP EASTERN,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,WILLIAMS TWSP EASTERN,U.S. House,7,REP,Dean N. Browning,80,33,0,113
+Northampton,WILLIAMS TWSP EASTERN,U.S. House,7,REP,Lisa Scheller,75,28,3,106
+Northampton,WILLIAMS TWSP EASTERN,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,WILLIAMS TWSP EASTERN,General Assembly,136,REP,Write-in,1,3,0,4
+Northampton,WILLIAMS TWSP MIDDLE,Registered Voters,,,,,,,1202
+Northampton,WILLIAMS TWSP MIDDLE,Registered Voters,,DEM,,,,,405
+Northampton,WILLIAMS TWSP MIDDLE,Registered Voters,,REP,,,,,570
+Northampton,WILLIAMS TWSP MIDDLE,Registered Voters,,NPA,,,,,227
+Northampton,WILLIAMS TWSP MIDDLE,Ballots Cast,,,,161,191,0,352
+Northampton,WILLIAMS TWSP MIDDLE,Ballots Cast,,DEM,,38,117,0,155
+Northampton,WILLIAMS TWSP MIDDLE,Ballots Cast,,REP,,123,74,0,197
+Northampton,WILLIAMS TWSP MIDDLE,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WILLIAMS TWSP MIDDLE,President,,DEM,Joseph R. Biden,28,97,0,125
+Northampton,WILLIAMS TWSP MIDDLE,President,,DEM,Bernie Sanders,4,16,0,20
+Northampton,WILLIAMS TWSP MIDDLE,President,,DEM,Tulsi Gabbard,3,1,0,4
+Northampton,WILLIAMS TWSP MIDDLE,President,,DEM,Write-in,1,1,0,2
+Northampton,WILLIAMS TWSP MIDDLE,Attorney General,,DEM,Josh Shapiro,22,103,0,125
+Northampton,WILLIAMS TWSP MIDDLE,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,DEM,Nina Ahmad,7,32,0,39
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,DEM,Christina M. Hartman,3,23,0,26
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,DEM,Rose Rosie Marie Davis,5,16,0,21
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,DEM,H Scott Conklin,4,11,0,15
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,DEM,Michael Lamb,6,6,0,12
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,DEM,Tracie Fountain,2,7,0,9
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP MIDDLE,State Treasurer,,DEM,Joe Torsella,22,95,0,117
+Northampton,WILLIAMS TWSP MIDDLE,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP MIDDLE,U.S. House,7,DEM,Susan Wild,32,113,0,145
+Northampton,WILLIAMS TWSP MIDDLE,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,WILLIAMS TWSP MIDDLE,General Assembly,136,DEM,Robert Freeman,29,113,0,142
+Northampton,WILLIAMS TWSP MIDDLE,General Assembly,136,DEM,Write-in,0,2,0,2
+Northampton,WILLIAMS TWSP MIDDLE,President,,REP,Donald J Trump,117,62,0,179
+Northampton,WILLIAMS TWSP MIDDLE,President,,REP,Bill Weld,3,8,0,11
+Northampton,WILLIAMS TWSP MIDDLE,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,WILLIAMS TWSP MIDDLE,President,,REP,Write-in,0,4,0,4
+Northampton,WILLIAMS TWSP MIDDLE,Attorney General,,REP,Heather Heidelbaugh,102,58,0,160
+Northampton,WILLIAMS TWSP MIDDLE,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,REP,Timothy Defoor,96,55,0,151
+Northampton,WILLIAMS TWSP MIDDLE,Auditor General,,REP,Write-in,0,2,0,2
+Northampton,WILLIAMS TWSP MIDDLE,State Treasurer,,REP,Stacy L. Garrity,97,57,0,154
+Northampton,WILLIAMS TWSP MIDDLE,State Treasurer,,REP,Write-in,0,2,0,2
+Northampton,WILLIAMS TWSP MIDDLE,U.S. House,7,REP,Lisa Scheller,62,34,0,96
+Northampton,WILLIAMS TWSP MIDDLE,U.S. House,7,REP,Dean N. Browning,54,32,0,86
+Northampton,WILLIAMS TWSP MIDDLE,U.S. House,7,REP,Write-in,2,5,0,7
+Northampton,WILLIAMS TWSP MIDDLE,General Assembly,136,REP,Write-in,3,5,0,8
+Northampton,WILLIAMS TWSP UPPER,Registered Voters,,,,,,,1680
+Northampton,WILLIAMS TWSP UPPER,Registered Voters,,DEM,,,,,624
+Northampton,WILLIAMS TWSP UPPER,Registered Voters,,REP,,,,,651
+Northampton,WILLIAMS TWSP UPPER,Registered Voters,,NPA,,,,,405
+Northampton,WILLIAMS TWSP UPPER,Ballots Cast,,,,107,244,3,354
+Northampton,WILLIAMS TWSP UPPER,Ballots Cast,,DEM,,40,166,0,206
+Northampton,WILLIAMS TWSP UPPER,Ballots Cast,,REP,,67,78,3,148
+Northampton,WILLIAMS TWSP UPPER,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,President,,DEM,Joseph R. Biden,34,140,0,174
+Northampton,WILLIAMS TWSP UPPER,President,,DEM,Bernie Sanders,3,20,0,23
+Northampton,WILLIAMS TWSP UPPER,President,,DEM,Tulsi Gabbard,0,4,0,4
+Northampton,WILLIAMS TWSP UPPER,President,,DEM,Write-in,1,1,0,2
+Northampton,WILLIAMS TWSP UPPER,Attorney General,,DEM,Josh Shapiro,29,146,0,175
+Northampton,WILLIAMS TWSP UPPER,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,DEM,Nina Ahmad,14,49,0,63
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,DEM,Rose Rosie Marie Davis,7,28,0,35
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,DEM,Christina M. Hartman,3,27,0,30
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,DEM,Tracie Fountain,3,18,0,21
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,DEM,Michael Lamb,8,8,0,16
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,DEM,H Scott Conklin,2,4,0,6
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,State Treasurer,,DEM,Joe Torsella,27,142,0,169
+Northampton,WILLIAMS TWSP UPPER,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,U.S. House,7,DEM,Susan Wild,32,157,0,189
+Northampton,WILLIAMS TWSP UPPER,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,General Assembly,136,DEM,Robert Freeman,28,149,0,177
+Northampton,WILLIAMS TWSP UPPER,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,President,,REP,Donald J Trump,65,68,3,136
+Northampton,WILLIAMS TWSP UPPER,President,,REP,Bill Weld,0,5,0,5
+Northampton,WILLIAMS TWSP UPPER,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,President,,REP,Write-in,0,3,0,3
+Northampton,WILLIAMS TWSP UPPER,Attorney General,,REP,Heather Heidelbaugh,58,64,2,124
+Northampton,WILLIAMS TWSP UPPER,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,REP,Timothy Defoor,60,62,2,124
+Northampton,WILLIAMS TWSP UPPER,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,State Treasurer,,REP,Stacy L. Garrity,58,64,2,124
+Northampton,WILLIAMS TWSP UPPER,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP UPPER,U.S. House,7,REP,Lisa Scheller,37,46,1,84
+Northampton,WILLIAMS TWSP UPPER,U.S. House,7,REP,Dean N. Browning,28,28,2,58
+Northampton,WILLIAMS TWSP UPPER,U.S. House,7,REP,Write-in,1,0,0,1
+Northampton,WILLIAMS TWSP UPPER,General Assembly,136,REP,Write-in,2,9,1,12
+Northampton,WILLIAMS TWSP WESTERN,Registered Voters,,,,,,,769
+Northampton,WILLIAMS TWSP WESTERN,Registered Voters,,DEM,,,,,284
+Northampton,WILLIAMS TWSP WESTERN,Registered Voters,,REP,,,,,351
+Northampton,WILLIAMS TWSP WESTERN,Registered Voters,,NPA,,,,,134
+Northampton,WILLIAMS TWSP WESTERN,Ballots Cast,,,,125,147,3,275
+Northampton,WILLIAMS TWSP WESTERN,Ballots Cast,,DEM,,30,111,1,142
+Northampton,WILLIAMS TWSP WESTERN,Ballots Cast,,REP,,95,36,2,133
+Northampton,WILLIAMS TWSP WESTERN,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WILLIAMS TWSP WESTERN,President,,DEM,Joseph R. Biden,23,94,1,118
+Northampton,WILLIAMS TWSP WESTERN,President,,DEM,Bernie Sanders,2,14,0,16
+Northampton,WILLIAMS TWSP WESTERN,President,,DEM,Tulsi Gabbard,2,0,0,2
+Northampton,WILLIAMS TWSP WESTERN,President,,DEM,Write-in,2,0,0,2
+Northampton,WILLIAMS TWSP WESTERN,Attorney General,,DEM,Josh Shapiro,18,104,1,123
+Northampton,WILLIAMS TWSP WESTERN,Attorney General,,DEM,Write-in,1,0,0,1
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,DEM,Nina Ahmad,7,32,0,39
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,DEM,Rose Rosie Marie Davis,4,19,0,23
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,DEM,Christina M. Hartman,3,16,0,19
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,DEM,Michael Lamb,4,13,1,18
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,DEM,Tracie Fountain,1,10,0,11
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,DEM,H Scott Conklin,3,6,0,9
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,DEM,Write-in,1,0,0,1
+Northampton,WILLIAMS TWSP WESTERN,State Treasurer,,DEM,Joe Torsella,14,100,1,115
+Northampton,WILLIAMS TWSP WESTERN,State Treasurer,,DEM,Write-in,1,0,0,1
+Northampton,WILLIAMS TWSP WESTERN,U.S. House,7,DEM,Susan Wild,21,108,1,130
+Northampton,WILLIAMS TWSP WESTERN,U.S. House,7,DEM,Write-in,1,0,0,1
+Northampton,WILLIAMS TWSP WESTERN,General Assembly,136,DEM,Robert Freeman,22,107,1,130
+Northampton,WILLIAMS TWSP WESTERN,General Assembly,136,DEM,Write-in,1,0,0,1
+Northampton,WILLIAMS TWSP WESTERN,President,,REP,Donald J Trump,86,33,2,121
+Northampton,WILLIAMS TWSP WESTERN,President,,REP,Bill Weld,4,0,0,4
+Northampton,WILLIAMS TWSP WESTERN,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,WILLIAMS TWSP WESTERN,President,,REP,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP WESTERN,Attorney General,,REP,Heather Heidelbaugh,70,27,2,99
+Northampton,WILLIAMS TWSP WESTERN,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,REP,Timothy Defoor,72,27,2,101
+Northampton,WILLIAMS TWSP WESTERN,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP WESTERN,State Treasurer,,REP,Stacy L. Garrity,72,27,1,100
+Northampton,WILLIAMS TWSP WESTERN,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP WESTERN,U.S. House,7,REP,Dean N. Browning,53,17,2,72
+Northampton,WILLIAMS TWSP WESTERN,U.S. House,7,REP,Lisa Scheller,40,16,0,56
+Northampton,WILLIAMS TWSP WESTERN,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,WILLIAMS TWSP WESTERN,General Assembly,136,REP,Write-in,0,1,0,1
+Northampton,WILSON BORO 1ST WARD,Registered Voters,,,,,,,1604
+Northampton,WILSON BORO 1ST WARD,Registered Voters,,DEM,,,,,886
+Northampton,WILSON BORO 1ST WARD,Registered Voters,,REP,,,,,379
+Northampton,WILSON BORO 1ST WARD,Registered Voters,,NPA,,,,,339
+Northampton,WILSON BORO 1ST WARD,Ballots Cast,,,,169,177,8,354
+Northampton,WILSON BORO 1ST WARD,Ballots Cast,,DEM,,104,147,5,256
+Northampton,WILSON BORO 1ST WARD,Ballots Cast,,REP,,65,30,3,98
+Northampton,WILSON BORO 1ST WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,President,,DEM,Joseph R. Biden,67,116,3,186
+Northampton,WILSON BORO 1ST WARD,President,,DEM,Bernie Sanders,25,24,2,51
+Northampton,WILSON BORO 1ST WARD,President,,DEM,Tulsi Gabbard,3,2,0,5
+Northampton,WILSON BORO 1ST WARD,President,,DEM,Write-in,2,2,0,4
+Northampton,WILSON BORO 1ST WARD,Attorney General,,DEM,Josh Shapiro,66,137,5,208
+Northampton,WILSON BORO 1ST WARD,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,WILSON BORO 1ST WARD,Auditor General,,DEM,Nina Ahmad,24,42,1,67
+Northampton,WILSON BORO 1ST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,15,29,0,44
+Northampton,WILSON BORO 1ST WARD,Auditor General,,DEM,Christina M. Hartman,6,25,0,31
+Northampton,WILSON BORO 1ST WARD,Auditor General,,DEM,Michael Lamb,12,17,1,30
+Northampton,WILSON BORO 1ST WARD,Auditor General,,DEM,H Scott Conklin,18,11,0,29
+Northampton,WILSON BORO 1ST WARD,Auditor General,,DEM,Tracie Fountain,2,12,1,15
+Northampton,WILSON BORO 1ST WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,State Treasurer,,DEM,Joe Torsella,66,137,3,206
+Northampton,WILSON BORO 1ST WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,U.S. House,7,DEM,Susan Wild,78,137,5,220
+Northampton,WILSON BORO 1ST WARD,U.S. House,7,DEM,Write-in,0,2,0,2
+Northampton,WILSON BORO 1ST WARD,General Assembly,136,DEM,Robert Freeman,87,142,4,233
+Northampton,WILSON BORO 1ST WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,President,,REP,Donald J Trump,60,24,3,87
+Northampton,WILSON BORO 1ST WARD,President,,REP,Bill Weld,3,6,0,9
+Northampton,WILSON BORO 1ST WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Northampton,WILSON BORO 1ST WARD,President,,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,Attorney General,,REP,Heather Heidelbaugh,55,24,3,82
+Northampton,WILSON BORO 1ST WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,Auditor General,,REP,Timothy Defoor,55,25,3,83
+Northampton,WILSON BORO 1ST WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,State Treasurer,,REP,Stacy L. Garrity,53,24,3,80
+Northampton,WILSON BORO 1ST WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,U.S. House,7,REP,Dean N. Browning,31,19,1,51
+Northampton,WILSON BORO 1ST WARD,U.S. House,7,REP,Lisa Scheller,33,10,2,45
+Northampton,WILSON BORO 1ST WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 1ST WARD,General Assembly,136,REP,Write-in,1,2,0,3
+Northampton,WILSON BORO 2ND WARD,Registered Voters,,,,,,,1238
+Northampton,WILSON BORO 2ND WARD,Registered Voters,,DEM,,,,,628
+Northampton,WILSON BORO 2ND WARD,Registered Voters,,REP,,,,,358
+Northampton,WILSON BORO 2ND WARD,Registered Voters,,NPA,,,,,252
+Northampton,WILSON BORO 2ND WARD,Ballots Cast,,,,138,148,0,286
+Northampton,WILSON BORO 2ND WARD,Ballots Cast,,DEM,,73,113,0,186
+Northampton,WILSON BORO 2ND WARD,Ballots Cast,,REP,,65,35,0,100
+Northampton,WILSON BORO 2ND WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WILSON BORO 2ND WARD,President,,DEM,Joseph R. Biden,54,80,0,134
+Northampton,WILSON BORO 2ND WARD,President,,DEM,Bernie Sanders,15,22,0,37
+Northampton,WILSON BORO 2ND WARD,President,,DEM,Tulsi Gabbard,1,3,0,4
+Northampton,WILSON BORO 2ND WARD,President,,DEM,Write-in,1,5,0,6
+Northampton,WILSON BORO 2ND WARD,Attorney General,,DEM,Josh Shapiro,42,97,0,139
+Northampton,WILSON BORO 2ND WARD,Attorney General,,DEM,Write-in,1,1,0,2
+Northampton,WILSON BORO 2ND WARD,Auditor General,,DEM,Nina Ahmad,19,34,0,53
+Northampton,WILSON BORO 2ND WARD,Auditor General,,DEM,Michael Lamb,18,7,0,25
+Northampton,WILSON BORO 2ND WARD,Auditor General,,DEM,Christina M. Hartman,6,19,0,25
+Northampton,WILSON BORO 2ND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,6,14,0,20
+Northampton,WILSON BORO 2ND WARD,Auditor General,,DEM,H Scott Conklin,7,11,0,18
+Northampton,WILSON BORO 2ND WARD,Auditor General,,DEM,Tracie Fountain,5,8,0,13
+Northampton,WILSON BORO 2ND WARD,Auditor General,,DEM,Write-in,0,2,0,2
+Northampton,WILSON BORO 2ND WARD,State Treasurer,,DEM,Joe Torsella,48,96,0,144
+Northampton,WILSON BORO 2ND WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WILSON BORO 2ND WARD,U.S. House,7,DEM,Susan Wild,59,101,0,160
+Northampton,WILSON BORO 2ND WARD,U.S. House,7,DEM,Write-in,1,1,0,2
+Northampton,WILSON BORO 2ND WARD,General Assembly,136,DEM,Robert Freeman,59,105,0,164
+Northampton,WILSON BORO 2ND WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,WILSON BORO 2ND WARD,President,,REP,Donald J Trump,62,29,0,91
+Northampton,WILSON BORO 2ND WARD,President,,REP,Bill Weld,1,4,0,5
+Northampton,WILSON BORO 2ND WARD,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Northampton,WILSON BORO 2ND WARD,President,,REP,Write-in,0,1,0,1
+Northampton,WILSON BORO 2ND WARD,Attorney General,,REP,Heather Heidelbaugh,54,32,0,86
+Northampton,WILSON BORO 2ND WARD,Attorney General,,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 2ND WARD,Auditor General,,REP,Timothy Defoor,53,32,0,85
+Northampton,WILSON BORO 2ND WARD,Auditor General,,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 2ND WARD,State Treasurer,,REP,Stacy L. Garrity,53,33,0,86
+Northampton,WILSON BORO 2ND WARD,State Treasurer,,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 2ND WARD,U.S. House,7,REP,Dean N. Browning,41,11,0,52
+Northampton,WILSON BORO 2ND WARD,U.S. House,7,REP,Lisa Scheller,22,20,0,42
+Northampton,WILSON BORO 2ND WARD,U.S. House,7,REP,Write-in,0,0,0,0
+Northampton,WILSON BORO 2ND WARD,General Assembly,136,REP,Write-in,3,3,0,6
+Northampton,WILSON BORO 3RD WARD,Registered Voters,,,,,,,1987
+Northampton,WILSON BORO 3RD WARD,Registered Voters,,DEM,,,,,1080
+Northampton,WILSON BORO 3RD WARD,Registered Voters,,REP,,,,,540
+Northampton,WILSON BORO 3RD WARD,Registered Voters,,NPA,,,,,367
+Northampton,WILSON BORO 3RD WARD,Ballots Cast,,,,211,296,8,515
+Northampton,WILSON BORO 3RD WARD,Ballots Cast,,DEM,,102,226,2,330
+Northampton,WILSON BORO 3RD WARD,Ballots Cast,,REP,,109,70,6,185
+Northampton,WILSON BORO 3RD WARD,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WILSON BORO 3RD WARD,President,,DEM,Joseph R. Biden,67,189,0,256
+Northampton,WILSON BORO 3RD WARD,President,,DEM,Bernie Sanders,21,25,2,48
+Northampton,WILSON BORO 3RD WARD,President,,DEM,Tulsi Gabbard,8,5,0,13
+Northampton,WILSON BORO 3RD WARD,President,,DEM,Write-in,2,2,0,4
+Northampton,WILSON BORO 3RD WARD,Attorney General,,DEM,Josh Shapiro,65,204,2,271
+Northampton,WILSON BORO 3RD WARD,Attorney General,,DEM,Write-in,0,1,0,1
+Northampton,WILSON BORO 3RD WARD,Auditor General,,DEM,Nina Ahmad,26,72,2,100
+Northampton,WILSON BORO 3RD WARD,Auditor General,,DEM,Rose Rosie Marie Davis,13,40,0,53
+Northampton,WILSON BORO 3RD WARD,Auditor General,,DEM,Christina M. Hartman,10,39,0,49
+Northampton,WILSON BORO 3RD WARD,Auditor General,,DEM,Michael Lamb,18,17,0,35
+Northampton,WILSON BORO 3RD WARD,Auditor General,,DEM,H Scott Conklin,14,10,0,24
+Northampton,WILSON BORO 3RD WARD,Auditor General,,DEM,Tracie Fountain,4,14,0,18
+Northampton,WILSON BORO 3RD WARD,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,WILSON BORO 3RD WARD,State Treasurer,,DEM,Joe Torsella,68,199,2,269
+Northampton,WILSON BORO 3RD WARD,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WILSON BORO 3RD WARD,U.S. House,7,DEM,Susan Wild,77,210,2,289
+Northampton,WILSON BORO 3RD WARD,U.S. House,7,DEM,Write-in,0,1,0,1
+Northampton,WILSON BORO 3RD WARD,General Assembly,136,DEM,Robert Freeman,80,215,2,297
+Northampton,WILSON BORO 3RD WARD,General Assembly,136,DEM,Write-in,0,0,0,0
+Northampton,WILSON BORO 3RD WARD,President,,REP,Donald J Trump,102,61,5,168
+Northampton,WILSON BORO 3RD WARD,President,,REP,Bill Weld,0,4,0,4
+Northampton,WILSON BORO 3RD WARD,President,,REP,Roque Rocky De La Fuente,3,0,0,3
+Northampton,WILSON BORO 3RD WARD,President,,REP,Write-in,1,4,0,5
+Northampton,WILSON BORO 3RD WARD,Attorney General,,REP,Heather Heidelbaugh,93,61,5,159
+Northampton,WILSON BORO 3RD WARD,Attorney General,,REP,Write-in,0,2,0,2
+Northampton,WILSON BORO 3RD WARD,Auditor General,,REP,Timothy Defoor,95,61,4,160
+Northampton,WILSON BORO 3RD WARD,Auditor General,,REP,Write-in,0,2,0,2
+Northampton,WILSON BORO 3RD WARD,State Treasurer,,REP,Stacy L. Garrity,93,63,5,161
+Northampton,WILSON BORO 3RD WARD,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,WILSON BORO 3RD WARD,U.S. House,7,REP,Dean N. Browning,62,29,1,92
+Northampton,WILSON BORO 3RD WARD,U.S. House,7,REP,Lisa Scheller,45,36,5,86
+Northampton,WILSON BORO 3RD WARD,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,WILSON BORO 3RD WARD,General Assembly,136,REP,Write-in,1,6,0,7
+Northampton,WIND GAP,Registered Voters,,,,,,,1700
+Northampton,WIND GAP,Registered Voters,,DEM,,,,,682
+Northampton,WIND GAP,Registered Voters,,REP,,,,,712
+Northampton,WIND GAP,Registered Voters,,NPA,,,,,306
+Northampton,WIND GAP,Ballots Cast,,,,252,244,12,508
+Northampton,WIND GAP,Ballots Cast,,DEM,,82,157,5,244
+Northampton,WIND GAP,Ballots Cast,,REP,,170,87,7,264
+Northampton,WIND GAP,Ballots Cast,,NPA,,0,0,0,0
+Northampton,WIND GAP,President,,DEM,Joseph R. Biden,51,128,3,182
+Northampton,WIND GAP,President,,DEM,Bernie Sanders,25,20,0,45
+Northampton,WIND GAP,President,,DEM,Tulsi Gabbard,3,3,1,7
+Northampton,WIND GAP,President,,DEM,Write-in,0,4,1,5
+Northampton,WIND GAP,Attorney General,,DEM,Josh Shapiro,62,141,4,207
+Northampton,WIND GAP,Attorney General,,DEM,Write-in,0,0,0,0
+Northampton,WIND GAP,Auditor General,,DEM,Rose Rosie Marie Davis,27,63,4,94
+Northampton,WIND GAP,Auditor General,,DEM,Nina Ahmad,7,28,0,35
+Northampton,WIND GAP,Auditor General,,DEM,Michael Lamb,16,12,0,28
+Northampton,WIND GAP,Auditor General,,DEM,Christina M. Hartman,5,23,0,28
+Northampton,WIND GAP,Auditor General,,DEM,H Scott Conklin,11,7,0,18
+Northampton,WIND GAP,Auditor General,,DEM,Tracie Fountain,3,12,1,16
+Northampton,WIND GAP,Auditor General,,DEM,Write-in,0,0,0,0
+Northampton,WIND GAP,State Treasurer,,DEM,Joe Torsella,61,139,4,204
+Northampton,WIND GAP,State Treasurer,,DEM,Write-in,0,0,0,0
+Northampton,WIND GAP,U.S. House,7,DEM,Susan Wild,74,147,4,225
+Northampton,WIND GAP,U.S. House,7,DEM,Write-in,0,0,0,0
+Northampton,WIND GAP,General Assembly,138,DEM,Tara Zrinski,66,143,5,214
+Northampton,WIND GAP,General Assembly,138,DEM,Write-in,0,2,0,2
+Northampton,WIND GAP,President,,REP,Donald J Trump,160,66,6,232
+Northampton,WIND GAP,President,,REP,Bill Weld,3,10,0,13
+Northampton,WIND GAP,President,,REP,Roque Rocky De La Fuente,2,3,0,5
+Northampton,WIND GAP,President,,REP,Write-in,1,3,0,4
+Northampton,WIND GAP,Attorney General,,REP,Heather Heidelbaugh,139,75,5,219
+Northampton,WIND GAP,Attorney General,,REP,Write-in,0,1,0,1
+Northampton,WIND GAP,Auditor General,,REP,Timothy Defoor,144,72,5,221
+Northampton,WIND GAP,Auditor General,,REP,Write-in,0,1,0,1
+Northampton,WIND GAP,State Treasurer,,REP,Stacy L. Garrity,140,76,5,221
+Northampton,WIND GAP,State Treasurer,,REP,Write-in,0,1,0,1
+Northampton,WIND GAP,U.S. House,7,REP,Dean N. Browning,93,39,2,134
+Northampton,WIND GAP,U.S. House,7,REP,Lisa Scheller,69,37,4,110
+Northampton,WIND GAP,U.S. House,7,REP,Write-in,0,1,0,1
+Northampton,WIND GAP,General Assembly,138,REP,Ann Flood,118,64,6,188
+Northampton,WIND GAP,General Assembly,138,REP,Tony Tarsi,43,19,1,63
+Northampton,WIND GAP,General Assembly,138,REP,Write-in,1,0,0,1

--- a/parsers/pa_bradford_primary_2020_results_parser.py
+++ b/parsers/pa_bradford_primary_2020_results_parser.py
@@ -215,7 +215,7 @@ class BradfordTableBodyParser(TableBodyParser):
         return ParsedRow(*row_data)
 
     def _parse_category_cell(self, category):
-        new_category = self._get_next_string().strip()
+        new_category = next(self._string_iterator).strip()
         assert(category == new_category)
 
 

--- a/parsers/pa_columbia_primary_2020_results_parser.py
+++ b/parsers/pa_columbia_primary_2020_results_parser.py
@@ -163,10 +163,6 @@ class ColumbiaTableBodyParser(TableBodyParser):
             if not office_is_invalid:
                 yield row
 
-    def _parse_category_cell(self, category):
-        new_category = self._get_next_string().strip()
-        assert(category == new_category)
-
 
 class ColumbiaPDFPageParser(PDFPageParser):
     _standard_header = COLUMBIA_HEADER

--- a/parsers/pa_northampton_primary_2020_results_parser.py
+++ b/parsers/pa_northampton_primary_2020_results_parser.py
@@ -1,0 +1,196 @@
+import csv
+import os
+from parsers.pa_pdf_parser import PDFPageIterator, PDFStringIterator
+
+
+# Uses Electionware Summary Precinct Results Report PDF format
+COUNTY = 'Northampton'
+
+OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__northampton__precinct.csv')
+OUTPUT_HEADER = ['county', 'precinct', 'office', 'district', 'party', 'candidate',
+                 'election_day', 'absentee', 'provisional', 'votes']
+
+NORTHAMPTON_FILE = os.path.join('..', '..', 'openelections-sources-pa', '2020',
+                                'Northampton PA Primary Precinct Results.pdf')
+NORTHAMPTON_HEADER = [
+    '',
+    'Summary Precinct Results Report',
+    'Primary Election',
+    'April 28, 2020',
+    'OFFICIAL RESULTS',
+    'NORTHAMPTON COUNTY, PENNSYLVANIA',
+]
+
+TABLE_HEADER = [
+    'TOTAL',
+    'Election Day',
+    'Absentee',
+    'Mail-in',
+    'Provisional',
+]
+# column ordering is the same but the header text strings order can be different
+TABLE_HEADER_VARIANT = [
+    'TOTAL',
+    'Election Day',
+    'Provisional',
+    'Absentee',
+    'Mail-in',
+]
+EXPECTED_TABLE_HEADERS = (' '.join(TABLE_HEADER), ' '.join(TABLE_HEADER_VARIANT))
+
+TABLE_HEADER_TO_DICT = {
+    'TOTAL': 'votes',
+    'Election Day': 'election_day',
+    'Absentee': 'absentee',
+    'Mail-in': 'provisional',
+}
+
+INSTRUCTION_ROW_SUBSTRING = 'Vote For'
+FIRST_FOOTER_SUBSTRING = 'Precinct Summary - 06/22/2020'
+SECOND_FOOTER_SUBSTRING = 'Report generated with Electionware'
+
+RAW_OFFICE_TO_OFFICE_AND_DISTRICT  = {
+    'President of the United States': ('President', ''),
+    'Representative in Congress': ('U.S. House', 7),
+    'Representative in the General Assembly 131st Legislative District': ('General Assembly', 131),
+    'Representative in the General Assembly 135th Legislative District': ('General Assembly', 135),
+    'Representative in the General Assembly 136th Legislative District': ('General Assembly', 136),
+    'Representative in the General Assembly 137th Legislative District': ('General Assembly', 137),
+    'Representative in the General Assembly 138th Legislative District': ('General Assembly', 138),
+    'Representative in the General Assembly 183rd Legislative District': ('General Assembly', 183),
+}
+
+PARTIES = {
+    'DEM',
+    'REP',
+}
+PARTY_ABBREVIATIONS = {
+    'Total': '',
+    'Blank': 'Blank',
+    'DEMOCRATIC': 'DEM',
+    'REPUBLICAN': 'REP',
+    'NONPARTISAN': 'NPA',    
+}
+
+
+class NorthamptonPDFStringIterator(PDFStringIterator):
+    def page_is_done(self):
+        s = self.peek()
+        return s.startswith(FIRST_FOOTER_SUBSTRING) or s.startswith(SECOND_FOOTER_SUBSTRING)
+
+    def table_is_done(self):
+        return self.peek().startswith(INSTRUCTION_ROW_SUBSTRING)
+
+    def swap_any_bad_ballots_cast_fields(self):
+        s = self._strings[self._strings_offset + 1]
+        if s.startswith('Ballots Cast'):
+            self._strings[self._strings_offset + 1] = self._strings[self._strings_offset]
+            self._strings[self._strings_offset] = s
+
+
+class NorthamptonPDFTableParser():
+    def __init__(self, precinct, string_iterator):
+        self._string_iterator = string_iterator
+        self._precinct = precinct
+        self._skip_instruction_row()
+        self._parse_header()
+        self._verify_table_header()
+
+    def __iter__(self):
+        while True:
+            row = self._parse_row()
+            if self._should_be_recorded(row):
+                yield row
+
+    def _parse_header(self):
+        self._office = next(self._string_iterator)
+        self._party = ''
+        for party in PARTIES:
+            if self._office.startswith(party):
+                self._party, self._office = self._office.split(' ', 1)
+
+    def _verify_table_header(self):
+        actual_header = ''
+        while len(actual_header) < len(EXPECTED_TABLE_HEADERS[0]):
+            actual_header += next(self._string_iterator) + ' '
+        assert(actual_header.strip() in EXPECTED_TABLE_HEADERS)
+
+    def _parse_row(self):
+        if self._string_iterator.page_is_done() or self._string_iterator.table_is_done():
+            raise StopIteration
+        self._string_iterator.swap_any_bad_ballots_cast_fields()
+        candidate = next(self._string_iterator)
+        row = {'county': COUNTY, 'precinct': self._precinct,'office': self._office, 'party': self._party,
+               'district': '', 'candidate': candidate.strip()}
+        self._clean_row(row)
+        self._populate_votes(row)
+        return row
+
+    def _populate_votes(self, row):
+        for header in TABLE_HEADER[:-1]:
+            votes_string = next(self._string_iterator)
+            if '%' not in votes_string:
+                row[TABLE_HEADER_TO_DICT[header]] = int(votes_string.replace(',', ''))
+            if row['office'] in ('Registered Voters', 'Voter Turnout'):
+                # only one column for each of these
+                break
+
+    def _skip_instruction_row(self):
+        if self._string_iterator.peek().startswith(INSTRUCTION_ROW_SUBSTRING):
+            next(self._string_iterator)
+
+    @staticmethod
+    def _clean_row(row):
+        if row['office'] == 'STATISTICS':
+            row['office'], party = row['candidate'].split(' - ', 1)
+            row['party'] = PARTY_ABBREVIATIONS[party]
+            row['candidate'] = ''
+        if row['office'] in RAW_OFFICE_TO_OFFICE_AND_DISTRICT:
+            row['office'], row['district'] = RAW_OFFICE_TO_OFFICE_AND_DISTRICT[row['office']]
+        if row['candidate'] == 'Write-In Totals':
+            row['candidate'] = 'Write-in'
+
+    @staticmethod
+    def _should_be_recorded(row):
+        if row['candidate'] == 'Not Assigned':
+            return False
+        if 'Delegate' in row['office'] or 'County Committee' in row['office']:
+            return False
+        if row['office'] in ('Voter Turnout', 'Library Tax Question'):
+            return False
+        if row['party'] == 'Blank':
+            return False
+        return True
+
+
+class NorthamptonPDFPageParser:
+    def __init__(self, page):
+        self._string_iterator = NorthamptonPDFStringIterator(page.get_strings())
+        self._verify_header()
+        self._init_precinct()
+
+    def __iter__(self):
+        while not self._string_iterator.page_is_done():
+            table_parser = NorthamptonPDFTableParser(self._precinct, self._string_iterator)
+            yield from iter(table_parser)
+
+    def _verify_header(self):
+        header = [next(self._string_iterator) for _ in range(len(NORTHAMPTON_HEADER))]
+        assert (header == NORTHAMPTON_HEADER)
+
+    def _init_precinct(self):
+        self._precinct = next(self._string_iterator)
+
+
+def pdf_to_csv(pdf, csv_writer):
+    csv_writer.writeheader()
+    for page in pdf:
+        print(f'processing page {page.get_page_number()}')
+        pdf_page_parser = NorthamptonPDFPageParser(page)
+        for row in pdf_page_parser:
+            csv_writer.writerow(row)
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', newline='') as f:
+        pdf_to_csv(PDFPageIterator(NORTHAMPTON_FILE), csv.DictWriter(f, OUTPUT_HEADER))


### PR DESCRIPTION
This parser will establish standard framework for parsing the
Electionware Summary Precinct Results Report PDF format.
Also refactors `PDFStringIterator` to be a component rather than a
parent class for parsers, and to behave appropriately as an iterator.