### PR TITLE
Electionware Precinct Results Report parsers and results

### DIFF
--- a/2020/20200602__pa__primary__adams__precinct.csv
+++ b/2020/20200602__pa__primary__adams__precinct.csv
@@ -1,0 +1,2101 @@
+county,precinct,office,district,party,candidate,election_day,absentee,votes
+Adams,Abbottstown,Registered Voters,,,,,,483
+Adams,Abbottstown,Registered Voters,,DEM,,,,183
+Adams,Abbottstown,Registered Voters,,REP,,,,300
+Adams,Abbottstown,Ballots Cast,,,,131,54,185
+Adams,Abbottstown,Ballots Cast,,DEM,,32,31,63
+Adams,Abbottstown,Ballots Cast,,REP,,99,23,122
+Adams,Abbottstown,President,,DEM,Bernie Sanders,8,3,11
+Adams,Abbottstown,President,,DEM,Joseph R Biden,17,27,44
+Adams,Abbottstown,President,,DEM,Tulsi Gabbard,3,0,3
+Adams,Abbottstown,President,,DEM,Write-in,5,1,6
+Adams,Abbottstown,Attorney General,,DEM,Josh Shapiro,26,28,54
+Adams,Abbottstown,Attorney General,,DEM,Write-in,3,0,3
+Adams,Abbottstown,Auditor General,,DEM,H Scott Conklin,6,3,9
+Adams,Abbottstown,Auditor General,,DEM,Michael Lamb,2,4,6
+Adams,Abbottstown,Auditor General,,DEM,Tracie Fountain,1,5,6
+Adams,Abbottstown,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,4
+Adams,Abbottstown,Auditor General,,DEM,Nina Ahmad,5,1,6
+Adams,Abbottstown,Auditor General,,DEM,Christina M Hartman,7,12,19
+Adams,Abbottstown,Auditor General,,DEM,Write-in,3,1,4
+Adams,Abbottstown,State Treasurer,,DEM,Joe Torsella,25,26,51
+Adams,Abbottstown,State Treasurer,,DEM,Write-in,3,0,3
+Adams,Abbottstown,U.S. House,13,DEM,Todd Rowley,25,24,49
+Adams,Abbottstown,U.S. House,13,DEM,Write-in,3,1,4
+Adams,Abbottstown,State Senate,33,DEM,Rich Sterner,26,26,52
+Adams,Abbottstown,State Senate,33,DEM,Write-in,3,1,4
+Adams,Abbottstown,General Assembly,193,DEM,Write-in,3,1,4
+Adams,Abbottstown,President,,REP,Donald J Trump,97,22,119
+Adams,Abbottstown,President,,REP,Roque Rocky De La Fuente,0,0,0
+Adams,Abbottstown,President,,REP,Bill Weld,0,1,1
+Adams,Abbottstown,President,,REP,Write-in,0,0,0
+Adams,Abbottstown,Attorney General,,REP,Heather Heidelbaugh,85,22,107
+Adams,Abbottstown,Attorney General,,REP,Write-in,3,0,3
+Adams,Abbottstown,Auditor General,,REP,Timothy Defoor,87,22,109
+Adams,Abbottstown,Auditor General,,REP,Write-in,0,0,0
+Adams,Abbottstown,State Treasurer,,REP,Stacy L Garrity,86,22,108
+Adams,Abbottstown,State Treasurer,,REP,Write-in,0,0,0
+Adams,Abbottstown,U.S. House,13,REP,John Joyce,89,23,112
+Adams,Abbottstown,U.S. House,13,REP,Write-in,0,0,0
+Adams,Abbottstown,State Senate,33,REP,Doug Mastriano,93,22,115
+Adams,Abbottstown,State Senate,33,REP,Write-in,0,0,0
+Adams,Abbottstown,General Assembly,193,REP,Torren Ecker,91,23,114
+Adams,Abbottstown,General Assembly,193,REP,Write-in,0,0,0
+Adams,Arendtsville,Registered Voters,,,,,,421
+Adams,Arendtsville,Registered Voters,,DEM,,,,148
+Adams,Arendtsville,Registered Voters,,REP,,,,273
+Adams,Arendtsville,Ballots Cast,,,,122,78,200
+Adams,Arendtsville,Ballots Cast,,DEM,,30,36,66
+Adams,Arendtsville,Ballots Cast,,REP,,92,42,134
+Adams,Arendtsville,President,,DEM,Bernie Sanders,4,3,7
+Adams,Arendtsville,President,,DEM,Joseph R Biden,24,32,56
+Adams,Arendtsville,President,,DEM,Tulsi Gabbard,0,0,0
+Adams,Arendtsville,President,,DEM,Write-in,0,0,0
+Adams,Arendtsville,Attorney General,,DEM,Josh Shapiro,26,35,61
+Adams,Arendtsville,Attorney General,,DEM,Write-in,0,0,0
+Adams,Arendtsville,Auditor General,,DEM,H Scott Conklin,2,1,3
+Adams,Arendtsville,Auditor General,,DEM,Michael Lamb,4,3,7
+Adams,Arendtsville,Auditor General,,DEM,Tracie Fountain,5,6,11
+Adams,Arendtsville,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,4
+Adams,Arendtsville,Auditor General,,DEM,Nina Ahmad,6,14,20
+Adams,Arendtsville,Auditor General,,DEM,Christina M Hartman,7,7,14
+Adams,Arendtsville,Auditor General,,DEM,Write-in,0,0,0
+Adams,Arendtsville,State Treasurer,,DEM,Joe Torsella,27,34,61
+Adams,Arendtsville,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Arendtsville,U.S. House,13,DEM,Todd Rowley,25,35,60
+Adams,Arendtsville,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Arendtsville,State Senate,33,DEM,Rich Sterner,27,36,63
+Adams,Arendtsville,State Senate,33,DEM,Write-in,0,0,0
+Adams,Arendtsville,General Assembly,193,DEM,Write-in,1,3,4
+Adams,Arendtsville,President,,REP,Donald J Trump,87,26,113
+Adams,Arendtsville,President,,REP,Roque Rocky De La Fuente,1,0,1
+Adams,Arendtsville,President,,REP,Bill Weld,1,10,11
+Adams,Arendtsville,President,,REP,Write-in,2,3,5
+Adams,Arendtsville,Attorney General,,REP,Heather Heidelbaugh,79,37,116
+Adams,Arendtsville,Attorney General,,REP,Write-in,1,1,2
+Adams,Arendtsville,Auditor General,,REP,Timothy Defoor,81,38,119
+Adams,Arendtsville,Auditor General,,REP,Write-in,0,1,1
+Adams,Arendtsville,State Treasurer,,REP,Stacy L Garrity,79,38,117
+Adams,Arendtsville,State Treasurer,,REP,Write-in,0,1,1
+Adams,Arendtsville,U.S. House,13,REP,John Joyce,85,36,121
+Adams,Arendtsville,U.S. House,13,REP,Write-in,0,3,3
+Adams,Arendtsville,State Senate,33,REP,Doug Mastriano,86,34,120
+Adams,Arendtsville,State Senate,33,REP,Write-in,0,5,5
+Adams,Arendtsville,General Assembly,193,REP,Torren Ecker,87,38,125
+Adams,Arendtsville,General Assembly,193,REP,Write-in,0,1,1
+Adams,Bendersville,Registered Voters,,,,,,304
+Adams,Bendersville,Registered Voters,,DEM,,,,121
+Adams,Bendersville,Registered Voters,,REP,,,,183
+Adams,Bendersville,Ballots Cast,,,,74,36,110
+Adams,Bendersville,Ballots Cast,,DEM,,18,17,35
+Adams,Bendersville,Ballots Cast,,REP,,56,19,75
+Adams,Bendersville,President,,DEM,Bernie Sanders,4,3,7
+Adams,Bendersville,President,,DEM,Joseph R Biden,9,13,22
+Adams,Bendersville,President,,DEM,Tulsi Gabbard,3,0,3
+Adams,Bendersville,President,,DEM,Write-in,2,0,2
+Adams,Bendersville,Attorney General,,DEM,Josh Shapiro,12,16,28
+Adams,Bendersville,Attorney General,,DEM,Write-in,1,0,1
+Adams,Bendersville,Auditor General,,DEM,H Scott Conklin,3,1,4
+Adams,Bendersville,Auditor General,,DEM,Michael Lamb,0,2,2
+Adams,Bendersville,Auditor General,,DEM,Tracie Fountain,2,8,10
+Adams,Bendersville,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0
+Adams,Bendersville,Auditor General,,DEM,Nina Ahmad,4,2,6
+Adams,Bendersville,Auditor General,,DEM,Christina M Hartman,5,2,7
+Adams,Bendersville,Auditor General,,DEM,Write-in,1,0,1
+Adams,Bendersville,State Treasurer,,DEM,Joe Torsella,13,16,29
+Adams,Bendersville,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Bendersville,U.S. House,13,DEM,Todd Rowley,13,16,29
+Adams,Bendersville,U.S. House,13,DEM,Write-in,1,0,1
+Adams,Bendersville,State Senate,33,DEM,Rich Sterner,14,17,31
+Adams,Bendersville,State Senate,33,DEM,Write-in,1,0,1
+Adams,Bendersville,General Assembly,193,DEM,Write-in,1,4,5
+Adams,Bendersville,President,,REP,Donald J Trump,53,14,67
+Adams,Bendersville,President,,REP,Roque Rocky De La Fuente,0,1,1
+Adams,Bendersville,President,,REP,Bill Weld,1,2,3
+Adams,Bendersville,President,,REP,Write-in,0,1,1
+Adams,Bendersville,Attorney General,,REP,Heather Heidelbaugh,47,18,65
+Adams,Bendersville,Attorney General,,REP,Write-in,1,0,1
+Adams,Bendersville,Auditor General,,REP,Timothy Defoor,48,18,66
+Adams,Bendersville,Auditor General,,REP,Write-in,0,0,0
+Adams,Bendersville,State Treasurer,,REP,Stacy L Garrity,46,17,63
+Adams,Bendersville,State Treasurer,,REP,Write-in,0,0,0
+Adams,Bendersville,U.S. House,13,REP,John Joyce,51,18,69
+Adams,Bendersville,U.S. House,13,REP,Write-in,0,0,0
+Adams,Bendersville,State Senate,33,REP,Doug Mastriano,55,17,72
+Adams,Bendersville,State Senate,33,REP,Write-in,0,0,0
+Adams,Bendersville,General Assembly,193,REP,Torren Ecker,49,19,68
+Adams,Bendersville,General Assembly,193,REP,Write-in,0,0,0
+Adams,Berwick,Registered Voters,,,,,,1350
+Adams,Berwick,Registered Voters,,DEM,,,,401
+Adams,Berwick,Registered Voters,,REP,,,,949
+Adams,Berwick,Ballots Cast,,,,299,214,513
+Adams,Berwick,Ballots Cast,,DEM,,52,111,163
+Adams,Berwick,Ballots Cast,,REP,,247,103,350
+Adams,Berwick,President,,DEM,Bernie Sanders,9,16,25
+Adams,Berwick,President,,DEM,Joseph R Biden,34,92,126
+Adams,Berwick,President,,DEM,Tulsi Gabbard,1,0,1
+Adams,Berwick,President,,DEM,Write-in,4,3,7
+Adams,Berwick,Attorney General,,DEM,Josh Shapiro,44,99,143
+Adams,Berwick,Attorney General,,DEM,Write-in,2,0,2
+Adams,Berwick,Auditor General,,DEM,H Scott Conklin,8,14,22
+Adams,Berwick,Auditor General,,DEM,Michael Lamb,6,12,18
+Adams,Berwick,Auditor General,,DEM,Tracie Fountain,5,18,23
+Adams,Berwick,Auditor General,,DEM,Rose Rosie Marie Davis,1,4,5
+Adams,Berwick,Auditor General,,DEM,Nina Ahmad,9,15,24
+Adams,Berwick,Auditor General,,DEM,Christina M Hartman,14,36,50
+Adams,Berwick,Auditor General,,DEM,Write-in,3,0,3
+Adams,Berwick,State Treasurer,,DEM,Joe Torsella,43,97,140
+Adams,Berwick,State Treasurer,,DEM,Write-in,2,0,2
+Adams,Berwick,U.S. House,13,DEM,Todd Rowley,42,97,139
+Adams,Berwick,U.S. House,13,DEM,Write-in,4,0,4
+Adams,Berwick,State Senate,33,DEM,Rich Sterner,44,104,148
+Adams,Berwick,State Senate,33,DEM,Write-in,3,0,3
+Adams,Berwick,General Assembly,193,DEM,Write-in,3,18,21
+Adams,Berwick,President,,REP,Donald J Trump,238,84,322
+Adams,Berwick,President,,REP,Roque Rocky De La Fuente,3,0,3
+Adams,Berwick,President,,REP,Bill Weld,4,9,13
+Adams,Berwick,President,,REP,Write-in,2,6,8
+Adams,Berwick,Attorney General,,REP,Heather Heidelbaugh,220,94,314
+Adams,Berwick,Attorney General,,REP,Write-in,0,2,2
+Adams,Berwick,Auditor General,,REP,Timothy Defoor,220,93,313
+Adams,Berwick,Auditor General,,REP,Write-in,0,1,1
+Adams,Berwick,State Treasurer,,REP,Stacy L Garrity,221,92,313
+Adams,Berwick,State Treasurer,,REP,Write-in,0,2,2
+Adams,Berwick,U.S. House,13,REP,John Joyce,220,94,314
+Adams,Berwick,U.S. House,13,REP,Write-in,1,2,3
+Adams,Berwick,State Senate,33,REP,Doug Mastriano,229,92,321
+Adams,Berwick,State Senate,33,REP,Write-in,1,3,4
+Adams,Berwick,General Assembly,193,REP,Torren Ecker,237,94,331
+Adams,Berwick,General Assembly,193,REP,Write-in,1,3,4
+Adams,Biglerville,Registered Voters,,,,,,563
+Adams,Biglerville,Registered Voters,,DEM,,,,199
+Adams,Biglerville,Registered Voters,,REP,,,,364
+Adams,Biglerville,Ballots Cast,,,,160,85,245
+Adams,Biglerville,Ballots Cast,,DEM,,35,38,73
+Adams,Biglerville,Ballots Cast,,REP,,125,47,172
+Adams,Biglerville,President,,DEM,Bernie Sanders,11,8,19
+Adams,Biglerville,President,,DEM,Joseph R Biden,17,25,42
+Adams,Biglerville,President,,DEM,Tulsi Gabbard,4,3,7
+Adams,Biglerville,President,,DEM,Write-in,2,1,3
+Adams,Biglerville,Attorney General,,DEM,Josh Shapiro,30,34,64
+Adams,Biglerville,Attorney General,,DEM,Write-in,0,1,1
+Adams,Biglerville,Auditor General,,DEM,H Scott Conklin,7,1,8
+Adams,Biglerville,Auditor General,,DEM,Michael Lamb,2,4,6
+Adams,Biglerville,Auditor General,,DEM,Tracie Fountain,1,11,12
+Adams,Biglerville,Auditor General,,DEM,Rose Rosie Marie Davis,5,2,7
+Adams,Biglerville,Auditor General,,DEM,Nina Ahmad,5,7,12
+Adams,Biglerville,Auditor General,,DEM,Christina M Hartman,11,11,22
+Adams,Biglerville,Auditor General,,DEM,Write-in,0,0,0
+Adams,Biglerville,State Treasurer,,DEM,Joe Torsella,30,34,64
+Adams,Biglerville,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Biglerville,U.S. House,13,DEM,Todd Rowley,30,34,64
+Adams,Biglerville,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Biglerville,State Senate,33,DEM,Rich Sterner,33,37,70
+Adams,Biglerville,State Senate,33,DEM,Write-in,0,0,0
+Adams,Biglerville,General Assembly,193,DEM,Write-in,1,8,9
+Adams,Biglerville,President,,REP,Donald J Trump,116,32,148
+Adams,Biglerville,President,,REP,Roque Rocky De La Fuente,2,0,2
+Adams,Biglerville,President,,REP,Bill Weld,1,11,12
+Adams,Biglerville,President,,REP,Write-in,0,1,1
+Adams,Biglerville,Attorney General,,REP,Heather Heidelbaugh,110,45,155
+Adams,Biglerville,Attorney General,,REP,Write-in,1,0,1
+Adams,Biglerville,Auditor General,,REP,Timothy Defoor,111,45,156
+Adams,Biglerville,Auditor General,,REP,Write-in,0,0,0
+Adams,Biglerville,State Treasurer,,REP,Stacy L Garrity,109,45,154
+Adams,Biglerville,State Treasurer,,REP,Write-in,0,0,0
+Adams,Biglerville,U.S. House,13,REP,John Joyce,115,41,156
+Adams,Biglerville,U.S. House,13,REP,Write-in,1,1,2
+Adams,Biglerville,State Senate,33,REP,Doug Mastriano,116,38,154
+Adams,Biglerville,State Senate,33,REP,Write-in,1,4,5
+Adams,Biglerville,General Assembly,193,REP,Torren Ecker,119,45,164
+Adams,Biglerville,General Assembly,193,REP,Write-in,0,0,0
+Adams,Bonneauville,Registered Voters,,,,,,867
+Adams,Bonneauville,Registered Voters,,DEM,,,,304
+Adams,Bonneauville,Registered Voters,,REP,,,,563
+Adams,Bonneauville,Ballots Cast,,,,185,114,299
+Adams,Bonneauville,Ballots Cast,,DEM,,42,58,100
+Adams,Bonneauville,Ballots Cast,,REP,,143,56,199
+Adams,Bonneauville,President,,DEM,Bernie Sanders,8,9,17
+Adams,Bonneauville,President,,DEM,Joseph R Biden,27,41,68
+Adams,Bonneauville,President,,DEM,Tulsi Gabbard,4,2,6
+Adams,Bonneauville,President,,DEM,Write-in,2,6,8
+Adams,Bonneauville,Attorney General,,DEM,Josh Shapiro,35,49,84
+Adams,Bonneauville,Attorney General,,DEM,Write-in,0,0,0
+Adams,Bonneauville,Auditor General,,DEM,H Scott Conklin,7,4,11
+Adams,Bonneauville,Auditor General,,DEM,Michael Lamb,6,6,12
+Adams,Bonneauville,Auditor General,,DEM,Tracie Fountain,3,7,10
+Adams,Bonneauville,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,6
+Adams,Bonneauville,Auditor General,,DEM,Nina Ahmad,10,10,20
+Adams,Bonneauville,Auditor General,,DEM,Christina M Hartman,11,20,31
+Adams,Bonneauville,Auditor General,,DEM,Write-in,0,0,0
+Adams,Bonneauville,State Treasurer,,DEM,Joe Torsella,35,49,84
+Adams,Bonneauville,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Bonneauville,U.S. House,13,DEM,Todd Rowley,36,48,84
+Adams,Bonneauville,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Bonneauville,State Senate,33,DEM,Rich Sterner,39,53,92
+Adams,Bonneauville,State Senate,33,DEM,Write-in,0,0,0
+Adams,Bonneauville,General Assembly,91,DEM,Write-in,1,5,6
+Adams,Bonneauville,President,,REP,Donald J Trump,141,45,186
+Adams,Bonneauville,President,,REP,Roque Rocky De La Fuente,1,2,3
+Adams,Bonneauville,President,,REP,Bill Weld,1,7,8
+Adams,Bonneauville,President,,REP,Write-in,0,1,1
+Adams,Bonneauville,Attorney General,,REP,Heather Heidelbaugh,127,49,176
+Adams,Bonneauville,Attorney General,,REP,Write-in,2,1,3
+Adams,Bonneauville,Auditor General,,REP,Timothy Defoor,127,49,176
+Adams,Bonneauville,Auditor General,,REP,Write-in,0,1,1
+Adams,Bonneauville,State Treasurer,,REP,Stacy L Garrity,125,49,174
+Adams,Bonneauville,State Treasurer,,REP,Write-in,0,1,1
+Adams,Bonneauville,U.S. House,13,REP,John Joyce,131,48,179
+Adams,Bonneauville,U.S. House,13,REP,Write-in,0,1,1
+Adams,Bonneauville,State Senate,33,REP,Doug Mastriano,135,51,186
+Adams,Bonneauville,State Senate,33,REP,Write-in,0,1,1
+Adams,Bonneauville,General Assembly,91,REP,Dan Moul,132,53,185
+Adams,Bonneauville,General Assembly,91,REP,Write-in,0,1,1
+Adams,Butler,Registered Voters,,,,,,1475
+Adams,Butler,Registered Voters,,DEM,,,,408
+Adams,Butler,Registered Voters,,REP,,,,1067
+Adams,Butler,Ballots Cast,,,,294,321,615
+Adams,Butler,Ballots Cast,,DEM,,45,127,172
+Adams,Butler,Ballots Cast,,REP,,249,194,443
+Adams,Butler,President,,DEM,Bernie Sanders,14,8,22
+Adams,Butler,President,,DEM,Joseph R Biden,19,110,129
+Adams,Butler,President,,DEM,Tulsi Gabbard,4,4,8
+Adams,Butler,President,,DEM,Write-in,5,3,8
+Adams,Butler,Attorney General,,DEM,Josh Shapiro,41,115,156
+Adams,Butler,Attorney General,,DEM,Write-in,0,0,0
+Adams,Butler,Auditor General,,DEM,H Scott Conklin,8,9,17
+Adams,Butler,Auditor General,,DEM,Michael Lamb,6,15,21
+Adams,Butler,Auditor General,,DEM,Tracie Fountain,7,22,29
+Adams,Butler,Auditor General,,DEM,Rose Rosie Marie Davis,4,4,8
+Adams,Butler,Auditor General,,DEM,Nina Ahmad,4,8,12
+Adams,Butler,Auditor General,,DEM,Christina M Hartman,13,50,63
+Adams,Butler,Auditor General,,DEM,Write-in,0,0,0
+Adams,Butler,State Treasurer,,DEM,Joe Torsella,40,111,151
+Adams,Butler,State Treasurer,,DEM,Write-in,2,0,2
+Adams,Butler,U.S. House,13,DEM,Todd Rowley,40,110,150
+Adams,Butler,U.S. House,13,DEM,Write-in,3,1,4
+Adams,Butler,State Senate,33,DEM,Rich Sterner,43,115,158
+Adams,Butler,State Senate,33,DEM,Write-in,0,2,2
+Adams,Butler,General Assembly,193,DEM,Write-in,4,7,11
+Adams,Butler,President,,REP,Donald J Trump,239,160,399
+Adams,Butler,President,,REP,Roque Rocky De La Fuente,1,2,3
+Adams,Butler,President,,REP,Bill Weld,6,16,22
+Adams,Butler,President,,REP,Write-in,0,5,5
+Adams,Butler,Attorney General,,REP,Heather Heidelbaugh,217,165,382
+Adams,Butler,Attorney General,,REP,Write-in,8,1,9
+Adams,Butler,Auditor General,,REP,Timothy Defoor,224,168,392
+Adams,Butler,Auditor General,,REP,Write-in,0,1,1
+Adams,Butler,State Treasurer,,REP,Stacy L Garrity,225,167,392
+Adams,Butler,State Treasurer,,REP,Write-in,0,2,2
+Adams,Butler,U.S. House,13,REP,John Joyce,234,172,406
+Adams,Butler,U.S. House,13,REP,Write-in,0,1,1
+Adams,Butler,State Senate,33,REP,Doug Mastriano,237,166,403
+Adams,Butler,State Senate,33,REP,Write-in,0,2,2
+Adams,Butler,General Assembly,193,REP,Torren Ecker,239,178,417
+Adams,Butler,General Assembly,193,REP,Write-in,1,1,2
+Adams,Carroll Valley #1,Registered Voters,,,,,,1285
+Adams,Carroll Valley #1,Registered Voters,,DEM,,,,436
+Adams,Carroll Valley #1,Registered Voters,,REP,,,,849
+Adams,Carroll Valley #1,Ballots Cast,,,,216,195,411
+Adams,Carroll Valley #1,Ballots Cast,,DEM,,41,126,167
+Adams,Carroll Valley #1,Ballots Cast,,REP,,175,69,244
+Adams,Carroll Valley #1,President,,DEM,Bernie Sanders,10,13,23
+Adams,Carroll Valley #1,President,,DEM,Joseph R Biden,26,108,134
+Adams,Carroll Valley #1,President,,DEM,Tulsi Gabbard,2,1,3
+Adams,Carroll Valley #1,President,,DEM,Write-in,3,1,4
+Adams,Carroll Valley #1,Attorney General,,DEM,Josh Shapiro,32,108,140
+Adams,Carroll Valley #1,Attorney General,,DEM,Write-in,2,0,2
+Adams,Carroll Valley #1,Auditor General,,DEM,H Scott Conklin,3,8,11
+Adams,Carroll Valley #1,Auditor General,,DEM,Michael Lamb,5,12,17
+Adams,Carroll Valley #1,Auditor General,,DEM,Tracie Fountain,5,37,42
+Adams,Carroll Valley #1,Auditor General,,DEM,Rose Rosie Marie Davis,3,4,7
+Adams,Carroll Valley #1,Auditor General,,DEM,Nina Ahmad,6,25,31
+Adams,Carroll Valley #1,Auditor General,,DEM,Christina M Hartman,6,13,19
+Adams,Carroll Valley #1,Auditor General,,DEM,Write-in,2,0,2
+Adams,Carroll Valley #1,State Treasurer,,DEM,Joe Torsella,30,109,139
+Adams,Carroll Valley #1,State Treasurer,,DEM,Write-in,2,0,2
+Adams,Carroll Valley #1,U.S. House,13,DEM,Todd Rowley,31,108,139
+Adams,Carroll Valley #1,U.S. House,13,DEM,Write-in,2,0,2
+Adams,Carroll Valley #1,State Senate,33,DEM,Rich Sterner,34,114,148
+Adams,Carroll Valley #1,State Senate,33,DEM,Write-in,2,1,3
+Adams,Carroll Valley #1,General Assembly,91,DEM,Write-in,6,14,20
+Adams,Carroll Valley #1,President,,REP,Donald J Trump,168,58,226
+Adams,Carroll Valley #1,President,,REP,Roque Rocky De La Fuente,1,1,2
+Adams,Carroll Valley #1,President,,REP,Bill Weld,4,4,8
+Adams,Carroll Valley #1,President,,REP,Write-in,1,2,3
+Adams,Carroll Valley #1,Attorney General,,REP,Heather Heidelbaugh,138,59,197
+Adams,Carroll Valley #1,Attorney General,,REP,Write-in,7,1,8
+Adams,Carroll Valley #1,Auditor General,,REP,Timothy Defoor,145,59,204
+Adams,Carroll Valley #1,Auditor General,,REP,Write-in,0,1,1
+Adams,Carroll Valley #1,State Treasurer,,REP,Stacy L Garrity,145,59,204
+Adams,Carroll Valley #1,State Treasurer,,REP,Write-in,0,1,1
+Adams,Carroll Valley #1,U.S. House,13,REP,John Joyce,149,59,208
+Adams,Carroll Valley #1,U.S. House,13,REP,Write-in,1,1,2
+Adams,Carroll Valley #1,State Senate,33,REP,Doug Mastriano,164,61,225
+Adams,Carroll Valley #1,State Senate,33,REP,Write-in,0,1,1
+Adams,Carroll Valley #1,General Assembly,91,REP,Dan Moul,159,61,220
+Adams,Carroll Valley #1,General Assembly,91,REP,Write-in,0,0,0
+Adams,Carroll Valley #2,Registered Voters,,,,,,1106
+Adams,Carroll Valley #2,Registered Voters,,DEM,,,,377
+Adams,Carroll Valley #2,Registered Voters,,REP,,,,729
+Adams,Carroll Valley #2,Ballots Cast,,,,196,193,389
+Adams,Carroll Valley #2,Ballots Cast,,DEM,,43,120,163
+Adams,Carroll Valley #2,Ballots Cast,,REP,,153,73,226
+Adams,Carroll Valley #2,President,,DEM,Bernie Sanders,17,19,36
+Adams,Carroll Valley #2,President,,DEM,Joseph R Biden,24,95,119
+Adams,Carroll Valley #2,President,,DEM,Tulsi Gabbard,0,1,1
+Adams,Carroll Valley #2,President,,DEM,Write-in,1,4,5
+Adams,Carroll Valley #2,Attorney General,,DEM,Josh Shapiro,34,98,132
+Adams,Carroll Valley #2,Attorney General,,DEM,Write-in,0,1,1
+Adams,Carroll Valley #2,Auditor General,,DEM,H Scott Conklin,3,6,9
+Adams,Carroll Valley #2,Auditor General,,DEM,Michael Lamb,4,6,10
+Adams,Carroll Valley #2,Auditor General,,DEM,Tracie Fountain,7,32,39
+Adams,Carroll Valley #2,Auditor General,,DEM,Rose Rosie Marie Davis,2,6,8
+Adams,Carroll Valley #2,Auditor General,,DEM,Nina Ahmad,6,26,32
+Adams,Carroll Valley #2,Auditor General,,DEM,Christina M Hartman,14,27,41
+Adams,Carroll Valley #2,Auditor General,,DEM,Write-in,0,0,0
+Adams,Carroll Valley #2,State Treasurer,,DEM,Joe Torsella,35,96,131
+Adams,Carroll Valley #2,State Treasurer,,DEM,Write-in,0,1,1
+Adams,Carroll Valley #2,U.S. House,13,DEM,Todd Rowley,33,96,129
+Adams,Carroll Valley #2,U.S. House,13,DEM,Write-in,1,1,2
+Adams,Carroll Valley #2,State Senate,33,DEM,Rich Sterner,37,101,138
+Adams,Carroll Valley #2,State Senate,33,DEM,Write-in,0,1,1
+Adams,Carroll Valley #2,General Assembly,91,DEM,Write-in,5,9,14
+Adams,Carroll Valley #2,President,,REP,Donald J Trump,143,56,199
+Adams,Carroll Valley #2,President,,REP,Roque Rocky De La Fuente,0,4,4
+Adams,Carroll Valley #2,President,,REP,Bill Weld,4,4,8
+Adams,Carroll Valley #2,President,,REP,Write-in,5,5,10
+Adams,Carroll Valley #2,Attorney General,,REP,Heather Heidelbaugh,126,61,187
+Adams,Carroll Valley #2,Attorney General,,REP,Write-in,6,1,7
+Adams,Carroll Valley #2,Auditor General,,REP,Timothy Defoor,134,59,193
+Adams,Carroll Valley #2,Auditor General,,REP,Write-in,0,2,2
+Adams,Carroll Valley #2,State Treasurer,,REP,Stacy L Garrity,133,60,193
+Adams,Carroll Valley #2,State Treasurer,,REP,Write-in,0,1,1
+Adams,Carroll Valley #2,U.S. House,13,REP,John Joyce,137,58,195
+Adams,Carroll Valley #2,U.S. House,13,REP,Write-in,2,3,5
+Adams,Carroll Valley #2,State Senate,33,REP,Doug Mastriano,146,59,205
+Adams,Carroll Valley #2,State Senate,33,REP,Write-in,2,2,4
+Adams,Carroll Valley #2,General Assembly,91,REP,Dan Moul,144,59,203
+Adams,Carroll Valley #2,General Assembly,91,REP,Write-in,1,1,2
+Adams,Conewago #1,Registered Voters,,,,,,1923
+Adams,Conewago #1,Registered Voters,,DEM,,,,653
+Adams,Conewago #1,Registered Voters,,REP,,,,1270
+Adams,Conewago #1,Ballots Cast,,,,306,421,727
+Adams,Conewago #1,Ballots Cast,,DEM,,49,219,268
+Adams,Conewago #1,Ballots Cast,,REP,,257,202,459
+Adams,Conewago #1,President,,DEM,Bernie Sanders,9,22,31
+Adams,Conewago #1,President,,DEM,Joseph R Biden,27,185,212
+Adams,Conewago #1,President,,DEM,Tulsi Gabbard,1,4,5
+Adams,Conewago #1,President,,DEM,Write-in,7,3,10
+Adams,Conewago #1,Attorney General,,DEM,Josh Shapiro,37,205,242
+Adams,Conewago #1,Attorney General,,DEM,Write-in,0,0,0
+Adams,Conewago #1,Auditor General,,DEM,H Scott Conklin,8,18,26
+Adams,Conewago #1,Auditor General,,DEM,Michael Lamb,6,19,25
+Adams,Conewago #1,Auditor General,,DEM,Tracie Fountain,2,39,41
+Adams,Conewago #1,Auditor General,,DEM,Rose Rosie Marie Davis,2,8,10
+Adams,Conewago #1,Auditor General,,DEM,Nina Ahmad,7,17,24
+Adams,Conewago #1,Auditor General,,DEM,Christina M Hartman,13,105,118
+Adams,Conewago #1,Auditor General,,DEM,Write-in,0,0,0
+Adams,Conewago #1,State Treasurer,,DEM,Joe Torsella,37,199,236
+Adams,Conewago #1,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Conewago #1,U.S. House,13,DEM,Todd Rowley,31,194,225
+Adams,Conewago #1,U.S. House,13,DEM,Write-in,1,0,1
+Adams,Conewago #1,State Senate,33,DEM,Rich Sterner,39,204,243
+Adams,Conewago #1,State Senate,33,DEM,Write-in,1,0,1
+Adams,Conewago #1,General Assembly,91,DEM,Write-in,2,18,20
+Adams,Conewago #1,President,,REP,Donald J Trump,248,173,421
+Adams,Conewago #1,President,,REP,Roque Rocky De La Fuente,1,4,5
+Adams,Conewago #1,President,,REP,Bill Weld,4,18,22
+Adams,Conewago #1,President,,REP,Write-in,1,5,6
+Adams,Conewago #1,Attorney General,,REP,Heather Heidelbaugh,230,170,400
+Adams,Conewago #1,Attorney General,,REP,Write-in,1,6,7
+Adams,Conewago #1,Auditor General,,REP,Timothy Defoor,230,173,403
+Adams,Conewago #1,Auditor General,,REP,Write-in,0,2,2
+Adams,Conewago #1,State Treasurer,,REP,Stacy L Garrity,232,175,407
+Adams,Conewago #1,State Treasurer,,REP,Write-in,0,2,2
+Adams,Conewago #1,U.S. House,13,REP,John Joyce,232,177,409
+Adams,Conewago #1,U.S. House,13,REP,Write-in,0,3,3
+Adams,Conewago #1,State Senate,33,REP,Doug Mastriano,242,177,419
+Adams,Conewago #1,State Senate,33,REP,Write-in,1,7,8
+Adams,Conewago #1,General Assembly,91,REP,Dan Moul,238,186,424
+Adams,Conewago #1,General Assembly,91,REP,Write-in,2,3,5
+Adams,Conewago #2,Registered Voters,,,,,,2205
+Adams,Conewago #2,Registered Voters,,DEM,,,,723
+Adams,Conewago #2,Registered Voters,,REP,,,,1482
+Adams,Conewago #2,Ballots Cast,,,,330,378,708
+Adams,Conewago #2,Ballots Cast,,DEM,,53,211,264
+Adams,Conewago #2,Ballots Cast,,REP,,277,167,444
+Adams,Conewago #2,President,,DEM,Bernie Sanders,12,29,41
+Adams,Conewago #2,President,,DEM,Joseph R Biden,29,167,196
+Adams,Conewago #2,President,,DEM,Tulsi Gabbard,3,7,10
+Adams,Conewago #2,President,,DEM,Write-in,5,6,11
+Adams,Conewago #2,Attorney General,,DEM,Josh Shapiro,44,183,227
+Adams,Conewago #2,Attorney General,,DEM,Write-in,1,0,1
+Adams,Conewago #2,Auditor General,,DEM,H Scott Conklin,11,19,30
+Adams,Conewago #2,Auditor General,,DEM,Michael Lamb,2,16,18
+Adams,Conewago #2,Auditor General,,DEM,Tracie Fountain,6,40,46
+Adams,Conewago #2,Auditor General,,DEM,Rose Rosie Marie Davis,2,6,8
+Adams,Conewago #2,Auditor General,,DEM,Nina Ahmad,5,41,46
+Adams,Conewago #2,Auditor General,,DEM,Christina M Hartman,21,65,86
+Adams,Conewago #2,Auditor General,,DEM,Write-in,1,0,1
+Adams,Conewago #2,State Treasurer,,DEM,Joe Torsella,43,178,221
+Adams,Conewago #2,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Conewago #2,U.S. House,13,DEM,Todd Rowley,41,183,224
+Adams,Conewago #2,U.S. House,13,DEM,Write-in,1,0,1
+Adams,Conewago #2,State Senate,33,DEM,Rich Sterner,45,192,237
+Adams,Conewago #2,State Senate,33,DEM,Write-in,1,0,1
+Adams,Conewago #2,General Assembly,91,DEM,Write-in,4,19,23
+Adams,Conewago #2,President,,REP,Donald J Trump,268,142,410
+Adams,Conewago #2,President,,REP,Roque Rocky De La Fuente,1,3,4
+Adams,Conewago #2,President,,REP,Bill Weld,5,12,17
+Adams,Conewago #2,President,,REP,Write-in,0,6,6
+Adams,Conewago #2,Attorney General,,REP,Heather Heidelbaugh,242,151,393
+Adams,Conewago #2,Attorney General,,REP,Write-in,3,2,5
+Adams,Conewago #2,Auditor General,,REP,Timothy Defoor,241,150,391
+Adams,Conewago #2,Auditor General,,REP,Write-in,1,1,2
+Adams,Conewago #2,State Treasurer,,REP,Stacy L Garrity,240,149,389
+Adams,Conewago #2,State Treasurer,,REP,Write-in,2,0,2
+Adams,Conewago #2,U.S. House,13,REP,John Joyce,254,150,404
+Adams,Conewago #2,U.S. House,13,REP,Write-in,0,3,3
+Adams,Conewago #2,State Senate,33,REP,Doug Mastriano,263,149,412
+Adams,Conewago #2,State Senate,33,REP,Write-in,0,5,5
+Adams,Conewago #2,General Assembly,91,REP,Dan Moul,262,153,415
+Adams,Conewago #2,General Assembly,91,REP,Write-in,4,4,8
+Adams,Cumberland #1,Registered Voters,,,,,,1285
+Adams,Cumberland #1,Registered Voters,,DEM,,,,574
+Adams,Cumberland #1,Registered Voters,,REP,,,,711
+Adams,Cumberland #1,Ballots Cast,,,,217,337,554
+Adams,Cumberland #1,Ballots Cast,,DEM,,66,216,282
+Adams,Cumberland #1,Ballots Cast,,REP,,151,121,272
+Adams,Cumberland #1,President,,DEM,Bernie Sanders,9,18,27
+Adams,Cumberland #1,President,,DEM,Joseph R Biden,51,187,238
+Adams,Cumberland #1,President,,DEM,Tulsi Gabbard,2,3,5
+Adams,Cumberland #1,President,,DEM,Write-in,4,5,9
+Adams,Cumberland #1,Attorney General,,DEM,Josh Shapiro,57,195,252
+Adams,Cumberland #1,Attorney General,,DEM,Write-in,0,0,0
+Adams,Cumberland #1,Auditor General,,DEM,H Scott Conklin,5,12,17
+Adams,Cumberland #1,Auditor General,,DEM,Michael Lamb,11,25,36
+Adams,Cumberland #1,Auditor General,,DEM,Tracie Fountain,11,51,62
+Adams,Cumberland #1,Auditor General,,DEM,Rose Rosie Marie Davis,3,9,12
+Adams,Cumberland #1,Auditor General,,DEM,Nina Ahmad,17,48,65
+Adams,Cumberland #1,Auditor General,,DEM,Christina M Hartman,11,46,57
+Adams,Cumberland #1,Auditor General,,DEM,Write-in,0,2,2
+Adams,Cumberland #1,State Treasurer,,DEM,Joe Torsella,55,189,244
+Adams,Cumberland #1,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Cumberland #1,U.S. House,13,DEM,Todd Rowley,55,193,248
+Adams,Cumberland #1,U.S. House,13,DEM,Write-in,1,2,3
+Adams,Cumberland #1,State Senate,33,DEM,Rich Sterner,62,200,262
+Adams,Cumberland #1,State Senate,33,DEM,Write-in,0,0,0
+Adams,Cumberland #1,General Assembly,91,DEM,Write-in,2,18,20
+Adams,Cumberland #1,President,,REP,Donald J Trump,143,81,224
+Adams,Cumberland #1,President,,REP,Roque Rocky De La Fuente,1,1,2
+Adams,Cumberland #1,President,,REP,Bill Weld,2,17,19
+Adams,Cumberland #1,President,,REP,Write-in,2,12,14
+Adams,Cumberland #1,Attorney General,,REP,Heather Heidelbaugh,124,103,227
+Adams,Cumberland #1,Attorney General,,REP,Write-in,10,3,13
+Adams,Cumberland #1,Auditor General,,REP,Timothy Defoor,131,99,230
+Adams,Cumberland #1,Auditor General,,REP,Write-in,1,3,4
+Adams,Cumberland #1,State Treasurer,,REP,Stacy L Garrity,132,101,233
+Adams,Cumberland #1,State Treasurer,,REP,Write-in,1,4,5
+Adams,Cumberland #1,U.S. House,13,REP,John Joyce,131,95,226
+Adams,Cumberland #1,U.S. House,13,REP,Write-in,2,9,11
+Adams,Cumberland #1,State Senate,33,REP,Doug Mastriano,135,88,223
+Adams,Cumberland #1,State Senate,33,REP,Write-in,4,8,12
+Adams,Cumberland #1,General Assembly,91,REP,Dan Moul,131,98,229
+Adams,Cumberland #1,General Assembly,91,REP,Write-in,4,5,9
+Adams,Cumberland #2,Registered Voters,,,,,,921
+Adams,Cumberland #2,Registered Voters,,DEM,,,,299
+Adams,Cumberland #2,Registered Voters,,REP,,,,622
+Adams,Cumberland #2,Ballots Cast,,,,196,173,369
+Adams,Cumberland #2,Ballots Cast,,DEM,,38,89,127
+Adams,Cumberland #2,Ballots Cast,,REP,,158,84,242
+Adams,Cumberland #2,President,,DEM,Bernie Sanders,9,9,18
+Adams,Cumberland #2,President,,DEM,Joseph R Biden,26,73,99
+Adams,Cumberland #2,President,,DEM,Tulsi Gabbard,0,1,1
+Adams,Cumberland #2,President,,DEM,Write-in,1,6,7
+Adams,Cumberland #2,Attorney General,,DEM,Josh Shapiro,32,67,99
+Adams,Cumberland #2,Attorney General,,DEM,Write-in,1,0,1
+Adams,Cumberland #2,Auditor General,,DEM,H Scott Conklin,6,4,10
+Adams,Cumberland #2,Auditor General,,DEM,Michael Lamb,6,11,17
+Adams,Cumberland #2,Auditor General,,DEM,Tracie Fountain,5,23,28
+Adams,Cumberland #2,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,4
+Adams,Cumberland #2,Auditor General,,DEM,Nina Ahmad,6,9,15
+Adams,Cumberland #2,Auditor General,,DEM,Christina M Hartman,10,17,27
+Adams,Cumberland #2,Auditor General,,DEM,Write-in,1,0,1
+Adams,Cumberland #2,State Treasurer,,DEM,Joe Torsella,31,65,96
+Adams,Cumberland #2,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Cumberland #2,U.S. House,13,DEM,Todd Rowley,30,66,96
+Adams,Cumberland #2,U.S. House,13,DEM,Write-in,1,0,1
+Adams,Cumberland #2,State Senate,33,DEM,Rich Sterner,34,71,105
+Adams,Cumberland #2,State Senate,33,DEM,Write-in,1,0,1
+Adams,Cumberland #2,General Assembly,91,DEM,Write-in,3,5,8
+Adams,Cumberland #2,President,,REP,Donald J Trump,148,69,217
+Adams,Cumberland #2,President,,REP,Roque Rocky De La Fuente,0,1,1
+Adams,Cumberland #2,President,,REP,Bill Weld,5,10,15
+Adams,Cumberland #2,President,,REP,Write-in,0,0,0
+Adams,Cumberland #2,Attorney General,,REP,Heather Heidelbaugh,132,73,205
+Adams,Cumberland #2,Attorney General,,REP,Write-in,7,1,8
+Adams,Cumberland #2,Auditor General,,REP,Timothy Defoor,136,73,209
+Adams,Cumberland #2,Auditor General,,REP,Write-in,2,1,3
+Adams,Cumberland #2,State Treasurer,,REP,Stacy L Garrity,133,73,206
+Adams,Cumberland #2,State Treasurer,,REP,Write-in,0,1,1
+Adams,Cumberland #2,U.S. House,13,REP,John Joyce,146,80,226
+Adams,Cumberland #2,U.S. House,13,REP,Write-in,0,0,0
+Adams,Cumberland #2,State Senate,33,REP,Doug Mastriano,151,72,223
+Adams,Cumberland #2,State Senate,33,REP,Write-in,0,1,1
+Adams,Cumberland #2,General Assembly,91,REP,Dan Moul,142,76,218
+Adams,Cumberland #2,General Assembly,91,REP,Write-in,1,3,4
+Adams,Cumberland #3,Registered Voters,,,,,,1156
+Adams,Cumberland #3,Registered Voters,,DEM,,,,501
+Adams,Cumberland #3,Registered Voters,,REP,,,,655
+Adams,Cumberland #3,Ballots Cast,,,,186,367,553
+Adams,Cumberland #3,Ballots Cast,,DEM,,44,234,278
+Adams,Cumberland #3,Ballots Cast,,REP,,142,133,275
+Adams,Cumberland #3,President,,DEM,Bernie Sanders,11,21,32
+Adams,Cumberland #3,President,,DEM,Joseph R Biden,28,204,232
+Adams,Cumberland #3,President,,DEM,Tulsi Gabbard,0,3,3
+Adams,Cumberland #3,President,,DEM,Write-in,5,4,9
+Adams,Cumberland #3,Attorney General,,DEM,Josh Shapiro,36,200,236
+Adams,Cumberland #3,Attorney General,,DEM,Write-in,0,3,3
+Adams,Cumberland #3,Auditor General,,DEM,H Scott Conklin,5,11,16
+Adams,Cumberland #3,Auditor General,,DEM,Michael Lamb,5,23,28
+Adams,Cumberland #3,Auditor General,,DEM,Tracie Fountain,6,62,68
+Adams,Cumberland #3,Auditor General,,DEM,Rose Rosie Marie Davis,5,5,10
+Adams,Cumberland #3,Auditor General,,DEM,Nina Ahmad,7,41,48
+Adams,Cumberland #3,Auditor General,,DEM,Christina M Hartman,8,56,64
+Adams,Cumberland #3,Auditor General,,DEM,Write-in,0,1,1
+Adams,Cumberland #3,State Treasurer,,DEM,Joe Torsella,31,193,224
+Adams,Cumberland #3,State Treasurer,,DEM,Write-in,0,1,1
+Adams,Cumberland #3,U.S. House,13,DEM,Todd Rowley,34,190,224
+Adams,Cumberland #3,U.S. House,13,DEM,Write-in,0,1,1
+Adams,Cumberland #3,State Senate,33,DEM,Rich Sterner,35,213,248
+Adams,Cumberland #3,State Senate,33,DEM,Write-in,1,1,2
+Adams,Cumberland #3,General Assembly,91,DEM,Write-in,1,16,17
+Adams,Cumberland #3,President,,REP,Donald J Trump,135,105,240
+Adams,Cumberland #3,President,,REP,Roque Rocky De La Fuente,1,1,2
+Adams,Cumberland #3,President,,REP,Bill Weld,4,13,17
+Adams,Cumberland #3,President,,REP,Write-in,0,5,5
+Adams,Cumberland #3,Attorney General,,REP,Heather Heidelbaugh,116,119,235
+Adams,Cumberland #3,Attorney General,,REP,Write-in,5,0,5
+Adams,Cumberland #3,Auditor General,,REP,Timothy Defoor,118,118,236
+Adams,Cumberland #3,Auditor General,,REP,Write-in,2,0,2
+Adams,Cumberland #3,State Treasurer,,REP,Stacy L Garrity,117,118,235
+Adams,Cumberland #3,State Treasurer,,REP,Write-in,2,0,2
+Adams,Cumberland #3,U.S. House,13,REP,John Joyce,127,117,244
+Adams,Cumberland #3,U.S. House,13,REP,Write-in,1,1,2
+Adams,Cumberland #3,State Senate,33,REP,Doug Mastriano,132,109,241
+Adams,Cumberland #3,State Senate,33,REP,Write-in,1,2,3
+Adams,Cumberland #3,General Assembly,91,REP,Dan Moul,129,126,255
+Adams,Cumberland #3,General Assembly,91,REP,Write-in,2,0,2
+Adams,Cumberland #4,Registered Voters,,,,,,1130
+Adams,Cumberland #4,Registered Voters,,DEM,,,,481
+Adams,Cumberland #4,Registered Voters,,REP,,,,649
+Adams,Cumberland #4,Ballots Cast,,,,191,382,573
+Adams,Cumberland #4,Ballots Cast,,DEM,,52,236,288
+Adams,Cumberland #4,Ballots Cast,,REP,,139,146,285
+Adams,Cumberland #4,President,,DEM,Bernie Sanders,5,29,34
+Adams,Cumberland #4,President,,DEM,Joseph R Biden,42,198,240
+Adams,Cumberland #4,President,,DEM,Tulsi Gabbard,1,3,4
+Adams,Cumberland #4,President,,DEM,Write-in,4,4,8
+Adams,Cumberland #4,Attorney General,,DEM,Josh Shapiro,41,206,247
+Adams,Cumberland #4,Attorney General,,DEM,Write-in,1,1,2
+Adams,Cumberland #4,Auditor General,,DEM,H Scott Conklin,9,18,27
+Adams,Cumberland #4,Auditor General,,DEM,Michael Lamb,4,17,21
+Adams,Cumberland #4,Auditor General,,DEM,Tracie Fountain,4,58,62
+Adams,Cumberland #4,Auditor General,,DEM,Rose Rosie Marie Davis,2,12,14
+Adams,Cumberland #4,Auditor General,,DEM,Nina Ahmad,10,37,47
+Adams,Cumberland #4,Auditor General,,DEM,Christina M Hartman,12,57,69
+Adams,Cumberland #4,Auditor General,,DEM,Write-in,0,0,0
+Adams,Cumberland #4,State Treasurer,,DEM,Joe Torsella,42,199,241
+Adams,Cumberland #4,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Cumberland #4,U.S. House,13,DEM,Todd Rowley,39,201,240
+Adams,Cumberland #4,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Cumberland #4,State Senate,33,DEM,Rich Sterner,42,217,259
+Adams,Cumberland #4,State Senate,33,DEM,Write-in,1,0,1
+Adams,Cumberland #4,General Assembly,91,DEM,Write-in,8,15,23
+Adams,Cumberland #4,President,,REP,Donald J Trump,122,103,225
+Adams,Cumberland #4,President,,REP,Roque Rocky De La Fuente,2,4,6
+Adams,Cumberland #4,President,,REP,Bill Weld,8,21,29
+Adams,Cumberland #4,President,,REP,Write-in,4,8,12
+Adams,Cumberland #4,Attorney General,,REP,Heather Heidelbaugh,123,123,246
+Adams,Cumberland #4,Attorney General,,REP,Write-in,4,1,5
+Adams,Cumberland #4,Auditor General,,REP,Timothy Defoor,124,125,249
+Adams,Cumberland #4,Auditor General,,REP,Write-in,1,1,2
+Adams,Cumberland #4,State Treasurer,,REP,Stacy L Garrity,124,125,249
+Adams,Cumberland #4,State Treasurer,,REP,Write-in,0,1,1
+Adams,Cumberland #4,U.S. House,13,REP,John Joyce,128,126,254
+Adams,Cumberland #4,U.S. House,13,REP,Write-in,0,4,4
+Adams,Cumberland #4,State Senate,33,REP,Doug Mastriano,126,114,240
+Adams,Cumberland #4,State Senate,33,REP,Write-in,3,4,7
+Adams,Cumberland #4,General Assembly,91,REP,Dan Moul,126,129,255
+Adams,Cumberland #4,General Assembly,91,REP,Write-in,2,4,6
+Adams,East Berlin,Registered Voters,,,,,,863
+Adams,East Berlin,Registered Voters,,DEM,,,,255
+Adams,East Berlin,Registered Voters,,REP,,,,608
+Adams,East Berlin,Ballots Cast,,,,220,135,355
+Adams,East Berlin,Ballots Cast,,DEM,,29,65,94
+Adams,East Berlin,Ballots Cast,,REP,,191,70,261
+Adams,East Berlin,President,,DEM,Bernie Sanders,6,10,16
+Adams,East Berlin,President,,DEM,Joseph R Biden,17,53,70
+Adams,East Berlin,President,,DEM,Tulsi Gabbard,2,0,2
+Adams,East Berlin,President,,DEM,Write-in,2,0,2
+Adams,East Berlin,Attorney General,,DEM,Josh Shapiro,27,60,87
+Adams,East Berlin,Attorney General,,DEM,Write-in,0,0,0
+Adams,East Berlin,Auditor General,,DEM,H Scott Conklin,8,10,18
+Adams,East Berlin,Auditor General,,DEM,Michael Lamb,3,8,11
+Adams,East Berlin,Auditor General,,DEM,Tracie Fountain,2,12,14
+Adams,East Berlin,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2
+Adams,East Berlin,Auditor General,,DEM,Nina Ahmad,5,14,19
+Adams,East Berlin,Auditor General,,DEM,Christina M Hartman,8,15,23
+Adams,East Berlin,Auditor General,,DEM,Write-in,0,0,0
+Adams,East Berlin,State Treasurer,,DEM,Joe Torsella,26,57,83
+Adams,East Berlin,State Treasurer,,DEM,Write-in,0,1,1
+Adams,East Berlin,U.S. House,13,DEM,Todd Rowley,27,57,84
+Adams,East Berlin,U.S. House,13,DEM,Write-in,1,2,3
+Adams,East Berlin,State Senate,33,DEM,Rich Sterner,27,60,87
+Adams,East Berlin,State Senate,33,DEM,Write-in,1,0,1
+Adams,East Berlin,General Assembly,193,DEM,Write-in,4,7,11
+Adams,East Berlin,President,,REP,Donald J Trump,182,60,242
+Adams,East Berlin,President,,REP,Roque Rocky De La Fuente,1,4,5
+Adams,East Berlin,President,,REP,Bill Weld,4,4,8
+Adams,East Berlin,President,,REP,Write-in,2,1,3
+Adams,East Berlin,Attorney General,,REP,Heather Heidelbaugh,175,64,239
+Adams,East Berlin,Attorney General,,REP,Write-in,2,0,2
+Adams,East Berlin,Auditor General,,REP,Timothy Defoor,172,65,237
+Adams,East Berlin,Auditor General,,REP,Write-in,4,0,4
+Adams,East Berlin,State Treasurer,,REP,Stacy L Garrity,174,65,239
+Adams,East Berlin,State Treasurer,,REP,Write-in,1,0,1
+Adams,East Berlin,U.S. House,13,REP,John Joyce,180,63,243
+Adams,East Berlin,U.S. House,13,REP,Write-in,1,0,1
+Adams,East Berlin,State Senate,33,REP,Doug Mastriano,177,63,240
+Adams,East Berlin,State Senate,33,REP,Write-in,4,0,4
+Adams,East Berlin,General Assembly,193,REP,Torren Ecker,182,68,250
+Adams,East Berlin,General Assembly,193,REP,Write-in,1,0,1
+Adams,Fairfield,Registered Voters,,,,,,325
+Adams,Fairfield,Registered Voters,,DEM,,,,111
+Adams,Fairfield,Registered Voters,,REP,,,,214
+Adams,Fairfield,Ballots Cast,,,,94,56,150
+Adams,Fairfield,Ballots Cast,,DEM,,28,35,63
+Adams,Fairfield,Ballots Cast,,REP,,66,21,87
+Adams,Fairfield,President,,DEM,Bernie Sanders,6,7,13
+Adams,Fairfield,President,,DEM,Joseph R Biden,16,26,42
+Adams,Fairfield,President,,DEM,Tulsi Gabbard,0,1,1
+Adams,Fairfield,President,,DEM,Write-in,3,0,3
+Adams,Fairfield,Attorney General,,DEM,Josh Shapiro,24,33,57
+Adams,Fairfield,Attorney General,,DEM,Write-in,0,0,0
+Adams,Fairfield,Auditor General,,DEM,H Scott Conklin,5,3,8
+Adams,Fairfield,Auditor General,,DEM,Michael Lamb,2,3,5
+Adams,Fairfield,Auditor General,,DEM,Tracie Fountain,4,15,19
+Adams,Fairfield,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Adams,Fairfield,Auditor General,,DEM,Nina Ahmad,4,5,9
+Adams,Fairfield,Auditor General,,DEM,Christina M Hartman,8,8,16
+Adams,Fairfield,Auditor General,,DEM,Write-in,0,0,0
+Adams,Fairfield,State Treasurer,,DEM,Joe Torsella,22,33,55
+Adams,Fairfield,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Fairfield,U.S. House,13,DEM,Todd Rowley,23,34,57
+Adams,Fairfield,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Fairfield,State Senate,33,DEM,Rich Sterner,24,32,56
+Adams,Fairfield,State Senate,33,DEM,Write-in,0,0,0
+Adams,Fairfield,General Assembly,91,DEM,Write-in,3,5,8
+Adams,Fairfield,President,,REP,Donald J Trump,60,17,77
+Adams,Fairfield,President,,REP,Roque Rocky De La Fuente,0,1,1
+Adams,Fairfield,President,,REP,Bill Weld,3,1,4
+Adams,Fairfield,President,,REP,Write-in,3,1,4
+Adams,Fairfield,Attorney General,,REP,Heather Heidelbaugh,53,18,71
+Adams,Fairfield,Attorney General,,REP,Write-in,2,1,3
+Adams,Fairfield,Auditor General,,REP,Timothy Defoor,53,18,71
+Adams,Fairfield,Auditor General,,REP,Write-in,1,1,2
+Adams,Fairfield,State Treasurer,,REP,Stacy L Garrity,54,19,73
+Adams,Fairfield,State Treasurer,,REP,Write-in,3,1,4
+Adams,Fairfield,U.S. House,13,REP,John Joyce,52,18,70
+Adams,Fairfield,U.S. House,13,REP,Write-in,2,1,3
+Adams,Fairfield,State Senate,33,REP,Doug Mastriano,60,15,75
+Adams,Fairfield,State Senate,33,REP,Write-in,0,1,1
+Adams,Fairfield,General Assembly,91,REP,Dan Moul,54,18,72
+Adams,Fairfield,General Assembly,91,REP,Write-in,1,0,1
+Adams,Franklin #1,Registered Voters,,,,,,1418
+Adams,Franklin #1,Registered Voters,,DEM,,,,438
+Adams,Franklin #1,Registered Voters,,REP,,,,980
+Adams,Franklin #1,Ballots Cast,,,,299,270,569
+Adams,Franklin #1,Ballots Cast,,DEM,,55,142,197
+Adams,Franklin #1,Ballots Cast,,REP,,244,128,372
+Adams,Franklin #1,President,,DEM,Bernie Sanders,14,26,40
+Adams,Franklin #1,President,,DEM,Joseph R Biden,28,112,140
+Adams,Franklin #1,President,,DEM,Tulsi Gabbard,3,0,3
+Adams,Franklin #1,President,,DEM,Write-in,7,1,8
+Adams,Franklin #1,Attorney General,,DEM,Josh Shapiro,46,125,171
+Adams,Franklin #1,Attorney General,,DEM,Write-in,2,0,2
+Adams,Franklin #1,Auditor General,,DEM,H Scott Conklin,5,10,15
+Adams,Franklin #1,Auditor General,,DEM,Michael Lamb,5,10,15
+Adams,Franklin #1,Auditor General,,DEM,Tracie Fountain,9,31,40
+Adams,Franklin #1,Auditor General,,DEM,Rose Rosie Marie Davis,2,9,11
+Adams,Franklin #1,Auditor General,,DEM,Nina Ahmad,8,30,38
+Adams,Franklin #1,Auditor General,,DEM,Christina M Hartman,14,30,44
+Adams,Franklin #1,Auditor General,,DEM,Write-in,1,0,1
+Adams,Franklin #1,State Treasurer,,DEM,Joe Torsella,43,117,160
+Adams,Franklin #1,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Franklin #1,U.S. House,13,DEM,Todd Rowley,43,122,165
+Adams,Franklin #1,U.S. House,13,DEM,Write-in,1,0,1
+Adams,Franklin #1,State Senate,33,DEM,Rich Sterner,46,133,179
+Adams,Franklin #1,State Senate,33,DEM,Write-in,2,1,3
+Adams,Franklin #1,General Assembly,91,DEM,Write-in,4,7,11
+Adams,Franklin #1,President,,REP,Donald J Trump,238,105,343
+Adams,Franklin #1,President,,REP,Roque Rocky De La Fuente,2,3,5
+Adams,Franklin #1,President,,REP,Bill Weld,3,8,11
+Adams,Franklin #1,President,,REP,Write-in,0,6,6
+Adams,Franklin #1,Attorney General,,REP,Heather Heidelbaugh,213,121,334
+Adams,Franklin #1,Attorney General,,REP,Write-in,5,1,6
+Adams,Franklin #1,Auditor General,,REP,Timothy Defoor,212,121,333
+Adams,Franklin #1,Auditor General,,REP,Write-in,2,1,3
+Adams,Franklin #1,State Treasurer,,REP,Stacy L Garrity,216,120,336
+Adams,Franklin #1,State Treasurer,,REP,Write-in,0,1,1
+Adams,Franklin #1,U.S. House,13,REP,John Joyce,219,121,340
+Adams,Franklin #1,U.S. House,13,REP,Write-in,0,1,1
+Adams,Franklin #1,State Senate,33,REP,Doug Mastriano,235,119,354
+Adams,Franklin #1,State Senate,33,REP,Write-in,0,4,4
+Adams,Franklin #1,General Assembly,91,REP,Dan Moul,229,121,350
+Adams,Franklin #1,General Assembly,91,REP,Write-in,3,2,5
+Adams,Franklin #2,Registered Voters,,,,,,1304
+Adams,Franklin #2,Registered Voters,,DEM,,,,391
+Adams,Franklin #2,Registered Voters,,REP,,,,913
+Adams,Franklin #2,Ballots Cast,,,,253,250,503
+Adams,Franklin #2,Ballots Cast,,DEM,,32,111,143
+Adams,Franklin #2,Ballots Cast,,REP,,221,139,360
+Adams,Franklin #2,President,,DEM,Bernie Sanders,10,10,20
+Adams,Franklin #2,President,,DEM,Joseph R Biden,11,95,106
+Adams,Franklin #2,President,,DEM,Tulsi Gabbard,4,3,7
+Adams,Franklin #2,President,,DEM,Write-in,5,2,7
+Adams,Franklin #2,Attorney General,,DEM,Josh Shapiro,27,98,125
+Adams,Franklin #2,Attorney General,,DEM,Write-in,1,0,1
+Adams,Franklin #2,Auditor General,,DEM,H Scott Conklin,7,9,16
+Adams,Franklin #2,Auditor General,,DEM,Michael Lamb,3,14,17
+Adams,Franklin #2,Auditor General,,DEM,Tracie Fountain,4,23,27
+Adams,Franklin #2,Auditor General,,DEM,Rose Rosie Marie Davis,1,6,7
+Adams,Franklin #2,Auditor General,,DEM,Nina Ahmad,4,13,17
+Adams,Franklin #2,Auditor General,,DEM,Christina M Hartman,7,34,41
+Adams,Franklin #2,Auditor General,,DEM,Write-in,1,1,2
+Adams,Franklin #2,State Treasurer,,DEM,Joe Torsella,25,96,121
+Adams,Franklin #2,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Franklin #2,U.S. House,13,DEM,Todd Rowley,23,96,119
+Adams,Franklin #2,U.S. House,13,DEM,Write-in,1,0,1
+Adams,Franklin #2,State Senate,33,DEM,Rich Sterner,28,100,128
+Adams,Franklin #2,State Senate,33,DEM,Write-in,1,0,1
+Adams,Franklin #2,General Assembly,91,DEM,Write-in,3,11,14
+Adams,Franklin #2,President,,REP,Donald J Trump,210,114,324
+Adams,Franklin #2,President,,REP,Roque Rocky De La Fuente,1,3,4
+Adams,Franklin #2,President,,REP,Bill Weld,5,12,17
+Adams,Franklin #2,President,,REP,Write-in,2,7,9
+Adams,Franklin #2,Attorney General,,REP,Heather Heidelbaugh,189,123,312
+Adams,Franklin #2,Attorney General,,REP,Write-in,5,1,6
+Adams,Franklin #2,Auditor General,,REP,Timothy Defoor,196,122,318
+Adams,Franklin #2,Auditor General,,REP,Write-in,0,2,2
+Adams,Franklin #2,State Treasurer,,REP,Stacy L Garrity,191,122,313
+Adams,Franklin #2,State Treasurer,,REP,Write-in,0,1,1
+Adams,Franklin #2,U.S. House,13,REP,John Joyce,198,125,323
+Adams,Franklin #2,U.S. House,13,REP,Write-in,1,2,3
+Adams,Franklin #2,State Senate,33,REP,Doug Mastriano,210,125,335
+Adams,Franklin #2,State Senate,33,REP,Write-in,2,4,6
+Adams,Franklin #2,General Assembly,91,REP,Dan Moul,202,128,330
+Adams,Franklin #2,General Assembly,91,REP,Write-in,4,0,4
+Adams,Freedom,Registered Voters,,,,,,573
+Adams,Freedom,Registered Voters,,DEM,,,,179
+Adams,Freedom,Registered Voters,,REP,,,,394
+Adams,Freedom,Ballots Cast,,,,153,107,260
+Adams,Freedom,Ballots Cast,,DEM,,31,58,89
+Adams,Freedom,Ballots Cast,,REP,,122,49,171
+Adams,Freedom,President,,DEM,Bernie Sanders,4,7,11
+Adams,Freedom,President,,DEM,Joseph R Biden,23,48,71
+Adams,Freedom,President,,DEM,Tulsi Gabbard,2,1,3
+Adams,Freedom,President,,DEM,Write-in,0,2,2
+Adams,Freedom,Attorney General,,DEM,Josh Shapiro,26,48,74
+Adams,Freedom,Attorney General,,DEM,Write-in,0,1,1
+Adams,Freedom,Auditor General,,DEM,H Scott Conklin,1,4,5
+Adams,Freedom,Auditor General,,DEM,Michael Lamb,3,8,11
+Adams,Freedom,Auditor General,,DEM,Tracie Fountain,6,10,16
+Adams,Freedom,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,1
+Adams,Freedom,Auditor General,,DEM,Nina Ahmad,8,7,15
+Adams,Freedom,Auditor General,,DEM,Christina M Hartman,5,14,19
+Adams,Freedom,Auditor General,,DEM,Write-in,0,0,0
+Adams,Freedom,State Treasurer,,DEM,Joe Torsella,23,45,68
+Adams,Freedom,State Treasurer,,DEM,Write-in,0,1,1
+Adams,Freedom,U.S. House,13,DEM,Todd Rowley,25,46,71
+Adams,Freedom,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Freedom,State Senate,33,DEM,Rich Sterner,25,53,78
+Adams,Freedom,State Senate,33,DEM,Write-in,0,0,0
+Adams,Freedom,General Assembly,91,DEM,Write-in,2,6,8
+Adams,Freedom,President,,REP,Donald J Trump,118,43,161
+Adams,Freedom,President,,REP,Roque Rocky De La Fuente,2,0,2
+Adams,Freedom,President,,REP,Bill Weld,0,5,5
+Adams,Freedom,President,,REP,Write-in,1,1,2
+Adams,Freedom,Attorney General,,REP,Heather Heidelbaugh,108,45,153
+Adams,Freedom,Attorney General,,REP,Write-in,1,0,1
+Adams,Freedom,Auditor General,,REP,Timothy Defoor,110,45,155
+Adams,Freedom,Auditor General,,REP,Write-in,0,0,0
+Adams,Freedom,State Treasurer,,REP,Stacy L Garrity,109,45,154
+Adams,Freedom,State Treasurer,,REP,Write-in,0,0,0
+Adams,Freedom,U.S. House,13,REP,John Joyce,114,45,159
+Adams,Freedom,U.S. House,13,REP,Write-in,0,1,1
+Adams,Freedom,State Senate,33,REP,Doug Mastriano,119,46,165
+Adams,Freedom,State Senate,33,REP,Write-in,0,1,1
+Adams,Freedom,General Assembly,91,REP,Dan Moul,112,45,157
+Adams,Freedom,General Assembly,91,REP,Write-in,0,1,1
+Adams,Germany,Registered Voters,,,,,,1726
+Adams,Germany,Registered Voters,,DEM,,,,431
+Adams,Germany,Registered Voters,,REP,,,,1295
+Adams,Germany,Ballots Cast,,,,285,300,585
+Adams,Germany,Ballots Cast,,DEM,,32,144,176
+Adams,Germany,Ballots Cast,,REP,,253,156,409
+Adams,Germany,President,,DEM,Bernie Sanders,12,14,26
+Adams,Germany,President,,DEM,Joseph R Biden,11,118,129
+Adams,Germany,President,,DEM,Tulsi Gabbard,4,6,10
+Adams,Germany,President,,DEM,Write-in,3,6,9
+Adams,Germany,Attorney General,,DEM,Josh Shapiro,26,127,153
+Adams,Germany,Attorney General,,DEM,Write-in,0,1,1
+Adams,Germany,Auditor General,,DEM,H Scott Conklin,6,17,23
+Adams,Germany,Auditor General,,DEM,Michael Lamb,5,8,13
+Adams,Germany,Auditor General,,DEM,Tracie Fountain,2,31,33
+Adams,Germany,Auditor General,,DEM,Rose Rosie Marie Davis,0,4,4
+Adams,Germany,Auditor General,,DEM,Nina Ahmad,3,14,17
+Adams,Germany,Auditor General,,DEM,Christina M Hartman,7,52,59
+Adams,Germany,Auditor General,,DEM,Write-in,0,2,2
+Adams,Germany,State Treasurer,,DEM,Joe Torsella,23,124,147
+Adams,Germany,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Germany,U.S. House,13,DEM,Todd Rowley,23,123,146
+Adams,Germany,U.S. House,13,DEM,Write-in,0,2,2
+Adams,Germany,State Senate,33,DEM,Rich Sterner,27,132,159
+Adams,Germany,State Senate,33,DEM,Write-in,1,1,2
+Adams,Germany,General Assembly,91,DEM,Write-in,0,8,8
+Adams,Germany,President,,REP,Donald J Trump,247,137,384
+Adams,Germany,President,,REP,Roque Rocky De La Fuente,0,7,7
+Adams,Germany,President,,REP,Bill Weld,6,5,11
+Adams,Germany,President,,REP,Write-in,0,4,4
+Adams,Germany,Attorney General,,REP,Heather Heidelbaugh,216,143,359
+Adams,Germany,Attorney General,,REP,Write-in,7,0,7
+Adams,Germany,Auditor General,,REP,Timothy Defoor,214,140,354
+Adams,Germany,Auditor General,,REP,Write-in,3,1,4
+Adams,Germany,State Treasurer,,REP,Stacy L Garrity,217,144,361
+Adams,Germany,State Treasurer,,REP,Write-in,2,1,3
+Adams,Germany,U.S. House,13,REP,John Joyce,222,143,365
+Adams,Germany,U.S. House,13,REP,Write-in,3,1,4
+Adams,Germany,State Senate,33,REP,Doug Mastriano,235,146,381
+Adams,Germany,State Senate,33,REP,Write-in,2,1,3
+Adams,Germany,General Assembly,91,REP,Dan Moul,227,145,372
+Adams,Germany,General Assembly,91,REP,Write-in,5,0,5
+Adams,Gettysburg #1,Registered Voters,,,,,,1081
+Adams,Gettysburg #1,Registered Voters,,DEM,,,,639
+Adams,Gettysburg #1,Registered Voters,,REP,,,,442
+Adams,Gettysburg #1,Ballots Cast,,,,177,245,422
+Adams,Gettysburg #1,Ballots Cast,,DEM,,84,202,286
+Adams,Gettysburg #1,Ballots Cast,,REP,,93,43,136
+Adams,Gettysburg #1,President,,DEM,Bernie Sanders,20,50,70
+Adams,Gettysburg #1,President,,DEM,Joseph R Biden,58,145,203
+Adams,Gettysburg #1,President,,DEM,Tulsi Gabbard,3,4,7
+Adams,Gettysburg #1,President,,DEM,Write-in,2,2,4
+Adams,Gettysburg #1,Attorney General,,DEM,Josh Shapiro,71,183,254
+Adams,Gettysburg #1,Attorney General,,DEM,Write-in,1,0,1
+Adams,Gettysburg #1,Auditor General,,DEM,H Scott Conklin,8,6,14
+Adams,Gettysburg #1,Auditor General,,DEM,Michael Lamb,5,17,22
+Adams,Gettysburg #1,Auditor General,,DEM,Tracie Fountain,20,41,61
+Adams,Gettysburg #1,Auditor General,,DEM,Rose Rosie Marie Davis,4,7,11
+Adams,Gettysburg #1,Auditor General,,DEM,Nina Ahmad,20,66,86
+Adams,Gettysburg #1,Auditor General,,DEM,Christina M Hartman,16,41,57
+Adams,Gettysburg #1,Auditor General,,DEM,Write-in,0,0,0
+Adams,Gettysburg #1,State Treasurer,,DEM,Joe Torsella,68,175,243
+Adams,Gettysburg #1,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Gettysburg #1,U.S. House,13,DEM,Todd Rowley,65,176,241
+Adams,Gettysburg #1,U.S. House,13,DEM,Write-in,1,0,1
+Adams,Gettysburg #1,State Senate,33,DEM,Rich Sterner,73,190,263
+Adams,Gettysburg #1,State Senate,33,DEM,Write-in,0,0,0
+Adams,Gettysburg #1,General Assembly,91,DEM,Write-in,14,29,43
+Adams,Gettysburg #1,President,,REP,Donald J Trump,84,29,113
+Adams,Gettysburg #1,President,,REP,Roque Rocky De La Fuente,0,2,2
+Adams,Gettysburg #1,President,,REP,Bill Weld,4,6,10
+Adams,Gettysburg #1,President,,REP,Write-in,5,4,9
+Adams,Gettysburg #1,Attorney General,,REP,Heather Heidelbaugh,71,37,108
+Adams,Gettysburg #1,Attorney General,,REP,Write-in,7,0,7
+Adams,Gettysburg #1,Auditor General,,REP,Timothy Defoor,78,38,116
+Adams,Gettysburg #1,Auditor General,,REP,Write-in,0,0,0
+Adams,Gettysburg #1,State Treasurer,,REP,Stacy L Garrity,79,38,117
+Adams,Gettysburg #1,State Treasurer,,REP,Write-in,0,0,0
+Adams,Gettysburg #1,U.S. House,13,REP,John Joyce,81,36,117
+Adams,Gettysburg #1,U.S. House,13,REP,Write-in,1,1,2
+Adams,Gettysburg #1,State Senate,33,REP,Doug Mastriano,85,34,119
+Adams,Gettysburg #1,State Senate,33,REP,Write-in,1,2,3
+Adams,Gettysburg #1,General Assembly,91,REP,Dan Moul,81,36,117
+Adams,Gettysburg #1,General Assembly,91,REP,Write-in,3,2,5
+Adams,Gettysburg #2,Registered Voters,,,,,,1643
+Adams,Gettysburg #2,Registered Voters,,DEM,,,,1106
+Adams,Gettysburg #2,Registered Voters,,REP,,,,537
+Adams,Gettysburg #2,Ballots Cast,,,,104,194,298
+Adams,Gettysburg #2,Ballots Cast,,DEM,,62,160,222
+Adams,Gettysburg #2,Ballots Cast,,REP,,42,34,76
+Adams,Gettysburg #2,President,,DEM,Bernie Sanders,17,33,50
+Adams,Gettysburg #2,President,,DEM,Joseph R Biden,43,122,165
+Adams,Gettysburg #2,President,,DEM,Tulsi Gabbard,1,2,3
+Adams,Gettysburg #2,President,,DEM,Write-in,1,2,3
+Adams,Gettysburg #2,Attorney General,,DEM,Josh Shapiro,54,141,195
+Adams,Gettysburg #2,Attorney General,,DEM,Write-in,0,0,0
+Adams,Gettysburg #2,Auditor General,,DEM,H Scott Conklin,1,6,7
+Adams,Gettysburg #2,Auditor General,,DEM,Michael Lamb,7,12,19
+Adams,Gettysburg #2,Auditor General,,DEM,Tracie Fountain,15,42,57
+Adams,Gettysburg #2,Auditor General,,DEM,Rose Rosie Marie Davis,0,9,9
+Adams,Gettysburg #2,Auditor General,,DEM,Nina Ahmad,23,41,64
+Adams,Gettysburg #2,Auditor General,,DEM,Christina M Hartman,11,33,44
+Adams,Gettysburg #2,Auditor General,,DEM,Write-in,0,0,0
+Adams,Gettysburg #2,State Treasurer,,DEM,Joe Torsella,55,137,192
+Adams,Gettysburg #2,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Gettysburg #2,U.S. House,13,DEM,Todd Rowley,54,137,191
+Adams,Gettysburg #2,U.S. House,13,DEM,Write-in,0,2,2
+Adams,Gettysburg #2,State Senate,33,DEM,Rich Sterner,55,145,200
+Adams,Gettysburg #2,State Senate,33,DEM,Write-in,1,0,1
+Adams,Gettysburg #2,General Assembly,91,DEM,Write-in,6,23,29
+Adams,Gettysburg #2,President,,REP,Donald J Trump,39,29,68
+Adams,Gettysburg #2,President,,REP,Roque Rocky De La Fuente,1,0,1
+Adams,Gettysburg #2,President,,REP,Bill Weld,0,2,2
+Adams,Gettysburg #2,President,,REP,Write-in,2,3,5
+Adams,Gettysburg #2,Attorney General,,REP,Heather Heidelbaugh,37,31,68
+Adams,Gettysburg #2,Attorney General,,REP,Write-in,0,0,0
+Adams,Gettysburg #2,Auditor General,,REP,Timothy Defoor,38,31,69
+Adams,Gettysburg #2,Auditor General,,REP,Write-in,0,0,0
+Adams,Gettysburg #2,State Treasurer,,REP,Stacy L Garrity,38,31,69
+Adams,Gettysburg #2,State Treasurer,,REP,Write-in,0,0,0
+Adams,Gettysburg #2,U.S. House,13,REP,John Joyce,40,32,72
+Adams,Gettysburg #2,U.S. House,13,REP,Write-in,0,0,0
+Adams,Gettysburg #2,State Senate,33,REP,Doug Mastriano,39,29,68
+Adams,Gettysburg #2,State Senate,33,REP,Write-in,0,1,1
+Adams,Gettysburg #2,General Assembly,91,REP,Dan Moul,41,33,74
+Adams,Gettysburg #2,General Assembly,91,REP,Write-in,0,0,0
+Adams,Gettysburg #3,Registered Voters,,,,,,913
+Adams,Gettysburg #3,Registered Voters,,DEM,,,,481
+Adams,Gettysburg #3,Registered Voters,,REP,,,,432
+Adams,Gettysburg #3,Ballots Cast,,,,140,252,392
+Adams,Gettysburg #3,Ballots Cast,,DEM,,43,175,218
+Adams,Gettysburg #3,Ballots Cast,,REP,,97,77,174
+Adams,Gettysburg #3,President,,DEM,Bernie Sanders,9,28,37
+Adams,Gettysburg #3,President,,DEM,Joseph R Biden,31,143,174
+Adams,Gettysburg #3,President,,DEM,Tulsi Gabbard,2,2,4
+Adams,Gettysburg #3,President,,DEM,Write-in,1,2,3
+Adams,Gettysburg #3,Attorney General,,DEM,Josh Shapiro,33,157,190
+Adams,Gettysburg #3,Attorney General,,DEM,Write-in,0,1,1
+Adams,Gettysburg #3,Auditor General,,DEM,H Scott Conklin,4,12,16
+Adams,Gettysburg #3,Auditor General,,DEM,Michael Lamb,2,16,18
+Adams,Gettysburg #3,Auditor General,,DEM,Tracie Fountain,5,31,36
+Adams,Gettysburg #3,Auditor General,,DEM,Rose Rosie Marie Davis,6,9,15
+Adams,Gettysburg #3,Auditor General,,DEM,Nina Ahmad,8,41,49
+Adams,Gettysburg #3,Auditor General,,DEM,Christina M Hartman,10,45,55
+Adams,Gettysburg #3,Auditor General,,DEM,Write-in,0,1,1
+Adams,Gettysburg #3,State Treasurer,,DEM,Joe Torsella,29,149,178
+Adams,Gettysburg #3,State Treasurer,,DEM,Write-in,0,2,2
+Adams,Gettysburg #3,U.S. House,13,DEM,Todd Rowley,27,152,179
+Adams,Gettysburg #3,U.S. House,13,DEM,Write-in,0,1,1
+Adams,Gettysburg #3,State Senate,33,DEM,Rich Sterner,36,153,189
+Adams,Gettysburg #3,State Senate,33,DEM,Write-in,0,4,4
+Adams,Gettysburg #3,General Assembly,91,DEM,Write-in,5,15,20
+Adams,Gettysburg #3,President,,REP,Donald J Trump,87,57,144
+Adams,Gettysburg #3,President,,REP,Roque Rocky De La Fuente,0,3,3
+Adams,Gettysburg #3,President,,REP,Bill Weld,5,9,14
+Adams,Gettysburg #3,President,,REP,Write-in,2,4,6
+Adams,Gettysburg #3,Attorney General,,REP,Heather Heidelbaugh,78,71,149
+Adams,Gettysburg #3,Attorney General,,REP,Write-in,3,1,4
+Adams,Gettysburg #3,Auditor General,,REP,Timothy Defoor,73,68,141
+Adams,Gettysburg #3,Auditor General,,REP,Write-in,2,0,2
+Adams,Gettysburg #3,State Treasurer,,REP,Stacy L Garrity,75,68,143
+Adams,Gettysburg #3,State Treasurer,,REP,Write-in,1,0,1
+Adams,Gettysburg #3,U.S. House,13,REP,John Joyce,84,66,150
+Adams,Gettysburg #3,U.S. House,13,REP,Write-in,0,1,1
+Adams,Gettysburg #3,State Senate,33,REP,Doug Mastriano,84,64,148
+Adams,Gettysburg #3,State Senate,33,REP,Write-in,1,4,5
+Adams,Gettysburg #3,General Assembly,91,REP,Dan Moul,88,66,154
+Adams,Gettysburg #3,General Assembly,91,REP,Write-in,1,4,5
+Adams,Hamilton,Registered Voters,,,,,,1540
+Adams,Hamilton,Registered Voters,,DEM,,,,415
+Adams,Hamilton,Registered Voters,,REP,,,,1125
+Adams,Hamilton,Ballots Cast,,,,350,248,598
+Adams,Hamilton,Ballots Cast,,DEM,,48,110,158
+Adams,Hamilton,Ballots Cast,,REP,,302,138,440
+Adams,Hamilton,President,,DEM,Bernie Sanders,11,16,27
+Adams,Hamilton,President,,DEM,Joseph R Biden,26,87,113
+Adams,Hamilton,President,,DEM,Tulsi Gabbard,6,0,6
+Adams,Hamilton,President,,DEM,Write-in,2,6,8
+Adams,Hamilton,Attorney General,,DEM,Josh Shapiro,44,99,143
+Adams,Hamilton,Attorney General,,DEM,Write-in,0,1,1
+Adams,Hamilton,Auditor General,,DEM,H Scott Conklin,10,9,19
+Adams,Hamilton,Auditor General,,DEM,Michael Lamb,4,11,15
+Adams,Hamilton,Auditor General,,DEM,Tracie Fountain,10,25,35
+Adams,Hamilton,Auditor General,,DEM,Rose Rosie Marie Davis,3,5,8
+Adams,Hamilton,Auditor General,,DEM,Nina Ahmad,6,9,15
+Adams,Hamilton,Auditor General,,DEM,Christina M Hartman,10,40,50
+Adams,Hamilton,Auditor General,,DEM,Write-in,0,3,3
+Adams,Hamilton,State Treasurer,,DEM,Joe Torsella,39,97,136
+Adams,Hamilton,State Treasurer,,DEM,Write-in,0,1,1
+Adams,Hamilton,U.S. House,13,DEM,Todd Rowley,41,93,134
+Adams,Hamilton,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Hamilton,State Senate,33,DEM,Rich Sterner,43,102,145
+Adams,Hamilton,State Senate,33,DEM,Write-in,0,1,1
+Adams,Hamilton,General Assembly,193,DEM,Write-in,1,9,10
+Adams,Hamilton,President,,REP,Donald J Trump,294,105,399
+Adams,Hamilton,President,,REP,Roque Rocky De La Fuente,1,2,3
+Adams,Hamilton,President,,REP,Bill Weld,3,14,17
+Adams,Hamilton,President,,REP,Write-in,0,12,12
+Adams,Hamilton,Attorney General,,REP,Heather Heidelbaugh,266,108,374
+Adams,Hamilton,Attorney General,,REP,Write-in,3,0,3
+Adams,Hamilton,Auditor General,,REP,Timothy Defoor,270,109,379
+Adams,Hamilton,Auditor General,,REP,Write-in,0,0,0
+Adams,Hamilton,State Treasurer,,REP,Stacy L Garrity,269,112,381
+Adams,Hamilton,State Treasurer,,REP,Write-in,0,1,1
+Adams,Hamilton,U.S. House,13,REP,John Joyce,279,113,392
+Adams,Hamilton,U.S. House,13,REP,Write-in,0,2,2
+Adams,Hamilton,State Senate,33,REP,Doug Mastriano,288,111,399
+Adams,Hamilton,State Senate,33,REP,Write-in,2,2,4
+Adams,Hamilton,General Assembly,193,REP,Torren Ecker,292,124,416
+Adams,Hamilton,General Assembly,193,REP,Write-in,0,1,1
+Adams,Hamiltonban,Registered Voters,,,,,,1272
+Adams,Hamiltonban,Registered Voters,,DEM,,,,384
+Adams,Hamiltonban,Registered Voters,,REP,,,,888
+Adams,Hamiltonban,Ballots Cast,,,,318,198,516
+Adams,Hamiltonban,Ballots Cast,,DEM,,63,103,166
+Adams,Hamiltonban,Ballots Cast,,REP,,255,95,350
+Adams,Hamiltonban,President,,DEM,Bernie Sanders,15,31,46
+Adams,Hamiltonban,President,,DEM,Joseph R Biden,31,63,94
+Adams,Hamiltonban,President,,DEM,Tulsi Gabbard,1,3,4
+Adams,Hamiltonban,President,,DEM,Write-in,12,4,16
+Adams,Hamiltonban,Attorney General,,DEM,Josh Shapiro,49,97,146
+Adams,Hamiltonban,Attorney General,,DEM,Write-in,1,0,1
+Adams,Hamiltonban,Auditor General,,DEM,H Scott Conklin,7,15,22
+Adams,Hamiltonban,Auditor General,,DEM,Michael Lamb,6,12,18
+Adams,Hamiltonban,Auditor General,,DEM,Tracie Fountain,10,21,31
+Adams,Hamiltonban,Auditor General,,DEM,Rose Rosie Marie Davis,6,4,10
+Adams,Hamiltonban,Auditor General,,DEM,Nina Ahmad,9,11,20
+Adams,Hamiltonban,Auditor General,,DEM,Christina M Hartman,10,26,36
+Adams,Hamiltonban,Auditor General,,DEM,Write-in,1,2,3
+Adams,Hamiltonban,State Treasurer,,DEM,Joe Torsella,48,91,139
+Adams,Hamiltonban,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Hamiltonban,U.S. House,13,DEM,Todd Rowley,47,92,139
+Adams,Hamiltonban,U.S. House,13,DEM,Write-in,2,2,4
+Adams,Hamiltonban,State Senate,33,DEM,Rich Sterner,50,95,145
+Adams,Hamiltonban,State Senate,33,DEM,Write-in,1,3,4
+Adams,Hamiltonban,General Assembly,91,DEM,Write-in,4,10,14
+Adams,Hamiltonban,President,,REP,Donald J Trump,250,80,330
+Adams,Hamiltonban,President,,REP,Roque Rocky De La Fuente,1,3,4
+Adams,Hamiltonban,President,,REP,Bill Weld,0,6,6
+Adams,Hamiltonban,President,,REP,Write-in,3,2,5
+Adams,Hamiltonban,Attorney General,,REP,Heather Heidelbaugh,210,71,281
+Adams,Hamiltonban,Attorney General,,REP,Write-in,2,2,4
+Adams,Hamiltonban,Auditor General,,REP,Timothy Defoor,212,71,283
+Adams,Hamiltonban,Auditor General,,REP,Write-in,0,0,0
+Adams,Hamiltonban,State Treasurer,,REP,Stacy L Garrity,216,72,288
+Adams,Hamiltonban,State Treasurer,,REP,Write-in,0,0,0
+Adams,Hamiltonban,U.S. House,13,REP,John Joyce,225,83,308
+Adams,Hamiltonban,U.S. House,13,REP,Write-in,0,0,0
+Adams,Hamiltonban,State Senate,33,REP,Doug Mastriano,243,83,326
+Adams,Hamiltonban,State Senate,33,REP,Write-in,1,2,3
+Adams,Hamiltonban,General Assembly,91,REP,Dan Moul,236,88,324
+Adams,Hamiltonban,General Assembly,91,REP,Write-in,0,0,0
+Adams,Highland,Registered Voters,,,,,,609
+Adams,Highland,Registered Voters,,DEM,,,,177
+Adams,Highland,Registered Voters,,REP,,,,432
+Adams,Highland,Ballots Cast,,,,139,122,261
+Adams,Highland,Ballots Cast,,DEM,,27,63,90
+Adams,Highland,Ballots Cast,,REP,,112,59,171
+Adams,Highland,President,,DEM,Bernie Sanders,1,10,11
+Adams,Highland,President,,DEM,Joseph R Biden,19,51,70
+Adams,Highland,President,,DEM,Tulsi Gabbard,0,2,2
+Adams,Highland,President,,DEM,Write-in,4,0,4
+Adams,Highland,Attorney General,,DEM,Josh Shapiro,21,59,80
+Adams,Highland,Attorney General,,DEM,Write-in,1,0,1
+Adams,Highland,Auditor General,,DEM,H Scott Conklin,1,5,6
+Adams,Highland,Auditor General,,DEM,Michael Lamb,5,8,13
+Adams,Highland,Auditor General,,DEM,Tracie Fountain,4,12,16
+Adams,Highland,Auditor General,,DEM,Rose Rosie Marie Davis,4,4,8
+Adams,Highland,Auditor General,,DEM,Nina Ahmad,0,7,7
+Adams,Highland,Auditor General,,DEM,Christina M Hartman,8,19,27
+Adams,Highland,Auditor General,,DEM,Write-in,0,0,0
+Adams,Highland,State Treasurer,,DEM,Joe Torsella,20,57,77
+Adams,Highland,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Highland,U.S. House,13,DEM,Todd Rowley,18,58,76
+Adams,Highland,U.S. House,13,DEM,Write-in,1,0,1
+Adams,Highland,State Senate,33,DEM,Rich Sterner,20,58,78
+Adams,Highland,State Senate,33,DEM,Write-in,1,1,2
+Adams,Highland,General Assembly,91,DEM,Write-in,1,5,6
+Adams,Highland,President,,REP,Donald J Trump,112,50,162
+Adams,Highland,President,,REP,Roque Rocky De La Fuente,0,1,1
+Adams,Highland,President,,REP,Bill Weld,0,1,1
+Adams,Highland,President,,REP,Write-in,0,3,3
+Adams,Highland,Attorney General,,REP,Heather Heidelbaugh,97,55,152
+Adams,Highland,Attorney General,,REP,Write-in,4,1,5
+Adams,Highland,Auditor General,,REP,Timothy Defoor,102,55,157
+Adams,Highland,Auditor General,,REP,Write-in,0,1,1
+Adams,Highland,State Treasurer,,REP,Stacy L Garrity,100,55,155
+Adams,Highland,State Treasurer,,REP,Write-in,0,1,1
+Adams,Highland,U.S. House,13,REP,John Joyce,102,53,155
+Adams,Highland,U.S. House,13,REP,Write-in,0,2,2
+Adams,Highland,State Senate,33,REP,Doug Mastriano,109,51,160
+Adams,Highland,State Senate,33,REP,Write-in,0,1,1
+Adams,Highland,General Assembly,91,REP,Dan Moul,106,53,159
+Adams,Highland,General Assembly,91,REP,Write-in,0,1,1
+Adams,Huntington,Registered Voters,,,,,,1299
+Adams,Huntington,Registered Voters,,DEM,,,,282
+Adams,Huntington,Registered Voters,,REP,,,,1017
+Adams,Huntington,Ballots Cast,,,,374,169,543
+Adams,Huntington,Ballots Cast,,DEM,,41,49,90
+Adams,Huntington,Ballots Cast,,REP,,333,120,453
+Adams,Huntington,President,,DEM,Bernie Sanders,5,8,13
+Adams,Huntington,President,,DEM,Joseph R Biden,19,38,57
+Adams,Huntington,President,,DEM,Tulsi Gabbard,5,2,7
+Adams,Huntington,President,,DEM,Write-in,6,0,6
+Adams,Huntington,Attorney General,,DEM,Josh Shapiro,28,46,74
+Adams,Huntington,Attorney General,,DEM,Write-in,2,0,2
+Adams,Huntington,Auditor General,,DEM,H Scott Conklin,11,5,16
+Adams,Huntington,Auditor General,,DEM,Michael Lamb,4,6,10
+Adams,Huntington,Auditor General,,DEM,Tracie Fountain,4,19,23
+Adams,Huntington,Auditor General,,DEM,Rose Rosie Marie Davis,5,0,5
+Adams,Huntington,Auditor General,,DEM,Nina Ahmad,6,4,10
+Adams,Huntington,Auditor General,,DEM,Christina M Hartman,5,13,18
+Adams,Huntington,Auditor General,,DEM,Write-in,1,0,1
+Adams,Huntington,State Treasurer,,DEM,Joe Torsella,31,46,77
+Adams,Huntington,State Treasurer,,DEM,Write-in,2,0,2
+Adams,Huntington,U.S. House,13,DEM,Todd Rowley,23,46,69
+Adams,Huntington,U.S. House,13,DEM,Write-in,4,0,4
+Adams,Huntington,State Senate,33,DEM,Rich Sterner,30,48,78
+Adams,Huntington,State Senate,33,DEM,Write-in,4,0,4
+Adams,Huntington,General Assembly,193,DEM,Write-in,4,6,10
+Adams,Huntington,President,,REP,Donald J Trump,327,95,422
+Adams,Huntington,President,,REP,Roque Rocky De La Fuente,0,1,1
+Adams,Huntington,President,,REP,Bill Weld,6,13,19
+Adams,Huntington,President,,REP,Write-in,0,4,4
+Adams,Huntington,Attorney General,,REP,Heather Heidelbaugh,301,100,401
+Adams,Huntington,Attorney General,,REP,Write-in,5,1,6
+Adams,Huntington,Auditor General,,REP,Timothy Defoor,305,104,409
+Adams,Huntington,Auditor General,,REP,Write-in,0,0,0
+Adams,Huntington,State Treasurer,,REP,Stacy L Garrity,302,104,406
+Adams,Huntington,State Treasurer,,REP,Write-in,0,0,0
+Adams,Huntington,U.S. House,13,REP,John Joyce,311,102,413
+Adams,Huntington,U.S. House,13,REP,Write-in,0,2,2
+Adams,Huntington,State Senate,33,REP,Doug Mastriano,318,99,417
+Adams,Huntington,State Senate,33,REP,Write-in,0,2,2
+Adams,Huntington,General Assembly,193,REP,Torren Ecker,315,109,424
+Adams,Huntington,General Assembly,193,REP,Write-in,3,1,4
+Adams,Latimore,Registered Voters,,,,,,1575
+Adams,Latimore,Registered Voters,,DEM,,,,407
+Adams,Latimore,Registered Voters,,REP,,,,1168
+Adams,Latimore,Ballots Cast,,,,359,307,666
+Adams,Latimore,Ballots Cast,,DEM,,38,162,200
+Adams,Latimore,Ballots Cast,,REP,,321,145,466
+Adams,Latimore,President,,DEM,Bernie Sanders,9,33,42
+Adams,Latimore,President,,DEM,Joseph R Biden,23,123,146
+Adams,Latimore,President,,DEM,Tulsi Gabbard,2,3,5
+Adams,Latimore,President,,DEM,Write-in,3,3,6
+Adams,Latimore,Attorney General,,DEM,Josh Shapiro,35,153,188
+Adams,Latimore,Attorney General,,DEM,Write-in,0,1,1
+Adams,Latimore,Auditor General,,DEM,H Scott Conklin,6,14,20
+Adams,Latimore,Auditor General,,DEM,Michael Lamb,5,16,21
+Adams,Latimore,Auditor General,,DEM,Tracie Fountain,11,43,54
+Adams,Latimore,Auditor General,,DEM,Rose Rosie Marie Davis,2,5,7
+Adams,Latimore,Auditor General,,DEM,Nina Ahmad,4,26,30
+Adams,Latimore,Auditor General,,DEM,Christina M Hartman,6,46,52
+Adams,Latimore,Auditor General,,DEM,Write-in,0,1,1
+Adams,Latimore,State Treasurer,,DEM,Joe Torsella,35,149,184
+Adams,Latimore,State Treasurer,,DEM,Write-in,0,2,2
+Adams,Latimore,U.S. House,13,DEM,Todd Rowley,35,142,177
+Adams,Latimore,U.S. House,13,DEM,Write-in,0,4,4
+Adams,Latimore,State Senate,33,DEM,Rich Sterner,34,152,186
+Adams,Latimore,State Senate,33,DEM,Write-in,2,3,5
+Adams,Latimore,General Assembly,193,DEM,Write-in,1,16,17
+Adams,Latimore,President,,REP,Donald J Trump,324,120,444
+Adams,Latimore,President,,REP,Roque Rocky De La Fuente,4,2,6
+Adams,Latimore,President,,REP,Bill Weld,1,11,12
+Adams,Latimore,President,,REP,Write-in,1,3,4
+Adams,Latimore,Attorney General,,REP,Heather Heidelbaugh,296,127,423
+Adams,Latimore,Attorney General,,REP,Write-in,4,0,4
+Adams,Latimore,Auditor General,,REP,Timothy Defoor,300,131,431
+Adams,Latimore,Auditor General,,REP,Write-in,1,0,1
+Adams,Latimore,State Treasurer,,REP,Stacy L Garrity,296,131,427
+Adams,Latimore,State Treasurer,,REP,Write-in,1,0,1
+Adams,Latimore,U.S. House,13,REP,John Joyce,310,127,437
+Adams,Latimore,U.S. House,13,REP,Write-in,2,5,7
+Adams,Latimore,State Senate,33,REP,Doug Mastriano,314,125,439
+Adams,Latimore,State Senate,33,REP,Write-in,1,3,4
+Adams,Latimore,General Assembly,193,REP,Torren Ecker,312,133,445
+Adams,Latimore,General Assembly,193,REP,Write-in,3,2,5
+Adams,Liberty,Registered Voters,,,,,,822
+Adams,Liberty,Registered Voters,,DEM,,,,263
+Adams,Liberty,Registered Voters,,REP,,,,559
+Adams,Liberty,Ballots Cast,,,,164,124,288
+Adams,Liberty,Ballots Cast,,DEM,,30,66,96
+Adams,Liberty,Ballots Cast,,REP,,134,58,192
+Adams,Liberty,President,,DEM,Bernie Sanders,4,8,12
+Adams,Liberty,President,,DEM,Joseph R Biden,21,56,77
+Adams,Liberty,President,,DEM,Tulsi Gabbard,2,0,2
+Adams,Liberty,President,,DEM,Write-in,3,0,3
+Adams,Liberty,Attorney General,,DEM,Josh Shapiro,23,54,77
+Adams,Liberty,Attorney General,,DEM,Write-in,1,0,1
+Adams,Liberty,Auditor General,,DEM,H Scott Conklin,4,5,9
+Adams,Liberty,Auditor General,,DEM,Michael Lamb,3,4,7
+Adams,Liberty,Auditor General,,DEM,Tracie Fountain,4,6,10
+Adams,Liberty,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,6
+Adams,Liberty,Auditor General,,DEM,Nina Ahmad,4,15,19
+Adams,Liberty,Auditor General,,DEM,Christina M Hartman,6,19,25
+Adams,Liberty,Auditor General,,DEM,Write-in,1,0,1
+Adams,Liberty,State Treasurer,,DEM,Joe Torsella,20,54,74
+Adams,Liberty,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Liberty,U.S. House,13,DEM,Todd Rowley,21,52,73
+Adams,Liberty,U.S. House,13,DEM,Write-in,1,1,2
+Adams,Liberty,State Senate,33,DEM,Rich Sterner,23,57,80
+Adams,Liberty,State Senate,33,DEM,Write-in,2,0,2
+Adams,Liberty,General Assembly,91,DEM,Write-in,2,2,4
+Adams,Liberty,President,,REP,Donald J Trump,132,47,179
+Adams,Liberty,President,,REP,Roque Rocky De La Fuente,0,2,2
+Adams,Liberty,President,,REP,Bill Weld,2,5,7
+Adams,Liberty,President,,REP,Write-in,0,3,3
+Adams,Liberty,Attorney General,,REP,Heather Heidelbaugh,111,50,161
+Adams,Liberty,Attorney General,,REP,Write-in,4,0,4
+Adams,Liberty,Auditor General,,REP,Timothy Defoor,110,50,160
+Adams,Liberty,Auditor General,,REP,Write-in,1,0,1
+Adams,Liberty,State Treasurer,,REP,Stacy L Garrity,108,50,158
+Adams,Liberty,State Treasurer,,REP,Write-in,1,0,1
+Adams,Liberty,U.S. House,13,REP,John Joyce,117,49,166
+Adams,Liberty,U.S. House,13,REP,Write-in,1,1,2
+Adams,Liberty,State Senate,33,REP,Doug Mastriano,126,52,178
+Adams,Liberty,State Senate,33,REP,Write-in,1,2,3
+Adams,Liberty,General Assembly,91,REP,Dan Moul,121,57,178
+Adams,Liberty,General Assembly,91,REP,Write-in,1,0,1
+Adams,Littlestown #1,Registered Voters,,,,,,1146
+Adams,Littlestown #1,Registered Voters,,DEM,,,,315
+Adams,Littlestown #1,Registered Voters,,REP,,,,831
+Adams,Littlestown #1,Ballots Cast,,,,251,142,393
+Adams,Littlestown #1,Ballots Cast,,DEM,,48,58,106
+Adams,Littlestown #1,Ballots Cast,,REP,,203,84,287
+Adams,Littlestown #1,President,,DEM,Bernie Sanders,9,14,23
+Adams,Littlestown #1,President,,DEM,Joseph R Biden,34,42,76
+Adams,Littlestown #1,President,,DEM,Tulsi Gabbard,1,1,2
+Adams,Littlestown #1,President,,DEM,Write-in,3,0,3
+Adams,Littlestown #1,Attorney General,,DEM,Josh Shapiro,37,54,91
+Adams,Littlestown #1,Attorney General,,DEM,Write-in,1,0,1
+Adams,Littlestown #1,Auditor General,,DEM,H Scott Conklin,5,5,10
+Adams,Littlestown #1,Auditor General,,DEM,Michael Lamb,3,6,9
+Adams,Littlestown #1,Auditor General,,DEM,Tracie Fountain,6,10,16
+Adams,Littlestown #1,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,6
+Adams,Littlestown #1,Auditor General,,DEM,Nina Ahmad,7,10,17
+Adams,Littlestown #1,Auditor General,,DEM,Christina M Hartman,14,17,31
+Adams,Littlestown #1,Auditor General,,DEM,Write-in,1,0,1
+Adams,Littlestown #1,State Treasurer,,DEM,Joe Torsella,36,52,88
+Adams,Littlestown #1,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Littlestown #1,U.S. House,13,DEM,Todd Rowley,31,52,83
+Adams,Littlestown #1,U.S. House,13,DEM,Write-in,3,0,3
+Adams,Littlestown #1,State Senate,33,DEM,Rich Sterner,40,55,95
+Adams,Littlestown #1,State Senate,33,DEM,Write-in,2,0,2
+Adams,Littlestown #1,General Assembly,91,DEM,Write-in,4,1,5
+Adams,Littlestown #1,President,,REP,Donald J Trump,201,74,275
+Adams,Littlestown #1,President,,REP,Roque Rocky De La Fuente,1,2,3
+Adams,Littlestown #1,President,,REP,Bill Weld,0,3,3
+Adams,Littlestown #1,President,,REP,Write-in,2,2,4
+Adams,Littlestown #1,Attorney General,,REP,Heather Heidelbaugh,179,76,255
+Adams,Littlestown #1,Attorney General,,REP,Write-in,1,0,1
+Adams,Littlestown #1,Auditor General,,REP,Timothy Defoor,180,75,255
+Adams,Littlestown #1,Auditor General,,REP,Write-in,0,0,0
+Adams,Littlestown #1,State Treasurer,,REP,Stacy L Garrity,177,75,252
+Adams,Littlestown #1,State Treasurer,,REP,Write-in,0,0,0
+Adams,Littlestown #1,U.S. House,13,REP,John Joyce,185,74,259
+Adams,Littlestown #1,U.S. House,13,REP,Write-in,0,1,1
+Adams,Littlestown #1,State Senate,33,REP,Doug Mastriano,192,72,264
+Adams,Littlestown #1,State Senate,33,REP,Write-in,1,2,3
+Adams,Littlestown #1,General Assembly,91,REP,Dan Moul,196,80,276
+Adams,Littlestown #1,General Assembly,91,REP,Write-in,0,1,1
+Adams,Littlestown #2,Registered Voters,,,,,,1279
+Adams,Littlestown #2,Registered Voters,,DEM,,,,404
+Adams,Littlestown #2,Registered Voters,,REP,,,,875
+Adams,Littlestown #2,Ballots Cast,,,,206,232,438
+Adams,Littlestown #2,Ballots Cast,,DEM,,42,99,141
+Adams,Littlestown #2,Ballots Cast,,REP,,164,133,297
+Adams,Littlestown #2,President,,DEM,Bernie Sanders,8,16,24
+Adams,Littlestown #2,President,,DEM,Joseph R Biden,26,82,108
+Adams,Littlestown #2,President,,DEM,Tulsi Gabbard,4,1,5
+Adams,Littlestown #2,President,,DEM,Write-in,2,0,2
+Adams,Littlestown #2,Attorney General,,DEM,Josh Shapiro,37,91,128
+Adams,Littlestown #2,Attorney General,,DEM,Write-in,0,0,0
+Adams,Littlestown #2,Auditor General,,DEM,H Scott Conklin,6,6,12
+Adams,Littlestown #2,Auditor General,,DEM,Michael Lamb,7,14,21
+Adams,Littlestown #2,Auditor General,,DEM,Tracie Fountain,6,23,29
+Adams,Littlestown #2,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,4
+Adams,Littlestown #2,Auditor General,,DEM,Nina Ahmad,7,14,21
+Adams,Littlestown #2,Auditor General,,DEM,Christina M Hartman,9,31,40
+Adams,Littlestown #2,Auditor General,,DEM,Write-in,0,0,0
+Adams,Littlestown #2,State Treasurer,,DEM,Joe Torsella,34,85,119
+Adams,Littlestown #2,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Littlestown #2,U.S. House,13,DEM,Todd Rowley,36,89,125
+Adams,Littlestown #2,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Littlestown #2,State Senate,33,DEM,Rich Sterner,39,92,131
+Adams,Littlestown #2,State Senate,33,DEM,Write-in,1,0,1
+Adams,Littlestown #2,General Assembly,91,DEM,Write-in,3,2,5
+Adams,Littlestown #2,President,,REP,Donald J Trump,157,107,264
+Adams,Littlestown #2,President,,REP,Roque Rocky De La Fuente,2,3,5
+Adams,Littlestown #2,President,,REP,Bill Weld,3,13,16
+Adams,Littlestown #2,President,,REP,Write-in,0,7,7
+Adams,Littlestown #2,Attorney General,,REP,Heather Heidelbaugh,144,119,263
+Adams,Littlestown #2,Attorney General,,REP,Write-in,1,0,1
+Adams,Littlestown #2,Auditor General,,REP,Timothy Defoor,141,118,259
+Adams,Littlestown #2,Auditor General,,REP,Write-in,2,0,2
+Adams,Littlestown #2,State Treasurer,,REP,Stacy L Garrity,141,118,259
+Adams,Littlestown #2,State Treasurer,,REP,Write-in,1,0,1
+Adams,Littlestown #2,U.S. House,13,REP,John Joyce,148,115,263
+Adams,Littlestown #2,U.S. House,13,REP,Write-in,1,0,1
+Adams,Littlestown #2,State Senate,33,REP,Doug Mastriano,147,123,270
+Adams,Littlestown #2,State Senate,33,REP,Write-in,2,2,4
+Adams,Littlestown #2,General Assembly,91,REP,Dan Moul,146,120,266
+Adams,Littlestown #2,General Assembly,91,REP,Write-in,3,1,4
+Adams,McSherrystown #1,Registered Voters,,,,,,781
+Adams,McSherrystown #1,Registered Voters,,DEM,,,,328
+Adams,McSherrystown #1,Registered Voters,,REP,,,,453
+Adams,McSherrystown #1,Ballots Cast,,,,132,120,252
+Adams,McSherrystown #1,Ballots Cast,,DEM,,42,75,117
+Adams,McSherrystown #1,Ballots Cast,,REP,,90,45,135
+Adams,McSherrystown #1,President,,DEM,Bernie Sanders,9,12,21
+Adams,McSherrystown #1,President,,DEM,Joseph R Biden,22,60,82
+Adams,McSherrystown #1,President,,DEM,Tulsi Gabbard,2,2,4
+Adams,McSherrystown #1,President,,DEM,Write-in,9,0,9
+Adams,McSherrystown #1,Attorney General,,DEM,Josh Shapiro,34,72,106
+Adams,McSherrystown #1,Attorney General,,DEM,Write-in,0,0,0
+Adams,McSherrystown #1,Auditor General,,DEM,H Scott Conklin,5,11,16
+Adams,McSherrystown #1,Auditor General,,DEM,Michael Lamb,4,7,11
+Adams,McSherrystown #1,Auditor General,,DEM,Tracie Fountain,3,17,20
+Adams,McSherrystown #1,Auditor General,,DEM,Rose Rosie Marie Davis,6,5,11
+Adams,McSherrystown #1,Auditor General,,DEM,Nina Ahmad,9,10,19
+Adams,McSherrystown #1,Auditor General,,DEM,Christina M Hartman,9,19,28
+Adams,McSherrystown #1,Auditor General,,DEM,Write-in,0,0,0
+Adams,McSherrystown #1,State Treasurer,,DEM,Joe Torsella,34,73,107
+Adams,McSherrystown #1,State Treasurer,,DEM,Write-in,1,0,1
+Adams,McSherrystown #1,U.S. House,13,DEM,Todd Rowley,30,72,102
+Adams,McSherrystown #1,U.S. House,13,DEM,Write-in,1,0,1
+Adams,McSherrystown #1,State Senate,33,DEM,Rich Sterner,33,74,107
+Adams,McSherrystown #1,State Senate,33,DEM,Write-in,2,0,2
+Adams,McSherrystown #1,General Assembly,91,DEM,Write-in,4,7,11
+Adams,McSherrystown #1,President,,REP,Donald J Trump,83,38,121
+Adams,McSherrystown #1,President,,REP,Roque Rocky De La Fuente,1,2,3
+Adams,McSherrystown #1,President,,REP,Bill Weld,5,3,8
+Adams,McSherrystown #1,President,,REP,Write-in,0,1,1
+Adams,McSherrystown #1,Attorney General,,REP,Heather Heidelbaugh,86,36,122
+Adams,McSherrystown #1,Attorney General,,REP,Write-in,1,3,4
+Adams,McSherrystown #1,Auditor General,,REP,Timothy Defoor,87,38,125
+Adams,McSherrystown #1,Auditor General,,REP,Write-in,0,2,2
+Adams,McSherrystown #1,State Treasurer,,REP,Stacy L Garrity,85,37,122
+Adams,McSherrystown #1,State Treasurer,,REP,Write-in,0,3,3
+Adams,McSherrystown #1,U.S. House,13,REP,John Joyce,87,38,125
+Adams,McSherrystown #1,U.S. House,13,REP,Write-in,0,2,2
+Adams,McSherrystown #1,State Senate,33,REP,Doug Mastriano,87,41,128
+Adams,McSherrystown #1,State Senate,33,REP,Write-in,0,2,2
+Adams,McSherrystown #1,General Assembly,91,REP,Dan Moul,80,42,122
+Adams,McSherrystown #1,General Assembly,91,REP,Write-in,6,2,8
+Adams,McSherrystown #2,Registered Voters,,,,,,613
+Adams,McSherrystown #2,Registered Voters,,DEM,,,,245
+Adams,McSherrystown #2,Registered Voters,,REP,,,,368
+Adams,McSherrystown #2,Ballots Cast,,,,107,82,189
+Adams,McSherrystown #2,Ballots Cast,,DEM,,20,43,63
+Adams,McSherrystown #2,Ballots Cast,,REP,,87,39,126
+Adams,McSherrystown #2,President,,DEM,Bernie Sanders,2,11,13
+Adams,McSherrystown #2,President,,DEM,Joseph R Biden,15,29,44
+Adams,McSherrystown #2,President,,DEM,Tulsi Gabbard,0,0,0
+Adams,McSherrystown #2,President,,DEM,Write-in,1,1,2
+Adams,McSherrystown #2,Attorney General,,DEM,Josh Shapiro,15,36,51
+Adams,McSherrystown #2,Attorney General,,DEM,Write-in,0,1,1
+Adams,McSherrystown #2,Auditor General,,DEM,H Scott Conklin,3,2,5
+Adams,McSherrystown #2,Auditor General,,DEM,Michael Lamb,0,3,3
+Adams,McSherrystown #2,Auditor General,,DEM,Tracie Fountain,4,2,6
+Adams,McSherrystown #2,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Adams,McSherrystown #2,Auditor General,,DEM,Nina Ahmad,2,5,7
+Adams,McSherrystown #2,Auditor General,,DEM,Christina M Hartman,6,26,32
+Adams,McSherrystown #2,Auditor General,,DEM,Write-in,0,2,2
+Adams,McSherrystown #2,State Treasurer,,DEM,Joe Torsella,12,35,47
+Adams,McSherrystown #2,State Treasurer,,DEM,Write-in,0,1,1
+Adams,McSherrystown #2,U.S. House,13,DEM,Todd Rowley,14,34,48
+Adams,McSherrystown #2,U.S. House,13,DEM,Write-in,0,2,2
+Adams,McSherrystown #2,State Senate,33,DEM,Rich Sterner,16,38,54
+Adams,McSherrystown #2,State Senate,33,DEM,Write-in,0,1,1
+Adams,McSherrystown #2,General Assembly,91,DEM,Write-in,0,4,4
+Adams,McSherrystown #2,President,,REP,Donald J Trump,86,27,113
+Adams,McSherrystown #2,President,,REP,Roque Rocky De La Fuente,0,2,2
+Adams,McSherrystown #2,President,,REP,Bill Weld,0,4,4
+Adams,McSherrystown #2,President,,REP,Write-in,0,4,4
+Adams,McSherrystown #2,Attorney General,,REP,Heather Heidelbaugh,80,35,115
+Adams,McSherrystown #2,Attorney General,,REP,Write-in,0,0,0
+Adams,McSherrystown #2,Auditor General,,REP,Timothy Defoor,82,35,117
+Adams,McSherrystown #2,Auditor General,,REP,Write-in,0,0,0
+Adams,McSherrystown #2,State Treasurer,,REP,Stacy L Garrity,80,36,116
+Adams,McSherrystown #2,State Treasurer,,REP,Write-in,0,0,0
+Adams,McSherrystown #2,U.S. House,13,REP,John Joyce,81,37,118
+Adams,McSherrystown #2,U.S. House,13,REP,Write-in,0,0,0
+Adams,McSherrystown #2,State Senate,33,REP,Doug Mastriano,82,36,118
+Adams,McSherrystown #2,State Senate,33,REP,Write-in,0,0,0
+Adams,McSherrystown #2,General Assembly,91,REP,Dan Moul,81,36,117
+Adams,McSherrystown #2,General Assembly,91,REP,Write-in,3,0,3
+Adams,Menallen,Registered Voters,,,,,,1847
+Adams,Menallen,Registered Voters,,DEM,,,,514
+Adams,Menallen,Registered Voters,,REP,,,,1333
+Adams,Menallen,Ballots Cast,,,,359,338,697
+Adams,Menallen,Ballots Cast,,DEM,,38,158,196
+Adams,Menallen,Ballots Cast,,REP,,321,180,501
+Adams,Menallen,President,,DEM,Bernie Sanders,10,9,19
+Adams,Menallen,President,,DEM,Joseph R Biden,14,146,160
+Adams,Menallen,President,,DEM,Tulsi Gabbard,7,2,9
+Adams,Menallen,President,,DEM,Write-in,8,0,8
+Adams,Menallen,Attorney General,,DEM,Josh Shapiro,30,148,178
+Adams,Menallen,Attorney General,,DEM,Write-in,4,2,6
+Adams,Menallen,Auditor General,,DEM,H Scott Conklin,5,12,17
+Adams,Menallen,Auditor General,,DEM,Michael Lamb,2,16,18
+Adams,Menallen,Auditor General,,DEM,Tracie Fountain,7,42,49
+Adams,Menallen,Auditor General,,DEM,Rose Rosie Marie Davis,0,5,5
+Adams,Menallen,Auditor General,,DEM,Nina Ahmad,7,21,28
+Adams,Menallen,Auditor General,,DEM,Christina M Hartman,10,40,50
+Adams,Menallen,Auditor General,,DEM,Write-in,4,0,4
+Adams,Menallen,State Treasurer,,DEM,Joe Torsella,30,139,169
+Adams,Menallen,State Treasurer,,DEM,Write-in,3,0,3
+Adams,Menallen,U.S. House,13,DEM,Todd Rowley,31,142,173
+Adams,Menallen,U.S. House,13,DEM,Write-in,3,1,4
+Adams,Menallen,State Senate,33,DEM,Rich Sterner,31,148,179
+Adams,Menallen,State Senate,33,DEM,Write-in,3,1,4
+Adams,Menallen,General Assembly,193,DEM,Write-in,5,13,18
+Adams,Menallen,President,,REP,Donald J Trump,310,150,460
+Adams,Menallen,President,,REP,Roque Rocky De La Fuente,1,4,5
+Adams,Menallen,President,,REP,Bill Weld,6,16,22
+Adams,Menallen,President,,REP,Write-in,2,4,6
+Adams,Menallen,Attorney General,,REP,Heather Heidelbaugh,269,161,430
+Adams,Menallen,Attorney General,,REP,Write-in,13,1,14
+Adams,Menallen,Auditor General,,REP,Timothy Defoor,277,159,436
+Adams,Menallen,Auditor General,,REP,Write-in,1,1,2
+Adams,Menallen,State Treasurer,,REP,Stacy L Garrity,281,158,439
+Adams,Menallen,State Treasurer,,REP,Write-in,1,2,3
+Adams,Menallen,U.S. House,13,REP,John Joyce,300,163,463
+Adams,Menallen,U.S. House,13,REP,Write-in,0,1,1
+Adams,Menallen,State Senate,33,REP,Doug Mastriano,313,161,474
+Adams,Menallen,State Senate,33,REP,Write-in,0,4,4
+Adams,Menallen,General Assembly,193,REP,Torren Ecker,303,171,474
+Adams,Menallen,General Assembly,193,REP,Write-in,0,1,1
+Adams,Mt Joy #1,Registered Voters,,,,,,1147
+Adams,Mt Joy #1,Registered Voters,,DEM,,,,417
+Adams,Mt Joy #1,Registered Voters,,REP,,,,730
+Adams,Mt Joy #1,Ballots Cast,,,,169,298,467
+Adams,Mt Joy #1,Ballots Cast,,DEM,,27,170,197
+Adams,Mt Joy #1,Ballots Cast,,REP,,142,128,270
+Adams,Mt Joy #1,President,,DEM,Bernie Sanders,5,15,20
+Adams,Mt Joy #1,President,,DEM,Joseph R Biden,17,149,166
+Adams,Mt Joy #1,President,,DEM,Tulsi Gabbard,3,3,6
+Adams,Mt Joy #1,President,,DEM,Write-in,1,3,4
+Adams,Mt Joy #1,Attorney General,,DEM,Josh Shapiro,20,157,177
+Adams,Mt Joy #1,Attorney General,,DEM,Write-in,0,0,0
+Adams,Mt Joy #1,Auditor General,,DEM,H Scott Conklin,1,15,16
+Adams,Mt Joy #1,Auditor General,,DEM,Michael Lamb,1,20,21
+Adams,Mt Joy #1,Auditor General,,DEM,Tracie Fountain,8,30,38
+Adams,Mt Joy #1,Auditor General,,DEM,Rose Rosie Marie Davis,3,8,11
+Adams,Mt Joy #1,Auditor General,,DEM,Nina Ahmad,4,30,34
+Adams,Mt Joy #1,Auditor General,,DEM,Christina M Hartman,3,50,53
+Adams,Mt Joy #1,Auditor General,,DEM,Write-in,0,0,0
+Adams,Mt Joy #1,State Treasurer,,DEM,Joe Torsella,18,153,171
+Adams,Mt Joy #1,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Mt Joy #1,U.S. House,13,DEM,Todd Rowley,19,148,167
+Adams,Mt Joy #1,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Mt Joy #1,State Senate,33,DEM,Rich Sterner,20,157,177
+Adams,Mt Joy #1,State Senate,33,DEM,Write-in,0,0,0
+Adams,Mt Joy #1,General Assembly,91,DEM,Write-in,0,6,6
+Adams,Mt Joy #1,President,,REP,Donald J Trump,132,93,225
+Adams,Mt Joy #1,President,,REP,Roque Rocky De La Fuente,1,4,5
+Adams,Mt Joy #1,President,,REP,Bill Weld,5,16,21
+Adams,Mt Joy #1,President,,REP,Write-in,2,7,9
+Adams,Mt Joy #1,Attorney General,,REP,Heather Heidelbaugh,119,104,223
+Adams,Mt Joy #1,Attorney General,,REP,Write-in,4,2,6
+Adams,Mt Joy #1,Auditor General,,REP,Timothy Defoor,120,108,228
+Adams,Mt Joy #1,Auditor General,,REP,Write-in,0,1,1
+Adams,Mt Joy #1,State Treasurer,,REP,Stacy L Garrity,120,106,226
+Adams,Mt Joy #1,State Treasurer,,REP,Write-in,0,2,2
+Adams,Mt Joy #1,U.S. House,13,REP,John Joyce,123,109,232
+Adams,Mt Joy #1,U.S. House,13,REP,Write-in,0,4,4
+Adams,Mt Joy #1,State Senate,33,REP,Doug Mastriano,128,107,235
+Adams,Mt Joy #1,State Senate,33,REP,Write-in,1,4,5
+Adams,Mt Joy #1,General Assembly,91,REP,Dan Moul,127,113,240
+Adams,Mt Joy #1,General Assembly,91,REP,Write-in,1,4,5
+Adams,Mt Joy #2,Registered Voters,,,,,,1191
+Adams,Mt Joy #2,Registered Voters,,DEM,,,,331
+Adams,Mt Joy #2,Registered Voters,,REP,,,,860
+Adams,Mt Joy #2,Ballots Cast,,,,238,265,503
+Adams,Mt Joy #2,Ballots Cast,,DEM,,42,134,176
+Adams,Mt Joy #2,Ballots Cast,,REP,,196,131,327
+Adams,Mt Joy #2,President,,DEM,Bernie Sanders,3,10,13
+Adams,Mt Joy #2,President,,DEM,Joseph R Biden,25,118,143
+Adams,Mt Joy #2,President,,DEM,Tulsi Gabbard,4,1,5
+Adams,Mt Joy #2,President,,DEM,Write-in,6,3,9
+Adams,Mt Joy #2,Attorney General,,DEM,Josh Shapiro,35,118,153
+Adams,Mt Joy #2,Attorney General,,DEM,Write-in,1,0,1
+Adams,Mt Joy #2,Auditor General,,DEM,H Scott Conklin,6,6,12
+Adams,Mt Joy #2,Auditor General,,DEM,Michael Lamb,6,11,17
+Adams,Mt Joy #2,Auditor General,,DEM,Tracie Fountain,10,27,37
+Adams,Mt Joy #2,Auditor General,,DEM,Rose Rosie Marie Davis,0,2,2
+Adams,Mt Joy #2,Auditor General,,DEM,Nina Ahmad,6,21,27
+Adams,Mt Joy #2,Auditor General,,DEM,Christina M Hartman,4,36,40
+Adams,Mt Joy #2,Auditor General,,DEM,Write-in,1,2,3
+Adams,Mt Joy #2,State Treasurer,,DEM,Joe Torsella,33,112,145
+Adams,Mt Joy #2,State Treasurer,,DEM,Write-in,1,2,3
+Adams,Mt Joy #2,U.S. House,13,DEM,Todd Rowley,32,112,144
+Adams,Mt Joy #2,U.S. House,13,DEM,Write-in,1,2,3
+Adams,Mt Joy #2,State Senate,33,DEM,Rich Sterner,37,120,157
+Adams,Mt Joy #2,State Senate,33,DEM,Write-in,1,2,3
+Adams,Mt Joy #2,General Assembly,91,DEM,Write-in,1,11,12
+Adams,Mt Joy #2,President,,REP,Donald J Trump,187,113,300
+Adams,Mt Joy #2,President,,REP,Roque Rocky De La Fuente,1,1,2
+Adams,Mt Joy #2,President,,REP,Bill Weld,2,10,12
+Adams,Mt Joy #2,President,,REP,Write-in,3,5,8
+Adams,Mt Joy #2,Attorney General,,REP,Heather Heidelbaugh,162,119,281
+Adams,Mt Joy #2,Attorney General,,REP,Write-in,5,1,6
+Adams,Mt Joy #2,Auditor General,,REP,Timothy Defoor,160,118,278
+Adams,Mt Joy #2,Auditor General,,REP,Write-in,0,1,1
+Adams,Mt Joy #2,State Treasurer,,REP,Stacy L Garrity,162,118,280
+Adams,Mt Joy #2,State Treasurer,,REP,Write-in,1,1,2
+Adams,Mt Joy #2,U.S. House,13,REP,John Joyce,174,121,295
+Adams,Mt Joy #2,U.S. House,13,REP,Write-in,0,1,1
+Adams,Mt Joy #2,State Senate,33,REP,Doug Mastriano,184,117,301
+Adams,Mt Joy #2,State Senate,33,REP,Write-in,0,3,3
+Adams,Mt Joy #2,General Assembly,91,REP,Dan Moul,180,125,305
+Adams,Mt Joy #2,General Assembly,91,REP,Write-in,2,1,3
+Adams,Mt Pleasant #1,Registered Voters,,,,,,1526
+Adams,Mt Pleasant #1,Registered Voters,,DEM,,,,503
+Adams,Mt Pleasant #1,Registered Voters,,REP,,,,1023
+Adams,Mt Pleasant #1,Ballots Cast,,,,263,290,553
+Adams,Mt Pleasant #1,Ballots Cast,,DEM,,38,175,213
+Adams,Mt Pleasant #1,Ballots Cast,,REP,,225,115,340
+Adams,Mt Pleasant #1,President,,DEM,Bernie Sanders,8,21,29
+Adams,Mt Pleasant #1,President,,DEM,Joseph R Biden,22,143,165
+Adams,Mt Pleasant #1,President,,DEM,Tulsi Gabbard,2,6,8
+Adams,Mt Pleasant #1,President,,DEM,Write-in,4,4,8
+Adams,Mt Pleasant #1,Attorney General,,DEM,Josh Shapiro,31,162,193
+Adams,Mt Pleasant #1,Attorney General,,DEM,Write-in,2,0,2
+Adams,Mt Pleasant #1,Auditor General,,DEM,H Scott Conklin,3,17,20
+Adams,Mt Pleasant #1,Auditor General,,DEM,Michael Lamb,4,18,22
+Adams,Mt Pleasant #1,Auditor General,,DEM,Tracie Fountain,6,40,46
+Adams,Mt Pleasant #1,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,6
+Adams,Mt Pleasant #1,Auditor General,,DEM,Nina Ahmad,10,31,41
+Adams,Mt Pleasant #1,Auditor General,,DEM,Christina M Hartman,11,45,56
+Adams,Mt Pleasant #1,Auditor General,,DEM,Write-in,0,0,0
+Adams,Mt Pleasant #1,State Treasurer,,DEM,Joe Torsella,32,158,190
+Adams,Mt Pleasant #1,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Mt Pleasant #1,U.S. House,13,DEM,Todd Rowley,33,156,189
+Adams,Mt Pleasant #1,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Mt Pleasant #1,State Senate,33,DEM,Rich Sterner,33,165,198
+Adams,Mt Pleasant #1,State Senate,33,DEM,Write-in,2,0,2
+Adams,Mt Pleasant #1,General Assembly,91,DEM,Write-in,1,21,22
+Adams,Mt Pleasant #1,President,,REP,Donald J Trump,221,88,309
+Adams,Mt Pleasant #1,President,,REP,Roque Rocky De La Fuente,0,3,3
+Adams,Mt Pleasant #1,President,,REP,Bill Weld,3,12,15
+Adams,Mt Pleasant #1,President,,REP,Write-in,0,9,9
+Adams,Mt Pleasant #1,Attorney General,,REP,Heather Heidelbaugh,204,101,305
+Adams,Mt Pleasant #1,Attorney General,,REP,Write-in,3,0,3
+Adams,Mt Pleasant #1,Auditor General,,REP,Timothy Defoor,209,99,308
+Adams,Mt Pleasant #1,Auditor General,,REP,Write-in,0,1,1
+Adams,Mt Pleasant #1,State Treasurer,,REP,Stacy L Garrity,208,101,309
+Adams,Mt Pleasant #1,State Treasurer,,REP,Write-in,0,0,0
+Adams,Mt Pleasant #1,U.S. House,13,REP,John Joyce,211,101,312
+Adams,Mt Pleasant #1,U.S. House,13,REP,Write-in,0,3,3
+Adams,Mt Pleasant #1,State Senate,33,REP,Doug Mastriano,215,99,314
+Adams,Mt Pleasant #1,State Senate,33,REP,Write-in,0,4,4
+Adams,Mt Pleasant #1,General Assembly,91,REP,Dan Moul,211,107,318
+Adams,Mt Pleasant #1,General Assembly,91,REP,Write-in,0,2,2
+Adams,Mt Pleasant #2,Registered Voters,,,,,,902
+Adams,Mt Pleasant #2,Registered Voters,,DEM,,,,300
+Adams,Mt Pleasant #2,Registered Voters,,REP,,,,602
+Adams,Mt Pleasant #2,Ballots Cast,,,,184,104,288
+Adams,Mt Pleasant #2,Ballots Cast,,DEM,,41,52,93
+Adams,Mt Pleasant #2,Ballots Cast,,REP,,143,52,195
+Adams,Mt Pleasant #2,President,,DEM,Bernie Sanders,11,5,16
+Adams,Mt Pleasant #2,President,,DEM,Joseph R Biden,24,42,66
+Adams,Mt Pleasant #2,President,,DEM,Tulsi Gabbard,0,3,3
+Adams,Mt Pleasant #2,President,,DEM,Write-in,3,1,4
+Adams,Mt Pleasant #2,Attorney General,,DEM,Josh Shapiro,35,47,82
+Adams,Mt Pleasant #2,Attorney General,,DEM,Write-in,0,0,0
+Adams,Mt Pleasant #2,Auditor General,,DEM,H Scott Conklin,3,7,10
+Adams,Mt Pleasant #2,Auditor General,,DEM,Michael Lamb,6,3,9
+Adams,Mt Pleasant #2,Auditor General,,DEM,Tracie Fountain,8,12,20
+Adams,Mt Pleasant #2,Auditor General,,DEM,Rose Rosie Marie Davis,5,3,8
+Adams,Mt Pleasant #2,Auditor General,,DEM,Nina Ahmad,4,6,10
+Adams,Mt Pleasant #2,Auditor General,,DEM,Christina M Hartman,10,13,23
+Adams,Mt Pleasant #2,Auditor General,,DEM,Write-in,0,0,0
+Adams,Mt Pleasant #2,State Treasurer,,DEM,Joe Torsella,36,46,82
+Adams,Mt Pleasant #2,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Mt Pleasant #2,U.S. House,13,DEM,Todd Rowley,35,46,81
+Adams,Mt Pleasant #2,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Mt Pleasant #2,State Senate,33,DEM,Rich Sterner,37,50,87
+Adams,Mt Pleasant #2,State Senate,33,DEM,Write-in,0,0,0
+Adams,Mt Pleasant #2,General Assembly,91,DEM,Write-in,1,6,7
+Adams,Mt Pleasant #2,President,,REP,Donald J Trump,136,36,172
+Adams,Mt Pleasant #2,President,,REP,Roque Rocky De La Fuente,1,1,2
+Adams,Mt Pleasant #2,President,,REP,Bill Weld,3,8,11
+Adams,Mt Pleasant #2,President,,REP,Write-in,3,3,6
+Adams,Mt Pleasant #2,Attorney General,,REP,Heather Heidelbaugh,130,43,173
+Adams,Mt Pleasant #2,Attorney General,,REP,Write-in,1,3,4
+Adams,Mt Pleasant #2,Auditor General,,REP,Timothy Defoor,132,44,176
+Adams,Mt Pleasant #2,Auditor General,,REP,Write-in,1,1,2
+Adams,Mt Pleasant #2,State Treasurer,,REP,Stacy L Garrity,134,44,178
+Adams,Mt Pleasant #2,State Treasurer,,REP,Write-in,1,2,3
+Adams,Mt Pleasant #2,U.S. House,13,REP,John Joyce,134,42,176
+Adams,Mt Pleasant #2,U.S. House,13,REP,Write-in,0,2,2
+Adams,Mt Pleasant #2,State Senate,33,REP,Doug Mastriano,137,46,183
+Adams,Mt Pleasant #2,State Senate,33,REP,Write-in,1,2,3
+Adams,Mt Pleasant #2,General Assembly,91,REP,Dan Moul,134,47,181
+Adams,Mt Pleasant #2,General Assembly,91,REP,Write-in,1,0,1
+Adams,New Oxford,Registered Voters,,,,,,796
+Adams,New Oxford,Registered Voters,,DEM,,,,362
+Adams,New Oxford,Registered Voters,,REP,,,,434
+Adams,New Oxford,Ballots Cast,,,,157,114,271
+Adams,New Oxford,Ballots Cast,,DEM,,47,67,114
+Adams,New Oxford,Ballots Cast,,REP,,110,47,157
+Adams,New Oxford,President,,DEM,Bernie Sanders,9,8,17
+Adams,New Oxford,President,,DEM,Joseph R Biden,28,54,82
+Adams,New Oxford,President,,DEM,Tulsi Gabbard,1,3,4
+Adams,New Oxford,President,,DEM,Write-in,9,2,11
+Adams,New Oxford,Attorney General,,DEM,Josh Shapiro,39,60,99
+Adams,New Oxford,Attorney General,,DEM,Write-in,1,0,1
+Adams,New Oxford,Auditor General,,DEM,H Scott Conklin,7,11,18
+Adams,New Oxford,Auditor General,,DEM,Michael Lamb,7,7,14
+Adams,New Oxford,Auditor General,,DEM,Tracie Fountain,6,15,21
+Adams,New Oxford,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,5
+Adams,New Oxford,Auditor General,,DEM,Nina Ahmad,7,9,16
+Adams,New Oxford,Auditor General,,DEM,Christina M Hartman,11,17,28
+Adams,New Oxford,Auditor General,,DEM,Write-in,1,0,1
+Adams,New Oxford,State Treasurer,,DEM,Joe Torsella,38,61,99
+Adams,New Oxford,State Treasurer,,DEM,Write-in,1,0,1
+Adams,New Oxford,U.S. House,13,DEM,Todd Rowley,38,61,99
+Adams,New Oxford,U.S. House,13,DEM,Write-in,2,0,2
+Adams,New Oxford,State Senate,33,DEM,Rich Sterner,41,63,104
+Adams,New Oxford,State Senate,33,DEM,Write-in,1,1,2
+Adams,New Oxford,General Assembly,193,DEM,Write-in,6,2,8
+Adams,New Oxford,President,,REP,Donald J Trump,98,40,138
+Adams,New Oxford,President,,REP,Roque Rocky De La Fuente,3,0,3
+Adams,New Oxford,President,,REP,Bill Weld,4,4,8
+Adams,New Oxford,President,,REP,Write-in,4,1,5
+Adams,New Oxford,Attorney General,,REP,Heather Heidelbaugh,96,41,137
+Adams,New Oxford,Attorney General,,REP,Write-in,1,0,1
+Adams,New Oxford,Auditor General,,REP,Timothy Defoor,95,41,136
+Adams,New Oxford,Auditor General,,REP,Write-in,0,0,0
+Adams,New Oxford,State Treasurer,,REP,Stacy L Garrity,96,41,137
+Adams,New Oxford,State Treasurer,,REP,Write-in,0,0,0
+Adams,New Oxford,U.S. House,13,REP,John Joyce,95,42,137
+Adams,New Oxford,U.S. House,13,REP,Write-in,0,0,0
+Adams,New Oxford,State Senate,33,REP,Doug Mastriano,101,41,142
+Adams,New Oxford,State Senate,33,REP,Write-in,0,0,0
+Adams,New Oxford,General Assembly,193,REP,Torren Ecker,105,44,149
+Adams,New Oxford,General Assembly,193,REP,Write-in,0,0,0
+Adams,Oxford #1,Registered Voters,,,,,,1601
+Adams,Oxford #1,Registered Voters,,DEM,,,,593
+Adams,Oxford #1,Registered Voters,,REP,,,,1008
+Adams,Oxford #1,Ballots Cast,,,,332,208,540
+Adams,Oxford #1,Ballots Cast,,DEM,,82,126,208
+Adams,Oxford #1,Ballots Cast,,REP,,250,82,332
+Adams,Oxford #1,President,,DEM,Bernie Sanders,21,20,41
+Adams,Oxford #1,President,,DEM,Joseph R Biden,46,99,145
+Adams,Oxford #1,President,,DEM,Tulsi Gabbard,4,4,8
+Adams,Oxford #1,President,,DEM,Write-in,9,2,11
+Adams,Oxford #1,Attorney General,,DEM,Josh Shapiro,69,117,186
+Adams,Oxford #1,Attorney General,,DEM,Write-in,1,0,1
+Adams,Oxford #1,Auditor General,,DEM,H Scott Conklin,13,11,24
+Adams,Oxford #1,Auditor General,,DEM,Michael Lamb,9,10,19
+Adams,Oxford #1,Auditor General,,DEM,Tracie Fountain,9,32,41
+Adams,Oxford #1,Auditor General,,DEM,Rose Rosie Marie Davis,4,4,8
+Adams,Oxford #1,Auditor General,,DEM,Nina Ahmad,8,17,25
+Adams,Oxford #1,Auditor General,,DEM,Christina M Hartman,24,40,64
+Adams,Oxford #1,Auditor General,,DEM,Write-in,0,0,0
+Adams,Oxford #1,State Treasurer,,DEM,Joe Torsella,66,113,179
+Adams,Oxford #1,State Treasurer,,DEM,Write-in,1,2,3
+Adams,Oxford #1,U.S. House,13,DEM,Todd Rowley,69,112,181
+Adams,Oxford #1,U.S. House,13,DEM,Write-in,3,1,4
+Adams,Oxford #1,State Senate,33,DEM,Rich Sterner,70,119,189
+Adams,Oxford #1,State Senate,33,DEM,Write-in,2,2,4
+Adams,Oxford #1,General Assembly,193,DEM,Write-in,5,11,16
+Adams,Oxford #1,President,,REP,Donald J Trump,246,73,319
+Adams,Oxford #1,President,,REP,Roque Rocky De La Fuente,1,1,2
+Adams,Oxford #1,President,,REP,Bill Weld,2,3,5
+Adams,Oxford #1,President,,REP,Write-in,1,3,4
+Adams,Oxford #1,Attorney General,,REP,Heather Heidelbaugh,227,70,297
+Adams,Oxford #1,Attorney General,,REP,Write-in,4,2,6
+Adams,Oxford #1,Auditor General,,REP,Timothy Defoor,227,71,298
+Adams,Oxford #1,Auditor General,,REP,Write-in,1,1,2
+Adams,Oxford #1,State Treasurer,,REP,Stacy L Garrity,224,71,295
+Adams,Oxford #1,State Treasurer,,REP,Write-in,2,1,3
+Adams,Oxford #1,U.S. House,13,REP,John Joyce,228,72,300
+Adams,Oxford #1,U.S. House,13,REP,Write-in,2,2,4
+Adams,Oxford #1,State Senate,33,REP,Doug Mastriano,238,71,309
+Adams,Oxford #1,State Senate,33,REP,Write-in,0,2,2
+Adams,Oxford #1,General Assembly,193,REP,Torren Ecker,237,79,316
+Adams,Oxford #1,General Assembly,193,REP,Write-in,0,1,1
+Adams,Oxford #2,Registered Voters,,,,,,1635
+Adams,Oxford #2,Registered Voters,,DEM,,,,536
+Adams,Oxford #2,Registered Voters,,REP,,,,1099
+Adams,Oxford #2,Ballots Cast,,,,227,510,737
+Adams,Oxford #2,Ballots Cast,,DEM,,37,217,254
+Adams,Oxford #2,Ballots Cast,,REP,,190,293,483
+Adams,Oxford #2,President,,DEM,Bernie Sanders,4,10,14
+Adams,Oxford #2,President,,DEM,Joseph R Biden,29,197,226
+Adams,Oxford #2,President,,DEM,Tulsi Gabbard,0,6,6
+Adams,Oxford #2,President,,DEM,Write-in,4,3,7
+Adams,Oxford #2,Attorney General,,DEM,Josh Shapiro,34,210,244
+Adams,Oxford #2,Attorney General,,DEM,Write-in,0,1,1
+Adams,Oxford #2,Auditor General,,DEM,H Scott Conklin,5,14,19
+Adams,Oxford #2,Auditor General,,DEM,Michael Lamb,2,24,26
+Adams,Oxford #2,Auditor General,,DEM,Tracie Fountain,5,46,51
+Adams,Oxford #2,Auditor General,,DEM,Rose Rosie Marie Davis,1,9,10
+Adams,Oxford #2,Auditor General,,DEM,Nina Ahmad,8,19,27
+Adams,Oxford #2,Auditor General,,DEM,Christina M Hartman,12,87,99
+Adams,Oxford #2,Auditor General,,DEM,Write-in,0,1,1
+Adams,Oxford #2,State Treasurer,,DEM,Joe Torsella,32,204,236
+Adams,Oxford #2,State Treasurer,,DEM,Write-in,0,1,1
+Adams,Oxford #2,U.S. House,13,DEM,Todd Rowley,34,196,230
+Adams,Oxford #2,U.S. House,13,DEM,Write-in,0,2,2
+Adams,Oxford #2,State Senate,33,DEM,Rich Sterner,35,210,245
+Adams,Oxford #2,State Senate,33,DEM,Write-in,0,1,1
+Adams,Oxford #2,General Assembly,193,DEM,Write-in,4,9,13
+Adams,Oxford #2,President,,REP,Donald J Trump,180,237,417
+Adams,Oxford #2,President,,REP,Roque Rocky De La Fuente,1,3,4
+Adams,Oxford #2,President,,REP,Bill Weld,4,22,26
+Adams,Oxford #2,President,,REP,Write-in,1,18,19
+Adams,Oxford #2,Attorney General,,REP,Heather Heidelbaugh,172,261,433
+Adams,Oxford #2,Attorney General,,REP,Write-in,2,1,3
+Adams,Oxford #2,Auditor General,,REP,Timothy Defoor,170,259,429
+Adams,Oxford #2,Auditor General,,REP,Write-in,0,1,1
+Adams,Oxford #2,State Treasurer,,REP,Stacy L Garrity,172,261,433
+Adams,Oxford #2,State Treasurer,,REP,Write-in,0,1,1
+Adams,Oxford #2,U.S. House,13,REP,John Joyce,173,267,440
+Adams,Oxford #2,U.S. House,13,REP,Write-in,0,2,2
+Adams,Oxford #2,State Senate,33,REP,Doug Mastriano,179,258,437
+Adams,Oxford #2,State Senate,33,REP,Write-in,1,6,7
+Adams,Oxford #2,General Assembly,193,REP,Torren Ecker,180,273,453
+Adams,Oxford #2,General Assembly,193,REP,Write-in,0,2,2
+Adams,Reading #1,Registered Voters,,,,,,1038
+Adams,Reading #1,Registered Voters,,DEM,,,,272
+Adams,Reading #1,Registered Voters,,REP,,,,766
+Adams,Reading #1,Ballots Cast,,,,217,150,367
+Adams,Reading #1,Ballots Cast,,DEM,,29,76,105
+Adams,Reading #1,Ballots Cast,,REP,,188,74,262
+Adams,Reading #1,President,,DEM,Bernie Sanders,6,7,13
+Adams,Reading #1,President,,DEM,Joseph R Biden,13,65,78
+Adams,Reading #1,President,,DEM,Tulsi Gabbard,2,2,4
+Adams,Reading #1,President,,DEM,Write-in,5,1,6
+Adams,Reading #1,Attorney General,,DEM,Josh Shapiro,26,61,87
+Adams,Reading #1,Attorney General,,DEM,Write-in,1,0,1
+Adams,Reading #1,Auditor General,,DEM,H Scott Conklin,3,9,12
+Adams,Reading #1,Auditor General,,DEM,Michael Lamb,2,10,12
+Adams,Reading #1,Auditor General,,DEM,Tracie Fountain,3,11,14
+Adams,Reading #1,Auditor General,,DEM,Rose Rosie Marie Davis,0,3,3
+Adams,Reading #1,Auditor General,,DEM,Nina Ahmad,3,8,11
+Adams,Reading #1,Auditor General,,DEM,Christina M Hartman,12,22,34
+Adams,Reading #1,Auditor General,,DEM,Write-in,1,0,1
+Adams,Reading #1,State Treasurer,,DEM,Joe Torsella,24,61,85
+Adams,Reading #1,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Reading #1,U.S. House,13,DEM,Todd Rowley,21,59,80
+Adams,Reading #1,U.S. House,13,DEM,Write-in,2,2,4
+Adams,Reading #1,State Senate,33,DEM,Rich Sterner,26,67,93
+Adams,Reading #1,State Senate,33,DEM,Write-in,2,0,2
+Adams,Reading #1,General Assembly,193,DEM,Write-in,4,6,10
+Adams,Reading #1,President,,REP,Donald J Trump,182,64,246
+Adams,Reading #1,President,,REP,Roque Rocky De La Fuente,3,1,4
+Adams,Reading #1,President,,REP,Bill Weld,2,4,6
+Adams,Reading #1,President,,REP,Write-in,0,3,3
+Adams,Reading #1,Attorney General,,REP,Heather Heidelbaugh,170,70,240
+Adams,Reading #1,Attorney General,,REP,Write-in,3,0,3
+Adams,Reading #1,Auditor General,,REP,Timothy Defoor,165,70,235
+Adams,Reading #1,Auditor General,,REP,Write-in,2,0,2
+Adams,Reading #1,State Treasurer,,REP,Stacy L Garrity,168,70,238
+Adams,Reading #1,State Treasurer,,REP,Write-in,2,0,2
+Adams,Reading #1,U.S. House,13,REP,John Joyce,171,72,243
+Adams,Reading #1,U.S. House,13,REP,Write-in,3,0,3
+Adams,Reading #1,State Senate,33,REP,Doug Mastriano,174,72,246
+Adams,Reading #1,State Senate,33,REP,Write-in,2,1,3
+Adams,Reading #1,General Assembly,193,REP,Torren Ecker,171,73,244
+Adams,Reading #1,General Assembly,193,REP,Write-in,1,0,1
+Adams,Reading #2,Registered Voters,,,,,,946
+Adams,Reading #2,Registered Voters,,DEM,,,,303
+Adams,Reading #2,Registered Voters,,REP,,,,643
+Adams,Reading #2,Ballots Cast,,,,211,134,345
+Adams,Reading #2,Ballots Cast,,DEM,,34,78,112
+Adams,Reading #2,Ballots Cast,,REP,,177,56,233
+Adams,Reading #2,President,,DEM,Bernie Sanders,11,13,24
+Adams,Reading #2,President,,DEM,Joseph R Biden,16,59,75
+Adams,Reading #2,President,,DEM,Tulsi Gabbard,3,5,8
+Adams,Reading #2,President,,DEM,Write-in,2,1,3
+Adams,Reading #2,Attorney General,,DEM,Josh Shapiro,31,71,102
+Adams,Reading #2,Attorney General,,DEM,Write-in,0,0,0
+Adams,Reading #2,Auditor General,,DEM,H Scott Conklin,7,3,10
+Adams,Reading #2,Auditor General,,DEM,Michael Lamb,3,6,9
+Adams,Reading #2,Auditor General,,DEM,Tracie Fountain,8,21,29
+Adams,Reading #2,Auditor General,,DEM,Rose Rosie Marie Davis,5,6,11
+Adams,Reading #2,Auditor General,,DEM,Nina Ahmad,2,14,16
+Adams,Reading #2,Auditor General,,DEM,Christina M Hartman,8,21,29
+Adams,Reading #2,Auditor General,,DEM,Write-in,0,0,0
+Adams,Reading #2,State Treasurer,,DEM,Joe Torsella,29,71,100
+Adams,Reading #2,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Reading #2,U.S. House,13,DEM,Todd Rowley,29,69,98
+Adams,Reading #2,U.S. House,13,DEM,Write-in,0,1,1
+Adams,Reading #2,State Senate,33,DEM,Rich Sterner,30,76,106
+Adams,Reading #2,State Senate,33,DEM,Write-in,0,0,0
+Adams,Reading #2,General Assembly,193,DEM,Write-in,3,4,7
+Adams,Reading #2,President,,REP,Donald J Trump,170,43,213
+Adams,Reading #2,President,,REP,Roque Rocky De La Fuente,2,2,4
+Adams,Reading #2,President,,REP,Bill Weld,3,5,8
+Adams,Reading #2,President,,REP,Write-in,0,4,4
+Adams,Reading #2,Attorney General,,REP,Heather Heidelbaugh,148,45,193
+Adams,Reading #2,Attorney General,,REP,Write-in,2,0,2
+Adams,Reading #2,Auditor General,,REP,Timothy Defoor,145,46,191
+Adams,Reading #2,Auditor General,,REP,Write-in,2,0,2
+Adams,Reading #2,State Treasurer,,REP,Stacy L Garrity,144,48,192
+Adams,Reading #2,State Treasurer,,REP,Write-in,2,0,2
+Adams,Reading #2,U.S. House,13,REP,John Joyce,153,49,202
+Adams,Reading #2,U.S. House,13,REP,Write-in,2,0,2
+Adams,Reading #2,State Senate,33,REP,Doug Mastriano,163,47,210
+Adams,Reading #2,State Senate,33,REP,Write-in,2,1,3
+Adams,Reading #2,General Assembly,193,REP,Torren Ecker,168,51,219
+Adams,Reading #2,General Assembly,193,REP,Write-in,2,0,2
+Adams,Reading #3,Registered Voters,,,,,,1219
+Adams,Reading #3,Registered Voters,,DEM,,,,361
+Adams,Reading #3,Registered Voters,,REP,,,,858
+Adams,Reading #3,Ballots Cast,,,,344,201,545
+Adams,Reading #3,Ballots Cast,,DEM,,51,136,187
+Adams,Reading #3,Ballots Cast,,REP,,293,65,358
+Adams,Reading #3,President,,DEM,Bernie Sanders,6,19,25
+Adams,Reading #3,President,,DEM,Joseph R Biden,38,109,147
+Adams,Reading #3,President,,DEM,Tulsi Gabbard,4,2,6
+Adams,Reading #3,President,,DEM,Write-in,2,6,8
+Adams,Reading #3,Attorney General,,DEM,Josh Shapiro,47,128,175
+Adams,Reading #3,Attorney General,,DEM,Write-in,1,0,1
+Adams,Reading #3,Auditor General,,DEM,H Scott Conklin,8,16,24
+Adams,Reading #3,Auditor General,,DEM,Michael Lamb,3,13,16
+Adams,Reading #3,Auditor General,,DEM,Tracie Fountain,11,40,51
+Adams,Reading #3,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2
+Adams,Reading #3,Auditor General,,DEM,Nina Ahmad,7,19,26
+Adams,Reading #3,Auditor General,,DEM,Christina M Hartman,18,36,54
+Adams,Reading #3,Auditor General,,DEM,Write-in,1,0,1
+Adams,Reading #3,State Treasurer,,DEM,Joe Torsella,46,126,172
+Adams,Reading #3,State Treasurer,,DEM,Write-in,1,0,1
+Adams,Reading #3,U.S. House,13,DEM,Todd Rowley,48,124,172
+Adams,Reading #3,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Reading #3,State Senate,33,DEM,Rich Sterner,48,131,179
+Adams,Reading #3,State Senate,33,DEM,Write-in,0,1,1
+Adams,Reading #3,General Assembly,193,DEM,Write-in,4,13,17
+Adams,Reading #3,President,,REP,Donald J Trump,282,61,343
+Adams,Reading #3,President,,REP,Roque Rocky De La Fuente,1,1,2
+Adams,Reading #3,President,,REP,Bill Weld,5,0,5
+Adams,Reading #3,President,,REP,Write-in,3,1,4
+Adams,Reading #3,Attorney General,,REP,Heather Heidelbaugh,262,63,325
+Adams,Reading #3,Attorney General,,REP,Write-in,8,0,8
+Adams,Reading #3,Auditor General,,REP,Timothy Defoor,269,62,331
+Adams,Reading #3,Auditor General,,REP,Write-in,0,1,1
+Adams,Reading #3,State Treasurer,,REP,Stacy L Garrity,265,60,325
+Adams,Reading #3,State Treasurer,,REP,Write-in,1,2,3
+Adams,Reading #3,U.S. House,13,REP,John Joyce,269,60,329
+Adams,Reading #3,U.S. House,13,REP,Write-in,1,2,3
+Adams,Reading #3,State Senate,33,REP,Doug Mastriano,279,60,339
+Adams,Reading #3,State Senate,33,REP,Write-in,1,1,2
+Adams,Reading #3,General Assembly,193,REP,Torren Ecker,283,61,344
+Adams,Reading #3,General Assembly,193,REP,Write-in,0,0,0
+Adams,Straban #1,Registered Voters,,,,,,1366
+Adams,Straban #1,Registered Voters,,DEM,,,,556
+Adams,Straban #1,Registered Voters,,REP,,,,810
+Adams,Straban #1,Ballots Cast,,,,257,369,626
+Adams,Straban #1,Ballots Cast,,DEM,,80,203,283
+Adams,Straban #1,Ballots Cast,,REP,,177,166,343
+Adams,Straban #1,President,,DEM,Bernie Sanders,19,27,46
+Adams,Straban #1,President,,DEM,Joseph R Biden,60,168,228
+Adams,Straban #1,President,,DEM,Tulsi Gabbard,3,2,5
+Adams,Straban #1,President,,DEM,Write-in,3,4,7
+Adams,Straban #1,Attorney General,,DEM,Josh Shapiro,70,185,255
+Adams,Straban #1,Attorney General,,DEM,Write-in,0,0,0
+Adams,Straban #1,Auditor General,,DEM,H Scott Conklin,9,16,25
+Adams,Straban #1,Auditor General,,DEM,Michael Lamb,4,31,35
+Adams,Straban #1,Auditor General,,DEM,Tracie Fountain,12,37,49
+Adams,Straban #1,Auditor General,,DEM,Rose Rosie Marie Davis,5,7,12
+Adams,Straban #1,Auditor General,,DEM,Nina Ahmad,14,33,47
+Adams,Straban #1,Auditor General,,DEM,Christina M Hartman,19,53,72
+Adams,Straban #1,Auditor General,,DEM,Write-in,0,0,0
+Adams,Straban #1,State Treasurer,,DEM,Joe Torsella,67,177,244
+Adams,Straban #1,State Treasurer,,DEM,Write-in,0,0,0
+Adams,Straban #1,U.S. House,13,DEM,Todd Rowley,67,177,244
+Adams,Straban #1,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Straban #1,State Senate,33,DEM,Rich Sterner,70,186,256
+Adams,Straban #1,State Senate,33,DEM,Write-in,1,0,1
+Adams,Straban #1,General Assembly,91,DEM,Write-in,3,13,16
+Adams,Straban #1,President,,REP,Donald J Trump,155,129,284
+Adams,Straban #1,President,,REP,Roque Rocky De La Fuente,5,1,6
+Adams,Straban #1,President,,REP,Bill Weld,6,17,23
+Adams,Straban #1,President,,REP,Write-in,5,9,14
+Adams,Straban #1,Attorney General,,REP,Heather Heidelbaugh,148,139,287
+Adams,Straban #1,Attorney General,,REP,Write-in,3,5,8
+Adams,Straban #1,Auditor General,,REP,Timothy Defoor,152,140,292
+Adams,Straban #1,Auditor General,,REP,Write-in,0,3,3
+Adams,Straban #1,State Treasurer,,REP,Stacy L Garrity,156,143,299
+Adams,Straban #1,State Treasurer,,REP,Write-in,0,1,1
+Adams,Straban #1,U.S. House,13,REP,John Joyce,160,144,304
+Adams,Straban #1,U.S. House,13,REP,Write-in,1,2,3
+Adams,Straban #1,State Senate,33,REP,Doug Mastriano,162,143,305
+Adams,Straban #1,State Senate,33,REP,Write-in,0,5,5
+Adams,Straban #1,General Assembly,91,REP,Dan Moul,165,139,304
+Adams,Straban #1,General Assembly,91,REP,Write-in,0,5,5
+Adams,Straban #2,Registered Voters,,,,,,1262
+Adams,Straban #2,Registered Voters,,DEM,,,,411
+Adams,Straban #2,Registered Voters,,REP,,,,851
+Adams,Straban #2,Ballots Cast,,,,303,178,481
+Adams,Straban #2,Ballots Cast,,DEM,,56,83,139
+Adams,Straban #2,Ballots Cast,,REP,,247,95,342
+Adams,Straban #2,President,,DEM,Bernie Sanders,9,14,23
+Adams,Straban #2,President,,DEM,Joseph R Biden,37,67,104
+Adams,Straban #2,President,,DEM,Tulsi Gabbard,4,0,4
+Adams,Straban #2,President,,DEM,Write-in,4,2,6
+Adams,Straban #2,Attorney General,,DEM,Josh Shapiro,52,75,127
+Adams,Straban #2,Attorney General,,DEM,Write-in,0,1,1
+Adams,Straban #2,Auditor General,,DEM,H Scott Conklin,8,8,16
+Adams,Straban #2,Auditor General,,DEM,Michael Lamb,6,7,13
+Adams,Straban #2,Auditor General,,DEM,Tracie Fountain,7,20,27
+Adams,Straban #2,Auditor General,,DEM,Rose Rosie Marie Davis,4,6,10
+Adams,Straban #2,Auditor General,,DEM,Nina Ahmad,6,12,18
+Adams,Straban #2,Auditor General,,DEM,Christina M Hartman,20,26,46
+Adams,Straban #2,Auditor General,,DEM,Write-in,0,1,1
+Adams,Straban #2,State Treasurer,,DEM,Joe Torsella,50,77,127
+Adams,Straban #2,State Treasurer,,DEM,Write-in,0,1,1
+Adams,Straban #2,U.S. House,13,DEM,Todd Rowley,49,74,123
+Adams,Straban #2,U.S. House,13,DEM,Write-in,2,1,3
+Adams,Straban #2,State Senate,33,DEM,Rich Sterner,51,77,128
+Adams,Straban #2,State Senate,33,DEM,Write-in,1,1,2
+Adams,Straban #2,General Assembly,91,DEM,Write-in,3,6,9
+Adams,Straban #2,President,,REP,Donald J Trump,236,80,316
+Adams,Straban #2,President,,REP,Roque Rocky De La Fuente,1,1,2
+Adams,Straban #2,President,,REP,Bill Weld,4,5,9
+Adams,Straban #2,President,,REP,Write-in,2,3,5
+Adams,Straban #2,Attorney General,,REP,Heather Heidelbaugh,225,81,306
+Adams,Straban #2,Attorney General,,REP,Write-in,4,0,4
+Adams,Straban #2,Auditor General,,REP,Timothy Defoor,221,82,303
+Adams,Straban #2,Auditor General,,REP,Write-in,0,0,0
+Adams,Straban #2,State Treasurer,,REP,Stacy L Garrity,225,82,307
+Adams,Straban #2,State Treasurer,,REP,Write-in,0,0,0
+Adams,Straban #2,U.S. House,13,REP,John Joyce,234,85,319
+Adams,Straban #2,U.S. House,13,REP,Write-in,0,0,0
+Adams,Straban #2,State Senate,33,REP,Doug Mastriano,235,83,318
+Adams,Straban #2,State Senate,33,REP,Write-in,3,0,3
+Adams,Straban #2,General Assembly,91,REP,Dan Moul,237,88,325
+Adams,Straban #2,General Assembly,91,REP,Write-in,0,0,0
+Adams,Tyrone,Registered Voters,,,,,,1147
+Adams,Tyrone,Registered Voters,,DEM,,,,341
+Adams,Tyrone,Registered Voters,,REP,,,,806
+Adams,Tyrone,Ballots Cast,,,,257,151,408
+Adams,Tyrone,Ballots Cast,,DEM,,43,73,116
+Adams,Tyrone,Ballots Cast,,REP,,214,78,292
+Adams,Tyrone,President,,DEM,Bernie Sanders,14,10,24
+Adams,Tyrone,President,,DEM,Joseph R Biden,23,58,81
+Adams,Tyrone,President,,DEM,Tulsi Gabbard,1,1,2
+Adams,Tyrone,President,,DEM,Write-in,1,1,2
+Adams,Tyrone,Attorney General,,DEM,Josh Shapiro,37,69,106
+Adams,Tyrone,Attorney General,,DEM,Write-in,2,0,2
+Adams,Tyrone,Auditor General,,DEM,H Scott Conklin,6,8,14
+Adams,Tyrone,Auditor General,,DEM,Michael Lamb,0,8,8
+Adams,Tyrone,Auditor General,,DEM,Tracie Fountain,7,17,24
+Adams,Tyrone,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Adams,Tyrone,Auditor General,,DEM,Nina Ahmad,13,10,23
+Adams,Tyrone,Auditor General,,DEM,Christina M Hartman,13,27,40
+Adams,Tyrone,Auditor General,,DEM,Write-in,1,0,1
+Adams,Tyrone,State Treasurer,,DEM,Joe Torsella,34,68,102
+Adams,Tyrone,State Treasurer,,DEM,Write-in,2,0,2
+Adams,Tyrone,U.S. House,13,DEM,Todd Rowley,32,66,98
+Adams,Tyrone,U.S. House,13,DEM,Write-in,2,1,3
+Adams,Tyrone,State Senate,33,DEM,Rich Sterner,33,71,104
+Adams,Tyrone,State Senate,33,DEM,Write-in,2,0,2
+Adams,Tyrone,General Assembly,193,DEM,Write-in,2,4,6
+Adams,Tyrone,President,,REP,Donald J Trump,200,69,269
+Adams,Tyrone,President,,REP,Roque Rocky De La Fuente,2,1,3
+Adams,Tyrone,President,,REP,Bill Weld,7,6,13
+Adams,Tyrone,President,,REP,Write-in,2,1,3
+Adams,Tyrone,Attorney General,,REP,Heather Heidelbaugh,194,68,262
+Adams,Tyrone,Attorney General,,REP,Write-in,4,0,4
+Adams,Tyrone,Auditor General,,REP,Timothy Defoor,196,69,265
+Adams,Tyrone,Auditor General,,REP,Write-in,0,0,0
+Adams,Tyrone,State Treasurer,,REP,Stacy L Garrity,196,68,264
+Adams,Tyrone,State Treasurer,,REP,Write-in,1,0,1
+Adams,Tyrone,U.S. House,13,REP,John Joyce,196,69,265
+Adams,Tyrone,U.S. House,13,REP,Write-in,1,0,1
+Adams,Tyrone,State Senate,33,REP,Doug Mastriano,203,69,272
+Adams,Tyrone,State Senate,33,REP,Write-in,1,1,2
+Adams,Tyrone,General Assembly,193,REP,Torren Ecker,203,70,273
+Adams,Tyrone,General Assembly,193,REP,Write-in,0,0,0
+Adams,Union,Registered Voters,,,,,,1860
+Adams,Union,Registered Voters,,DEM,,,,484
+Adams,Union,Registered Voters,,REP,,,,1376
+Adams,Union,Ballots Cast,,,,357,259,616
+Adams,Union,Ballots Cast,,DEM,,57,119,176
+Adams,Union,Ballots Cast,,REP,,300,140,440
+Adams,Union,President,,DEM,Bernie Sanders,20,16,36
+Adams,Union,President,,DEM,Joseph R Biden,31,95,126
+Adams,Union,President,,DEM,Tulsi Gabbard,2,2,4
+Adams,Union,President,,DEM,Write-in,2,2,4
+Adams,Union,Attorney General,,DEM,Josh Shapiro,51,108,159
+Adams,Union,Attorney General,,DEM,Write-in,0,0,0
+Adams,Union,Auditor General,,DEM,H Scott Conklin,7,10,17
+Adams,Union,Auditor General,,DEM,Michael Lamb,6,11,17
+Adams,Union,Auditor General,,DEM,Tracie Fountain,11,25,36
+Adams,Union,Auditor General,,DEM,Rose Rosie Marie Davis,4,2,6
+Adams,Union,Auditor General,,DEM,Nina Ahmad,5,15,20
+Adams,Union,Auditor General,,DEM,Christina M Hartman,13,45,58
+Adams,Union,Auditor General,,DEM,Write-in,0,0,0
+Adams,Union,State Treasurer,,DEM,Joe Torsella,47,107,154
+Adams,Union,State Treasurer,,DEM,Write-in,0,1,1
+Adams,Union,U.S. House,13,DEM,Todd Rowley,48,103,151
+Adams,Union,U.S. House,13,DEM,Write-in,0,0,0
+Adams,Union,State Senate,33,DEM,Rich Sterner,54,115,169
+Adams,Union,State Senate,33,DEM,Write-in,0,0,0
+Adams,Union,General Assembly,91,DEM,Write-in,7,16,23
+Adams,Union,President,,REP,Donald J Trump,295,119,414
+Adams,Union,President,,REP,Roque Rocky De La Fuente,1,3,4
+Adams,Union,President,,REP,Bill Weld,2,10,12
+Adams,Union,President,,REP,Write-in,0,4,4
+Adams,Union,Attorney General,,REP,Heather Heidelbaugh,264,123,387
+Adams,Union,Attorney General,,REP,Write-in,4,3,7
+Adams,Union,Auditor General,,REP,Timothy Defoor,260,123,383
+Adams,Union,Auditor General,,REP,Write-in,1,3,4
+Adams,Union,State Treasurer,,REP,Stacy L Garrity,264,121,385
+Adams,Union,State Treasurer,,REP,Write-in,0,3,3
+Adams,Union,U.S. House,13,REP,John Joyce,279,123,402
+Adams,Union,U.S. House,13,REP,Write-in,1,4,5
+Adams,Union,State Senate,33,REP,Doug Mastriano,283,121,404
+Adams,Union,State Senate,33,REP,Write-in,0,6,6
+Adams,Union,General Assembly,91,REP,Dan Moul,278,125,403
+Adams,Union,General Assembly,91,REP,Write-in,6,1,7
+Adams,York Springs,Registered Voters,,,,,,232
+Adams,York Springs,Registered Voters,,DEM,,,,103
+Adams,York Springs,Registered Voters,,REP,,,,129
+Adams,York Springs,Ballots Cast,,,,59,25,84
+Adams,York Springs,Ballots Cast,,DEM,,18,18,36
+Adams,York Springs,Ballots Cast,,REP,,41,7,48
+Adams,York Springs,President,,DEM,Bernie Sanders,5,7,12
+Adams,York Springs,President,,DEM,Joseph R Biden,9,11,20
+Adams,York Springs,President,,DEM,Tulsi Gabbard,2,0,2
+Adams,York Springs,President,,DEM,Write-in,2,0,2
+Adams,York Springs,Attorney General,,DEM,Josh Shapiro,17,18,35
+Adams,York Springs,Attorney General,,DEM,Write-in,0,0,0
+Adams,York Springs,Auditor General,,DEM,H Scott Conklin,0,2,2
+Adams,York Springs,Auditor General,,DEM,Michael Lamb,2,0,2
+Adams,York Springs,Auditor General,,DEM,Tracie Fountain,5,10,15
+Adams,York Springs,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,3
+Adams,York Springs,Auditor General,,DEM,Nina Ahmad,5,1,6
+Adams,York Springs,Auditor General,,DEM,Christina M Hartman,2,3,5
+Adams,York Springs,Auditor General,,DEM,Write-in,0,0,0
+Adams,York Springs,State Treasurer,,DEM,Joe Torsella,15,18,33
+Adams,York Springs,State Treasurer,,DEM,Write-in,0,0,0
+Adams,York Springs,U.S. House,13,DEM,Todd Rowley,14,18,32
+Adams,York Springs,U.S. House,13,DEM,Write-in,0,0,0
+Adams,York Springs,State Senate,33,DEM,Rich Sterner,16,18,34
+Adams,York Springs,State Senate,33,DEM,Write-in,0,0,0
+Adams,York Springs,General Assembly,193,DEM,Write-in,2,1,3
+Adams,York Springs,President,,REP,Donald J Trump,40,4,44
+Adams,York Springs,President,,REP,Roque Rocky De La Fuente,0,0,0
+Adams,York Springs,President,,REP,Bill Weld,1,0,1
+Adams,York Springs,President,,REP,Write-in,0,1,1
+Adams,York Springs,Attorney General,,REP,Heather Heidelbaugh,37,7,44
+Adams,York Springs,Attorney General,,REP,Write-in,0,0,0
+Adams,York Springs,Auditor General,,REP,Timothy Defoor,37,7,44
+Adams,York Springs,Auditor General,,REP,Write-in,0,0,0
+Adams,York Springs,State Treasurer,,REP,Stacy L Garrity,37,7,44
+Adams,York Springs,State Treasurer,,REP,Write-in,0,0,0
+Adams,York Springs,U.S. House,13,REP,John Joyce,38,7,45
+Adams,York Springs,U.S. House,13,REP,Write-in,0,0,0
+Adams,York Springs,State Senate,33,REP,Doug Mastriano,39,7,46
+Adams,York Springs,State Senate,33,REP,Write-in,0,0,0
+Adams,York Springs,General Assembly,193,REP,Torren Ecker,39,7,46
+Adams,York Springs,General Assembly,193,REP,Write-in,0,0,0

--- a/2020/20200602__pa__primary__cambria__precinct.csv
+++ b/2020/20200602__pa__primary__cambria__precinct.csv
@@ -1,0 +1,5363 @@
+county,precinct,office,district,party,candidate,election_day,mail_in,provisional,votes
+Cambria,ADAMS TOWNSHIP NO. 1,Registered Voters,,,,,,,1060
+Cambria,ADAMS TOWNSHIP NO. 1,Registered Voters,,DEM,,,,,421
+Cambria,ADAMS TOWNSHIP NO. 1,Registered Voters,,REP,,,,,540
+Cambria,ADAMS TOWNSHIP NO. 1,Ballots Cast,,,,255,135,2,392
+Cambria,ADAMS TOWNSHIP NO. 1,Ballots Cast,,DEM,,86,88,1,175
+Cambria,ADAMS TOWNSHIP NO. 1,Ballots Cast,,REP,,169,47,1,217
+Cambria,ADAMS TOWNSHIP NO. 1,President,,DEM,Bernie Sanders,13,10,0,23
+Cambria,ADAMS TOWNSHIP NO. 1,President,,DEM,Joseph R. Biden,41,75,1,117
+Cambria,ADAMS TOWNSHIP NO. 1,President,,DEM,Tulsi Gabbard,10,1,0,11
+Cambria,ADAMS TOWNSHIP NO. 1,President,,DEM,Write-In,10,1,0,11
+Cambria,ADAMS TOWNSHIP NO. 1,Attorney General,,DEM,Josh Shapiro,74,86,1,161
+Cambria,ADAMS TOWNSHIP NO. 1,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,DEM,H. Scott Conklin,38,47,0,85
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,DEM,Michael Lamb,21,23,1,45
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,DEM,Tracie Fountain,3,2,0,5
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,4,2,0,6
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,DEM,Nina Ahmad,1,3,0,4
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,DEM,Christina M. Hartman,10,11,0,21
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP NO. 1,State Treasurer,,DEM,Joe Torsella,69,83,1,153
+Cambria,ADAMS TOWNSHIP NO. 1,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP NO. 1,U.S. House,15,DEM,Robert Williams,71,82,1,154
+Cambria,ADAMS TOWNSHIP NO. 1,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,ADAMS TOWNSHIP NO. 1,State Senator,35,DEM,Shaun Dougherty,68,88,1,157
+Cambria,ADAMS TOWNSHIP NO. 1,State Senator,35,DEM,Write-In,3,0,0,3
+Cambria,ADAMS TOWNSHIP NO. 1,General Assembly,71,DEM,Write-In,6,10,0,16
+Cambria,ADAMS TOWNSHIP NO. 1,President,,REP,Donald J. Trump,164,36,1,201
+Cambria,ADAMS TOWNSHIP NO. 1,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,ADAMS TOWNSHIP NO. 1,President,,REP,Bill Weld,2,5,0,7
+Cambria,ADAMS TOWNSHIP NO. 1,President,,REP,Write-In,2,3,0,5
+Cambria,ADAMS TOWNSHIP NO. 1,Attorney General,,REP,Heather Heidelbaugh,161,34,1,196
+Cambria,ADAMS TOWNSHIP NO. 1,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,REP,Timothy Defoor,156,33,1,190
+Cambria,ADAMS TOWNSHIP NO. 1,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP NO. 1,State Treasurer,,REP,Stacy L. Garrity,158,34,1,193
+Cambria,ADAMS TOWNSHIP NO. 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP NO. 1,U.S. House,15,REP,Glenn Gt Thompson,157,39,1,197
+Cambria,ADAMS TOWNSHIP NO. 1,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,164,46,1,211
+Cambria,ADAMS TOWNSHIP NO. 1,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP NO. 1,General Assembly,71,REP,Jim Rigby,163,44,1,208
+Cambria,ADAMS TOWNSHIP NO. 1,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP - DUNLO,Registered Voters,,,,,,,512
+Cambria,ADAMS TOWNSHIP - DUNLO,Registered Voters,,DEM,,,,,254
+Cambria,ADAMS TOWNSHIP - DUNLO,Registered Voters,,REP,,,,,208
+Cambria,ADAMS TOWNSHIP - DUNLO,Ballots Cast,,,,115,59,0,174
+Cambria,ADAMS TOWNSHIP - DUNLO,Ballots Cast,,DEM,,50,41,0,91
+Cambria,ADAMS TOWNSHIP - DUNLO,Ballots Cast,,REP,,65,18,0,83
+Cambria,ADAMS TOWNSHIP - DUNLO,President,,DEM,Bernie Sanders,5,5,0,10
+Cambria,ADAMS TOWNSHIP - DUNLO,President,,DEM,Joseph R. Biden,20,28,0,48
+Cambria,ADAMS TOWNSHIP - DUNLO,President,,DEM,Tulsi Gabbard,5,5,0,10
+Cambria,ADAMS TOWNSHIP - DUNLO,President,,DEM,Write-In,11,3,0,14
+Cambria,ADAMS TOWNSHIP - DUNLO,Attorney General,,DEM,Josh Shapiro,42,34,0,76
+Cambria,ADAMS TOWNSHIP - DUNLO,Attorney General,,DEM,Write-In,3,0,0,3
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,DEM,H. Scott Conklin,32,18,0,50
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,DEM,Michael Lamb,6,12,0,18
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,DEM,Tracie Fountain,1,1,0,2
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,2
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,DEM,Nina Ahmad,0,3,0,3
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,DEM,Christina M. Hartman,4,3,0,7
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,DEM,Write-In,3,0,0,3
+Cambria,ADAMS TOWNSHIP - DUNLO,State Treasurer,,DEM,Joe Torsella,39,34,0,73
+Cambria,ADAMS TOWNSHIP - DUNLO,State Treasurer,,DEM,Write-In,4,0,0,4
+Cambria,ADAMS TOWNSHIP - DUNLO,U.S. House,15,DEM,Robert Williams,39,33,0,72
+Cambria,ADAMS TOWNSHIP - DUNLO,U.S. House,15,DEM,Write-In,5,1,0,6
+Cambria,ADAMS TOWNSHIP - DUNLO,State Senator,35,DEM,Shaun Dougherty,42,34,0,76
+Cambria,ADAMS TOWNSHIP - DUNLO,State Senator,35,DEM,Write-In,4,0,0,4
+Cambria,ADAMS TOWNSHIP - DUNLO,General Assembly,71,DEM,Write-In,10,4,0,14
+Cambria,ADAMS TOWNSHIP - DUNLO,President,,REP,Donald J. Trump,64,17,0,81
+Cambria,ADAMS TOWNSHIP - DUNLO,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,ADAMS TOWNSHIP - DUNLO,President,,REP,Bill Weld,0,1,0,1
+Cambria,ADAMS TOWNSHIP - DUNLO,President,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - DUNLO,Attorney General,,REP,Heather Heidelbaugh,57,15,0,72
+Cambria,ADAMS TOWNSHIP - DUNLO,Attorney General,,REP,Write-In,2,0,0,2
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,REP,Timothy Defoor,56,15,0,71
+Cambria,ADAMS TOWNSHIP - DUNLO,Auditor General,,REP,Write-In,2,0,0,2
+Cambria,ADAMS TOWNSHIP - DUNLO,State Treasurer,,REP,Stacy L. Garrity,59,15,0,74
+Cambria,ADAMS TOWNSHIP - DUNLO,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - DUNLO,U.S. House,15,REP,Glenn Gt Thompson,62,15,0,77
+Cambria,ADAMS TOWNSHIP - DUNLO,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - DUNLO,State Senator,35,REP,Wayne Langerholc Jr.,63,15,0,78
+Cambria,ADAMS TOWNSHIP - DUNLO,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - DUNLO,General Assembly,71,REP,Jim Rigby,63,16,0,79
+Cambria,ADAMS TOWNSHIP - DUNLO,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ELTON,Registered Voters,,,,,,,1070
+Cambria,ADAMS TOWNSHIP - ELTON,Registered Voters,,DEM,,,,,381
+Cambria,ADAMS TOWNSHIP - ELTON,Registered Voters,,REP,,,,,597
+Cambria,ADAMS TOWNSHIP - ELTON,Ballots Cast,,,,222,179,8,409
+Cambria,ADAMS TOWNSHIP - ELTON,Ballots Cast,,DEM,,52,96,1,149
+Cambria,ADAMS TOWNSHIP - ELTON,Ballots Cast,,REP,,170,83,7,260
+Cambria,ADAMS TOWNSHIP - ELTON,President,,DEM,Bernie Sanders,8,8,1,17
+Cambria,ADAMS TOWNSHIP - ELTON,President,,DEM,Joseph R. Biden,32,68,0,100
+Cambria,ADAMS TOWNSHIP - ELTON,President,,DEM,Tulsi Gabbard,1,9,0,10
+Cambria,ADAMS TOWNSHIP - ELTON,President,,DEM,Write-In,7,9,0,16
+Cambria,ADAMS TOWNSHIP - ELTON,Attorney General,,DEM,Josh Shapiro,47,93,1,141
+Cambria,ADAMS TOWNSHIP - ELTON,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,DEM,H. Scott Conklin,22,50,1,73
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,DEM,Michael Lamb,16,32,0,48
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,5
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,DEM,Nina Ahmad,3,2,0,5
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,DEM,Christina M. Hartman,5,5,0,10
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,DEM,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,State Treasurer,,DEM,Joe Torsella,47,90,1,138
+Cambria,ADAMS TOWNSHIP - ELTON,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,U.S. House,15,DEM,Robert Williams,46,94,1,141
+Cambria,ADAMS TOWNSHIP - ELTON,U.S. House,15,DEM,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,State Senator,35,DEM,Shaun Dougherty,50,92,1,143
+Cambria,ADAMS TOWNSHIP - ELTON,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,General Assembly,71,DEM,Write-In,4,5,0,9
+Cambria,ADAMS TOWNSHIP - ELTON,President,,REP,Donald J. Trump,169,74,7,250
+Cambria,ADAMS TOWNSHIP - ELTON,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ELTON,President,,REP,Bill Weld,0,6,0,6
+Cambria,ADAMS TOWNSHIP - ELTON,President,,REP,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,Attorney General,,REP,Heather Heidelbaugh,160,78,7,245
+Cambria,ADAMS TOWNSHIP - ELTON,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,REP,Timothy Defoor,160,78,7,245
+Cambria,ADAMS TOWNSHIP - ELTON,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,State Treasurer,,REP,Stacy L. Garrity,163,78,7,248
+Cambria,ADAMS TOWNSHIP - ELTON,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ELTON,U.S. House,15,REP,Glenn Gt Thompson,162,78,7,247
+Cambria,ADAMS TOWNSHIP - ELTON,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ELTON,State Senator,35,REP,Wayne Langerholc Jr.,168,80,7,255
+Cambria,ADAMS TOWNSHIP - ELTON,State Senator,35,REP,Write-In,1,2,0,3
+Cambria,ADAMS TOWNSHIP - ELTON,General Assembly,71,REP,Jim Rigby,164,81,7,252
+Cambria,ADAMS TOWNSHIP - ELTON,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Registered Voters,,,,,,,593
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Registered Voters,,DEM,,,,,212
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Registered Voters,,REP,,,,,340
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Ballots Cast,,,,152,78,3,233
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Ballots Cast,,DEM,,39,34,1,74
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Ballots Cast,,REP,,113,44,2,159
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,President,,DEM,Bernie Sanders,9,2,0,11
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,President,,DEM,Joseph R. Biden,14,28,0,42
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,President,,DEM,Tulsi Gabbard,6,0,0,6
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,President,,DEM,Write-In,8,4,1,13
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Attorney General,,DEM,Josh Shapiro,33,32,1,66
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Attorney General,,DEM,Write-In,1,1,0,2
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,DEM,H. Scott Conklin,23,20,0,43
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,DEM,Michael Lamb,3,8,0,11
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,DEM,Tracie Fountain,0,2,0,2
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,DEM,Nina Ahmad,3,0,0,3
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,DEM,Christina M. Hartman,5,2,1,8
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,DEM,Write-In,1,1,0,2
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,State Treasurer,,DEM,Joe Torsella,32,32,1,65
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,U.S. House,15,DEM,Robert Williams,32,31,1,64
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,State Senator,35,DEM,Shaun Dougherty,34,31,1,66
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,State Senator,35,DEM,Write-In,1,2,0,3
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,General Assembly,71,DEM,Write-In,3,7,0,10
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,President,,REP,Donald J. Trump,109,34,2,145
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,President,,REP,Roque Rocky De La Fuente,2,2,0,4
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,President,,REP,Bill Weld,2,5,0,7
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,President,,REP,Write-In,0,1,0,1
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Attorney General,,REP,Heather Heidelbaugh,90,37,1,128
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Attorney General,,REP,Write-In,2,1,0,3
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,REP,Timothy Defoor,90,35,2,127
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,Auditor General,,REP,Write-In,1,3,0,4
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,State Treasurer,,REP,Stacy L. Garrity,95,38,2,135
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,U.S. House,15,REP,Glenn Gt Thompson,95,39,2,136
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,U.S. House,15,REP,Write-In,2,0,0,2
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,State Senator,35,REP,Wayne Langerholc Jr.,105,42,2,149
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,General Assembly,71,REP,Jim Rigby,105,42,2,149
+Cambria,ADAMS TOWNSHIP- - GRAMLINGTOWN,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Registered Voters,,,,,,,702
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Registered Voters,,DEM,,,,,358
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Registered Voters,,REP,,,,,280
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Ballots Cast,,,,156,104,2,262
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Ballots Cast,,DEM,,87,72,0,159
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Ballots Cast,,REP,,69,32,2,103
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,President,,DEM,Bernie Sanders,17,8,0,25
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,President,,DEM,Joseph R. Biden,46,56,0,102
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,President,,DEM,Tulsi Gabbard,14,2,0,16
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,President,,DEM,Write-In,6,1,0,7
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Attorney General,,DEM,Josh Shapiro,82,72,0,154
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,DEM,H. Scott Conklin,44,46,0,90
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,DEM,Michael Lamb,19,18,0,37
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,DEM,Tracie Fountain,1,4,0,5
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,DEM,Rose Rosie Marie Davis,6,1,0,7
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,DEM,Nina Ahmad,0,1,0,1
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,DEM,Christina M. Hartman,15,2,0,17
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,State Treasurer,,DEM,Joe Torsella,79,69,0,148
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,U.S. House,15,DEM,Robert Williams,77,69,0,146
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,State Senator,35,DEM,Shaun Dougherty,83,69,0,152
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,General Assembly,71,DEM,Write-In,8,3,0,11
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,President,,REP,Donald J. Trump,66,32,2,100
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,President,,REP,Bill Weld,2,0,0,2
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,President,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Attorney General,,REP,Heather Heidelbaugh,65,32,2,99
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,REP,Timothy Defoor,63,32,2,97
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,State Treasurer,,REP,Stacy L. Garrity,63,32,2,97
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,U.S. House,15,REP,Glenn Gt Thompson,64,32,2,98
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,State Senator,35,REP,Wayne Langerholc Jr.,65,32,2,99
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,General Assembly,71,REP,Jim Rigby,64,31,2,97
+Cambria,ADAMS TOWNSHIP - ST. MICHAEL,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,ALLEGHENY TOWNSHIP,Registered Voters,,,,,,,1117
+Cambria,ALLEGHENY TOWNSHIP,Registered Voters,,DEM,,,,,450
+Cambria,ALLEGHENY TOWNSHIP,Registered Voters,,REP,,,,,566
+Cambria,ALLEGHENY TOWNSHIP,Ballots Cast,,,,221,160,5,386
+Cambria,ALLEGHENY TOWNSHIP,Ballots Cast,,DEM,,83,102,3,188
+Cambria,ALLEGHENY TOWNSHIP,Ballots Cast,,REP,,138,58,2,198
+Cambria,ALLEGHENY TOWNSHIP,President,,DEM,Bernie Sanders,14,17,1,32
+Cambria,ALLEGHENY TOWNSHIP,President,,DEM,Joseph R. Biden,36,66,1,103
+Cambria,ALLEGHENY TOWNSHIP,President,,DEM,Tulsi Gabbard,12,7,0,19
+Cambria,ALLEGHENY TOWNSHIP,President,,DEM,Write-In,12,5,1,18
+Cambria,ALLEGHENY TOWNSHIP,Attorney General,,DEM,Josh Shapiro,68,80,3,151
+Cambria,ALLEGHENY TOWNSHIP,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,43,58,2,103
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,DEM,Michael Lamb,18,14,1,33
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,DEM,Tracie Fountain,2,2,0,4
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,0,6
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,DEM,Nina Ahmad,2,7,0,9
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,8,7,0,15
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,ALLEGHENY TOWNSHIP,State Treasurer,,DEM,Joe Torsella,68,86,2,156
+Cambria,ALLEGHENY TOWNSHIP,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,ALLEGHENY TOWNSHIP,U.S. House,15,DEM,Robert Williams,69,86,3,158
+Cambria,ALLEGHENY TOWNSHIP,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,ALLEGHENY TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,67,87,3,157
+Cambria,ALLEGHENY TOWNSHIP,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,ALLEGHENY TOWNSHIP,General Assembly,72,DEM,Frank Burns,71,91,2,164
+Cambria,ALLEGHENY TOWNSHIP,General Assembly,72,DEM,Write-In,2,0,1,3
+Cambria,ALLEGHENY TOWNSHIP,President,,REP,Donald J. Trump,137,52,2,191
+Cambria,ALLEGHENY TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,ALLEGHENY TOWNSHIP,President,,REP,Bill Weld,0,2,0,2
+Cambria,ALLEGHENY TOWNSHIP,President,,REP,Write-In,1,2,0,3
+Cambria,ALLEGHENY TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,125,56,2,183
+Cambria,ALLEGHENY TOWNSHIP,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,REP,Timothy Defoor,123,56,2,181
+Cambria,ALLEGHENY TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,ALLEGHENY TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,123,56,2,181
+Cambria,ALLEGHENY TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,ALLEGHENY TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,120,58,2,180
+Cambria,ALLEGHENY TOWNSHIP,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,ALLEGHENY TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,122,54,2,178
+Cambria,ALLEGHENY TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,ALLEGHENY TOWNSHIP,General Assembly,72,REP,Howard Terndrup,79,38,2,119
+Cambria,ALLEGHENY TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,49,16,0,65
+Cambria,ALLEGHENY TOWNSHIP,General Assembly,72,REP,Write-In,4,1,0,5
+Cambria,ASHVILLE BOROUGH,Registered Voters,,,,,,,156
+Cambria,ASHVILLE BOROUGH,Registered Voters,,DEM,,,,,71
+Cambria,ASHVILLE BOROUGH,Registered Voters,,REP,,,,,58
+Cambria,ASHVILLE BOROUGH,Ballots Cast,,,,38,14,0,52
+Cambria,ASHVILLE BOROUGH,Ballots Cast,,DEM,,16,12,0,28
+Cambria,ASHVILLE BOROUGH,Ballots Cast,,REP,,22,2,0,24
+Cambria,ASHVILLE BOROUGH,President,,DEM,Bernie Sanders,4,5,0,9
+Cambria,ASHVILLE BOROUGH,President,,DEM,Joseph R. Biden,4,7,0,11
+Cambria,ASHVILLE BOROUGH,President,,DEM,Tulsi Gabbard,4,0,0,4
+Cambria,ASHVILLE BOROUGH,President,,DEM,Write-In,2,0,0,2
+Cambria,ASHVILLE BOROUGH,Attorney General,,DEM,Josh Shapiro,12,11,0,23
+Cambria,ASHVILLE BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,Auditor General,,DEM,H. Scott Conklin,9,9,0,18
+Cambria,ASHVILLE BOROUGH,Auditor General,,DEM,Michael Lamb,2,2,0,4
+Cambria,ASHVILLE BOROUGH,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Cambria,ASHVILLE BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,ASHVILLE BOROUGH,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,ASHVILLE BOROUGH,Auditor General,,DEM,Christina M. Hartman,1,1,0,2
+Cambria,ASHVILLE BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,State Treasurer,,DEM,Joe Torsella,13,12,0,25
+Cambria,ASHVILLE BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,U.S. House,15,DEM,Robert Williams,14,12,0,26
+Cambria,ASHVILLE BOROUGH,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,State Senator,35,DEM,Shaun Dougherty,13,12,0,25
+Cambria,ASHVILLE BOROUGH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,General Assembly,72,DEM,Frank Burns,13,12,0,25
+Cambria,ASHVILLE BOROUGH,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,ASHVILLE BOROUGH,President,,REP,Donald J. Trump,20,2,0,22
+Cambria,ASHVILLE BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,ASHVILLE BOROUGH,President,,REP,Bill Weld,2,0,0,2
+Cambria,ASHVILLE BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,Attorney General,,REP,Heather Heidelbaugh,19,1,0,20
+Cambria,ASHVILLE BOROUGH,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,ASHVILLE BOROUGH,Auditor General,,REP,Timothy Defoor,20,1,0,21
+Cambria,ASHVILLE BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,State Treasurer,,REP,Stacy L. Garrity,20,2,0,22
+Cambria,ASHVILLE BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,21,1,0,22
+Cambria,ASHVILLE BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,21,2,0,23
+Cambria,ASHVILLE BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,ASHVILLE BOROUGH,General Assembly,72,REP,Howard Terndrup,12,0,0,12
+Cambria,ASHVILLE BOROUGH,General Assembly,72,REP,Jerry Carnicella,8,2,0,10
+Cambria,ASHVILLE BOROUGH,General Assembly,72,REP,Write-In,0,0,0,0
+Cambria,BARR TOWNSHIP,Registered Voters,,,,,,,1290
+Cambria,BARR TOWNSHIP,Registered Voters,,DEM,,,,,454
+Cambria,BARR TOWNSHIP,Registered Voters,,REP,,,,,743
+Cambria,BARR TOWNSHIP,Ballots Cast,,,,356,162,10,528
+Cambria,BARR TOWNSHIP,Ballots Cast,,DEM,,95,105,2,202
+Cambria,BARR TOWNSHIP,Ballots Cast,,REP,,261,57,8,326
+Cambria,BARR TOWNSHIP,President,,DEM,Bernie Sanders,15,6,0,21
+Cambria,BARR TOWNSHIP,President,,DEM,Joseph R. Biden,32,85,1,118
+Cambria,BARR TOWNSHIP,President,,DEM,Tulsi Gabbard,13,2,0,15
+Cambria,BARR TOWNSHIP,President,,DEM,Write-In,23,5,1,29
+Cambria,BARR TOWNSHIP,Attorney General,,DEM,Josh Shapiro,70,98,1,169
+Cambria,BARR TOWNSHIP,Attorney General,,DEM,Write-In,6,1,0,7
+Cambria,BARR TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,52,73,2,127
+Cambria,BARR TOWNSHIP,Auditor General,,DEM,Michael Lamb,19,18,0,37
+Cambria,BARR TOWNSHIP,Auditor General,,DEM,Tracie Fountain,5,2,0,7
+Cambria,BARR TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,3
+Cambria,BARR TOWNSHIP,Auditor General,,DEM,Nina Ahmad,2,3,0,5
+Cambria,BARR TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,3,2,0,5
+Cambria,BARR TOWNSHIP,Auditor General,,DEM,Write-In,4,1,0,5
+Cambria,BARR TOWNSHIP,State Treasurer,,DEM,Joe Torsella,68,94,1,163
+Cambria,BARR TOWNSHIP,State Treasurer,,DEM,Write-In,6,2,0,8
+Cambria,BARR TOWNSHIP,U.S. House,15,DEM,Robert Williams,70,92,1,163
+Cambria,BARR TOWNSHIP,U.S. House,15,DEM,Write-In,6,1,0,7
+Cambria,BARR TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,72,98,1,171
+Cambria,BARR TOWNSHIP,State Senator,35,DEM,Write-In,7,2,0,9
+Cambria,BARR TOWNSHIP,General Assembly,73,DEM,Write-In,13,6,1,20
+Cambria,BARR TOWNSHIP,President,,REP,Donald J. Trump,258,52,8,318
+Cambria,BARR TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,BARR TOWNSHIP,President,,REP,Bill Weld,1,4,0,5
+Cambria,BARR TOWNSHIP,President,,REP,Write-In,1,0,0,1
+Cambria,BARR TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,233,52,8,293
+Cambria,BARR TOWNSHIP,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,BARR TOWNSHIP,Auditor General,,REP,Timothy Defoor,234,51,8,293
+Cambria,BARR TOWNSHIP,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,BARR TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,233,53,8,294
+Cambria,BARR TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,BARR TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,235,53,8,296
+Cambria,BARR TOWNSHIP,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,BARR TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,240,55,7,302
+Cambria,BARR TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,BARR TOWNSHIP,General Assembly,73,REP,Tommy Sankey,230,57,7,294
+Cambria,BARR TOWNSHIP,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,Registered Voters,,,,,,,1169
+Cambria,BLACKLICK TOWNSHIP,Registered Voters,,DEM,,,,,544
+Cambria,BLACKLICK TOWNSHIP,Registered Voters,,REP,,,,,515
+Cambria,BLACKLICK TOWNSHIP,Ballots Cast,,,,251,138,6,395
+Cambria,BLACKLICK TOWNSHIP,Ballots Cast,,DEM,,99,88,0,187
+Cambria,BLACKLICK TOWNSHIP,Ballots Cast,,REP,,152,50,6,208
+Cambria,BLACKLICK TOWNSHIP,President,,DEM,Bernie Sanders,22,5,0,27
+Cambria,BLACKLICK TOWNSHIP,President,,DEM,Joseph R. Biden,50,73,0,123
+Cambria,BLACKLICK TOWNSHIP,President,,DEM,Tulsi Gabbard,13,2,0,15
+Cambria,BLACKLICK TOWNSHIP,President,,DEM,Write-In,6,3,0,9
+Cambria,BLACKLICK TOWNSHIP,Attorney General,,DEM,Josh Shapiro,90,85,0,175
+Cambria,BLACKLICK TOWNSHIP,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,50,50,0,100
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,DEM,Michael Lamb,16,24,0,40
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,DEM,Tracie Fountain,8,2,0,10
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,6,2,0,8
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,DEM,Nina Ahmad,2,1,0,3
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,7,8,0,15
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,State Treasurer,,DEM,Joe Torsella,86,85,0,171
+Cambria,BLACKLICK TOWNSHIP,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,U.S. House,15,DEM,Robert Williams,83,84,0,167
+Cambria,BLACKLICK TOWNSHIP,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,85,85,0,170
+Cambria,BLACKLICK TOWNSHIP,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,BLACKLICK TOWNSHIP,General Assembly,73,DEM,Write-In,6,9,0,15
+Cambria,BLACKLICK TOWNSHIP,President,,REP,Donald J. Trump,150,44,6,200
+Cambria,BLACKLICK TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Cambria,BLACKLICK TOWNSHIP,President,,REP,Bill Weld,1,1,0,2
+Cambria,BLACKLICK TOWNSHIP,President,,REP,Write-In,1,1,0,2
+Cambria,BLACKLICK TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,136,47,5,188
+Cambria,BLACKLICK TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,REP,Timothy Defoor,135,47,5,187
+Cambria,BLACKLICK TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,136,48,5,189
+Cambria,BLACKLICK TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,142,47,5,194
+Cambria,BLACKLICK TOWNSHIP,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,BLACKLICK TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,145,48,6,199
+Cambria,BLACKLICK TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,BLACKLICK TOWNSHIP,General Assembly,73,REP,Tommy Sankey,138,47,5,190
+Cambria,BLACKLICK TOWNSHIP,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,BROWNSTOWN BOROUGH,Registered Voters,,,,,,,474
+Cambria,BROWNSTOWN BOROUGH,Registered Voters,,DEM,,,,,258
+Cambria,BROWNSTOWN BOROUGH,Registered Voters,,REP,,,,,180
+Cambria,BROWNSTOWN BOROUGH,Ballots Cast,,,,112,97,1,210
+Cambria,BROWNSTOWN BOROUGH,Ballots Cast,,DEM,,55,60,0,115
+Cambria,BROWNSTOWN BOROUGH,Ballots Cast,,REP,,57,37,1,95
+Cambria,BROWNSTOWN BOROUGH,President,,DEM,Bernie Sanders,13,12,0,25
+Cambria,BROWNSTOWN BOROUGH,President,,DEM,Joseph R. Biden,26,44,0,70
+Cambria,BROWNSTOWN BOROUGH,President,,DEM,Tulsi Gabbard,2,2,0,4
+Cambria,BROWNSTOWN BOROUGH,President,,DEM,Write-In,3,1,0,4
+Cambria,BROWNSTOWN BOROUGH,Attorney General,,DEM,Josh Shapiro,47,58,0,105
+Cambria,BROWNSTOWN BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,DEM,H. Scott Conklin,22,34,0,56
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,DEM,Michael Lamb,18,15,0,33
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,2
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,DEM,Nina Ahmad,1,3,0,4
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,DEM,Christina M. Hartman,4,2,0,6
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,BROWNSTOWN BOROUGH,State Treasurer,,DEM,Joe Torsella,43,57,0,100
+Cambria,BROWNSTOWN BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,BROWNSTOWN BOROUGH,U.S. House,13,DEM,Todd Rowley,44,56,0,100
+Cambria,BROWNSTOWN BOROUGH,U.S. House,13,DEM,Write-In,0,1,0,1
+Cambria,BROWNSTOWN BOROUGH,State Senator,35,DEM,Shaun Dougherty,44,58,0,102
+Cambria,BROWNSTOWN BOROUGH,State Senator,35,DEM,Write-In,1,1,0,2
+Cambria,BROWNSTOWN BOROUGH,General Assembly,71,DEM,Write-In,14,6,0,20
+Cambria,BROWNSTOWN BOROUGH,President,,REP,Donald J. Trump,53,36,1,90
+Cambria,BROWNSTOWN BOROUGH,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,BROWNSTOWN BOROUGH,President,,REP,Bill Weld,1,0,0,1
+Cambria,BROWNSTOWN BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,BROWNSTOWN BOROUGH,Attorney General,,REP,Heather Heidelbaugh,52,30,1,83
+Cambria,BROWNSTOWN BOROUGH,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,REP,Timothy Defoor,49,29,1,79
+Cambria,BROWNSTOWN BOROUGH,Auditor General,,REP,Write-In,1,1,0,2
+Cambria,BROWNSTOWN BOROUGH,State Treasurer,,REP,Stacy L. Garrity,51,30,1,82
+Cambria,BROWNSTOWN BOROUGH,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,BROWNSTOWN BOROUGH,U.S. House,13,REP,John Joyce,52,34,1,87
+Cambria,BROWNSTOWN BOROUGH,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,BROWNSTOWN BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,55,33,1,89
+Cambria,BROWNSTOWN BOROUGH,State Senator,35,REP,Write-In,0,2,0,2
+Cambria,BROWNSTOWN BOROUGH,General Assembly,71,REP,Jim Rigby,57,37,1,95
+Cambria,BROWNSTOWN BOROUGH,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 1,Registered Voters,,,,,,,1173
+Cambria,CAMBRIA TOWNSHIP NO. 1,Registered Voters,,DEM,,,,,579
+Cambria,CAMBRIA TOWNSHIP NO. 1,Registered Voters,,REP,,,,,506
+Cambria,CAMBRIA TOWNSHIP NO. 1,Ballots Cast,,,,235,230,3,468
+Cambria,CAMBRIA TOWNSHIP NO. 1,Ballots Cast,,DEM,,87,166,0,253
+Cambria,CAMBRIA TOWNSHIP NO. 1,Ballots Cast,,REP,,148,64,3,215
+Cambria,CAMBRIA TOWNSHIP NO. 1,President,,DEM,Bernie Sanders,5,20,0,25
+Cambria,CAMBRIA TOWNSHIP NO. 1,President,,DEM,Joseph R. Biden,49,111,0,160
+Cambria,CAMBRIA TOWNSHIP NO. 1,President,,DEM,Tulsi Gabbard,12,13,0,25
+Cambria,CAMBRIA TOWNSHIP NO. 1,President,,DEM,Write-In,10,10,0,20
+Cambria,CAMBRIA TOWNSHIP NO. 1,Attorney General,,DEM,Josh Shapiro,70,150,0,220
+Cambria,CAMBRIA TOWNSHIP NO. 1,Attorney General,,DEM,Write-In,1,2,0,3
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,DEM,H. Scott Conklin,59,82,0,141
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,DEM,Michael Lamb,13,38,0,51
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,5
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,DEM,Nina Ahmad,0,14,0,14
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,DEM,Christina M. Hartman,2,15,0,17
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,DEM,Write-In,1,2,0,3
+Cambria,CAMBRIA TOWNSHIP NO. 1,State Treasurer,,DEM,Joe Torsella,69,148,0,217
+Cambria,CAMBRIA TOWNSHIP NO. 1,State Treasurer,,DEM,Write-In,1,3,0,4
+Cambria,CAMBRIA TOWNSHIP NO. 1,U.S. House,15,DEM,Robert Williams,66,149,0,215
+Cambria,CAMBRIA TOWNSHIP NO. 1,U.S. House,15,DEM,Write-In,1,3,0,4
+Cambria,CAMBRIA TOWNSHIP NO. 1,State Senator,35,DEM,Shaun Dougherty,70,147,0,217
+Cambria,CAMBRIA TOWNSHIP NO. 1,State Senator,35,DEM,Write-In,2,5,0,7
+Cambria,CAMBRIA TOWNSHIP NO. 1,General Assembly,72,DEM,Frank Burns,75,155,0,230
+Cambria,CAMBRIA TOWNSHIP NO. 1,General Assembly,72,DEM,Write-In,3,3,0,6
+Cambria,CAMBRIA TOWNSHIP NO. 1,President,,REP,Donald J. Trump,143,55,3,201
+Cambria,CAMBRIA TOWNSHIP NO. 1,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP NO. 1,President,,REP,Bill Weld,1,2,0,3
+Cambria,CAMBRIA TOWNSHIP NO. 1,President,,REP,Write-In,0,2,0,2
+Cambria,CAMBRIA TOWNSHIP NO. 1,Attorney General,,REP,Heather Heidelbaugh,134,58,3,195
+Cambria,CAMBRIA TOWNSHIP NO. 1,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,REP,Timothy Defoor,131,57,3,191
+Cambria,CAMBRIA TOWNSHIP NO. 1,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 1,State Treasurer,,REP,Stacy L. Garrity,129,55,3,187
+Cambria,CAMBRIA TOWNSHIP NO. 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 1,U.S. House,15,REP,Glenn Gt Thompson,136,60,3,199
+Cambria,CAMBRIA TOWNSHIP NO. 1,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,138,61,3,202
+Cambria,CAMBRIA TOWNSHIP NO. 1,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP NO. 1,General Assembly,72,REP,Howard Terndrup,116,53,2,171
+Cambria,CAMBRIA TOWNSHIP NO. 1,General Assembly,72,REP,Jerry Carnicella,22,9,1,32
+Cambria,CAMBRIA TOWNSHIP NO. 1,General Assembly,72,REP,Write-In,7,0,0,7
+Cambria,CAMBRIA TOWNSHIP - COLVER,Registered Voters,,,,,,,791
+Cambria,CAMBRIA TOWNSHIP - COLVER,Registered Voters,,DEM,,,,,389
+Cambria,CAMBRIA TOWNSHIP - COLVER,Registered Voters,,REP,,,,,337
+Cambria,CAMBRIA TOWNSHIP - COLVER,Ballots Cast,,,,255,92,0,347
+Cambria,CAMBRIA TOWNSHIP - COLVER,Ballots Cast,,DEM,,127,65,0,192
+Cambria,CAMBRIA TOWNSHIP - COLVER,Ballots Cast,,REP,,128,27,0,155
+Cambria,CAMBRIA TOWNSHIP - COLVER,President,,DEM,Bernie Sanders,18,10,0,28
+Cambria,CAMBRIA TOWNSHIP - COLVER,President,,DEM,Joseph R. Biden,46,43,0,89
+Cambria,CAMBRIA TOWNSHIP - COLVER,President,,DEM,Tulsi Gabbard,15,4,0,19
+Cambria,CAMBRIA TOWNSHIP - COLVER,President,,DEM,Write-In,32,3,0,35
+Cambria,CAMBRIA TOWNSHIP - COLVER,Attorney General,,DEM,Josh Shapiro,103,61,0,164
+Cambria,CAMBRIA TOWNSHIP - COLVER,Attorney General,,DEM,Write-In,8,1,0,9
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,DEM,H. Scott Conklin,71,34,0,105
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,DEM,Michael Lamb,16,16,0,32
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,DEM,Tracie Fountain,3,2,0,5
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,DEM,Rose Rosie Marie Davis,4,3,0,7
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,DEM,Nina Ahmad,5,4,0,9
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,DEM,Christina M. Hartman,5,3,0,8
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,DEM,Write-In,8,0,0,8
+Cambria,CAMBRIA TOWNSHIP - COLVER,State Treasurer,,DEM,Joe Torsella,97,60,0,157
+Cambria,CAMBRIA TOWNSHIP - COLVER,State Treasurer,,DEM,Write-In,9,0,0,9
+Cambria,CAMBRIA TOWNSHIP - COLVER,U.S. House,15,DEM,Robert Williams,102,57,0,159
+Cambria,CAMBRIA TOWNSHIP - COLVER,U.S. House,15,DEM,Write-In,10,1,0,11
+Cambria,CAMBRIA TOWNSHIP - COLVER,State Senator,35,DEM,Shaun Dougherty,99,58,0,157
+Cambria,CAMBRIA TOWNSHIP - COLVER,State Senator,35,DEM,Write-In,9,0,0,9
+Cambria,CAMBRIA TOWNSHIP - COLVER,General Assembly,72,DEM,Frank Burns,117,60,0,177
+Cambria,CAMBRIA TOWNSHIP - COLVER,General Assembly,72,DEM,Write-In,7,3,0,10
+Cambria,CAMBRIA TOWNSHIP - COLVER,President,,REP,Donald J. Trump,124,23,0,147
+Cambria,CAMBRIA TOWNSHIP - COLVER,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Cambria,CAMBRIA TOWNSHIP - COLVER,President,,REP,Bill Weld,2,2,0,4
+Cambria,CAMBRIA TOWNSHIP - COLVER,President,,REP,Write-In,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP - COLVER,Attorney General,,REP,Heather Heidelbaugh,113,23,0,136
+Cambria,CAMBRIA TOWNSHIP - COLVER,Attorney General,,REP,Write-In,3,0,0,3
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,REP,Timothy Defoor,111,23,0,134
+Cambria,CAMBRIA TOWNSHIP - COLVER,Auditor General,,REP,Write-In,3,0,0,3
+Cambria,CAMBRIA TOWNSHIP - COLVER,State Treasurer,,REP,Stacy L. Garrity,113,23,0,136
+Cambria,CAMBRIA TOWNSHIP - COLVER,State Treasurer,,REP,Write-In,2,0,0,2
+Cambria,CAMBRIA TOWNSHIP - COLVER,U.S. House,15,REP,Glenn Gt Thompson,118,27,0,145
+Cambria,CAMBRIA TOWNSHIP - COLVER,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,CAMBRIA TOWNSHIP - COLVER,State Senator,35,REP,Wayne Langerholc Jr.,118,25,0,143
+Cambria,CAMBRIA TOWNSHIP - COLVER,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP - COLVER,General Assembly,72,REP,Howard Terndrup,87,20,0,107
+Cambria,CAMBRIA TOWNSHIP - COLVER,General Assembly,72,REP,Jerry Carnicella,29,5,0,34
+Cambria,CAMBRIA TOWNSHIP - COLVER,General Assembly,72,REP,Write-In,11,1,0,12
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Registered Voters,,,,,,,498
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Registered Voters,,DEM,,,,,244
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Registered Voters,,REP,,,,,215
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Ballots Cast,,,,144,59,5,208
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Ballots Cast,,DEM,,73,43,1,117
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Ballots Cast,,REP,,71,16,4,91
+Cambria,CAMBRIA TOWNSHIP - REVLOC,President,,DEM,Bernie Sanders,15,3,0,18
+Cambria,CAMBRIA TOWNSHIP - REVLOC,President,,DEM,Joseph R. Biden,30,33,1,64
+Cambria,CAMBRIA TOWNSHIP - REVLOC,President,,DEM,Tulsi Gabbard,7,3,0,10
+Cambria,CAMBRIA TOWNSHIP - REVLOC,President,,DEM,Write-In,13,2,0,15
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Attorney General,,DEM,Josh Shapiro,61,41,1,103
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,DEM,H. Scott Conklin,48,32,1,81
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,DEM,Michael Lamb,7,6,0,13
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,DEM,Tracie Fountain,6,2,0,8
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,3
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,DEM,Nina Ahmad,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,DEM,Christina M. Hartman,3,1,0,4
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP - REVLOC,State Treasurer,,DEM,Joe Torsella,59,38,1,98
+Cambria,CAMBRIA TOWNSHIP - REVLOC,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,CAMBRIA TOWNSHIP - REVLOC,U.S. House,15,DEM,Robert Williams,59,39,1,99
+Cambria,CAMBRIA TOWNSHIP - REVLOC,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,CAMBRIA TOWNSHIP - REVLOC,State Senator,35,DEM,Shaun Dougherty,58,39,1,98
+Cambria,CAMBRIA TOWNSHIP - REVLOC,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,CAMBRIA TOWNSHIP - REVLOC,General Assembly,72,DEM,Frank Burns,64,41,1,106
+Cambria,CAMBRIA TOWNSHIP - REVLOC,General Assembly,72,DEM,Write-In,3,0,0,3
+Cambria,CAMBRIA TOWNSHIP - REVLOC,President,,REP,Donald J. Trump,69,13,4,86
+Cambria,CAMBRIA TOWNSHIP - REVLOC,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Cambria,CAMBRIA TOWNSHIP - REVLOC,President,,REP,Bill Weld,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP - REVLOC,President,,REP,Write-In,1,2,0,3
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Attorney General,,REP,Heather Heidelbaugh,67,11,4,82
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,REP,Timothy Defoor,67,11,4,82
+Cambria,CAMBRIA TOWNSHIP - REVLOC,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP - REVLOC,State Treasurer,,REP,Stacy L. Garrity,65,12,4,81
+Cambria,CAMBRIA TOWNSHIP - REVLOC,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP - REVLOC,U.S. House,15,REP,Glenn Gt Thompson,65,12,4,81
+Cambria,CAMBRIA TOWNSHIP - REVLOC,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP - REVLOC,State Senator,35,REP,Wayne Langerholc Jr.,67,13,4,84
+Cambria,CAMBRIA TOWNSHIP - REVLOC,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP - REVLOC,General Assembly,72,REP,Howard Terndrup,54,10,4,68
+Cambria,CAMBRIA TOWNSHIP - REVLOC,General Assembly,72,REP,Jerry Carnicella,16,3,0,19
+Cambria,CAMBRIA TOWNSHIP - REVLOC,General Assembly,72,REP,Write-In,1,1,0,2
+Cambria,CAMBRIA TOWNSHIP NO. 4,Registered Voters,,,,,,,1013
+Cambria,CAMBRIA TOWNSHIP NO. 4,Registered Voters,,DEM,,,,,428
+Cambria,CAMBRIA TOWNSHIP NO. 4,Registered Voters,,REP,,,,,491
+Cambria,CAMBRIA TOWNSHIP NO. 4,Ballots Cast,,,,238,160,0,398
+Cambria,CAMBRIA TOWNSHIP NO. 4,Ballots Cast,,DEM,,86,100,0,186
+Cambria,CAMBRIA TOWNSHIP NO. 4,Ballots Cast,,REP,,152,60,0,212
+Cambria,CAMBRIA TOWNSHIP NO. 4,President,,DEM,Bernie Sanders,19,6,0,25
+Cambria,CAMBRIA TOWNSHIP NO. 4,President,,DEM,Joseph R. Biden,37,78,0,115
+Cambria,CAMBRIA TOWNSHIP NO. 4,President,,DEM,Tulsi Gabbard,5,9,0,14
+Cambria,CAMBRIA TOWNSHIP NO. 4,President,,DEM,Write-In,19,3,0,22
+Cambria,CAMBRIA TOWNSHIP NO. 4,Attorney General,,DEM,Josh Shapiro,74,93,0,167
+Cambria,CAMBRIA TOWNSHIP NO. 4,Attorney General,,DEM,Write-In,2,1,0,3
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,DEM,H. Scott Conklin,54,51,0,105
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,DEM,Michael Lamb,17,23,0,40
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,DEM,Tracie Fountain,3,5,0,8
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,DEM,Rose Rosie Marie Davis,0,5,0,5
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,DEM,Nina Ahmad,2,2,0,4
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,DEM,Christina M. Hartman,3,7,0,10
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,DEM,Write-In,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP NO. 4,State Treasurer,,DEM,Joe Torsella,70,91,0,161
+Cambria,CAMBRIA TOWNSHIP NO. 4,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP NO. 4,U.S. House,15,DEM,Robert Williams,70,90,0,160
+Cambria,CAMBRIA TOWNSHIP NO. 4,U.S. House,15,DEM,Write-In,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP NO. 4,State Senator,35,DEM,Shaun Dougherty,73,92,0,165
+Cambria,CAMBRIA TOWNSHIP NO. 4,State Senator,35,DEM,Write-In,0,2,0,2
+Cambria,CAMBRIA TOWNSHIP NO. 4,General Assembly,72,DEM,Frank Burns,80,93,0,173
+Cambria,CAMBRIA TOWNSHIP NO. 4,General Assembly,72,DEM,Write-In,5,2,0,7
+Cambria,CAMBRIA TOWNSHIP NO. 4,President,,REP,Donald J. Trump,145,53,0,198
+Cambria,CAMBRIA TOWNSHIP NO. 4,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,CAMBRIA TOWNSHIP NO. 4,President,,REP,Bill Weld,4,4,0,8
+Cambria,CAMBRIA TOWNSHIP NO. 4,President,,REP,Write-In,2,0,0,2
+Cambria,CAMBRIA TOWNSHIP NO. 4,Attorney General,,REP,Heather Heidelbaugh,132,53,0,185
+Cambria,CAMBRIA TOWNSHIP NO. 4,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,REP,Timothy Defoor,132,55,0,187
+Cambria,CAMBRIA TOWNSHIP NO. 4,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 4,State Treasurer,,REP,Stacy L. Garrity,131,53,0,184
+Cambria,CAMBRIA TOWNSHIP NO. 4,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 4,U.S. House,15,REP,Glenn Gt Thompson,139,56,0,195
+Cambria,CAMBRIA TOWNSHIP NO. 4,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 4,State Senator,35,REP,Wayne Langerholc Jr.,136,57,0,193
+Cambria,CAMBRIA TOWNSHIP NO. 4,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CAMBRIA TOWNSHIP NO. 4,General Assembly,72,REP,Howard Terndrup,124,46,0,170
+Cambria,CAMBRIA TOWNSHIP NO. 4,General Assembly,72,REP,Jerry Carnicella,24,12,0,36
+Cambria,CAMBRIA TOWNSHIP NO. 4,General Assembly,72,REP,Write-In,4,1,0,5
+Cambria,CARROLLTOWN BOROUGH,Registered Voters,,,,,,,704
+Cambria,CARROLLTOWN BOROUGH,Registered Voters,,DEM,,,,,342
+Cambria,CARROLLTOWN BOROUGH,Registered Voters,,REP,,,,,292
+Cambria,CARROLLTOWN BOROUGH,Ballots Cast,,,,181,87,6,274
+Cambria,CARROLLTOWN BOROUGH,Ballots Cast,,DEM,,66,72,2,140
+Cambria,CARROLLTOWN BOROUGH,Ballots Cast,,REP,,115,15,4,134
+Cambria,CARROLLTOWN BOROUGH,President,,DEM,Bernie Sanders,10,6,1,17
+Cambria,CARROLLTOWN BOROUGH,President,,DEM,Joseph R. Biden,33,57,0,90
+Cambria,CARROLLTOWN BOROUGH,President,,DEM,Tulsi Gabbard,5,5,1,11
+Cambria,CARROLLTOWN BOROUGH,President,,DEM,Write-In,10,3,0,13
+Cambria,CARROLLTOWN BOROUGH,Attorney General,,DEM,Josh Shapiro,55,64,2,121
+Cambria,CARROLLTOWN BOROUGH,Attorney General,,DEM,Write-In,4,0,0,4
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,DEM,H. Scott Conklin,30,43,1,74
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,DEM,Michael Lamb,16,13,0,29
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,DEM,Tracie Fountain,2,3,0,5
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,3
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,DEM,Nina Ahmad,2,3,0,5
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,DEM,Christina M. Hartman,5,4,1,10
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,DEM,Write-In,3,0,0,3
+Cambria,CARROLLTOWN BOROUGH,State Treasurer,,DEM,Joe Torsella,56,64,2,122
+Cambria,CARROLLTOWN BOROUGH,State Treasurer,,DEM,Write-In,5,0,0,5
+Cambria,CARROLLTOWN BOROUGH,U.S. House,15,DEM,Robert Williams,50,62,2,114
+Cambria,CARROLLTOWN BOROUGH,U.S. House,15,DEM,Write-In,5,0,0,5
+Cambria,CARROLLTOWN BOROUGH,State Senator,35,DEM,Shaun Dougherty,53,60,2,115
+Cambria,CARROLLTOWN BOROUGH,State Senator,35,DEM,Write-In,4,1,0,5
+Cambria,CARROLLTOWN BOROUGH,General Assembly,72,DEM,Frank Burns,57,64,2,123
+Cambria,CARROLLTOWN BOROUGH,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,CARROLLTOWN BOROUGH,President,,REP,Donald J. Trump,113,14,3,130
+Cambria,CARROLLTOWN BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,CARROLLTOWN BOROUGH,President,,REP,Bill Weld,1,1,1,3
+Cambria,CARROLLTOWN BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,CARROLLTOWN BOROUGH,Attorney General,,REP,Heather Heidelbaugh,103,14,3,120
+Cambria,CARROLLTOWN BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,REP,Timothy Defoor,97,14,3,114
+Cambria,CARROLLTOWN BOROUGH,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,CARROLLTOWN BOROUGH,State Treasurer,,REP,Stacy L. Garrity,98,14,3,115
+Cambria,CARROLLTOWN BOROUGH,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,CARROLLTOWN BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,105,14,3,122
+Cambria,CARROLLTOWN BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CARROLLTOWN BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,104,13,3,120
+Cambria,CARROLLTOWN BOROUGH,State Senator,35,REP,Write-In,1,1,0,2
+Cambria,CARROLLTOWN BOROUGH,General Assembly,72,REP,Howard Terndrup,67,11,3,81
+Cambria,CARROLLTOWN BOROUGH,General Assembly,72,REP,Jerry Carnicella,43,3,0,46
+Cambria,CARROLLTOWN BOROUGH,General Assembly,72,REP,Write-In,4,0,1,5
+Cambria,CASSANDRA BOROUGH,Registered Voters,,,,,,,98
+Cambria,CASSANDRA BOROUGH,Registered Voters,,DEM,,,,,44
+Cambria,CASSANDRA BOROUGH,Registered Voters,,REP,,,,,45
+Cambria,CASSANDRA BOROUGH,Ballots Cast,,,,32,12,0,44
+Cambria,CASSANDRA BOROUGH,Ballots Cast,,DEM,,9,7,0,16
+Cambria,CASSANDRA BOROUGH,Ballots Cast,,REP,,23,5,0,28
+Cambria,CASSANDRA BOROUGH,President,,DEM,Bernie Sanders,0,0,0,0
+Cambria,CASSANDRA BOROUGH,President,,DEM,Joseph R. Biden,3,5,0,8
+Cambria,CASSANDRA BOROUGH,President,,DEM,Tulsi Gabbard,2,2,0,4
+Cambria,CASSANDRA BOROUGH,President,,DEM,Write-In,3,0,0,3
+Cambria,CASSANDRA BOROUGH,Attorney General,,DEM,Josh Shapiro,6,7,0,13
+Cambria,CASSANDRA BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,CASSANDRA BOROUGH,Auditor General,,DEM,H. Scott Conklin,6,7,0,13
+Cambria,CASSANDRA BOROUGH,Auditor General,,DEM,Michael Lamb,1,0,0,1
+Cambria,CASSANDRA BOROUGH,Auditor General,,DEM,Tracie Fountain,0,0,0,0
+Cambria,CASSANDRA BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,CASSANDRA BOROUGH,Auditor General,,DEM,Nina Ahmad,0,0,0,0
+Cambria,CASSANDRA BOROUGH,Auditor General,,DEM,Christina M. Hartman,1,0,0,1
+Cambria,CASSANDRA BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,CASSANDRA BOROUGH,State Treasurer,,DEM,Joe Torsella,4,7,0,11
+Cambria,CASSANDRA BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,CASSANDRA BOROUGH,U.S. House,15,DEM,Robert Williams,5,6,0,11
+Cambria,CASSANDRA BOROUGH,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,CASSANDRA BOROUGH,State Senator,35,DEM,Shaun Dougherty,7,6,0,13
+Cambria,CASSANDRA BOROUGH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,CASSANDRA BOROUGH,General Assembly,72,DEM,Frank Burns,7,7,0,14
+Cambria,CASSANDRA BOROUGH,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,CASSANDRA BOROUGH,President,,REP,Donald J. Trump,23,4,0,27
+Cambria,CASSANDRA BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,CASSANDRA BOROUGH,President,,REP,Bill Weld,0,0,0,0
+Cambria,CASSANDRA BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,CASSANDRA BOROUGH,Attorney General,,REP,Heather Heidelbaugh,21,5,0,26
+Cambria,CASSANDRA BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CASSANDRA BOROUGH,Auditor General,,REP,Timothy Defoor,19,5,0,24
+Cambria,CASSANDRA BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CASSANDRA BOROUGH,State Treasurer,,REP,Stacy L. Garrity,20,5,0,25
+Cambria,CASSANDRA BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CASSANDRA BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,20,5,0,25
+Cambria,CASSANDRA BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CASSANDRA BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,22,5,0,27
+Cambria,CASSANDRA BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CASSANDRA BOROUGH,General Assembly,72,REP,Howard Terndrup,10,3,0,13
+Cambria,CASSANDRA BOROUGH,General Assembly,72,REP,Jerry Carnicella,9,2,0,11
+Cambria,CASSANDRA BOROUGH,General Assembly,72,REP,Write-In,1,0,0,1
+Cambria,CHEST SPRINGS BOROUGH,Registered Voters,,,,,,,101
+Cambria,CHEST SPRINGS BOROUGH,Registered Voters,,DEM,,,,,45
+Cambria,CHEST SPRINGS BOROUGH,Registered Voters,,REP,,,,,47
+Cambria,CHEST SPRINGS BOROUGH,Ballots Cast,,,,44,7,0,51
+Cambria,CHEST SPRINGS BOROUGH,Ballots Cast,,DEM,,22,4,0,26
+Cambria,CHEST SPRINGS BOROUGH,Ballots Cast,,REP,,22,3,0,25
+Cambria,CHEST SPRINGS BOROUGH,President,,DEM,Bernie Sanders,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,President,,DEM,Joseph R. Biden,12,3,0,15
+Cambria,CHEST SPRINGS BOROUGH,President,,DEM,Tulsi Gabbard,2,0,0,2
+Cambria,CHEST SPRINGS BOROUGH,President,,DEM,Write-In,5,1,0,6
+Cambria,CHEST SPRINGS BOROUGH,Attorney General,,DEM,Josh Shapiro,20,3,0,23
+Cambria,CHEST SPRINGS BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,DEM,H. Scott Conklin,19,3,0,22
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,DEM,Michael Lamb,3,1,0,4
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,DEM,Tracie Fountain,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,DEM,Nina Ahmad,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,DEM,Christina M. Hartman,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,State Treasurer,,DEM,Joe Torsella,18,3,0,21
+Cambria,CHEST SPRINGS BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,U.S. House,15,DEM,Robert Williams,18,3,0,21
+Cambria,CHEST SPRINGS BOROUGH,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,CHEST SPRINGS BOROUGH,State Senator,35,DEM,Shaun Dougherty,19,3,0,22
+Cambria,CHEST SPRINGS BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,CHEST SPRINGS BOROUGH,General Assembly,72,DEM,Frank Burns,18,4,0,22
+Cambria,CHEST SPRINGS BOROUGH,General Assembly,72,DEM,Write-In,2,0,0,2
+Cambria,CHEST SPRINGS BOROUGH,President,,REP,Donald J. Trump,21,2,0,23
+Cambria,CHEST SPRINGS BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,President,,REP,Bill Weld,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,President,,REP,Write-In,0,1,0,1
+Cambria,CHEST SPRINGS BOROUGH,Attorney General,,REP,Heather Heidelbaugh,19,2,0,21
+Cambria,CHEST SPRINGS BOROUGH,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,REP,Timothy Defoor,19,2,0,21
+Cambria,CHEST SPRINGS BOROUGH,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,CHEST SPRINGS BOROUGH,State Treasurer,,REP,Stacy L. Garrity,18,2,0,20
+Cambria,CHEST SPRINGS BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,19,3,0,22
+Cambria,CHEST SPRINGS BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,21,3,0,24
+Cambria,CHEST SPRINGS BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CHEST SPRINGS BOROUGH,General Assembly,72,REP,Howard Terndrup,14,2,0,16
+Cambria,CHEST SPRINGS BOROUGH,General Assembly,72,REP,Jerry Carnicella,6,1,0,7
+Cambria,CHEST SPRINGS BOROUGH,General Assembly,72,REP,Write-In,2,0,0,2
+Cambria,CHEST TOWNSHIP,Registered Voters,,,,,,,301
+Cambria,CHEST TOWNSHIP,Registered Voters,,DEM,,,,,95
+Cambria,CHEST TOWNSHIP,Registered Voters,,REP,,,,,169
+Cambria,CHEST TOWNSHIP,Ballots Cast,,,,53,39,5,97
+Cambria,CHEST TOWNSHIP,Ballots Cast,,DEM,,5,23,0,28
+Cambria,CHEST TOWNSHIP,Ballots Cast,,REP,,48,16,5,69
+Cambria,CHEST TOWNSHIP,President,,DEM,Bernie Sanders,1,5,0,6
+Cambria,CHEST TOWNSHIP,President,,DEM,Joseph R. Biden,4,15,0,19
+Cambria,CHEST TOWNSHIP,President,,DEM,Tulsi Gabbard,0,2,0,2
+Cambria,CHEST TOWNSHIP,President,,DEM,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,Attorney General,,DEM,Josh Shapiro,5,21,0,26
+Cambria,CHEST TOWNSHIP,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,4,14,0,18
+Cambria,CHEST TOWNSHIP,Auditor General,,DEM,Michael Lamb,1,3,0,4
+Cambria,CHEST TOWNSHIP,Auditor General,,DEM,Tracie Fountain,0,0,0,0
+Cambria,CHEST TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,CHEST TOWNSHIP,Auditor General,,DEM,Nina Ahmad,0,2,0,2
+Cambria,CHEST TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,0,3,0,3
+Cambria,CHEST TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,State Treasurer,,DEM,Joe Torsella,4,21,0,25
+Cambria,CHEST TOWNSHIP,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,U.S. House,15,DEM,Robert Williams,3,21,0,24
+Cambria,CHEST TOWNSHIP,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,3,20,0,23
+Cambria,CHEST TOWNSHIP,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,General Assembly,72,DEM,Frank Burns,5,21,0,26
+Cambria,CHEST TOWNSHIP,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,President,,REP,Donald J. Trump,48,13,5,66
+Cambria,CHEST TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,CHEST TOWNSHIP,President,,REP,Bill Weld,0,2,0,2
+Cambria,CHEST TOWNSHIP,President,,REP,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,41,14,3,58
+Cambria,CHEST TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,Auditor General,,REP,Timothy Defoor,40,15,3,58
+Cambria,CHEST TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,41,15,3,59
+Cambria,CHEST TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CHEST TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,42,15,4,61
+Cambria,CHEST TOWNSHIP,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,CHEST TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,40,16,5,61
+Cambria,CHEST TOWNSHIP,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,CHEST TOWNSHIP,General Assembly,72,REP,Howard Terndrup,23,9,1,33
+Cambria,CHEST TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,22,7,4,33
+Cambria,CHEST TOWNSHIP,General Assembly,72,REP,Write-In,1,0,0,1
+Cambria,CLEARFIELD TOWNSHIP,Registered Voters,,,,,,,1014
+Cambria,CLEARFIELD TOWNSHIP,Registered Voters,,DEM,,,,,419
+Cambria,CLEARFIELD TOWNSHIP,Registered Voters,,REP,,,,,508
+Cambria,CLEARFIELD TOWNSHIP,Ballots Cast,,,,240,122,5,367
+Cambria,CLEARFIELD TOWNSHIP,Ballots Cast,,DEM,,98,76,4,178
+Cambria,CLEARFIELD TOWNSHIP,Ballots Cast,,REP,,142,46,1,189
+Cambria,CLEARFIELD TOWNSHIP,President,,DEM,Bernie Sanders,13,9,0,22
+Cambria,CLEARFIELD TOWNSHIP,President,,DEM,Joseph R. Biden,51,53,2,106
+Cambria,CLEARFIELD TOWNSHIP,President,,DEM,Tulsi Gabbard,11,6,0,17
+Cambria,CLEARFIELD TOWNSHIP,President,,DEM,Write-In,15,5,2,22
+Cambria,CLEARFIELD TOWNSHIP,Attorney General,,DEM,Josh Shapiro,85,68,3,156
+Cambria,CLEARFIELD TOWNSHIP,Attorney General,,DEM,Write-In,3,0,0,3
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,61,51,3,115
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,DEM,Michael Lamb,18,11,0,29
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,DEM,Tracie Fountain,0,2,0,2
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,0,6
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,DEM,Nina Ahmad,1,2,0,3
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,8,2,0,10
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,CLEARFIELD TOWNSHIP,State Treasurer,,DEM,Joe Torsella,82,65,3,150
+Cambria,CLEARFIELD TOWNSHIP,State Treasurer,,DEM,Write-In,2,0,1,3
+Cambria,CLEARFIELD TOWNSHIP,U.S. House,15,DEM,Robert Williams,87,69,3,159
+Cambria,CLEARFIELD TOWNSHIP,U.S. House,15,DEM,Write-In,2,0,1,3
+Cambria,CLEARFIELD TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,82,68,3,153
+Cambria,CLEARFIELD TOWNSHIP,State Senator,35,DEM,Write-In,2,0,1,3
+Cambria,CLEARFIELD TOWNSHIP,General Assembly,72,DEM,Frank Burns,84,68,3,155
+Cambria,CLEARFIELD TOWNSHIP,General Assembly,72,DEM,Write-In,7,4,1,12
+Cambria,CLEARFIELD TOWNSHIP,President,,REP,Donald J. Trump,138,43,1,182
+Cambria,CLEARFIELD TOWNSHIP,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Cambria,CLEARFIELD TOWNSHIP,President,,REP,Bill Weld,1,0,0,1
+Cambria,CLEARFIELD TOWNSHIP,President,,REP,Write-In,0,0,0,0
+Cambria,CLEARFIELD TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,131,42,1,174
+Cambria,CLEARFIELD TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,REP,Timothy Defoor,129,43,1,173
+Cambria,CLEARFIELD TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CLEARFIELD TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,128,43,1,172
+Cambria,CLEARFIELD TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CLEARFIELD TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,130,43,1,174
+Cambria,CLEARFIELD TOWNSHIP,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CLEARFIELD TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,131,42,1,174
+Cambria,CLEARFIELD TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CLEARFIELD TOWNSHIP,General Assembly,72,REP,Howard Terndrup,77,34,1,112
+Cambria,CLEARFIELD TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,60,12,0,72
+Cambria,CLEARFIELD TOWNSHIP,General Assembly,72,REP,Write-In,3,0,0,3
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Registered Voters,,,,,,,618
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Registered Voters,,DEM,,,,,294
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Registered Voters,,REP,,,,,276
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Ballots Cast,,,,161,84,4,249
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Ballots Cast,,DEM,,62,58,2,122
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Ballots Cast,,REP,,99,26,2,127
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,President,,DEM,Bernie Sanders,16,4,0,20
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,President,,DEM,Joseph R. Biden,21,46,1,68
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,President,,DEM,Tulsi Gabbard,6,3,0,9
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,President,,DEM,Write-In,5,3,0,8
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Attorney General,,DEM,Josh Shapiro,55,54,2,111
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,DEM,H. Scott Conklin,24,29,2,55
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,DEM,Michael Lamb,25,21,0,46
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,DEM,Tracie Fountain,2,0,0,2
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,DEM,Rose Rosie Marie Davis,5,0,0,5
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,DEM,Christina M. Hartman,1,4,0,5
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,State Treasurer,,DEM,Joe Torsella,50,51,2,103
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,U.S. House,13,DEM,Todd Rowley,50,49,1,100
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,U.S. House,13,DEM,Write-In,2,0,0,2
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,State Senator,35,DEM,Shaun Dougherty,49,53,1,103
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,General Assembly,71,DEM,Write-In,7,8,0,15
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,President,,REP,Donald J. Trump,93,22,2,117
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,President,,REP,Bill Weld,3,0,0,3
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,President,,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Attorney General,,REP,Heather Heidelbaugh,89,19,2,110
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,REP,Timothy Defoor,86,20,2,108
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,State Treasurer,,REP,Stacy L. Garrity,86,20,2,108
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,U.S. House,13,REP,John Joyce,91,23,2,116
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,State Senator,35,REP,Wayne Langerholc Jr.,94,24,2,120
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,General Assembly,71,REP,Jim Rigby,92,24,2,118
+Cambria,CONEMAUGH TOWNSHIP - COVER HILL,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Registered Voters,,,,,,,715
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Registered Voters,,DEM,,,,,314
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Registered Voters,,REP,,,,,353
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Ballots Cast,,,,191,116,2,309
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Ballots Cast,,DEM,,68,76,0,144
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Ballots Cast,,REP,,123,40,2,165
+Cambria,CONEMAUGH TOWNSHIP - CENTER,President,,DEM,Bernie Sanders,18,8,0,26
+Cambria,CONEMAUGH TOWNSHIP - CENTER,President,,DEM,Joseph R. Biden,28,53,0,81
+Cambria,CONEMAUGH TOWNSHIP - CENTER,President,,DEM,Tulsi Gabbard,7,2,0,9
+Cambria,CONEMAUGH TOWNSHIP - CENTER,President,,DEM,Write-In,8,6,0,14
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Attorney General,,DEM,Josh Shapiro,60,65,0,125
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Attorney General,,DEM,Write-In,2,0,0,2
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,DEM,H. Scott Conklin,26,39,0,65
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,DEM,Michael Lamb,21,18,0,39
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,DEM,Tracie Fountain,0,4,0,4
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,0,6
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,DEM,Nina Ahmad,2,3,0,5
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,DEM,Christina M. Hartman,6,4,0,10
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,CONEMAUGH TOWNSHIP - CENTER,State Treasurer,,DEM,Joe Torsella,59,61,0,120
+Cambria,CONEMAUGH TOWNSHIP - CENTER,State Treasurer,,DEM,Write-In,2,2,0,4
+Cambria,CONEMAUGH TOWNSHIP - CENTER,U.S. House,13,DEM,Todd Rowley,54,61,0,115
+Cambria,CONEMAUGH TOWNSHIP - CENTER,U.S. House,13,DEM,Write-In,2,1,0,3
+Cambria,CONEMAUGH TOWNSHIP - CENTER,State Senator,35,DEM,Shaun Dougherty,57,68,0,125
+Cambria,CONEMAUGH TOWNSHIP - CENTER,State Senator,35,DEM,Write-In,4,2,0,6
+Cambria,CONEMAUGH TOWNSHIP - CENTER,General Assembly,71,DEM,Write-In,13,11,0,24
+Cambria,CONEMAUGH TOWNSHIP - CENTER,President,,REP,Donald J. Trump,120,35,2,157
+Cambria,CONEMAUGH TOWNSHIP - CENTER,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - CENTER,President,,REP,Bill Weld,1,4,0,5
+Cambria,CONEMAUGH TOWNSHIP - CENTER,President,,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Attorney General,,REP,Heather Heidelbaugh,109,36,2,147
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,REP,Timothy Defoor,110,38,2,150
+Cambria,CONEMAUGH TOWNSHIP - CENTER,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - CENTER,State Treasurer,,REP,Stacy L. Garrity,109,36,2,147
+Cambria,CONEMAUGH TOWNSHIP - CENTER,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - CENTER,U.S. House,13,REP,John Joyce,120,38,2,160
+Cambria,CONEMAUGH TOWNSHIP - CENTER,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - CENTER,State Senator,35,REP,Wayne Langerholc Jr.,121,38,2,161
+Cambria,CONEMAUGH TOWNSHIP - CENTER,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CONEMAUGH TOWNSHIP - CENTER,General Assembly,71,REP,Jim Rigby,116,37,2,155
+Cambria,CONEMAUGH TOWNSHIP - CENTER,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,CRESSON BOROUGH,Registered Voters,,,,,,,910
+Cambria,CRESSON BOROUGH,Registered Voters,,DEM,,,,,414
+Cambria,CRESSON BOROUGH,Registered Voters,,REP,,,,,393
+Cambria,CRESSON BOROUGH,Ballots Cast,,,,236,117,0,353
+Cambria,CRESSON BOROUGH,Ballots Cast,,DEM,,100,76,0,176
+Cambria,CRESSON BOROUGH,Ballots Cast,,REP,,136,41,0,177
+Cambria,CRESSON BOROUGH,President,,DEM,Bernie Sanders,14,12,0,26
+Cambria,CRESSON BOROUGH,President,,DEM,Joseph R. Biden,53,56,0,109
+Cambria,CRESSON BOROUGH,President,,DEM,Tulsi Gabbard,14,4,0,18
+Cambria,CRESSON BOROUGH,President,,DEM,Write-In,7,1,0,8
+Cambria,CRESSON BOROUGH,Attorney General,,DEM,Josh Shapiro,85,72,0,157
+Cambria,CRESSON BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,CRESSON BOROUGH,Auditor General,,DEM,H. Scott Conklin,55,44,0,99
+Cambria,CRESSON BOROUGH,Auditor General,,DEM,Michael Lamb,20,9,0,29
+Cambria,CRESSON BOROUGH,Auditor General,,DEM,Tracie Fountain,5,7,0,12
+Cambria,CRESSON BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,4,5,0,9
+Cambria,CRESSON BOROUGH,Auditor General,,DEM,Nina Ahmad,4,3,0,7
+Cambria,CRESSON BOROUGH,Auditor General,,DEM,Christina M. Hartman,5,6,0,11
+Cambria,CRESSON BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,CRESSON BOROUGH,State Treasurer,,DEM,Joe Torsella,83,67,0,150
+Cambria,CRESSON BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,CRESSON BOROUGH,U.S. House,15,DEM,Robert Williams,81,70,0,151
+Cambria,CRESSON BOROUGH,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,CRESSON BOROUGH,State Senator,35,DEM,Shaun Dougherty,87,70,0,157
+Cambria,CRESSON BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,CRESSON BOROUGH,General Assembly,72,DEM,Frank Burns,91,66,0,157
+Cambria,CRESSON BOROUGH,General Assembly,72,DEM,Write-In,3,2,0,5
+Cambria,CRESSON BOROUGH,President,,REP,Donald J. Trump,130,32,0,162
+Cambria,CRESSON BOROUGH,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,CRESSON BOROUGH,President,,REP,Bill Weld,3,5,0,8
+Cambria,CRESSON BOROUGH,President,,REP,Write-In,1,2,0,3
+Cambria,CRESSON BOROUGH,Attorney General,,REP,Heather Heidelbaugh,117,32,0,149
+Cambria,CRESSON BOROUGH,Attorney General,,REP,Write-In,1,1,0,2
+Cambria,CRESSON BOROUGH,Auditor General,,REP,Timothy Defoor,116,31,0,147
+Cambria,CRESSON BOROUGH,Auditor General,,REP,Write-In,2,1,0,3
+Cambria,CRESSON BOROUGH,State Treasurer,,REP,Stacy L. Garrity,119,32,0,151
+Cambria,CRESSON BOROUGH,State Treasurer,,REP,Write-In,1,1,0,2
+Cambria,CRESSON BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,116,30,0,146
+Cambria,CRESSON BOROUGH,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,CRESSON BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,122,34,0,156
+Cambria,CRESSON BOROUGH,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,CRESSON BOROUGH,General Assembly,72,REP,Howard Terndrup,81,25,0,106
+Cambria,CRESSON BOROUGH,General Assembly,72,REP,Jerry Carnicella,43,12,0,55
+Cambria,CRESSON BOROUGH,General Assembly,72,REP,Write-In,4,2,0,6
+Cambria,CRESSON TOWNSHIP - NORTH,Registered Voters,,,,,,,901
+Cambria,CRESSON TOWNSHIP - NORTH,Registered Voters,,DEM,,,,,384
+Cambria,CRESSON TOWNSHIP - NORTH,Registered Voters,,REP,,,,,403
+Cambria,CRESSON TOWNSHIP - NORTH,Ballots Cast,,,,188,104,0,292
+Cambria,CRESSON TOWNSHIP - NORTH,Ballots Cast,,DEM,,76,66,0,142
+Cambria,CRESSON TOWNSHIP - NORTH,Ballots Cast,,REP,,112,38,0,150
+Cambria,CRESSON TOWNSHIP - NORTH,President,,DEM,Bernie Sanders,19,5,0,24
+Cambria,CRESSON TOWNSHIP - NORTH,President,,DEM,Joseph R. Biden,38,49,0,87
+Cambria,CRESSON TOWNSHIP - NORTH,President,,DEM,Tulsi Gabbard,6,2,0,8
+Cambria,CRESSON TOWNSHIP - NORTH,President,,DEM,Write-In,8,6,0,14
+Cambria,CRESSON TOWNSHIP - NORTH,Attorney General,,DEM,Josh Shapiro,67,64,0,131
+Cambria,CRESSON TOWNSHIP - NORTH,Attorney General,,DEM,Write-In,1,1,0,2
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,DEM,H. Scott Conklin,42,43,0,85
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,DEM,Michael Lamb,10,11,0,21
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,DEM,Tracie Fountain,1,2,0,3
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,2
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,DEM,Nina Ahmad,8,4,0,12
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,DEM,Christina M. Hartman,9,5,0,14
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,CRESSON TOWNSHIP - NORTH,State Treasurer,,DEM,Joe Torsella,66,63,0,129
+Cambria,CRESSON TOWNSHIP - NORTH,State Treasurer,,DEM,Write-In,1,3,0,4
+Cambria,CRESSON TOWNSHIP - NORTH,U.S. House,15,DEM,Robert Williams,68,61,0,129
+Cambria,CRESSON TOWNSHIP - NORTH,U.S. House,15,DEM,Write-In,1,4,0,5
+Cambria,CRESSON TOWNSHIP - NORTH,State Senator,35,DEM,Shaun Dougherty,66,63,0,129
+Cambria,CRESSON TOWNSHIP - NORTH,State Senator,35,DEM,Write-In,1,3,0,4
+Cambria,CRESSON TOWNSHIP - NORTH,General Assembly,72,DEM,Frank Burns,70,66,0,136
+Cambria,CRESSON TOWNSHIP - NORTH,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,CRESSON TOWNSHIP - NORTH,President,,REP,Donald J. Trump,108,34,0,142
+Cambria,CRESSON TOWNSHIP - NORTH,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Cambria,CRESSON TOWNSHIP - NORTH,President,,REP,Bill Weld,3,2,0,5
+Cambria,CRESSON TOWNSHIP - NORTH,President,,REP,Write-In,0,0,0,0
+Cambria,CRESSON TOWNSHIP - NORTH,Attorney General,,REP,Heather Heidelbaugh,103,30,0,133
+Cambria,CRESSON TOWNSHIP - NORTH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,REP,Timothy Defoor,98,30,0,128
+Cambria,CRESSON TOWNSHIP - NORTH,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,CRESSON TOWNSHIP - NORTH,State Treasurer,,REP,Stacy L. Garrity,100,31,0,131
+Cambria,CRESSON TOWNSHIP - NORTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CRESSON TOWNSHIP - NORTH,U.S. House,15,REP,Glenn Gt Thompson,98,32,0,130
+Cambria,CRESSON TOWNSHIP - NORTH,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,CRESSON TOWNSHIP - NORTH,State Senator,35,REP,Wayne Langerholc Jr.,103,31,0,134
+Cambria,CRESSON TOWNSHIP - NORTH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CRESSON TOWNSHIP - NORTH,General Assembly,72,REP,Howard Terndrup,52,21,0,73
+Cambria,CRESSON TOWNSHIP - NORTH,General Assembly,72,REP,Jerry Carnicella,45,14,0,59
+Cambria,CRESSON TOWNSHIP - NORTH,General Assembly,72,REP,Write-In,7,0,0,7
+Cambria,CRESSON TOWNSHIP - SOUTH,Registered Voters,,,,,,,722
+Cambria,CRESSON TOWNSHIP - SOUTH,Registered Voters,,DEM,,,,,315
+Cambria,CRESSON TOWNSHIP - SOUTH,Registered Voters,,REP,,,,,341
+Cambria,CRESSON TOWNSHIP - SOUTH,Ballots Cast,,,,166,93,4,263
+Cambria,CRESSON TOWNSHIP - SOUTH,Ballots Cast,,DEM,,68,66,1,135
+Cambria,CRESSON TOWNSHIP - SOUTH,Ballots Cast,,REP,,98,27,3,128
+Cambria,CRESSON TOWNSHIP - SOUTH,President,,DEM,Bernie Sanders,11,10,0,21
+Cambria,CRESSON TOWNSHIP - SOUTH,President,,DEM,Joseph R. Biden,34,52,1,87
+Cambria,CRESSON TOWNSHIP - SOUTH,President,,DEM,Tulsi Gabbard,7,1,0,8
+Cambria,CRESSON TOWNSHIP - SOUTH,President,,DEM,Write-In,9,0,0,9
+Cambria,CRESSON TOWNSHIP - SOUTH,Attorney General,,DEM,Josh Shapiro,58,66,1,125
+Cambria,CRESSON TOWNSHIP - SOUTH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,DEM,H. Scott Conklin,39,46,1,86
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,DEM,Michael Lamb,10,4,0,14
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,DEM,Tracie Fountain,0,4,0,4
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,DEM,Rose Rosie Marie Davis,4,3,0,7
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,DEM,Nina Ahmad,1,3,0,4
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,DEM,Christina M. Hartman,9,3,0,12
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,CRESSON TOWNSHIP - SOUTH,State Treasurer,,DEM,Joe Torsella,56,62,1,119
+Cambria,CRESSON TOWNSHIP - SOUTH,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,CRESSON TOWNSHIP - SOUTH,U.S. House,15,DEM,Robert Williams,56,62,0,118
+Cambria,CRESSON TOWNSHIP - SOUTH,U.S. House,15,DEM,Write-In,3,0,0,3
+Cambria,CRESSON TOWNSHIP - SOUTH,State Senator,35,DEM,Shaun Dougherty,59,62,1,122
+Cambria,CRESSON TOWNSHIP - SOUTH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,CRESSON TOWNSHIP - SOUTH,General Assembly,72,DEM,Frank Burns,60,63,1,124
+Cambria,CRESSON TOWNSHIP - SOUTH,General Assembly,72,DEM,Write-In,2,1,0,3
+Cambria,CRESSON TOWNSHIP - SOUTH,President,,REP,Donald J. Trump,93,24,1,118
+Cambria,CRESSON TOWNSHIP - SOUTH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,CRESSON TOWNSHIP - SOUTH,President,,REP,Bill Weld,4,3,1,8
+Cambria,CRESSON TOWNSHIP - SOUTH,President,,REP,Write-In,0,0,0,0
+Cambria,CRESSON TOWNSHIP - SOUTH,Attorney General,,REP,Heather Heidelbaugh,87,24,3,114
+Cambria,CRESSON TOWNSHIP - SOUTH,Attorney General,,REP,Write-In,1,1,0,2
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,REP,Timothy Defoor,90,24,3,117
+Cambria,CRESSON TOWNSHIP - SOUTH,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,CRESSON TOWNSHIP - SOUTH,State Treasurer,,REP,Stacy L. Garrity,88,24,3,115
+Cambria,CRESSON TOWNSHIP - SOUTH,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,CRESSON TOWNSHIP - SOUTH,U.S. House,15,REP,Glenn Gt Thompson,88,23,2,113
+Cambria,CRESSON TOWNSHIP - SOUTH,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,CRESSON TOWNSHIP - SOUTH,State Senator,35,REP,Wayne Langerholc Jr.,90,25,3,118
+Cambria,CRESSON TOWNSHIP - SOUTH,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,CRESSON TOWNSHIP - SOUTH,General Assembly,72,REP,Howard Terndrup,54,20,2,76
+Cambria,CRESSON TOWNSHIP - SOUTH,General Assembly,72,REP,Jerry Carnicella,36,7,1,44
+Cambria,CRESSON TOWNSHIP - SOUTH,General Assembly,72,REP,Write-In,5,0,0,5
+Cambria,CROYLE TOWNSHIP NO. 1,Registered Voters,,,,,,,711
+Cambria,CROYLE TOWNSHIP NO. 1,Registered Voters,,DEM,,,,,258
+Cambria,CROYLE TOWNSHIP NO. 1,Registered Voters,,REP,,,,,396
+Cambria,CROYLE TOWNSHIP NO. 1,Ballots Cast,,,,182,86,0,268
+Cambria,CROYLE TOWNSHIP NO. 1,Ballots Cast,,DEM,,57,54,0,111
+Cambria,CROYLE TOWNSHIP NO. 1,Ballots Cast,,REP,,125,32,0,157
+Cambria,CROYLE TOWNSHIP NO. 1,President,,DEM,Bernie Sanders,16,5,0,21
+Cambria,CROYLE TOWNSHIP NO. 1,President,,DEM,Joseph R. Biden,26,47,0,73
+Cambria,CROYLE TOWNSHIP NO. 1,President,,DEM,Tulsi Gabbard,5,1,0,6
+Cambria,CROYLE TOWNSHIP NO. 1,President,,DEM,Write-In,7,0,0,7
+Cambria,CROYLE TOWNSHIP NO. 1,Attorney General,,DEM,Josh Shapiro,46,54,0,100
+Cambria,CROYLE TOWNSHIP NO. 1,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,DEM,H. Scott Conklin,28,31,0,59
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,DEM,Michael Lamb,12,17,0,29
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,DEM,Tracie Fountain,1,4,0,5
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,4,2,0,6
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,DEM,Nina Ahmad,3,0,0,3
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,DEM,Christina M. Hartman,2,0,0,2
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,State Treasurer,,DEM,Joe Torsella,37,53,0,90
+Cambria,CROYLE TOWNSHIP NO. 1,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,U.S. House,15,DEM,Robert Williams,41,53,0,94
+Cambria,CROYLE TOWNSHIP NO. 1,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,State Senator,35,DEM,Shaun Dougherty,44,51,0,95
+Cambria,CROYLE TOWNSHIP NO. 1,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,General Assembly,72,DEM,Frank Burns,54,51,0,105
+Cambria,CROYLE TOWNSHIP NO. 1,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,President,,REP,Donald J. Trump,122,28,0,150
+Cambria,CROYLE TOWNSHIP NO. 1,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,President,,REP,Bill Weld,1,3,0,4
+Cambria,CROYLE TOWNSHIP NO. 1,President,,REP,Write-In,1,1,0,2
+Cambria,CROYLE TOWNSHIP NO. 1,Attorney General,,REP,Heather Heidelbaugh,111,25,0,136
+Cambria,CROYLE TOWNSHIP NO. 1,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,REP,Timothy Defoor,114,24,0,138
+Cambria,CROYLE TOWNSHIP NO. 1,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,State Treasurer,,REP,Stacy L. Garrity,113,24,0,137
+Cambria,CROYLE TOWNSHIP NO. 1,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,CROYLE TOWNSHIP NO. 1,U.S. House,15,REP,Glenn Gt Thompson,115,27,0,142
+Cambria,CROYLE TOWNSHIP NO. 1,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,119,27,0,146
+Cambria,CROYLE TOWNSHIP NO. 1,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP NO. 1,General Assembly,72,REP,Howard Terndrup,73,24,0,97
+Cambria,CROYLE TOWNSHIP NO. 1,General Assembly,72,REP,Jerry Carnicella,47,4,0,51
+Cambria,CROYLE TOWNSHIP NO. 1,General Assembly,72,REP,Write-In,1,0,0,1
+Cambria,CROYLE TOWNSHIP - NO. 2,Registered Voters,,,,,,,798
+Cambria,CROYLE TOWNSHIP - NO. 2,Registered Voters,,DEM,,,,,338
+Cambria,CROYLE TOWNSHIP - NO. 2,Registered Voters,,REP,,,,,389
+Cambria,CROYLE TOWNSHIP - NO. 2,Ballots Cast,,,,169,98,3,270
+Cambria,CROYLE TOWNSHIP - NO. 2,Ballots Cast,,DEM,,66,57,0,123
+Cambria,CROYLE TOWNSHIP - NO. 2,Ballots Cast,,REP,,103,41,3,147
+Cambria,CROYLE TOWNSHIP - NO. 2,President,,DEM,Bernie Sanders,12,8,0,20
+Cambria,CROYLE TOWNSHIP - NO. 2,President,,DEM,Joseph R. Biden,29,44,0,73
+Cambria,CROYLE TOWNSHIP - NO. 2,President,,DEM,Tulsi Gabbard,4,2,0,6
+Cambria,CROYLE TOWNSHIP - NO. 2,President,,DEM,Write-In,10,0,0,10
+Cambria,CROYLE TOWNSHIP - NO. 2,Attorney General,,DEM,Josh Shapiro,53,53,0,106
+Cambria,CROYLE TOWNSHIP - NO. 2,Attorney General,,DEM,Write-In,3,0,0,3
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,DEM,H. Scott Conklin,35,30,0,65
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,DEM,Michael Lamb,10,13,0,23
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,DEM,Tracie Fountain,4,4,0,8
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,2
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,DEM,Nina Ahmad,4,1,0,5
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,DEM,Christina M. Hartman,6,6,0,12
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,CROYLE TOWNSHIP - NO. 2,State Treasurer,,DEM,Joe Torsella,54,52,0,106
+Cambria,CROYLE TOWNSHIP - NO. 2,State Treasurer,,DEM,Write-In,3,1,0,4
+Cambria,CROYLE TOWNSHIP - NO. 2,U.S. House,15,DEM,Robert Williams,54,52,0,106
+Cambria,CROYLE TOWNSHIP - NO. 2,U.S. House,15,DEM,Write-In,4,0,0,4
+Cambria,CROYLE TOWNSHIP - NO. 2,State Senator,35,DEM,Shaun Dougherty,56,52,0,108
+Cambria,CROYLE TOWNSHIP - NO. 2,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,CROYLE TOWNSHIP - NO. 2,General Assembly,72,DEM,Frank Burns,58,53,0,111
+Cambria,CROYLE TOWNSHIP - NO. 2,General Assembly,72,DEM,Write-In,2,0,0,2
+Cambria,CROYLE TOWNSHIP - NO. 2,President,,REP,Donald J. Trump,95,32,3,130
+Cambria,CROYLE TOWNSHIP - NO. 2,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Cambria,CROYLE TOWNSHIP - NO. 2,President,,REP,Bill Weld,3,4,0,7
+Cambria,CROYLE TOWNSHIP - NO. 2,President,,REP,Write-In,0,3,0,3
+Cambria,CROYLE TOWNSHIP - NO. 2,Attorney General,,REP,Heather Heidelbaugh,88,36,3,127
+Cambria,CROYLE TOWNSHIP - NO. 2,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,REP,Timothy Defoor,85,37,3,125
+Cambria,CROYLE TOWNSHIP - NO. 2,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP - NO. 2,State Treasurer,,REP,Stacy L. Garrity,86,37,3,126
+Cambria,CROYLE TOWNSHIP - NO. 2,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP - NO. 2,U.S. House,15,REP,Glenn Gt Thompson,85,38,3,126
+Cambria,CROYLE TOWNSHIP - NO. 2,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP - NO. 2,State Senator,35,REP,Wayne Langerholc Jr.,96,41,3,140
+Cambria,CROYLE TOWNSHIP - NO. 2,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,CROYLE TOWNSHIP - NO. 2,General Assembly,72,REP,Howard Terndrup,64,30,1,95
+Cambria,CROYLE TOWNSHIP - NO. 2,General Assembly,72,REP,Jerry Carnicella,36,9,2,47
+Cambria,CROYLE TOWNSHIP - NO. 2,General Assembly,72,REP,Write-In,0,0,0,0
+Cambria,DAISYTOWN BOROUGH,Registered Voters,,,,,,,216
+Cambria,DAISYTOWN BOROUGH,Registered Voters,,DEM,,,,,115
+Cambria,DAISYTOWN BOROUGH,Registered Voters,,REP,,,,,83
+Cambria,DAISYTOWN BOROUGH,Ballots Cast,,,,72,24,2,98
+Cambria,DAISYTOWN BOROUGH,Ballots Cast,,DEM,,37,15,1,53
+Cambria,DAISYTOWN BOROUGH,Ballots Cast,,REP,,35,9,1,45
+Cambria,DAISYTOWN BOROUGH,President,,DEM,Bernie Sanders,6,2,0,8
+Cambria,DAISYTOWN BOROUGH,President,,DEM,Joseph R. Biden,14,9,1,24
+Cambria,DAISYTOWN BOROUGH,President,,DEM,Tulsi Gabbard,7,0,0,7
+Cambria,DAISYTOWN BOROUGH,President,,DEM,Write-In,4,1,0,5
+Cambria,DAISYTOWN BOROUGH,Attorney General,,DEM,Josh Shapiro,31,14,1,46
+Cambria,DAISYTOWN BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,DAISYTOWN BOROUGH,Auditor General,,DEM,H. Scott Conklin,15,8,0,23
+Cambria,DAISYTOWN BOROUGH,Auditor General,,DEM,Michael Lamb,8,3,0,11
+Cambria,DAISYTOWN BOROUGH,Auditor General,,DEM,Tracie Fountain,1,1,0,2
+Cambria,DAISYTOWN BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,6,0,0,6
+Cambria,DAISYTOWN BOROUGH,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,DAISYTOWN BOROUGH,Auditor General,,DEM,Christina M. Hartman,3,2,0,5
+Cambria,DAISYTOWN BOROUGH,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,DAISYTOWN BOROUGH,State Treasurer,,DEM,Joe Torsella,29,12,0,41
+Cambria,DAISYTOWN BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,DAISYTOWN BOROUGH,U.S. House,13,DEM,Todd Rowley,33,12,1,46
+Cambria,DAISYTOWN BOROUGH,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,DAISYTOWN BOROUGH,State Senator,35,DEM,Shaun Dougherty,31,15,0,46
+Cambria,DAISYTOWN BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,DAISYTOWN BOROUGH,General Assembly,71,DEM,Write-In,2,0,0,2
+Cambria,DAISYTOWN BOROUGH,President,,REP,Donald J. Trump,34,7,1,42
+Cambria,DAISYTOWN BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,DAISYTOWN BOROUGH,President,,REP,Bill Weld,1,2,0,3
+Cambria,DAISYTOWN BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,DAISYTOWN BOROUGH,Attorney General,,REP,Heather Heidelbaugh,29,9,1,39
+Cambria,DAISYTOWN BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,DAISYTOWN BOROUGH,Auditor General,,REP,Timothy Defoor,28,9,1,38
+Cambria,DAISYTOWN BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,DAISYTOWN BOROUGH,State Treasurer,,REP,Stacy L. Garrity,28,9,1,38
+Cambria,DAISYTOWN BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,DAISYTOWN BOROUGH,U.S. House,13,REP,John Joyce,31,9,1,41
+Cambria,DAISYTOWN BOROUGH,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,DAISYTOWN BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,33,9,1,43
+Cambria,DAISYTOWN BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,DAISYTOWN BOROUGH,General Assembly,71,REP,Jim Rigby,33,9,1,43
+Cambria,DAISYTOWN BOROUGH,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,DALE BOROUGH,Registered Voters,,,,,,,596
+Cambria,DALE BOROUGH,Registered Voters,,DEM,,,,,287
+Cambria,DALE BOROUGH,Registered Voters,,REP,,,,,224
+Cambria,DALE BOROUGH,Ballots Cast,,,,110,56,3,169
+Cambria,DALE BOROUGH,Ballots Cast,,DEM,,43,38,2,83
+Cambria,DALE BOROUGH,Ballots Cast,,REP,,67,18,1,86
+Cambria,DALE BOROUGH,President,,DEM,Bernie Sanders,18,3,0,21
+Cambria,DALE BOROUGH,President,,DEM,Joseph R. Biden,18,30,0,48
+Cambria,DALE BOROUGH,President,,DEM,Tulsi Gabbard,2,3,1,6
+Cambria,DALE BOROUGH,President,,DEM,Write-In,4,2,1,7
+Cambria,DALE BOROUGH,Attorney General,,DEM,Josh Shapiro,41,35,2,78
+Cambria,DALE BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,DALE BOROUGH,Auditor General,,DEM,H. Scott Conklin,15,21,1,37
+Cambria,DALE BOROUGH,Auditor General,,DEM,Michael Lamb,7,8,0,15
+Cambria,DALE BOROUGH,Auditor General,,DEM,Tracie Fountain,3,1,0,4
+Cambria,DALE BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,1,4
+Cambria,DALE BOROUGH,Auditor General,,DEM,Nina Ahmad,4,2,0,6
+Cambria,DALE BOROUGH,Auditor General,,DEM,Christina M. Hartman,6,4,0,10
+Cambria,DALE BOROUGH,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,DALE BOROUGH,State Treasurer,,DEM,Joe Torsella,37,34,1,72
+Cambria,DALE BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,DALE BOROUGH,U.S. House,13,DEM,Todd Rowley,35,33,0,68
+Cambria,DALE BOROUGH,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,DALE BOROUGH,State Senator,35,DEM,Shaun Dougherty,37,33,0,70
+Cambria,DALE BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,DALE BOROUGH,General Assembly,71,DEM,Write-In,5,1,0,6
+Cambria,DALE BOROUGH,President,,REP,Donald J. Trump,63,14,1,78
+Cambria,DALE BOROUGH,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,DALE BOROUGH,President,,REP,Bill Weld,0,2,0,2
+Cambria,DALE BOROUGH,President,,REP,Write-In,2,1,0,3
+Cambria,DALE BOROUGH,Attorney General,,REP,Heather Heidelbaugh,60,17,0,77
+Cambria,DALE BOROUGH,Attorney General,,REP,Write-In,0,0,1,1
+Cambria,DALE BOROUGH,Auditor General,,REP,Timothy Defoor,59,18,1,78
+Cambria,DALE BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,DALE BOROUGH,State Treasurer,,REP,Stacy L. Garrity,60,18,1,79
+Cambria,DALE BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,DALE BOROUGH,U.S. House,13,REP,John Joyce,64,18,1,83
+Cambria,DALE BOROUGH,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,DALE BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,65,18,1,84
+Cambria,DALE BOROUGH,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,DALE BOROUGH,General Assembly,71,REP,Jim Rigby,66,18,1,85
+Cambria,DALE BOROUGH,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,Registered Voters,,,,,,,234
+Cambria,DEAN TOWNSHIP,Registered Voters,,DEM,,,,,83
+Cambria,DEAN TOWNSHIP,Registered Voters,,REP,,,,,120
+Cambria,DEAN TOWNSHIP,Ballots Cast,,,,60,28,1,89
+Cambria,DEAN TOWNSHIP,Ballots Cast,,DEM,,24,13,1,38
+Cambria,DEAN TOWNSHIP,Ballots Cast,,REP,,36,15,0,51
+Cambria,DEAN TOWNSHIP,President,,DEM,Bernie Sanders,2,4,0,6
+Cambria,DEAN TOWNSHIP,President,,DEM,Joseph R. Biden,16,7,1,24
+Cambria,DEAN TOWNSHIP,President,,DEM,Tulsi Gabbard,3,2,0,5
+Cambria,DEAN TOWNSHIP,President,,DEM,Write-In,1,0,0,1
+Cambria,DEAN TOWNSHIP,Attorney General,,DEM,Josh Shapiro,22,12,0,34
+Cambria,DEAN TOWNSHIP,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,19,11,0,30
+Cambria,DEAN TOWNSHIP,Auditor General,,DEM,Michael Lamb,2,0,0,2
+Cambria,DEAN TOWNSHIP,Auditor General,,DEM,Tracie Fountain,0,0,0,0
+Cambria,DEAN TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,DEAN TOWNSHIP,Auditor General,,DEM,Nina Ahmad,0,2,0,2
+Cambria,DEAN TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,1,0,0,1
+Cambria,DEAN TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,State Treasurer,,DEM,Joe Torsella,22,11,0,33
+Cambria,DEAN TOWNSHIP,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,U.S. House,15,DEM,Robert Williams,20,13,0,33
+Cambria,DEAN TOWNSHIP,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,21,13,0,34
+Cambria,DEAN TOWNSHIP,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,General Assembly,72,DEM,Frank Burns,24,13,1,38
+Cambria,DEAN TOWNSHIP,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,President,,REP,Donald J. Trump,36,15,0,51
+Cambria,DEAN TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,DEAN TOWNSHIP,President,,REP,Bill Weld,0,0,0,0
+Cambria,DEAN TOWNSHIP,President,,REP,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,34,13,0,47
+Cambria,DEAN TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,Auditor General,,REP,Timothy Defoor,33,13,0,46
+Cambria,DEAN TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,35,13,0,48
+Cambria,DEAN TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,35,13,0,48
+Cambria,DEAN TOWNSHIP,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,DEAN TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,34,13,0,47
+Cambria,DEAN TOWNSHIP,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,DEAN TOWNSHIP,General Assembly,72,REP,Howard Terndrup,14,5,0,19
+Cambria,DEAN TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,21,8,0,29
+Cambria,DEAN TOWNSHIP,General Assembly,72,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Registered Voters,,,,,,,235
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Registered Voters,,DEM,,,,,128
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Registered Voters,,REP,,,,,85
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Ballots Cast,,,,61,34,2,97
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Ballots Cast,,DEM,,33,25,2,60
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Ballots Cast,,REP,,28,9,0,37
+Cambria,EAST CARROLL TOWNSHIP - NORTH,President,,DEM,Bernie Sanders,9,7,0,16
+Cambria,EAST CARROLL TOWNSHIP - NORTH,President,,DEM,Joseph R. Biden,12,16,1,29
+Cambria,EAST CARROLL TOWNSHIP - NORTH,President,,DEM,Tulsi Gabbard,3,1,0,4
+Cambria,EAST CARROLL TOWNSHIP - NORTH,President,,DEM,Write-In,6,1,0,7
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Attorney General,,DEM,Josh Shapiro,32,23,2,57
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,H. Scott Conklin,27,20,1,48
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Michael Lamb,4,0,1,5
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,1
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Nina Ahmad,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Christina M. Hartman,2,1,0,3
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,State Treasurer,,DEM,Joe Torsella,32,23,2,57
+Cambria,EAST CARROLL TOWNSHIP - NORTH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,EAST CARROLL TOWNSHIP - NORTH,U.S. House,15,DEM,Robert Williams,32,22,1,55
+Cambria,EAST CARROLL TOWNSHIP - NORTH,U.S. House,15,DEM,Write-In,0,0,1,1
+Cambria,EAST CARROLL TOWNSHIP - NORTH,State Senator,35,DEM,Shaun Dougherty,32,22,2,56
+Cambria,EAST CARROLL TOWNSHIP - NORTH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,General Assembly,72,DEM,Frank Burns,27,22,2,51
+Cambria,EAST CARROLL TOWNSHIP - NORTH,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,EAST CARROLL TOWNSHIP - NORTH,President,,REP,Donald J. Trump,27,9,0,36
+Cambria,EAST CARROLL TOWNSHIP - NORTH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,President,,REP,Bill Weld,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,President,,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Attorney General,,REP,Heather Heidelbaugh,27,9,0,36
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,REP,Timothy Defoor,27,9,0,36
+Cambria,EAST CARROLL TOWNSHIP - NORTH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,State Treasurer,,REP,Stacy L. Garrity,27,9,0,36
+Cambria,EAST CARROLL TOWNSHIP - NORTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,U.S. House,15,REP,Glenn Gt Thompson,26,9,0,35
+Cambria,EAST CARROLL TOWNSHIP - NORTH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,State Senator,35,REP,Wayne Langerholc Jr.,27,9,0,36
+Cambria,EAST CARROLL TOWNSHIP - NORTH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - NORTH,General Assembly,72,REP,Howard Terndrup,21,8,0,29
+Cambria,EAST CARROLL TOWNSHIP - NORTH,General Assembly,72,REP,Jerry Carnicella,7,1,0,8
+Cambria,EAST CARROLL TOWNSHIP - NORTH,General Assembly,72,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Registered Voters,,,,,,,792
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Registered Voters,,DEM,,,,,320
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Registered Voters,,REP,,,,,393
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Ballots Cast,,,,187,101,1,289
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Ballots Cast,,DEM,,50,61,0,111
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Ballots Cast,,REP,,137,40,1,178
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,President,,DEM,Bernie Sanders,2,11,0,13
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,President,,DEM,Joseph R. Biden,22,38,0,60
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,President,,DEM,Tulsi Gabbard,14,5,0,19
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,President,,DEM,Write-In,4,3,0,7
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Attorney General,,DEM,Josh Shapiro,43,53,0,96
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,H. Scott Conklin,34,39,0,73
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Michael Lamb,8,14,0,22
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,2
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Nina Ahmad,2,2,0,4
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Christina M. Hartman,3,0,0,3
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,State Treasurer,,DEM,Joe Torsella,39,52,0,91
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,State Treasurer,,DEM,Write-In,0,2,0,2
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,U.S. House,15,DEM,Robert Williams,40,55,0,95
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,State Senator,35,DEM,Shaun Dougherty,39,52,0,91
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,State Senator,35,DEM,Write-In,0,2,0,2
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,General Assembly,72,DEM,Frank Burns,44,56,0,100
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,General Assembly,72,DEM,Write-In,0,2,0,2
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,President,,REP,Donald J. Trump,136,33,1,170
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,President,,REP,Bill Weld,0,5,0,5
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,President,,REP,Write-In,1,0,0,1
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Attorney General,,REP,Heather Heidelbaugh,128,34,1,163
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,REP,Timothy Defoor,124,33,1,158
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,State Treasurer,,REP,Stacy L. Garrity,125,34,1,160
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,U.S. House,15,REP,Glenn Gt Thompson,128,33,1,162
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,State Senator,35,REP,Wayne Langerholc Jr.,127,37,1,165
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,General Assembly,72,REP,Howard Terndrup,88,29,1,118
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,General Assembly,72,REP,Jerry Carnicella,44,8,0,52
+Cambria,EAST CARROLL TOWNSHIP - SOUTH,General Assembly,72,REP,Write-In,4,2,0,6
+Cambria,EAST CONEMAUGH BOROUGH,Registered Voters,,,,,,,579
+Cambria,EAST CONEMAUGH BOROUGH,Registered Voters,,DEM,,,,,343
+Cambria,EAST CONEMAUGH BOROUGH,Registered Voters,,REP,,,,,162
+Cambria,EAST CONEMAUGH BOROUGH,Ballots Cast,,,,118,69,1,188
+Cambria,EAST CONEMAUGH BOROUGH,Ballots Cast,,DEM,,80,53,1,134
+Cambria,EAST CONEMAUGH BOROUGH,Ballots Cast,,REP,,38,16,0,54
+Cambria,EAST CONEMAUGH BOROUGH,President,,DEM,Bernie Sanders,19,9,0,28
+Cambria,EAST CONEMAUGH BOROUGH,President,,DEM,Joseph R. Biden,37,39,1,77
+Cambria,EAST CONEMAUGH BOROUGH,President,,DEM,Tulsi Gabbard,5,0,0,5
+Cambria,EAST CONEMAUGH BOROUGH,President,,DEM,Write-In,13,4,0,17
+Cambria,EAST CONEMAUGH BOROUGH,Attorney General,,DEM,Josh Shapiro,72,51,0,123
+Cambria,EAST CONEMAUGH BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,DEM,H. Scott Conklin,34,33,0,67
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,DEM,Michael Lamb,22,15,0,37
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,DEM,Tracie Fountain,5,2,0,7
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,0,6
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,DEM,Nina Ahmad,3,0,0,3
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,DEM,Christina M. Hartman,5,1,1,7
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,EAST CONEMAUGH BOROUGH,State Treasurer,,DEM,Joe Torsella,65,52,0,117
+Cambria,EAST CONEMAUGH BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,EAST CONEMAUGH BOROUGH,U.S. House,13,DEM,Todd Rowley,66,50,0,116
+Cambria,EAST CONEMAUGH BOROUGH,U.S. House,13,DEM,Write-In,1,1,0,2
+Cambria,EAST CONEMAUGH BOROUGH,State Senator,35,DEM,Shaun Dougherty,71,50,0,121
+Cambria,EAST CONEMAUGH BOROUGH,State Senator,35,DEM,Write-In,1,1,0,2
+Cambria,EAST CONEMAUGH BOROUGH,General Assembly,71,DEM,Write-In,11,4,0,15
+Cambria,EAST CONEMAUGH BOROUGH,President,,REP,Donald J. Trump,35,14,0,49
+Cambria,EAST CONEMAUGH BOROUGH,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Cambria,EAST CONEMAUGH BOROUGH,President,,REP,Bill Weld,1,0,0,1
+Cambria,EAST CONEMAUGH BOROUGH,President,,REP,Write-In,0,1,0,1
+Cambria,EAST CONEMAUGH BOROUGH,Attorney General,,REP,Heather Heidelbaugh,33,14,0,47
+Cambria,EAST CONEMAUGH BOROUGH,Attorney General,,REP,Write-In,0,2,0,2
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,REP,Timothy Defoor,33,15,0,48
+Cambria,EAST CONEMAUGH BOROUGH,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,EAST CONEMAUGH BOROUGH,State Treasurer,,REP,Stacy L. Garrity,32,15,0,47
+Cambria,EAST CONEMAUGH BOROUGH,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,EAST CONEMAUGH BOROUGH,U.S. House,13,REP,John Joyce,34,14,0,48
+Cambria,EAST CONEMAUGH BOROUGH,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,EAST CONEMAUGH BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,34,16,0,50
+Cambria,EAST CONEMAUGH BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,EAST CONEMAUGH BOROUGH,General Assembly,71,REP,Jim Rigby,34,16,0,50
+Cambria,EAST CONEMAUGH BOROUGH,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Registered Voters,,,,,,,1059
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Registered Voters,,DEM,,,,,541
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Registered Voters,,REP,,,,,438
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Ballots Cast,,,,237,156,5,398
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Ballots Cast,,DEM,,110,108,3,221
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Ballots Cast,,REP,,127,48,2,177
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,President,,DEM,Bernie Sanders,19,10,0,29
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,President,,DEM,Joseph R. Biden,35,82,3,120
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,President,,DEM,Tulsi Gabbard,15,4,0,19
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,President,,DEM,Write-In,19,7,0,26
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Attorney General,,DEM,Josh Shapiro,94,103,3,200
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Attorney General,,DEM,Write-In,2,0,0,2
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,DEM,H. Scott Conklin,47,72,2,121
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,DEM,Michael Lamb,32,21,1,54
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,DEM,Tracie Fountain,2,2,0,4
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,0,4
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,DEM,Nina Ahmad,2,4,0,6
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,DEM,Christina M. Hartman,11,5,0,16
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,State Treasurer,,DEM,Joe Torsella,89,100,2,191
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,U.S. House,15,DEM,Robert Williams,90,96,2,188
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,State Senator,35,DEM,Shaun Dougherty,93,96,3,192
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,State Senator,35,DEM,Write-In,2,2,0,4
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,General Assembly,72,DEM,Frank Burns,100,102,3,205
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,General Assembly,72,DEM,Write-In,3,0,0,3
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,President,,REP,Donald J. Trump,126,45,2,173
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,President,,REP,Bill Weld,0,2,0,2
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,President,,REP,Write-In,1,1,0,2
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Attorney General,,REP,Heather Heidelbaugh,115,37,2,154
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,REP,Timothy Defoor,111,37,2,150
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,State Treasurer,,REP,Stacy L. Garrity,113,36,2,151
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,State Treasurer,,REP,Write-In,1,1,0,2
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,U.S. House,15,REP,Glenn Gt Thompson,118,41,2,161
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,117,48,2,167
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,General Assembly,72,REP,Howard Terndrup,88,34,2,124
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,General Assembly,72,REP,Jerry Carnicella,24,8,0,32
+Cambria,EAST TAYLOR TOWNSHIP - NO. 1,General Assembly,72,REP,Write-In,7,2,0,9
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Registered Voters,,,,,,,541
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Registered Voters,,DEM,,,,,254
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Registered Voters,,REP,,,,,238
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Ballots Cast,,,,117,89,1,207
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Ballots Cast,,DEM,,49,62,0,111
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Ballots Cast,,REP,,68,27,1,96
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,President,,DEM,Bernie Sanders,9,5,0,14
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,President,,DEM,Joseph R. Biden,31,48,0,79
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,President,,DEM,Tulsi Gabbard,4,2,0,6
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,President,,DEM,Write-In,5,4,0,9
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Attorney General,,DEM,Josh Shapiro,49,53,0,102
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,DEM,H. Scott Conklin,24,29,0,53
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,DEM,Michael Lamb,15,15,0,30
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,DEM,Tracie Fountain,2,2,0,4
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,DEM,Rose Rosie Marie Davis,1,4,0,5
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,DEM,Nina Ahmad,1,3,0,4
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,DEM,Christina M. Hartman,6,4,0,10
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,State Treasurer,,DEM,Joe Torsella,48,52,0,100
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,U.S. House,13,DEM,Todd Rowley,48,51,0,99
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,State Senator,35,DEM,Shaun Dougherty,48,51,0,99
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,General Assembly,72,DEM,Frank Burns,48,57,0,105
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,General Assembly,72,DEM,Write-In,0,1,0,1
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,President,,REP,Donald J. Trump,68,24,1,93
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,President,,REP,Bill Weld,0,3,0,3
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,President,,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Attorney General,,REP,Heather Heidelbaugh,62,23,1,86
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,REP,Timothy Defoor,61,24,1,86
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,State Treasurer,,REP,Stacy L. Garrity,61,24,1,86
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,U.S. House,13,REP,John Joyce,59,25,1,85
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,State Senator,35,REP,Wayne Langerholc Jr.,65,25,1,91
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,General Assembly,72,REP,Howard Terndrup,42,18,1,61
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,General Assembly,72,REP,Jerry Carnicella,20,8,0,28
+Cambria,EAST TAYLOR TOWNSHIP NO. 2,General Assembly,72,REP,Write-In,3,0,0,3
+Cambria,EBENSBURG BOROUGH - CENTER,Registered Voters,,,,,,,691
+Cambria,EBENSBURG BOROUGH - CENTER,Registered Voters,,DEM,,,,,375
+Cambria,EBENSBURG BOROUGH - CENTER,Registered Voters,,REP,,,,,250
+Cambria,EBENSBURG BOROUGH - CENTER,Ballots Cast,,,,147,125,1,273
+Cambria,EBENSBURG BOROUGH - CENTER,Ballots Cast,,DEM,,68,84,0,152
+Cambria,EBENSBURG BOROUGH - CENTER,Ballots Cast,,REP,,79,41,1,121
+Cambria,EBENSBURG BOROUGH - CENTER,President,,DEM,Bernie Sanders,10,12,0,22
+Cambria,EBENSBURG BOROUGH - CENTER,President,,DEM,Joseph R. Biden,37,67,0,104
+Cambria,EBENSBURG BOROUGH - CENTER,President,,DEM,Tulsi Gabbard,5,3,0,8
+Cambria,EBENSBURG BOROUGH - CENTER,President,,DEM,Write-In,7,0,0,7
+Cambria,EBENSBURG BOROUGH - CENTER,Attorney General,,DEM,Josh Shapiro,59,81,0,140
+Cambria,EBENSBURG BOROUGH - CENTER,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,DEM,H. Scott Conklin,41,46,0,87
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,DEM,Michael Lamb,12,16,0,28
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,DEM,Tracie Fountain,1,8,0,9
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,DEM,Rose Rosie Marie Davis,1,5,0,6
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,DEM,Nina Ahmad,0,1,0,1
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,DEM,Christina M. Hartman,8,4,0,12
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,State Treasurer,,DEM,Joe Torsella,57,77,0,134
+Cambria,EBENSBURG BOROUGH - CENTER,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,U.S. House,15,DEM,Robert Williams,56,80,0,136
+Cambria,EBENSBURG BOROUGH - CENTER,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,State Senator,35,DEM,Shaun Dougherty,60,77,0,137
+Cambria,EBENSBURG BOROUGH - CENTER,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - CENTER,General Assembly,72,DEM,Frank Burns,63,76,0,139
+Cambria,EBENSBURG BOROUGH - CENTER,General Assembly,72,DEM,Write-In,2,3,0,5
+Cambria,EBENSBURG BOROUGH - CENTER,President,,REP,Donald J. Trump,77,38,1,116
+Cambria,EBENSBURG BOROUGH - CENTER,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,President,,REP,Bill Weld,1,0,0,1
+Cambria,EBENSBURG BOROUGH - CENTER,President,,REP,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - CENTER,Attorney General,,REP,Heather Heidelbaugh,73,35,1,109
+Cambria,EBENSBURG BOROUGH - CENTER,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,REP,Timothy Defoor,74,34,1,109
+Cambria,EBENSBURG BOROUGH - CENTER,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,State Treasurer,,REP,Stacy L. Garrity,75,35,1,111
+Cambria,EBENSBURG BOROUGH - CENTER,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,U.S. House,15,REP,Glenn Gt Thompson,77,39,1,117
+Cambria,EBENSBURG BOROUGH - CENTER,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,State Senator,35,REP,Wayne Langerholc Jr.,73,37,1,111
+Cambria,EBENSBURG BOROUGH - CENTER,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - CENTER,General Assembly,72,REP,Howard Terndrup,60,34,1,95
+Cambria,EBENSBURG BOROUGH - CENTER,General Assembly,72,REP,Jerry Carnicella,17,4,0,21
+Cambria,EBENSBURG BOROUGH - CENTER,General Assembly,72,REP,Write-In,0,2,0,2
+Cambria,EBENSBURG BOROUGH - EAST,Registered Voters,,,,,,,777
+Cambria,EBENSBURG BOROUGH - EAST,Registered Voters,,DEM,,,,,384
+Cambria,EBENSBURG BOROUGH - EAST,Registered Voters,,REP,,,,,313
+Cambria,EBENSBURG BOROUGH - EAST,Ballots Cast,,,,192,132,0,324
+Cambria,EBENSBURG BOROUGH - EAST,Ballots Cast,,DEM,,91,89,0,180
+Cambria,EBENSBURG BOROUGH - EAST,Ballots Cast,,REP,,101,43,0,144
+Cambria,EBENSBURG BOROUGH - EAST,President,,DEM,Bernie Sanders,14,7,0,21
+Cambria,EBENSBURG BOROUGH - EAST,President,,DEM,Joseph R. Biden,54,72,0,126
+Cambria,EBENSBURG BOROUGH - EAST,President,,DEM,Tulsi Gabbard,6,2,0,8
+Cambria,EBENSBURG BOROUGH - EAST,President,,DEM,Write-In,10,5,0,15
+Cambria,EBENSBURG BOROUGH - EAST,Attorney General,,DEM,Josh Shapiro,79,78,0,157
+Cambria,EBENSBURG BOROUGH - EAST,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,DEM,H. Scott Conklin,50,44,0,94
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,DEM,Michael Lamb,19,32,0,51
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,DEM,Tracie Fountain,2,3,0,5
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,DEM,Nina Ahmad,4,6,0,10
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,DEM,Christina M. Hartman,6,0,0,6
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - EAST,State Treasurer,,DEM,Joe Torsella,73,77,0,150
+Cambria,EBENSBURG BOROUGH - EAST,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - EAST,U.S. House,15,DEM,Robert Williams,75,78,0,153
+Cambria,EBENSBURG BOROUGH - EAST,U.S. House,15,DEM,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - EAST,State Senator,35,DEM,Shaun Dougherty,73,78,0,151
+Cambria,EBENSBURG BOROUGH - EAST,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,EBENSBURG BOROUGH - EAST,General Assembly,72,DEM,Frank Burns,82,82,0,164
+Cambria,EBENSBURG BOROUGH - EAST,General Assembly,72,DEM,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - EAST,President,,REP,Donald J. Trump,93,38,0,131
+Cambria,EBENSBURG BOROUGH - EAST,President,,REP,Roque Rocky De La Fuente,3,1,0,4
+Cambria,EBENSBURG BOROUGH - EAST,President,,REP,Bill Weld,3,3,0,6
+Cambria,EBENSBURG BOROUGH - EAST,President,,REP,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - EAST,Attorney General,,REP,Heather Heidelbaugh,86,37,0,123
+Cambria,EBENSBURG BOROUGH - EAST,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,REP,Timothy Defoor,83,35,0,118
+Cambria,EBENSBURG BOROUGH - EAST,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - EAST,State Treasurer,,REP,Stacy L. Garrity,83,36,0,119
+Cambria,EBENSBURG BOROUGH - EAST,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - EAST,U.S. House,15,REP,Glenn Gt Thompson,88,39,0,127
+Cambria,EBENSBURG BOROUGH - EAST,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,EBENSBURG BOROUGH - EAST,State Senator,35,REP,Wayne Langerholc Jr.,91,39,0,130
+Cambria,EBENSBURG BOROUGH - EAST,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,EBENSBURG BOROUGH - EAST,General Assembly,72,REP,Howard Terndrup,82,35,0,117
+Cambria,EBENSBURG BOROUGH - EAST,General Assembly,72,REP,Jerry Carnicella,12,6,0,18
+Cambria,EBENSBURG BOROUGH - EAST,General Assembly,72,REP,Write-In,6,1,0,7
+Cambria,EBENSBURG BOROUGH - WEST,Registered Voters,,,,,,,893
+Cambria,EBENSBURG BOROUGH - WEST,Registered Voters,,DEM,,,,,445
+Cambria,EBENSBURG BOROUGH - WEST,Registered Voters,,REP,,,,,363
+Cambria,EBENSBURG BOROUGH - WEST,Ballots Cast,,,,189,180,0,369
+Cambria,EBENSBURG BOROUGH - WEST,Ballots Cast,,DEM,,90,123,0,213
+Cambria,EBENSBURG BOROUGH - WEST,Ballots Cast,,REP,,99,57,0,156
+Cambria,EBENSBURG BOROUGH - WEST,President,,DEM,Bernie Sanders,16,10,0,26
+Cambria,EBENSBURG BOROUGH - WEST,President,,DEM,Joseph R. Biden,49,93,0,142
+Cambria,EBENSBURG BOROUGH - WEST,President,,DEM,Tulsi Gabbard,9,9,0,18
+Cambria,EBENSBURG BOROUGH - WEST,President,,DEM,Write-In,10,6,0,16
+Cambria,EBENSBURG BOROUGH - WEST,Attorney General,,DEM,Josh Shapiro,75,106,0,181
+Cambria,EBENSBURG BOROUGH - WEST,Attorney General,,DEM,Write-In,3,0,0,3
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,DEM,H. Scott Conklin,38,73,0,111
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,DEM,Michael Lamb,16,23,0,39
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,DEM,Tracie Fountain,3,1,0,4
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,DEM,Rose Rosie Marie Davis,6,2,0,8
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,DEM,Nina Ahmad,14,7,0,21
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,DEM,Christina M. Hartman,6,7,0,13
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,EBENSBURG BOROUGH - WEST,State Treasurer,,DEM,Joe Torsella,74,105,0,179
+Cambria,EBENSBURG BOROUGH - WEST,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,EBENSBURG BOROUGH - WEST,U.S. House,15,DEM,Robert Williams,73,107,0,180
+Cambria,EBENSBURG BOROUGH - WEST,U.S. House,15,DEM,Write-In,3,0,0,3
+Cambria,EBENSBURG BOROUGH - WEST,State Senator,35,DEM,Shaun Dougherty,72,110,0,182
+Cambria,EBENSBURG BOROUGH - WEST,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,EBENSBURG BOROUGH - WEST,General Assembly,72,DEM,Frank Burns,82,110,0,192
+Cambria,EBENSBURG BOROUGH - WEST,General Assembly,72,DEM,Write-In,3,4,0,7
+Cambria,EBENSBURG BOROUGH - WEST,President,,REP,Donald J. Trump,95,45,0,140
+Cambria,EBENSBURG BOROUGH - WEST,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,EBENSBURG BOROUGH - WEST,President,,REP,Bill Weld,3,6,0,9
+Cambria,EBENSBURG BOROUGH - WEST,President,,REP,Write-In,0,3,0,3
+Cambria,EBENSBURG BOROUGH - WEST,Attorney General,,REP,Heather Heidelbaugh,93,50,0,143
+Cambria,EBENSBURG BOROUGH - WEST,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,REP,Timothy Defoor,94,50,0,144
+Cambria,EBENSBURG BOROUGH - WEST,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - WEST,State Treasurer,,REP,Stacy L. Garrity,94,52,0,146
+Cambria,EBENSBURG BOROUGH - WEST,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - WEST,U.S. House,15,REP,Glenn Gt Thompson,97,53,0,150
+Cambria,EBENSBURG BOROUGH - WEST,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - WEST,State Senator,35,REP,Wayne Langerholc Jr.,96,54,0,150
+Cambria,EBENSBURG BOROUGH - WEST,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,EBENSBURG BOROUGH - WEST,General Assembly,72,REP,Howard Terndrup,69,44,0,113
+Cambria,EBENSBURG BOROUGH - WEST,General Assembly,72,REP,Jerry Carnicella,25,11,0,36
+Cambria,EBENSBURG BOROUGH - WEST,General Assembly,72,REP,Write-In,4,1,0,5
+Cambria,EHRENFELD BOROUGH,Registered Voters,,,,,,,115
+Cambria,EHRENFELD BOROUGH,Registered Voters,,DEM,,,,,54
+Cambria,EHRENFELD BOROUGH,Registered Voters,,REP,,,,,43
+Cambria,EHRENFELD BOROUGH,Ballots Cast,,,,35,6,0,41
+Cambria,EHRENFELD BOROUGH,Ballots Cast,,DEM,,20,4,0,24
+Cambria,EHRENFELD BOROUGH,Ballots Cast,,REP,,15,2,0,17
+Cambria,EHRENFELD BOROUGH,President,,DEM,Bernie Sanders,6,1,0,7
+Cambria,EHRENFELD BOROUGH,President,,DEM,Joseph R. Biden,12,3,0,15
+Cambria,EHRENFELD BOROUGH,President,,DEM,Tulsi Gabbard,0,0,0,0
+Cambria,EHRENFELD BOROUGH,President,,DEM,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,Attorney General,,DEM,Josh Shapiro,16,4,0,20
+Cambria,EHRENFELD BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,EHRENFELD BOROUGH,Auditor General,,DEM,H. Scott Conklin,8,1,0,9
+Cambria,EHRENFELD BOROUGH,Auditor General,,DEM,Michael Lamb,6,0,0,6
+Cambria,EHRENFELD BOROUGH,Auditor General,,DEM,Tracie Fountain,1,1,0,2
+Cambria,EHRENFELD BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,1
+Cambria,EHRENFELD BOROUGH,Auditor General,,DEM,Nina Ahmad,0,0,0,0
+Cambria,EHRENFELD BOROUGH,Auditor General,,DEM,Christina M. Hartman,1,1,0,2
+Cambria,EHRENFELD BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,State Treasurer,,DEM,Joe Torsella,16,4,0,20
+Cambria,EHRENFELD BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,U.S. House,15,DEM,Robert Williams,16,3,0,19
+Cambria,EHRENFELD BOROUGH,U.S. House,15,DEM,Write-In,0,1,0,1
+Cambria,EHRENFELD BOROUGH,State Senator,35,DEM,Shaun Dougherty,17,4,0,21
+Cambria,EHRENFELD BOROUGH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,General Assembly,71,DEM,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,President,,REP,Donald J. Trump,13,1,0,14
+Cambria,EHRENFELD BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,EHRENFELD BOROUGH,President,,REP,Bill Weld,2,0,0,2
+Cambria,EHRENFELD BOROUGH,President,,REP,Write-In,0,1,0,1
+Cambria,EHRENFELD BOROUGH,Attorney General,,REP,Heather Heidelbaugh,12,2,0,14
+Cambria,EHRENFELD BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,Auditor General,,REP,Timothy Defoor,12,2,0,14
+Cambria,EHRENFELD BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,State Treasurer,,REP,Stacy L. Garrity,13,2,0,15
+Cambria,EHRENFELD BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,13,2,0,15
+Cambria,EHRENFELD BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,14,2,0,16
+Cambria,EHRENFELD BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,EHRENFELD BOROUGH,General Assembly,71,REP,Jim Rigby,15,2,0,17
+Cambria,EHRENFELD BOROUGH,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,ELDER TOWNSHIP,Registered Voters,,,,,,,552
+Cambria,ELDER TOWNSHIP,Registered Voters,,DEM,,,,,302
+Cambria,ELDER TOWNSHIP,Registered Voters,,REP,,,,,203
+Cambria,ELDER TOWNSHIP,Ballots Cast,,,,137,72,1,210
+Cambria,ELDER TOWNSHIP,Ballots Cast,,DEM,,66,52,1,119
+Cambria,ELDER TOWNSHIP,Ballots Cast,,REP,,71,20,0,91
+Cambria,ELDER TOWNSHIP,President,,DEM,Bernie Sanders,9,6,0,15
+Cambria,ELDER TOWNSHIP,President,,DEM,Joseph R. Biden,33,37,0,70
+Cambria,ELDER TOWNSHIP,President,,DEM,Tulsi Gabbard,7,4,0,11
+Cambria,ELDER TOWNSHIP,President,,DEM,Write-In,10,2,1,13
+Cambria,ELDER TOWNSHIP,Attorney General,,DEM,Josh Shapiro,58,50,0,108
+Cambria,ELDER TOWNSHIP,Attorney General,,DEM,Write-In,2,0,0,2
+Cambria,ELDER TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,44,34,1,79
+Cambria,ELDER TOWNSHIP,Auditor General,,DEM,Michael Lamb,10,9,0,19
+Cambria,ELDER TOWNSHIP,Auditor General,,DEM,Tracie Fountain,3,0,0,3
+Cambria,ELDER TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,0,4
+Cambria,ELDER TOWNSHIP,Auditor General,,DEM,Nina Ahmad,2,2,0,4
+Cambria,ELDER TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,2,5,0,7
+Cambria,ELDER TOWNSHIP,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,ELDER TOWNSHIP,State Treasurer,,DEM,Joe Torsella,56,46,0,102
+Cambria,ELDER TOWNSHIP,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,ELDER TOWNSHIP,U.S. House,15,DEM,Robert Williams,60,50,1,111
+Cambria,ELDER TOWNSHIP,U.S. House,15,DEM,Write-In,2,0,0,2
+Cambria,ELDER TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,54,49,0,103
+Cambria,ELDER TOWNSHIP,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,ELDER TOWNSHIP,General Assembly,72,DEM,Frank Burns,58,50,0,108
+Cambria,ELDER TOWNSHIP,General Assembly,72,DEM,Write-In,6,0,0,6
+Cambria,ELDER TOWNSHIP,President,,REP,Donald J. Trump,70,19,0,89
+Cambria,ELDER TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,ELDER TOWNSHIP,President,,REP,Bill Weld,1,1,0,2
+Cambria,ELDER TOWNSHIP,President,,REP,Write-In,0,0,0,0
+Cambria,ELDER TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,61,18,0,79
+Cambria,ELDER TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,ELDER TOWNSHIP,Auditor General,,REP,Timothy Defoor,60,18,0,78
+Cambria,ELDER TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,ELDER TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,61,18,0,79
+Cambria,ELDER TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,ELDER TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,67,19,0,86
+Cambria,ELDER TOWNSHIP,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,ELDER TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,67,19,0,86
+Cambria,ELDER TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,ELDER TOWNSHIP,General Assembly,72,REP,Howard Terndrup,45,17,0,62
+Cambria,ELDER TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,23,3,0,26
+Cambria,ELDER TOWNSHIP,General Assembly,72,REP,Write-In,1,0,0,1
+Cambria,FERNDALE BOROUGH,Registered Voters,,,,,,,965
+Cambria,FERNDALE BOROUGH,Registered Voters,,DEM,,,,,445
+Cambria,FERNDALE BOROUGH,Registered Voters,,REP,,,,,417
+Cambria,FERNDALE BOROUGH,Ballots Cast,,,,192,126,4,322
+Cambria,FERNDALE BOROUGH,Ballots Cast,,DEM,,75,76,2,153
+Cambria,FERNDALE BOROUGH,Ballots Cast,,REP,,117,50,2,169
+Cambria,FERNDALE BOROUGH,President,,DEM,Bernie Sanders,17,15,0,32
+Cambria,FERNDALE BOROUGH,President,,DEM,Joseph R. Biden,37,53,1,91
+Cambria,FERNDALE BOROUGH,President,,DEM,Tulsi Gabbard,7,6,0,13
+Cambria,FERNDALE BOROUGH,President,,DEM,Write-In,3,1,0,4
+Cambria,FERNDALE BOROUGH,Attorney General,,DEM,Josh Shapiro,67,67,1,135
+Cambria,FERNDALE BOROUGH,Attorney General,,DEM,Write-In,1,2,0,3
+Cambria,FERNDALE BOROUGH,Auditor General,,DEM,H. Scott Conklin,31,28,1,60
+Cambria,FERNDALE BOROUGH,Auditor General,,DEM,Michael Lamb,23,27,0,50
+Cambria,FERNDALE BOROUGH,Auditor General,,DEM,Tracie Fountain,0,6,0,6
+Cambria,FERNDALE BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,6,2,0,8
+Cambria,FERNDALE BOROUGH,Auditor General,,DEM,Nina Ahmad,4,1,0,5
+Cambria,FERNDALE BOROUGH,Auditor General,,DEM,Christina M. Hartman,4,6,1,11
+Cambria,FERNDALE BOROUGH,Auditor General,,DEM,Write-In,1,1,0,2
+Cambria,FERNDALE BOROUGH,State Treasurer,,DEM,Joe Torsella,66,69,1,136
+Cambria,FERNDALE BOROUGH,State Treasurer,,DEM,Write-In,1,1,0,2
+Cambria,FERNDALE BOROUGH,U.S. House,13,DEM,Todd Rowley,65,68,2,135
+Cambria,FERNDALE BOROUGH,U.S. House,13,DEM,Write-In,1,1,0,2
+Cambria,FERNDALE BOROUGH,State Senator,35,DEM,Shaun Dougherty,63,68,2,133
+Cambria,FERNDALE BOROUGH,State Senator,35,DEM,Write-In,1,1,0,2
+Cambria,FERNDALE BOROUGH,General Assembly,71,DEM,Write-In,8,6,0,14
+Cambria,FERNDALE BOROUGH,President,,REP,Donald J. Trump,114,42,2,158
+Cambria,FERNDALE BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,FERNDALE BOROUGH,President,,REP,Bill Weld,1,6,0,7
+Cambria,FERNDALE BOROUGH,President,,REP,Write-In,1,1,0,2
+Cambria,FERNDALE BOROUGH,Attorney General,,REP,Heather Heidelbaugh,108,44,2,154
+Cambria,FERNDALE BOROUGH,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,FERNDALE BOROUGH,Auditor General,,REP,Timothy Defoor,108,44,2,154
+Cambria,FERNDALE BOROUGH,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,FERNDALE BOROUGH,State Treasurer,,REP,Stacy L. Garrity,108,45,2,155
+Cambria,FERNDALE BOROUGH,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,FERNDALE BOROUGH,U.S. House,13,REP,John Joyce,111,47,2,160
+Cambria,FERNDALE BOROUGH,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,FERNDALE BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,115,44,2,161
+Cambria,FERNDALE BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,FERNDALE BOROUGH,General Assembly,71,REP,Jim Rigby,114,50,2,166
+Cambria,FERNDALE BOROUGH,General Assembly,71,REP,Write-In,3,0,0,3
+Cambria,FRANKLIN BOROUGH,Registered Voters,,,,,,,173
+Cambria,FRANKLIN BOROUGH,Registered Voters,,DEM,,,,,125
+Cambria,FRANKLIN BOROUGH,Registered Voters,,REP,,,,,34
+Cambria,FRANKLIN BOROUGH,Ballots Cast,,,,49,23,0,72
+Cambria,FRANKLIN BOROUGH,Ballots Cast,,DEM,,35,20,0,55
+Cambria,FRANKLIN BOROUGH,Ballots Cast,,REP,,14,3,0,17
+Cambria,FRANKLIN BOROUGH,President,,DEM,Bernie Sanders,8,1,0,9
+Cambria,FRANKLIN BOROUGH,President,,DEM,Joseph R. Biden,17,19,0,36
+Cambria,FRANKLIN BOROUGH,President,,DEM,Tulsi Gabbard,2,0,0,2
+Cambria,FRANKLIN BOROUGH,President,,DEM,Write-In,3,0,0,3
+Cambria,FRANKLIN BOROUGH,Attorney General,,DEM,Josh Shapiro,30,20,0,50
+Cambria,FRANKLIN BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,Auditor General,,DEM,H. Scott Conklin,11,11,0,22
+Cambria,FRANKLIN BOROUGH,Auditor General,,DEM,Michael Lamb,14,6,0,20
+Cambria,FRANKLIN BOROUGH,Auditor General,,DEM,Tracie Fountain,2,0,0,2
+Cambria,FRANKLIN BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,1
+Cambria,FRANKLIN BOROUGH,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,FRANKLIN BOROUGH,Auditor General,,DEM,Christina M. Hartman,5,1,0,6
+Cambria,FRANKLIN BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,State Treasurer,,DEM,Joe Torsella,30,19,0,49
+Cambria,FRANKLIN BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,U.S. House,13,DEM,Todd Rowley,31,18,0,49
+Cambria,FRANKLIN BOROUGH,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,State Senator,35,DEM,Shaun Dougherty,32,18,0,50
+Cambria,FRANKLIN BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,FRANKLIN BOROUGH,General Assembly,71,DEM,Write-In,2,1,0,3
+Cambria,FRANKLIN BOROUGH,President,,REP,Donald J. Trump,13,3,0,16
+Cambria,FRANKLIN BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,FRANKLIN BOROUGH,President,,REP,Bill Weld,0,0,0,0
+Cambria,FRANKLIN BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,Attorney General,,REP,Heather Heidelbaugh,13,3,0,16
+Cambria,FRANKLIN BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,Auditor General,,REP,Timothy Defoor,13,3,0,16
+Cambria,FRANKLIN BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,State Treasurer,,REP,Stacy L. Garrity,13,3,0,16
+Cambria,FRANKLIN BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,U.S. House,13,REP,John Joyce,14,3,0,17
+Cambria,FRANKLIN BOROUGH,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,14,3,0,17
+Cambria,FRANKLIN BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,FRANKLIN BOROUGH,General Assembly,71,REP,Jim Rigby,14,3,0,17
+Cambria,FRANKLIN BOROUGH,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,GALLITZIN BOROUGH,Registered Voters,,,,,,,895
+Cambria,GALLITZIN BOROUGH,Registered Voters,,DEM,,,,,416
+Cambria,GALLITZIN BOROUGH,Registered Voters,,REP,,,,,356
+Cambria,GALLITZIN BOROUGH,Ballots Cast,,,,258,74,1,333
+Cambria,GALLITZIN BOROUGH,Ballots Cast,,DEM,,129,52,0,181
+Cambria,GALLITZIN BOROUGH,Ballots Cast,,REP,,129,22,1,152
+Cambria,GALLITZIN BOROUGH,President,,DEM,Bernie Sanders,28,10,0,38
+Cambria,GALLITZIN BOROUGH,President,,DEM,Joseph R. Biden,65,38,0,103
+Cambria,GALLITZIN BOROUGH,President,,DEM,Tulsi Gabbard,12,2,0,14
+Cambria,GALLITZIN BOROUGH,President,,DEM,Write-In,15,1,0,16
+Cambria,GALLITZIN BOROUGH,Attorney General,,DEM,Josh Shapiro,117,48,0,165
+Cambria,GALLITZIN BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,GALLITZIN BOROUGH,Auditor General,,DEM,H. Scott Conklin,64,29,0,93
+Cambria,GALLITZIN BOROUGH,Auditor General,,DEM,Michael Lamb,34,11,0,45
+Cambria,GALLITZIN BOROUGH,Auditor General,,DEM,Tracie Fountain,5,2,0,7
+Cambria,GALLITZIN BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,7,1,0,8
+Cambria,GALLITZIN BOROUGH,Auditor General,,DEM,Nina Ahmad,6,6,0,12
+Cambria,GALLITZIN BOROUGH,Auditor General,,DEM,Christina M. Hartman,9,1,0,10
+Cambria,GALLITZIN BOROUGH,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,GALLITZIN BOROUGH,State Treasurer,,DEM,Joe Torsella,117,51,0,168
+Cambria,GALLITZIN BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,GALLITZIN BOROUGH,U.S. House,15,DEM,Robert Williams,114,47,0,161
+Cambria,GALLITZIN BOROUGH,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,GALLITZIN BOROUGH,State Senator,35,DEM,Shaun Dougherty,117,49,0,166
+Cambria,GALLITZIN BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,GALLITZIN BOROUGH,General Assembly,72,DEM,Frank Burns,125,51,0,176
+Cambria,GALLITZIN BOROUGH,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,GALLITZIN BOROUGH,President,,REP,Donald J. Trump,127,20,1,148
+Cambria,GALLITZIN BOROUGH,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,GALLITZIN BOROUGH,President,,REP,Bill Weld,0,1,0,1
+Cambria,GALLITZIN BOROUGH,President,,REP,Write-In,1,0,0,1
+Cambria,GALLITZIN BOROUGH,Attorney General,,REP,Heather Heidelbaugh,122,22,1,145
+Cambria,GALLITZIN BOROUGH,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,GALLITZIN BOROUGH,Auditor General,,REP,Timothy Defoor,118,22,1,141
+Cambria,GALLITZIN BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,GALLITZIN BOROUGH,State Treasurer,,REP,Stacy L. Garrity,122,22,1,145
+Cambria,GALLITZIN BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,GALLITZIN BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,119,22,1,142
+Cambria,GALLITZIN BOROUGH,U.S. House,15,REP,Write-In,3,0,0,3
+Cambria,GALLITZIN BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,121,22,1,144
+Cambria,GALLITZIN BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,GALLITZIN BOROUGH,General Assembly,72,REP,Howard Terndrup,65,10,0,75
+Cambria,GALLITZIN BOROUGH,General Assembly,72,REP,Jerry Carnicella,54,12,1,67
+Cambria,GALLITZIN BOROUGH,General Assembly,72,REP,Write-In,8,0,0,8
+Cambria,GALLITZIN TOWNSHIP,Registered Voters,,,,,,,820
+Cambria,GALLITZIN TOWNSHIP,Registered Voters,,DEM,,,,,317
+Cambria,GALLITZIN TOWNSHIP,Registered Voters,,REP,,,,,427
+Cambria,GALLITZIN TOWNSHIP,Ballots Cast,,,,200,76,9,285
+Cambria,GALLITZIN TOWNSHIP,Ballots Cast,,DEM,,76,46,1,123
+Cambria,GALLITZIN TOWNSHIP,Ballots Cast,,REP,,124,30,8,162
+Cambria,GALLITZIN TOWNSHIP,President,,DEM,Bernie Sanders,15,5,1,21
+Cambria,GALLITZIN TOWNSHIP,President,,DEM,Joseph R. Biden,32,39,0,71
+Cambria,GALLITZIN TOWNSHIP,President,,DEM,Tulsi Gabbard,14,1,0,15
+Cambria,GALLITZIN TOWNSHIP,President,,DEM,Write-In,8,0,0,8
+Cambria,GALLITZIN TOWNSHIP,Attorney General,,DEM,Josh Shapiro,65,42,0,107
+Cambria,GALLITZIN TOWNSHIP,Attorney General,,DEM,Write-In,6,1,0,7
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,33,32,0,65
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,DEM,Michael Lamb,21,4,0,25
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,DEM,Tracie Fountain,2,2,0,4
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,5
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,DEM,Nina Ahmad,3,1,1,5
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,5,3,0,8
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,DEM,Write-In,5,0,0,5
+Cambria,GALLITZIN TOWNSHIP,State Treasurer,,DEM,Joe Torsella,66,41,0,107
+Cambria,GALLITZIN TOWNSHIP,State Treasurer,,DEM,Write-In,6,1,0,7
+Cambria,GALLITZIN TOWNSHIP,U.S. House,15,DEM,Robert Williams,62,41,0,103
+Cambria,GALLITZIN TOWNSHIP,U.S. House,15,DEM,Write-In,6,0,0,6
+Cambria,GALLITZIN TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,63,41,0,104
+Cambria,GALLITZIN TOWNSHIP,State Senator,35,DEM,Write-In,5,0,0,5
+Cambria,GALLITZIN TOWNSHIP,General Assembly,72,DEM,Frank Burns,71,45,0,116
+Cambria,GALLITZIN TOWNSHIP,General Assembly,72,DEM,Write-In,3,0,0,3
+Cambria,GALLITZIN TOWNSHIP,President,,REP,Donald J. Trump,117,29,8,154
+Cambria,GALLITZIN TOWNSHIP,President,,REP,Roque Rocky De La Fuente,5,0,0,5
+Cambria,GALLITZIN TOWNSHIP,President,,REP,Bill Weld,1,0,0,1
+Cambria,GALLITZIN TOWNSHIP,President,,REP,Write-In,1,0,0,1
+Cambria,GALLITZIN TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,113,23,6,142
+Cambria,GALLITZIN TOWNSHIP,Attorney General,,REP,Write-In,2,0,0,2
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,REP,Timothy Defoor,111,24,6,141
+Cambria,GALLITZIN TOWNSHIP,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,GALLITZIN TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,113,24,6,143
+Cambria,GALLITZIN TOWNSHIP,State Treasurer,,REP,Write-In,2,0,0,2
+Cambria,GALLITZIN TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,115,24,7,146
+Cambria,GALLITZIN TOWNSHIP,U.S. House,15,REP,Write-In,2,0,0,2
+Cambria,GALLITZIN TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,112,25,7,144
+Cambria,GALLITZIN TOWNSHIP,State Senator,35,REP,Write-In,2,0,0,2
+Cambria,GALLITZIN TOWNSHIP,General Assembly,72,REP,Howard Terndrup,59,15,1,75
+Cambria,GALLITZIN TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,61,11,6,78
+Cambria,GALLITZIN TOWNSHIP,General Assembly,72,REP,Write-In,2,0,0,2
+Cambria,GEISTOWN BOROUGH NO. 1,Registered Voters,,,,,,,672
+Cambria,GEISTOWN BOROUGH NO. 1,Registered Voters,,DEM,,,,,281
+Cambria,GEISTOWN BOROUGH NO. 1,Registered Voters,,REP,,,,,306
+Cambria,GEISTOWN BOROUGH NO. 1,Ballots Cast,,,,113,130,1,244
+Cambria,GEISTOWN BOROUGH NO. 1,Ballots Cast,,DEM,,36,80,1,117
+Cambria,GEISTOWN BOROUGH NO. 1,Ballots Cast,,REP,,77,50,0,127
+Cambria,GEISTOWN BOROUGH NO. 1,President,,DEM,Bernie Sanders,5,15,0,20
+Cambria,GEISTOWN BOROUGH NO. 1,President,,DEM,Joseph R. Biden,23,55,0,78
+Cambria,GEISTOWN BOROUGH NO. 1,President,,DEM,Tulsi Gabbard,3,3,1,7
+Cambria,GEISTOWN BOROUGH NO. 1,President,,DEM,Write-In,1,3,0,4
+Cambria,GEISTOWN BOROUGH NO. 1,Attorney General,,DEM,Josh Shapiro,32,77,1,110
+Cambria,GEISTOWN BOROUGH NO. 1,Attorney General,,DEM,Write-In,0,2,0,2
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,DEM,H. Scott Conklin,17,41,0,58
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,DEM,Michael Lamb,13,16,1,30
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,DEM,Tracie Fountain,1,4,0,5
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,1,4,0,5
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,DEM,Nina Ahmad,1,9,0,10
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,DEM,Christina M. Hartman,2,4,0,6
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,DEM,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 1,State Treasurer,,DEM,Joe Torsella,33,72,1,106
+Cambria,GEISTOWN BOROUGH NO. 1,State Treasurer,,DEM,Write-In,0,2,0,2
+Cambria,GEISTOWN BOROUGH NO. 1,U.S. House,15,DEM,Robert Williams,32,73,1,106
+Cambria,GEISTOWN BOROUGH NO. 1,U.S. House,15,DEM,Write-In,0,2,0,2
+Cambria,GEISTOWN BOROUGH NO. 1,State Senator,35,DEM,Shaun Dougherty,31,77,1,109
+Cambria,GEISTOWN BOROUGH NO. 1,State Senator,35,DEM,Write-In,0,2,0,2
+Cambria,GEISTOWN BOROUGH NO. 1,General Assembly,71,DEM,Write-In,2,12,0,14
+Cambria,GEISTOWN BOROUGH NO. 1,President,,REP,Donald J. Trump,76,45,0,121
+Cambria,GEISTOWN BOROUGH NO. 1,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,GEISTOWN BOROUGH NO. 1,President,,REP,Bill Weld,0,4,0,4
+Cambria,GEISTOWN BOROUGH NO. 1,President,,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 1,Attorney General,,REP,Heather Heidelbaugh,71,46,0,117
+Cambria,GEISTOWN BOROUGH NO. 1,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,REP,Timothy Defoor,73,46,0,119
+Cambria,GEISTOWN BOROUGH NO. 1,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 1,State Treasurer,,REP,Stacy L. Garrity,73,45,0,118
+Cambria,GEISTOWN BOROUGH NO. 1,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 1,U.S. House,15,REP,Glenn Gt Thompson,75,47,0,122
+Cambria,GEISTOWN BOROUGH NO. 1,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,77,49,0,126
+Cambria,GEISTOWN BOROUGH NO. 1,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 1,General Assembly,71,REP,Jim Rigby,76,49,0,125
+Cambria,GEISTOWN BOROUGH NO. 1,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 2,Registered Voters,,,,,,,997
+Cambria,GEISTOWN BOROUGH NO. 2,Registered Voters,,DEM,,,,,450
+Cambria,GEISTOWN BOROUGH NO. 2,Registered Voters,,REP,,,,,461
+Cambria,GEISTOWN BOROUGH NO. 2,Ballots Cast,,,,214,190,4,408
+Cambria,GEISTOWN BOROUGH NO. 2,Ballots Cast,,DEM,,81,132,3,216
+Cambria,GEISTOWN BOROUGH NO. 2,Ballots Cast,,REP,,133,58,1,192
+Cambria,GEISTOWN BOROUGH NO. 2,President,,DEM,Bernie Sanders,15,12,1,28
+Cambria,GEISTOWN BOROUGH NO. 2,President,,DEM,Joseph R. Biden,45,108,1,154
+Cambria,GEISTOWN BOROUGH NO. 2,President,,DEM,Tulsi Gabbard,5,5,0,10
+Cambria,GEISTOWN BOROUGH NO. 2,President,,DEM,Write-In,4,4,1,9
+Cambria,GEISTOWN BOROUGH NO. 2,Attorney General,,DEM,Josh Shapiro,75,120,2,197
+Cambria,GEISTOWN BOROUGH NO. 2,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,DEM,H. Scott Conklin,43,72,0,115
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,DEM,Michael Lamb,18,36,0,54
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,DEM,Tracie Fountain,3,8,0,11
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,DEM,Rose Rosie Marie Davis,5,4,1,10
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,DEM,Nina Ahmad,6,4,1,11
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,DEM,Christina M. Hartman,2,2,0,4
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,GEISTOWN BOROUGH NO. 2,State Treasurer,,DEM,Joe Torsella,75,113,2,190
+Cambria,GEISTOWN BOROUGH NO. 2,State Treasurer,,DEM,Write-In,1,2,0,3
+Cambria,GEISTOWN BOROUGH NO. 2,U.S. House,15,DEM,Robert Williams,74,119,2,195
+Cambria,GEISTOWN BOROUGH NO. 2,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,GEISTOWN BOROUGH NO. 2,State Senator,35,DEM,Shaun Dougherty,72,116,2,190
+Cambria,GEISTOWN BOROUGH NO. 2,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,GEISTOWN BOROUGH NO. 2,General Assembly,71,DEM,Write-In,3,13,1,17
+Cambria,GEISTOWN BOROUGH NO. 2,President,,REP,Donald J. Trump,130,46,1,177
+Cambria,GEISTOWN BOROUGH NO. 2,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,GEISTOWN BOROUGH NO. 2,President,,REP,Bill Weld,2,1,0,3
+Cambria,GEISTOWN BOROUGH NO. 2,President,,REP,Write-In,0,6,0,6
+Cambria,GEISTOWN BOROUGH NO. 2,Attorney General,,REP,Heather Heidelbaugh,116,47,1,164
+Cambria,GEISTOWN BOROUGH NO. 2,Attorney General,,REP,Write-In,0,3,0,3
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,REP,Timothy Defoor,117,48,1,166
+Cambria,GEISTOWN BOROUGH NO. 2,Auditor General,,REP,Write-In,0,2,0,2
+Cambria,GEISTOWN BOROUGH NO. 2,State Treasurer,,REP,Stacy L. Garrity,116,47,1,164
+Cambria,GEISTOWN BOROUGH NO. 2,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 2,U.S. House,15,REP,Glenn Gt Thompson,122,52,1,175
+Cambria,GEISTOWN BOROUGH NO. 2,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 2,State Senator,35,REP,Wayne Langerholc Jr.,127,54,1,182
+Cambria,GEISTOWN BOROUGH NO. 2,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,GEISTOWN BOROUGH NO. 2,General Assembly,71,REP,Jim Rigby,129,54,1,184
+Cambria,GEISTOWN BOROUGH NO. 2,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,HASTINGS BOROUGH,Registered Voters,,,,,,,707
+Cambria,HASTINGS BOROUGH,Registered Voters,,DEM,,,,,368
+Cambria,HASTINGS BOROUGH,Registered Voters,,REP,,,,,254
+Cambria,HASTINGS BOROUGH,Ballots Cast,,,,152,82,2,236
+Cambria,HASTINGS BOROUGH,Ballots Cast,,DEM,,67,58,1,126
+Cambria,HASTINGS BOROUGH,Ballots Cast,,REP,,85,24,1,110
+Cambria,HASTINGS BOROUGH,President,,DEM,Bernie Sanders,10,3,0,13
+Cambria,HASTINGS BOROUGH,President,,DEM,Joseph R. Biden,36,47,1,84
+Cambria,HASTINGS BOROUGH,President,,DEM,Tulsi Gabbard,8,5,0,13
+Cambria,HASTINGS BOROUGH,President,,DEM,Write-In,11,2,0,13
+Cambria,HASTINGS BOROUGH,Attorney General,,DEM,Josh Shapiro,57,54,0,111
+Cambria,HASTINGS BOROUGH,Attorney General,,DEM,Write-In,3,0,0,3
+Cambria,HASTINGS BOROUGH,Auditor General,,DEM,H. Scott Conklin,40,37,0,77
+Cambria,HASTINGS BOROUGH,Auditor General,,DEM,Michael Lamb,12,9,1,22
+Cambria,HASTINGS BOROUGH,Auditor General,,DEM,Tracie Fountain,1,1,0,2
+Cambria,HASTINGS BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,0,3
+Cambria,HASTINGS BOROUGH,Auditor General,,DEM,Nina Ahmad,4,1,0,5
+Cambria,HASTINGS BOROUGH,Auditor General,,DEM,Christina M. Hartman,4,6,0,10
+Cambria,HASTINGS BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,HASTINGS BOROUGH,State Treasurer,,DEM,Joe Torsella,54,49,0,103
+Cambria,HASTINGS BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,HASTINGS BOROUGH,U.S. House,15,DEM,Robert Williams,58,52,1,111
+Cambria,HASTINGS BOROUGH,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,HASTINGS BOROUGH,State Senator,35,DEM,Shaun Dougherty,58,49,1,108
+Cambria,HASTINGS BOROUGH,State Senator,35,DEM,Write-In,2,1,0,3
+Cambria,HASTINGS BOROUGH,General Assembly,73,DEM,Write-In,3,6,0,9
+Cambria,HASTINGS BOROUGH,President,,REP,Donald J. Trump,81,23,1,105
+Cambria,HASTINGS BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,HASTINGS BOROUGH,President,,REP,Bill Weld,2,1,0,3
+Cambria,HASTINGS BOROUGH,President,,REP,Write-In,2,0,0,2
+Cambria,HASTINGS BOROUGH,Attorney General,,REP,Heather Heidelbaugh,79,18,1,98
+Cambria,HASTINGS BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,HASTINGS BOROUGH,Auditor General,,REP,Timothy Defoor,78,19,1,98
+Cambria,HASTINGS BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,HASTINGS BOROUGH,State Treasurer,,REP,Stacy L. Garrity,79,18,1,98
+Cambria,HASTINGS BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,HASTINGS BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,83,22,1,106
+Cambria,HASTINGS BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,HASTINGS BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,84,22,1,107
+Cambria,HASTINGS BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,HASTINGS BOROUGH,General Assembly,73,REP,Tommy Sankey,81,22,1,104
+Cambria,HASTINGS BOROUGH,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO. 1,Registered Voters,,,,,,,542
+Cambria,JACKSON TOWNSHIP NO. 1,Registered Voters,,DEM,,,,,229
+Cambria,JACKSON TOWNSHIP NO. 1,Registered Voters,,REP,,,,,264
+Cambria,JACKSON TOWNSHIP NO. 1,Ballots Cast,,,,141,76,5,222
+Cambria,JACKSON TOWNSHIP NO. 1,Ballots Cast,,DEM,,46,51,3,100
+Cambria,JACKSON TOWNSHIP NO. 1,Ballots Cast,,REP,,95,25,2,122
+Cambria,JACKSON TOWNSHIP NO. 1,President,,DEM,Bernie Sanders,11,5,0,16
+Cambria,JACKSON TOWNSHIP NO. 1,President,,DEM,Joseph R. Biden,14,45,3,62
+Cambria,JACKSON TOWNSHIP NO. 1,President,,DEM,Tulsi Gabbard,9,1,0,10
+Cambria,JACKSON TOWNSHIP NO. 1,President,,DEM,Write-In,9,0,0,9
+Cambria,JACKSON TOWNSHIP NO. 1,Attorney General,,DEM,Josh Shapiro,38,50,3,91
+Cambria,JACKSON TOWNSHIP NO. 1,Attorney General,,DEM,Write-In,2,0,0,2
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,DEM,H. Scott Conklin,18,31,0,49
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,DEM,Michael Lamb,14,11,2,27
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,DEM,Tracie Fountain,0,2,0,2
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,3
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,DEM,Christina M. Hartman,5,3,0,8
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO. 1,State Treasurer,,DEM,Joe Torsella,38,47,3,88
+Cambria,JACKSON TOWNSHIP NO. 1,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,JACKSON TOWNSHIP NO. 1,U.S. House,15,DEM,Robert Williams,39,48,3,90
+Cambria,JACKSON TOWNSHIP NO. 1,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO. 1,State Senator,35,DEM,Shaun Dougherty,40,47,3,90
+Cambria,JACKSON TOWNSHIP NO. 1,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,JACKSON TOWNSHIP NO. 1,General Assembly,72,DEM,Frank Burns,43,49,3,95
+Cambria,JACKSON TOWNSHIP NO. 1,General Assembly,72,DEM,Write-In,0,1,0,1
+Cambria,JACKSON TOWNSHIP NO. 1,President,,REP,Donald J. Trump,93,20,2,115
+Cambria,JACKSON TOWNSHIP NO. 1,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,JACKSON TOWNSHIP NO. 1,President,,REP,Bill Weld,1,3,0,4
+Cambria,JACKSON TOWNSHIP NO. 1,President,,REP,Write-In,0,1,0,1
+Cambria,JACKSON TOWNSHIP NO. 1,Attorney General,,REP,Heather Heidelbaugh,88,25,2,115
+Cambria,JACKSON TOWNSHIP NO. 1,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,REP,Timothy Defoor,89,25,2,116
+Cambria,JACKSON TOWNSHIP NO. 1,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO. 1,State Treasurer,,REP,Stacy L. Garrity,87,25,2,114
+Cambria,JACKSON TOWNSHIP NO. 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO. 1,U.S. House,15,REP,Glenn Gt Thompson,89,25,2,116
+Cambria,JACKSON TOWNSHIP NO. 1,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,92,23,2,117
+Cambria,JACKSON TOWNSHIP NO. 1,State Senator,35,REP,Write-In,1,1,0,2
+Cambria,JACKSON TOWNSHIP NO. 1,General Assembly,72,REP,Howard Terndrup,64,23,2,89
+Cambria,JACKSON TOWNSHIP NO. 1,General Assembly,72,REP,Jerry Carnicella,25,2,0,27
+Cambria,JACKSON TOWNSHIP NO. 1,General Assembly,72,REP,Write-In,5,0,0,5
+Cambria,JACKSON TOWNSHIP - VINCO,Registered Voters,,,,,,,1085
+Cambria,JACKSON TOWNSHIP - VINCO,Registered Voters,,DEM,,,,,440
+Cambria,JACKSON TOWNSHIP - VINCO,Registered Voters,,REP,,,,,541
+Cambria,JACKSON TOWNSHIP - VINCO,Ballots Cast,,,,270,194,0,464
+Cambria,JACKSON TOWNSHIP - VINCO,Ballots Cast,,DEM,,90,111,0,201
+Cambria,JACKSON TOWNSHIP - VINCO,Ballots Cast,,REP,,180,83,0,263
+Cambria,JACKSON TOWNSHIP - VINCO,President,,DEM,Bernie Sanders,17,16,0,33
+Cambria,JACKSON TOWNSHIP - VINCO,President,,DEM,Joseph R. Biden,37,74,0,111
+Cambria,JACKSON TOWNSHIP - VINCO,President,,DEM,Tulsi Gabbard,13,8,0,21
+Cambria,JACKSON TOWNSHIP - VINCO,President,,DEM,Write-In,16,8,0,24
+Cambria,JACKSON TOWNSHIP - VINCO,Attorney General,,DEM,Josh Shapiro,81,97,0,178
+Cambria,JACKSON TOWNSHIP - VINCO,Attorney General,,DEM,Write-In,1,1,0,2
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,DEM,H. Scott Conklin,39,61,0,100
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,DEM,Michael Lamb,16,21,0,37
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,DEM,Tracie Fountain,3,2,0,5
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,DEM,Rose Rosie Marie Davis,6,4,0,10
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,DEM,Nina Ahmad,7,7,0,14
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,DEM,Christina M. Hartman,10,6,0,16
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,JACKSON TOWNSHIP - VINCO,State Treasurer,,DEM,Joe Torsella,75,94,0,169
+Cambria,JACKSON TOWNSHIP - VINCO,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,JACKSON TOWNSHIP - VINCO,U.S. House,15,DEM,Robert Williams,76,97,0,173
+Cambria,JACKSON TOWNSHIP - VINCO,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,JACKSON TOWNSHIP - VINCO,State Senator,35,DEM,Shaun Dougherty,81,101,0,182
+Cambria,JACKSON TOWNSHIP - VINCO,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,JACKSON TOWNSHIP - VINCO,General Assembly,72,DEM,Frank Burns,85,103,0,188
+Cambria,JACKSON TOWNSHIP - VINCO,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,JACKSON TOWNSHIP - VINCO,President,,REP,Donald J. Trump,174,72,0,246
+Cambria,JACKSON TOWNSHIP - VINCO,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Cambria,JACKSON TOWNSHIP - VINCO,President,,REP,Bill Weld,4,7,0,11
+Cambria,JACKSON TOWNSHIP - VINCO,President,,REP,Write-In,1,1,0,2
+Cambria,JACKSON TOWNSHIP - VINCO,Attorney General,,REP,Heather Heidelbaugh,161,74,0,235
+Cambria,JACKSON TOWNSHIP - VINCO,Attorney General,,REP,Write-In,2,0,0,2
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,REP,Timothy Defoor,154,74,0,228
+Cambria,JACKSON TOWNSHIP - VINCO,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,JACKSON TOWNSHIP - VINCO,State Treasurer,,REP,Stacy L. Garrity,158,73,0,231
+Cambria,JACKSON TOWNSHIP - VINCO,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,JACKSON TOWNSHIP - VINCO,U.S. House,15,REP,Glenn Gt Thompson,158,74,0,232
+Cambria,JACKSON TOWNSHIP - VINCO,U.S. House,15,REP,Write-In,2,1,0,3
+Cambria,JACKSON TOWNSHIP - VINCO,State Senator,35,REP,Wayne Langerholc Jr.,166,79,0,245
+Cambria,JACKSON TOWNSHIP - VINCO,State Senator,35,REP,Write-In,3,1,0,4
+Cambria,JACKSON TOWNSHIP - VINCO,General Assembly,72,REP,Howard Terndrup,106,64,0,170
+Cambria,JACKSON TOWNSHIP - VINCO,General Assembly,72,REP,Jerry Carnicella,45,13,0,58
+Cambria,JACKSON TOWNSHIP - VINCO,General Assembly,72,REP,Write-In,22,4,0,26
+Cambria,JACKSON TOWNSHIP NO.3,Registered Voters,,,,,,,1147
+Cambria,JACKSON TOWNSHIP NO.3,Registered Voters,,DEM,,,,,458
+Cambria,JACKSON TOWNSHIP NO.3,Registered Voters,,REP,,,,,590
+Cambria,JACKSON TOWNSHIP NO.3,Ballots Cast,,,,284,139,7,430
+Cambria,JACKSON TOWNSHIP NO.3,Ballots Cast,,DEM,,95,71,1,167
+Cambria,JACKSON TOWNSHIP NO.3,Ballots Cast,,REP,,189,68,6,263
+Cambria,JACKSON TOWNSHIP NO.3,President,,DEM,Bernie Sanders,20,8,1,29
+Cambria,JACKSON TOWNSHIP NO.3,President,,DEM,Joseph R. Biden,32,53,0,85
+Cambria,JACKSON TOWNSHIP NO.3,President,,DEM,Tulsi Gabbard,13,1,0,14
+Cambria,JACKSON TOWNSHIP NO.3,President,,DEM,Write-In,22,1,0,23
+Cambria,JACKSON TOWNSHIP NO.3,Attorney General,,DEM,Josh Shapiro,82,70,1,153
+Cambria,JACKSON TOWNSHIP NO.3,Attorney General,,DEM,Write-In,2,1,0,3
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,DEM,H. Scott Conklin,59,46,0,105
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,DEM,Michael Lamb,18,15,0,33
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,DEM,Tracie Fountain,2,3,0,5
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,0,4
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,DEM,Nina Ahmad,4,5,1,10
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,DEM,Christina M. Hartman,6,0,0,6
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,JACKSON TOWNSHIP NO.3,State Treasurer,,DEM,Joe Torsella,82,66,1,149
+Cambria,JACKSON TOWNSHIP NO.3,State Treasurer,,DEM,Write-In,2,1,0,3
+Cambria,JACKSON TOWNSHIP NO.3,U.S. House,15,DEM,Robert Williams,81,66,1,148
+Cambria,JACKSON TOWNSHIP NO.3,U.S. House,15,DEM,Write-In,4,1,0,5
+Cambria,JACKSON TOWNSHIP NO.3,State Senator,35,DEM,Shaun Dougherty,79,67,1,147
+Cambria,JACKSON TOWNSHIP NO.3,State Senator,35,DEM,Write-In,3,1,0,4
+Cambria,JACKSON TOWNSHIP NO.3,General Assembly,72,DEM,Frank Burns,88,68,1,157
+Cambria,JACKSON TOWNSHIP NO.3,General Assembly,72,DEM,Write-In,3,1,0,4
+Cambria,JACKSON TOWNSHIP NO.3,President,,REP,Donald J. Trump,188,63,6,257
+Cambria,JACKSON TOWNSHIP NO.3,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO.3,President,,REP,Bill Weld,0,2,0,2
+Cambria,JACKSON TOWNSHIP NO.3,President,,REP,Write-In,0,1,0,1
+Cambria,JACKSON TOWNSHIP NO.3,Attorney General,,REP,Heather Heidelbaugh,166,65,5,236
+Cambria,JACKSON TOWNSHIP NO.3,Attorney General,,REP,Write-In,2,1,0,3
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,REP,Timothy Defoor,165,65,5,235
+Cambria,JACKSON TOWNSHIP NO.3,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO.3,State Treasurer,,REP,Stacy L. Garrity,170,66,5,241
+Cambria,JACKSON TOWNSHIP NO.3,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JACKSON TOWNSHIP NO.3,U.S. House,15,REP,Glenn Gt Thompson,176,65,5,246
+Cambria,JACKSON TOWNSHIP NO.3,U.S. House,15,REP,Write-In,1,1,0,2
+Cambria,JACKSON TOWNSHIP NO.3,State Senator,35,REP,Wayne Langerholc Jr.,178,66,6,250
+Cambria,JACKSON TOWNSHIP NO.3,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,JACKSON TOWNSHIP NO.3,General Assembly,72,REP,Howard Terndrup,123,55,5,183
+Cambria,JACKSON TOWNSHIP NO.3,General Assembly,72,REP,Jerry Carnicella,48,8,1,57
+Cambria,JACKSON TOWNSHIP NO.3,General Assembly,72,REP,Write-In,12,2,0,14
+Cambria,LILLY BOROUGH - FIRST WARD,Registered Voters,,,,,,,201
+Cambria,LILLY BOROUGH - FIRST WARD,Registered Voters,,DEM,,,,,94
+Cambria,LILLY BOROUGH - FIRST WARD,Registered Voters,,REP,,,,,92
+Cambria,LILLY BOROUGH - FIRST WARD,Ballots Cast,,,,46,27,0,73
+Cambria,LILLY BOROUGH - FIRST WARD,Ballots Cast,,DEM,,20,24,0,44
+Cambria,LILLY BOROUGH - FIRST WARD,Ballots Cast,,REP,,26,3,0,29
+Cambria,LILLY BOROUGH - FIRST WARD,President,,DEM,Bernie Sanders,2,1,0,3
+Cambria,LILLY BOROUGH - FIRST WARD,President,,DEM,Joseph R. Biden,11,18,0,29
+Cambria,LILLY BOROUGH - FIRST WARD,President,,DEM,Tulsi Gabbard,6,1,0,7
+Cambria,LILLY BOROUGH - FIRST WARD,President,,DEM,Write-In,1,1,0,2
+Cambria,LILLY BOROUGH - FIRST WARD,Attorney General,,DEM,Josh Shapiro,20,20,0,40
+Cambria,LILLY BOROUGH - FIRST WARD,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,DEM,H. Scott Conklin,5,14,0,19
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,DEM,Michael Lamb,8,4,0,12
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,3
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,DEM,Christina M. Hartman,3,1,0,4
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,State Treasurer,,DEM,Joe Torsella,20,20,0,40
+Cambria,LILLY BOROUGH - FIRST WARD,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,U.S. House,15,DEM,Robert Williams,20,18,0,38
+Cambria,LILLY BOROUGH - FIRST WARD,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,State Senator,35,DEM,Shaun Dougherty,19,19,0,38
+Cambria,LILLY BOROUGH - FIRST WARD,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,LILLY BOROUGH - FIRST WARD,General Assembly,72,DEM,Frank Burns,18,23,0,41
+Cambria,LILLY BOROUGH - FIRST WARD,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,LILLY BOROUGH - FIRST WARD,President,,REP,Donald J. Trump,24,3,0,27
+Cambria,LILLY BOROUGH - FIRST WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,LILLY BOROUGH - FIRST WARD,President,,REP,Bill Weld,1,0,0,1
+Cambria,LILLY BOROUGH - FIRST WARD,President,,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,Attorney General,,REP,Heather Heidelbaugh,24,1,0,25
+Cambria,LILLY BOROUGH - FIRST WARD,Attorney General,,REP,Write-In,0,2,0,2
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,REP,Timothy Defoor,24,3,0,27
+Cambria,LILLY BOROUGH - FIRST WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,State Treasurer,,REP,Stacy L. Garrity,24,3,0,27
+Cambria,LILLY BOROUGH - FIRST WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,U.S. House,15,REP,Glenn Gt Thompson,25,3,0,28
+Cambria,LILLY BOROUGH - FIRST WARD,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,State Senator,35,REP,Wayne Langerholc Jr.,24,3,0,27
+Cambria,LILLY BOROUGH - FIRST WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - FIRST WARD,General Assembly,72,REP,Howard Terndrup,15,2,0,17
+Cambria,LILLY BOROUGH - FIRST WARD,General Assembly,72,REP,Jerry Carnicella,9,1,0,10
+Cambria,LILLY BOROUGH - FIRST WARD,General Assembly,72,REP,Write-In,1,0,0,1
+Cambria,LILLY BOROUGH - SECOND WARD,Registered Voters,,,,,,,315
+Cambria,LILLY BOROUGH - SECOND WARD,Registered Voters,,DEM,,,,,159
+Cambria,LILLY BOROUGH - SECOND WARD,Registered Voters,,REP,,,,,130
+Cambria,LILLY BOROUGH - SECOND WARD,Ballots Cast,,,,87,30,1,118
+Cambria,LILLY BOROUGH - SECOND WARD,Ballots Cast,,DEM,,39,23,1,63
+Cambria,LILLY BOROUGH - SECOND WARD,Ballots Cast,,REP,,48,7,0,55
+Cambria,LILLY BOROUGH - SECOND WARD,President,,DEM,Bernie Sanders,8,2,0,10
+Cambria,LILLY BOROUGH - SECOND WARD,President,,DEM,Joseph R. Biden,19,20,1,40
+Cambria,LILLY BOROUGH - SECOND WARD,President,,DEM,Tulsi Gabbard,4,0,0,4
+Cambria,LILLY BOROUGH - SECOND WARD,President,,DEM,Write-In,5,0,0,5
+Cambria,LILLY BOROUGH - SECOND WARD,Attorney General,,DEM,Josh Shapiro,36,22,1,59
+Cambria,LILLY BOROUGH - SECOND WARD,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,DEM,H. Scott Conklin,21,16,1,38
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,DEM,Michael Lamb,7,4,0,11
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,DEM,Tracie Fountain,2,2,0,4
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,3
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,DEM,Christina M. Hartman,3,1,0,4
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,State Treasurer,,DEM,Joe Torsella,36,21,1,58
+Cambria,LILLY BOROUGH - SECOND WARD,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,U.S. House,15,DEM,Robert Williams,35,18,1,54
+Cambria,LILLY BOROUGH - SECOND WARD,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,State Senator,35,DEM,Shaun Dougherty,35,19,1,55
+Cambria,LILLY BOROUGH - SECOND WARD,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,General Assembly,72,DEM,Frank Burns,38,20,1,59
+Cambria,LILLY BOROUGH - SECOND WARD,General Assembly,72,DEM,Write-In,0,1,0,1
+Cambria,LILLY BOROUGH - SECOND WARD,President,,REP,Donald J. Trump,47,5,0,52
+Cambria,LILLY BOROUGH - SECOND WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,President,,REP,Bill Weld,1,2,0,3
+Cambria,LILLY BOROUGH - SECOND WARD,President,,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,Attorney General,,REP,Heather Heidelbaugh,43,7,0,50
+Cambria,LILLY BOROUGH - SECOND WARD,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,REP,Timothy Defoor,42,7,0,49
+Cambria,LILLY BOROUGH - SECOND WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,State Treasurer,,REP,Stacy L. Garrity,42,7,0,49
+Cambria,LILLY BOROUGH - SECOND WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,U.S. House,15,REP,Glenn Gt Thompson,44,7,0,51
+Cambria,LILLY BOROUGH - SECOND WARD,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,State Senator,35,REP,Wayne Langerholc Jr.,45,7,0,52
+Cambria,LILLY BOROUGH - SECOND WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,LILLY BOROUGH - SECOND WARD,General Assembly,72,REP,Howard Terndrup,19,3,0,22
+Cambria,LILLY BOROUGH - SECOND WARD,General Assembly,72,REP,Jerry Carnicella,24,4,0,28
+Cambria,LILLY BOROUGH - SECOND WARD,General Assembly,72,REP,Write-In,3,0,0,3
+Cambria,LORAIN BOROUGH,Registered Voters,,,,,,,368
+Cambria,LORAIN BOROUGH,Registered Voters,,DEM,,,,,173
+Cambria,LORAIN BOROUGH,Registered Voters,,REP,,,,,150
+Cambria,LORAIN BOROUGH,Ballots Cast,,,,81,55,2,138
+Cambria,LORAIN BOROUGH,Ballots Cast,,DEM,,35,43,1,79
+Cambria,LORAIN BOROUGH,Ballots Cast,,REP,,46,12,1,59
+Cambria,LORAIN BOROUGH,President,,DEM,Bernie Sanders,5,6,0,11
+Cambria,LORAIN BOROUGH,President,,DEM,Joseph R. Biden,12,36,0,48
+Cambria,LORAIN BOROUGH,President,,DEM,Tulsi Gabbard,6,0,1,7
+Cambria,LORAIN BOROUGH,President,,DEM,Write-In,9,0,0,9
+Cambria,LORAIN BOROUGH,Attorney General,,DEM,Josh Shapiro,29,41,1,71
+Cambria,LORAIN BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,LORAIN BOROUGH,Auditor General,,DEM,H. Scott Conklin,16,25,0,41
+Cambria,LORAIN BOROUGH,Auditor General,,DEM,Michael Lamb,6,7,0,13
+Cambria,LORAIN BOROUGH,Auditor General,,DEM,Tracie Fountain,1,3,0,4
+Cambria,LORAIN BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,2
+Cambria,LORAIN BOROUGH,Auditor General,,DEM,Nina Ahmad,3,2,0,5
+Cambria,LORAIN BOROUGH,Auditor General,,DEM,Christina M. Hartman,3,5,1,9
+Cambria,LORAIN BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,LORAIN BOROUGH,State Treasurer,,DEM,Joe Torsella,28,41,1,70
+Cambria,LORAIN BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,LORAIN BOROUGH,U.S. House,13,DEM,Todd Rowley,28,42,1,71
+Cambria,LORAIN BOROUGH,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,LORAIN BOROUGH,State Senator,35,DEM,Shaun Dougherty,31,38,1,70
+Cambria,LORAIN BOROUGH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,LORAIN BOROUGH,General Assembly,71,DEM,Write-In,7,5,0,12
+Cambria,LORAIN BOROUGH,President,,REP,Donald J. Trump,44,10,1,55
+Cambria,LORAIN BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,LORAIN BOROUGH,President,,REP,Bill Weld,1,1,0,2
+Cambria,LORAIN BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,LORAIN BOROUGH,Attorney General,,REP,Heather Heidelbaugh,42,12,1,55
+Cambria,LORAIN BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,LORAIN BOROUGH,Auditor General,,REP,Timothy Defoor,40,12,1,53
+Cambria,LORAIN BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,LORAIN BOROUGH,State Treasurer,,REP,Stacy L. Garrity,41,11,1,53
+Cambria,LORAIN BOROUGH,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,LORAIN BOROUGH,U.S. House,13,REP,John Joyce,42,12,1,55
+Cambria,LORAIN BOROUGH,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,LORAIN BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,45,12,1,58
+Cambria,LORAIN BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,LORAIN BOROUGH,General Assembly,71,REP,Jim Rigby,43,12,1,56
+Cambria,LORAIN BOROUGH,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,LORETTO BOROUGH,Registered Voters,,,,,,,357
+Cambria,LORETTO BOROUGH,Registered Voters,,DEM,,,,,120
+Cambria,LORETTO BOROUGH,Registered Voters,,REP,,,,,166
+Cambria,LORETTO BOROUGH,Ballots Cast,,,,42,20,0,62
+Cambria,LORETTO BOROUGH,Ballots Cast,,DEM,,13,13,0,26
+Cambria,LORETTO BOROUGH,Ballots Cast,,REP,,29,7,0,36
+Cambria,LORETTO BOROUGH,President,,DEM,Bernie Sanders,3,1,0,4
+Cambria,LORETTO BOROUGH,President,,DEM,Joseph R. Biden,9,8,0,17
+Cambria,LORETTO BOROUGH,President,,DEM,Tulsi Gabbard,0,1,0,1
+Cambria,LORETTO BOROUGH,President,,DEM,Write-In,1,0,0,1
+Cambria,LORETTO BOROUGH,Attorney General,,DEM,Josh Shapiro,8,11,0,19
+Cambria,LORETTO BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,LORETTO BOROUGH,Auditor General,,DEM,H. Scott Conklin,4,9,0,13
+Cambria,LORETTO BOROUGH,Auditor General,,DEM,Michael Lamb,5,3,0,8
+Cambria,LORETTO BOROUGH,Auditor General,,DEM,Tracie Fountain,0,0,0,0
+Cambria,LORETTO BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,LORETTO BOROUGH,Auditor General,,DEM,Nina Ahmad,2,0,0,2
+Cambria,LORETTO BOROUGH,Auditor General,,DEM,Christina M. Hartman,1,0,0,1
+Cambria,LORETTO BOROUGH,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,LORETTO BOROUGH,State Treasurer,,DEM,Joe Torsella,10,13,0,23
+Cambria,LORETTO BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,LORETTO BOROUGH,U.S. House,15,DEM,Robert Williams,10,11,0,21
+Cambria,LORETTO BOROUGH,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,LORETTO BOROUGH,State Senator,35,DEM,Shaun Dougherty,11,10,0,21
+Cambria,LORETTO BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,LORETTO BOROUGH,General Assembly,72,DEM,Frank Burns,11,13,0,24
+Cambria,LORETTO BOROUGH,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,LORETTO BOROUGH,President,,REP,Donald J. Trump,28,6,0,34
+Cambria,LORETTO BOROUGH,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,LORETTO BOROUGH,President,,REP,Bill Weld,0,0,0,0
+Cambria,LORETTO BOROUGH,President,,REP,Write-In,0,1,0,1
+Cambria,LORETTO BOROUGH,Attorney General,,REP,Heather Heidelbaugh,23,6,0,29
+Cambria,LORETTO BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,LORETTO BOROUGH,Auditor General,,REP,Timothy Defoor,24,6,0,30
+Cambria,LORETTO BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,LORETTO BOROUGH,State Treasurer,,REP,Stacy L. Garrity,24,6,0,30
+Cambria,LORETTO BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,LORETTO BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,26,6,0,32
+Cambria,LORETTO BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,LORETTO BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,27,6,0,33
+Cambria,LORETTO BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,LORETTO BOROUGH,General Assembly,72,REP,Howard Terndrup,16,3,0,19
+Cambria,LORETTO BOROUGH,General Assembly,72,REP,Jerry Carnicella,11,3,0,14
+Cambria,LORETTO BOROUGH,General Assembly,72,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO.1,Registered Voters,,,,,,,867
+Cambria,LOWER YODER TOWNSHIP NO.1,Registered Voters,,DEM,,,,,456
+Cambria,LOWER YODER TOWNSHIP NO.1,Registered Voters,,REP,,,,,313
+Cambria,LOWER YODER TOWNSHIP NO.1,Ballots Cast,,,,201,144,2,347
+Cambria,LOWER YODER TOWNSHIP NO.1,Ballots Cast,,DEM,,106,87,2,195
+Cambria,LOWER YODER TOWNSHIP NO.1,Ballots Cast,,REP,,95,57,0,152
+Cambria,LOWER YODER TOWNSHIP NO.1,President,,DEM,Bernie Sanders,19,10,0,29
+Cambria,LOWER YODER TOWNSHIP NO.1,President,,DEM,Joseph R. Biden,46,70,0,116
+Cambria,LOWER YODER TOWNSHIP NO.1,President,,DEM,Tulsi Gabbard,7,3,1,11
+Cambria,LOWER YODER TOWNSHIP NO.1,President,,DEM,Write-In,24,0,1,25
+Cambria,LOWER YODER TOWNSHIP NO.1,Attorney General,,DEM,Josh Shapiro,88,82,1,171
+Cambria,LOWER YODER TOWNSHIP NO.1,Attorney General,,DEM,Write-In,1,0,1,2
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,DEM,H. Scott Conklin,41,43,0,84
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,DEM,Michael Lamb,32,29,0,61
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,DEM,Tracie Fountain,1,6,0,7
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,5
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,DEM,Nina Ahmad,7,1,0,8
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,DEM,Christina M. Hartman,5,3,1,9
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,DEM,Write-In,3,0,1,4
+Cambria,LOWER YODER TOWNSHIP NO.1,State Treasurer,,DEM,Joe Torsella,80,78,1,159
+Cambria,LOWER YODER TOWNSHIP NO.1,State Treasurer,,DEM,Write-In,4,0,1,5
+Cambria,LOWER YODER TOWNSHIP NO.1,U.S. House,13,DEM,Todd Rowley,86,78,1,165
+Cambria,LOWER YODER TOWNSHIP NO.1,U.S. House,13,DEM,Write-In,5,0,1,6
+Cambria,LOWER YODER TOWNSHIP NO.1,State Senator,35,DEM,Shaun Dougherty,87,82,1,170
+Cambria,LOWER YODER TOWNSHIP NO.1,State Senator,35,DEM,Write-In,4,1,1,6
+Cambria,LOWER YODER TOWNSHIP NO.1,General Assembly,72,DEM,Frank Burns,100,81,1,182
+Cambria,LOWER YODER TOWNSHIP NO.1,General Assembly,72,DEM,Write-In,3,0,1,4
+Cambria,LOWER YODER TOWNSHIP NO.1,President,,REP,Donald J. Trump,95,47,0,142
+Cambria,LOWER YODER TOWNSHIP NO.1,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Cambria,LOWER YODER TOWNSHIP NO.1,President,,REP,Bill Weld,0,6,0,6
+Cambria,LOWER YODER TOWNSHIP NO.1,President,,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO.1,Attorney General,,REP,Heather Heidelbaugh,87,52,0,139
+Cambria,LOWER YODER TOWNSHIP NO.1,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,REP,Timothy Defoor,86,52,0,138
+Cambria,LOWER YODER TOWNSHIP NO.1,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO.1,State Treasurer,,REP,Stacy L. Garrity,90,52,0,142
+Cambria,LOWER YODER TOWNSHIP NO.1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO.1,U.S. House,13,REP,John Joyce,92,51,0,143
+Cambria,LOWER YODER TOWNSHIP NO.1,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO.1,State Senator,35,REP,Wayne Langerholc Jr.,91,56,0,147
+Cambria,LOWER YODER TOWNSHIP NO.1,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,LOWER YODER TOWNSHIP NO.1,General Assembly,72,REP,Howard Terndrup,60,40,0,100
+Cambria,LOWER YODER TOWNSHIP NO.1,General Assembly,72,REP,Jerry Carnicella,32,15,0,47
+Cambria,LOWER YODER TOWNSHIP NO.1,General Assembly,72,REP,Write-In,1,0,0,1
+Cambria,LOWER YODER TOWNSHIP NO. 2,Registered Voters,,,,,,,872
+Cambria,LOWER YODER TOWNSHIP NO. 2,Registered Voters,,DEM,,,,,445
+Cambria,LOWER YODER TOWNSHIP NO. 2,Registered Voters,,REP,,,,,353
+Cambria,LOWER YODER TOWNSHIP NO. 2,Ballots Cast,,,,186,199,0,385
+Cambria,LOWER YODER TOWNSHIP NO. 2,Ballots Cast,,DEM,,71,133,0,204
+Cambria,LOWER YODER TOWNSHIP NO. 2,Ballots Cast,,REP,,115,66,0,181
+Cambria,LOWER YODER TOWNSHIP NO. 2,President,,DEM,Bernie Sanders,11,8,0,19
+Cambria,LOWER YODER TOWNSHIP NO. 2,President,,DEM,Joseph R. Biden,39,110,0,149
+Cambria,LOWER YODER TOWNSHIP NO. 2,President,,DEM,Tulsi Gabbard,0,5,0,5
+Cambria,LOWER YODER TOWNSHIP NO. 2,President,,DEM,Write-In,9,7,0,16
+Cambria,LOWER YODER TOWNSHIP NO. 2,Attorney General,,DEM,Josh Shapiro,61,131,0,192
+Cambria,LOWER YODER TOWNSHIP NO. 2,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,DEM,H. Scott Conklin,38,64,0,102
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Michael Lamb,13,51,0,64
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Tracie Fountain,4,5,0,9
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,2
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Nina Ahmad,3,5,0,8
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Christina M. Hartman,6,3,0,9
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,LOWER YODER TOWNSHIP NO. 2,State Treasurer,,DEM,Joe Torsella,62,125,0,187
+Cambria,LOWER YODER TOWNSHIP NO. 2,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,LOWER YODER TOWNSHIP NO. 2,U.S. House,13,DEM,Todd Rowley,57,122,0,179
+Cambria,LOWER YODER TOWNSHIP NO. 2,U.S. House,13,DEM,Write-In,2,0,0,2
+Cambria,LOWER YODER TOWNSHIP NO. 2,State Senator,35,DEM,Shaun Dougherty,61,125,0,186
+Cambria,LOWER YODER TOWNSHIP NO. 2,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,LOWER YODER TOWNSHIP NO. 2,General Assembly,72,DEM,Frank Burns,66,130,0,196
+Cambria,LOWER YODER TOWNSHIP NO. 2,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO. 2,President,,REP,Donald J. Trump,113,62,0,175
+Cambria,LOWER YODER TOWNSHIP NO. 2,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO. 2,President,,REP,Bill Weld,0,3,0,3
+Cambria,LOWER YODER TOWNSHIP NO. 2,President,,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO. 2,Attorney General,,REP,Heather Heidelbaugh,103,60,0,163
+Cambria,LOWER YODER TOWNSHIP NO. 2,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,REP,Timothy Defoor,99,58,0,157
+Cambria,LOWER YODER TOWNSHIP NO. 2,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO. 2,State Treasurer,,REP,Stacy L. Garrity,98,62,0,160
+Cambria,LOWER YODER TOWNSHIP NO. 2,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO. 2,U.S. House,13,REP,John Joyce,103,64,0,167
+Cambria,LOWER YODER TOWNSHIP NO. 2,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO. 2,State Senator,35,REP,Wayne Langerholc Jr.,106,66,0,172
+Cambria,LOWER YODER TOWNSHIP NO. 2,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,LOWER YODER TOWNSHIP NO. 2,General Assembly,72,REP,Howard Terndrup,71,45,0,116
+Cambria,LOWER YODER TOWNSHIP NO. 2,General Assembly,72,REP,Jerry Carnicella,37,21,0,58
+Cambria,LOWER YODER TOWNSHIP NO. 2,General Assembly,72,REP,Write-In,4,0,0,4
+Cambria,MIDDLE TAYLOR TOWNSHIP,Registered Voters,,,,,,,462
+Cambria,MIDDLE TAYLOR TOWNSHIP,Registered Voters,,DEM,,,,,200
+Cambria,MIDDLE TAYLOR TOWNSHIP,Registered Voters,,REP,,,,,230
+Cambria,MIDDLE TAYLOR TOWNSHIP,Ballots Cast,,,,120,74,4,198
+Cambria,MIDDLE TAYLOR TOWNSHIP,Ballots Cast,,DEM,,50,46,0,96
+Cambria,MIDDLE TAYLOR TOWNSHIP,Ballots Cast,,REP,,70,28,4,102
+Cambria,MIDDLE TAYLOR TOWNSHIP,President,,DEM,Bernie Sanders,8,7,0,15
+Cambria,MIDDLE TAYLOR TOWNSHIP,President,,DEM,Joseph R. Biden,26,35,0,61
+Cambria,MIDDLE TAYLOR TOWNSHIP,President,,DEM,Tulsi Gabbard,6,1,0,7
+Cambria,MIDDLE TAYLOR TOWNSHIP,President,,DEM,Write-In,4,1,0,5
+Cambria,MIDDLE TAYLOR TOWNSHIP,Attorney General,,DEM,Josh Shapiro,47,42,0,89
+Cambria,MIDDLE TAYLOR TOWNSHIP,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,20,25,0,45
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,DEM,Michael Lamb,17,13,0,30
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,DEM,Tracie Fountain,1,1,0,2
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,2
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,DEM,Nina Ahmad,2,4,0,6
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,6,0,0,6
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,MIDDLE TAYLOR TOWNSHIP,State Treasurer,,DEM,Joe Torsella,45,43,0,88
+Cambria,MIDDLE TAYLOR TOWNSHIP,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,MIDDLE TAYLOR TOWNSHIP,U.S. House,13,DEM,Todd Rowley,47,40,0,87
+Cambria,MIDDLE TAYLOR TOWNSHIP,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,MIDDLE TAYLOR TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,47,43,0,90
+Cambria,MIDDLE TAYLOR TOWNSHIP,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,MIDDLE TAYLOR TOWNSHIP,General Assembly,72,DEM,Frank Burns,48,44,0,92
+Cambria,MIDDLE TAYLOR TOWNSHIP,General Assembly,72,DEM,Write-In,1,2,0,3
+Cambria,MIDDLE TAYLOR TOWNSHIP,President,,REP,Donald J. Trump,69,23,4,96
+Cambria,MIDDLE TAYLOR TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,MIDDLE TAYLOR TOWNSHIP,President,,REP,Bill Weld,1,1,0,2
+Cambria,MIDDLE TAYLOR TOWNSHIP,President,,REP,Write-In,0,3,0,3
+Cambria,MIDDLE TAYLOR TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,64,27,4,95
+Cambria,MIDDLE TAYLOR TOWNSHIP,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,REP,Timothy Defoor,63,27,4,94
+Cambria,MIDDLE TAYLOR TOWNSHIP,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,MIDDLE TAYLOR TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,64,27,4,95
+Cambria,MIDDLE TAYLOR TOWNSHIP,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,MIDDLE TAYLOR TOWNSHIP,U.S. House,13,REP,John Joyce,67,26,4,97
+Cambria,MIDDLE TAYLOR TOWNSHIP,U.S. House,13,REP,Write-In,1,0,0,1
+Cambria,MIDDLE TAYLOR TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,69,27,4,100
+Cambria,MIDDLE TAYLOR TOWNSHIP,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,MIDDLE TAYLOR TOWNSHIP,General Assembly,72,REP,Howard Terndrup,52,25,4,81
+Cambria,MIDDLE TAYLOR TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,16,3,0,19
+Cambria,MIDDLE TAYLOR TOWNSHIP,General Assembly,72,REP,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,Registered Voters,,,,,,,455
+Cambria,MUNSTER TOWNSHIP,Registered Voters,,DEM,,,,,137
+Cambria,MUNSTER TOWNSHIP,Registered Voters,,REP,,,,,277
+Cambria,MUNSTER TOWNSHIP,Ballots Cast,,,,129,46,2,177
+Cambria,MUNSTER TOWNSHIP,Ballots Cast,,DEM,,35,21,0,56
+Cambria,MUNSTER TOWNSHIP,Ballots Cast,,REP,,94,25,2,121
+Cambria,MUNSTER TOWNSHIP,President,,DEM,Bernie Sanders,5,1,0,6
+Cambria,MUNSTER TOWNSHIP,President,,DEM,Joseph R. Biden,10,18,0,28
+Cambria,MUNSTER TOWNSHIP,President,,DEM,Tulsi Gabbard,5,0,0,5
+Cambria,MUNSTER TOWNSHIP,President,,DEM,Write-In,9,1,0,10
+Cambria,MUNSTER TOWNSHIP,Attorney General,,DEM,Josh Shapiro,24,18,0,42
+Cambria,MUNSTER TOWNSHIP,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,11,18,0,29
+Cambria,MUNSTER TOWNSHIP,Auditor General,,DEM,Michael Lamb,9,0,0,9
+Cambria,MUNSTER TOWNSHIP,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Cambria,MUNSTER TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,3
+Cambria,MUNSTER TOWNSHIP,Auditor General,,DEM,Nina Ahmad,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,5,0,0,5
+Cambria,MUNSTER TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,State Treasurer,,DEM,Joe Torsella,26,18,0,44
+Cambria,MUNSTER TOWNSHIP,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,U.S. House,15,DEM,Robert Williams,25,16,0,41
+Cambria,MUNSTER TOWNSHIP,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,24,16,0,40
+Cambria,MUNSTER TOWNSHIP,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,MUNSTER TOWNSHIP,General Assembly,72,DEM,Frank Burns,33,19,0,52
+Cambria,MUNSTER TOWNSHIP,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,President,,REP,Donald J. Trump,89,24,2,115
+Cambria,MUNSTER TOWNSHIP,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,MUNSTER TOWNSHIP,President,,REP,Bill Weld,1,1,0,2
+Cambria,MUNSTER TOWNSHIP,President,,REP,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,80,19,2,101
+Cambria,MUNSTER TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,Auditor General,,REP,Timothy Defoor,80,20,2,102
+Cambria,MUNSTER TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,80,20,2,102
+Cambria,MUNSTER TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,80,22,2,104
+Cambria,MUNSTER TOWNSHIP,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,83,22,2,107
+Cambria,MUNSTER TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,MUNSTER TOWNSHIP,General Assembly,72,REP,Howard Terndrup,55,16,1,72
+Cambria,MUNSTER TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,32,5,1,38
+Cambria,MUNSTER TOWNSHIP,General Assembly,72,REP,Write-In,4,1,0,5
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Registered Voters,,,,,,,624
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Registered Voters,,DEM,,,,,320
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Registered Voters,,REP,,,,,246
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Ballots Cast,,,,143,73,0,216
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Ballots Cast,,DEM,,79,50,0,129
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Ballots Cast,,REP,,64,23,0,87
+Cambria,NANTY GLO BOROUGH - FIRST WARD,President,,DEM,Bernie Sanders,10,8,0,18
+Cambria,NANTY GLO BOROUGH - FIRST WARD,President,,DEM,Joseph R. Biden,34,36,0,70
+Cambria,NANTY GLO BOROUGH - FIRST WARD,President,,DEM,Tulsi Gabbard,10,1,0,11
+Cambria,NANTY GLO BOROUGH - FIRST WARD,President,,DEM,Write-In,18,2,0,20
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Attorney General,,DEM,Josh Shapiro,69,44,0,113
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Attorney General,,DEM,Write-In,3,1,0,4
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,DEM,H. Scott Conklin,45,25,0,70
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,DEM,Michael Lamb,19,13,0,32
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,DEM,Tracie Fountain,2,0,0,2
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,2
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,DEM,Nina Ahmad,2,2,0,4
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,DEM,Christina M. Hartman,1,5,0,6
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,DEM,Write-In,1,1,0,2
+Cambria,NANTY GLO BOROUGH - FIRST WARD,State Treasurer,,DEM,Joe Torsella,66,42,0,108
+Cambria,NANTY GLO BOROUGH - FIRST WARD,State Treasurer,,DEM,Write-In,3,1,0,4
+Cambria,NANTY GLO BOROUGH - FIRST WARD,U.S. House,15,DEM,Robert Williams,69,45,0,114
+Cambria,NANTY GLO BOROUGH - FIRST WARD,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,NANTY GLO BOROUGH - FIRST WARD,State Senator,35,DEM,Shaun Dougherty,66,45,0,111
+Cambria,NANTY GLO BOROUGH - FIRST WARD,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,NANTY GLO BOROUGH - FIRST WARD,General Assembly,73,DEM,Write-In,8,5,0,13
+Cambria,NANTY GLO BOROUGH - FIRST WARD,President,,REP,Donald J. Trump,63,19,0,82
+Cambria,NANTY GLO BOROUGH - FIRST WARD,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,NANTY GLO BOROUGH - FIRST WARD,President,,REP,Bill Weld,0,2,0,2
+Cambria,NANTY GLO BOROUGH - FIRST WARD,President,,REP,Write-In,0,0,0,0
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Attorney General,,REP,Heather Heidelbaugh,59,21,0,80
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,REP,Timothy Defoor,58,21,0,79
+Cambria,NANTY GLO BOROUGH - FIRST WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,NANTY GLO BOROUGH - FIRST WARD,State Treasurer,,REP,Stacy L. Garrity,55,21,0,76
+Cambria,NANTY GLO BOROUGH - FIRST WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,NANTY GLO BOROUGH - FIRST WARD,U.S. House,15,REP,Glenn Gt Thompson,57,21,0,78
+Cambria,NANTY GLO BOROUGH - FIRST WARD,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,NANTY GLO BOROUGH - FIRST WARD,State Senator,35,REP,Wayne Langerholc Jr.,59,22,0,81
+Cambria,NANTY GLO BOROUGH - FIRST WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,NANTY GLO BOROUGH - FIRST WARD,General Assembly,73,REP,Tommy Sankey,57,21,0,78
+Cambria,NANTY GLO BOROUGH - FIRST WARD,General Assembly,73,REP,Write-In,1,0,0,1
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Registered Voters,,,,,,,811
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Registered Voters,,DEM,,,,,472
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Registered Voters,,REP,,,,,268
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Ballots Cast,,,,173,110,0,283
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Ballots Cast,,DEM,,111,84,0,195
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Ballots Cast,,REP,,62,26,0,88
+Cambria,NANTY GLO BOROUGH - SECOND WARD,President,,DEM,Bernie Sanders,17,11,0,28
+Cambria,NANTY GLO BOROUGH - SECOND WARD,President,,DEM,Joseph R. Biden,58,64,0,122
+Cambria,NANTY GLO BOROUGH - SECOND WARD,President,,DEM,Tulsi Gabbard,8,3,0,11
+Cambria,NANTY GLO BOROUGH - SECOND WARD,President,,DEM,Write-In,15,4,0,19
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Attorney General,,DEM,Josh Shapiro,102,78,0,180
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,DEM,H. Scott Conklin,51,45,0,96
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,DEM,Michael Lamb,33,19,0,52
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,DEM,Tracie Fountain,3,3,0,6
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,4,4,0,8
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,DEM,Nina Ahmad,2,1,0,3
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,DEM,Christina M. Hartman,8,7,0,15
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,NANTY GLO BOROUGH - SECOND WARD,State Treasurer,,DEM,Joe Torsella,100,72,0,172
+Cambria,NANTY GLO BOROUGH - SECOND WARD,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,NANTY GLO BOROUGH - SECOND WARD,U.S. House,15,DEM,Robert Williams,98,74,0,172
+Cambria,NANTY GLO BOROUGH - SECOND WARD,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,NANTY GLO BOROUGH - SECOND WARD,State Senator,35,DEM,Shaun Dougherty,98,70,0,168
+Cambria,NANTY GLO BOROUGH - SECOND WARD,State Senator,35,DEM,Write-In,1,2,0,3
+Cambria,NANTY GLO BOROUGH - SECOND WARD,General Assembly,73,DEM,Write-In,12,7,0,19
+Cambria,NANTY GLO BOROUGH - SECOND WARD,President,,REP,Donald J. Trump,59,18,0,77
+Cambria,NANTY GLO BOROUGH - SECOND WARD,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,NANTY GLO BOROUGH - SECOND WARD,President,,REP,Bill Weld,2,5,0,7
+Cambria,NANTY GLO BOROUGH - SECOND WARD,President,,REP,Write-In,0,3,0,3
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Attorney General,,REP,Heather Heidelbaugh,57,20,0,77
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Attorney General,,REP,Write-In,0,2,0,2
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,REP,Timothy Defoor,55,20,0,75
+Cambria,NANTY GLO BOROUGH - SECOND WARD,Auditor General,,REP,Write-In,0,2,0,2
+Cambria,NANTY GLO BOROUGH - SECOND WARD,State Treasurer,,REP,Stacy L. Garrity,57,21,0,78
+Cambria,NANTY GLO BOROUGH - SECOND WARD,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,NANTY GLO BOROUGH - SECOND WARD,U.S. House,15,REP,Glenn Gt Thompson,60,22,0,82
+Cambria,NANTY GLO BOROUGH - SECOND WARD,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,NANTY GLO BOROUGH - SECOND WARD,State Senator,35,REP,Wayne Langerholc Jr.,59,22,0,81
+Cambria,NANTY GLO BOROUGH - SECOND WARD,State Senator,35,REP,Write-In,0,2,0,2
+Cambria,NANTY GLO BOROUGH - SECOND WARD,General Assembly,73,REP,Tommy Sankey,58,22,0,80
+Cambria,NANTY GLO BOROUGH - SECOND WARD,General Assembly,73,REP,Write-In,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Registered Voters,,,,,,,770
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Registered Voters,,DEM,,,,,368
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Registered Voters,,REP,,,,,318
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Ballots Cast,,,,155,73,4,232
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Ballots Cast,,DEM,,73,53,0,126
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Ballots Cast,,REP,,82,20,4,106
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,President,,DEM,Bernie Sanders,15,4,0,19
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,President,,DEM,Joseph R. Biden,31,43,0,74
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,President,,DEM,Tulsi Gabbard,8,0,0,8
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,President,,DEM,Write-In,9,2,0,11
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Attorney General,,DEM,Josh Shapiro,56,45,0,101
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,DEM,H. Scott Conklin,42,38,0,80
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,DEM,Michael Lamb,13,6,0,19
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,DEM,Tracie Fountain,3,2,0,5
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,2
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,DEM,Nina Ahmad,3,0,0,3
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,DEM,Christina M. Hartman,4,2,0,6
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,State Treasurer,,DEM,Joe Torsella,59,43,0,102
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,U.S. House,15,DEM,Robert Williams,60,46,0,106
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,U.S. House,15,DEM,Write-In,2,0,0,2
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,State Senator,35,DEM,Shaun Dougherty,57,46,0,103
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,General Assembly,73,DEM,Write-In,3,4,0,7
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,President,,REP,Donald J. Trump,81,18,4,103
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,President,,REP,Bill Weld,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,President,,REP,Write-In,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Attorney General,,REP,Heather Heidelbaugh,75,16,2,93
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,REP,Timothy Defoor,75,14,2,91
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,State Treasurer,,REP,Stacy L. Garrity,73,18,2,93
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,U.S. House,15,REP,Glenn Gt Thompson,75,17,2,94
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,State Senator,35,REP,Wayne Langerholc Jr.,74,18,2,94
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,General Assembly,73,REP,Tommy Sankey,75,18,3,96
+Cambria,NORTHERN CAMBRIA BOROUGH - NORTH,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Registered Voters,,,,,,,739
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Registered Voters,,DEM,,,,,354
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Registered Voters,,REP,,,,,309
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Ballots Cast,,,,180,90,2,272
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Ballots Cast,,DEM,,72,71,1,144
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Ballots Cast,,REP,,108,19,1,128
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,President,,DEM,Bernie Sanders,4,12,0,16
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,President,,DEM,Joseph R. Biden,41,46,1,88
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,President,,DEM,Tulsi Gabbard,9,6,0,15
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,President,,DEM,Write-In,8,2,0,10
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Attorney General,,DEM,Josh Shapiro,63,64,0,127
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Attorney General,,DEM,Write-In,1,1,0,2
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,DEM,H. Scott Conklin,45,38,0,83
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,DEM,Michael Lamb,11,14,0,25
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,DEM,Tracie Fountain,1,2,0,3
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,3
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,DEM,Nina Ahmad,0,3,0,3
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,DEM,Christina M. Hartman,8,7,0,15
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,State Treasurer,,DEM,Joe Torsella,59,61,0,120
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,State Treasurer,,DEM,Write-In,1,1,0,2
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,U.S. House,15,DEM,Robert Williams,65,61,0,126
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,State Senator,35,DEM,Shaun Dougherty,62,60,0,122
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,General Assembly,73,DEM,Write-In,5,4,0,9
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,President,,REP,Donald J. Trump,106,18,1,125
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,President,,REP,Bill Weld,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,President,,REP,Write-In,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Attorney General,,REP,Heather Heidelbaugh,99,16,1,116
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,REP,Timothy Defoor,97,17,1,115
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,State Treasurer,,REP,Stacy L. Garrity,96,17,1,114
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,U.S. House,15,REP,Glenn Gt Thompson,100,19,1,120
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,State Senator,35,REP,Wayne Langerholc Jr.,98,17,1,116
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,General Assembly,73,REP,Tommy Sankey,96,19,1,116
+Cambria,NORTHERN CAMBRIA BOROUGH - CENTER,General Assembly,73,REP,Write-In,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Registered Voters,,,,,,,515
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Registered Voters,,DEM,,,,,267
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Registered Voters,,REP,,,,,199
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Ballots Cast,,,,137,71,0,208
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Ballots Cast,,DEM,,65,59,0,124
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Ballots Cast,,REP,,72,12,0,84
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,President,,DEM,Bernie Sanders,10,1,0,11
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,President,,DEM,Joseph R. Biden,30,45,0,75
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,President,,DEM,Tulsi Gabbard,10,11,0,21
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,President,,DEM,Write-In,7,2,0,9
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Attorney General,,DEM,Josh Shapiro,54,51,0,105
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,DEM,H. Scott Conklin,40,26,0,66
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,DEM,Michael Lamb,13,13,0,26
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,DEM,Tracie Fountain,1,3,0,4
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,0,4
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,DEM,Nina Ahmad,2,1,0,3
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,DEM,Christina M. Hartman,4,13,0,17
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,State Treasurer,,DEM,Joe Torsella,47,50,0,97
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,U.S. House,15,DEM,Robert Williams,52,51,0,103
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,U.S. House,15,DEM,Write-In,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,State Senator,35,DEM,Shaun Dougherty,52,52,0,104
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,General Assembly,73,DEM,Write-In,5,2,0,7
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,President,,REP,Donald J. Trump,72,10,0,82
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,President,,REP,Bill Weld,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,President,,REP,Write-In,0,1,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Attorney General,,REP,Heather Heidelbaugh,65,10,0,75
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,REP,Timothy Defoor,63,10,0,73
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,State Treasurer,,REP,Stacy L. Garrity,60,10,0,70
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,U.S. House,15,REP,Glenn Gt Thompson,63,12,0,75
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,State Senator,35,REP,Wayne Langerholc Jr.,62,12,0,74
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,General Assembly,73,REP,Tommy Sankey,65,12,0,77
+Cambria,NORTHERN CAMBRIA BOROUGH - SOUTH,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - FIRST WARD,Registered Voters,,,,,,,504
+Cambria,PATTON BOROUGH - FIRST WARD,Registered Voters,,DEM,,,,,248
+Cambria,PATTON BOROUGH - FIRST WARD,Registered Voters,,REP,,,,,217
+Cambria,PATTON BOROUGH - FIRST WARD,Ballots Cast,,,,134,78,1,213
+Cambria,PATTON BOROUGH - FIRST WARD,Ballots Cast,,DEM,,51,57,1,109
+Cambria,PATTON BOROUGH - FIRST WARD,Ballots Cast,,REP,,83,21,0,104
+Cambria,PATTON BOROUGH - FIRST WARD,President,,DEM,Bernie Sanders,4,6,1,11
+Cambria,PATTON BOROUGH - FIRST WARD,President,,DEM,Joseph R. Biden,24,41,0,65
+Cambria,PATTON BOROUGH - FIRST WARD,President,,DEM,Tulsi Gabbard,8,3,0,11
+Cambria,PATTON BOROUGH - FIRST WARD,President,,DEM,Write-In,9,5,0,14
+Cambria,PATTON BOROUGH - FIRST WARD,Attorney General,,DEM,Josh Shapiro,43,49,1,93
+Cambria,PATTON BOROUGH - FIRST WARD,Attorney General,,DEM,Write-In,0,4,0,4
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,DEM,H. Scott Conklin,26,29,0,55
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,DEM,Michael Lamb,10,9,0,19
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,DEM,Tracie Fountain,0,4,0,4
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,4,3,0,7
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,DEM,Nina Ahmad,0,2,0,2
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,DEM,Christina M. Hartman,3,3,1,7
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,DEM,Write-In,1,4,0,5
+Cambria,PATTON BOROUGH - FIRST WARD,State Treasurer,,DEM,Joe Torsella,42,49,1,92
+Cambria,PATTON BOROUGH - FIRST WARD,State Treasurer,,DEM,Write-In,1,4,0,5
+Cambria,PATTON BOROUGH - FIRST WARD,U.S. House,15,DEM,Robert Williams,40,51,1,92
+Cambria,PATTON BOROUGH - FIRST WARD,U.S. House,15,DEM,Write-In,0,3,0,3
+Cambria,PATTON BOROUGH - FIRST WARD,State Senator,35,DEM,Shaun Dougherty,37,49,1,87
+Cambria,PATTON BOROUGH - FIRST WARD,State Senator,35,DEM,Write-In,1,3,0,4
+Cambria,PATTON BOROUGH - FIRST WARD,General Assembly,72,DEM,Frank Burns,45,54,1,100
+Cambria,PATTON BOROUGH - FIRST WARD,General Assembly,72,DEM,Write-In,2,2,0,4
+Cambria,PATTON BOROUGH - FIRST WARD,President,,REP,Donald J. Trump,83,17,0,100
+Cambria,PATTON BOROUGH - FIRST WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,PATTON BOROUGH - FIRST WARD,President,,REP,Bill Weld,0,2,0,2
+Cambria,PATTON BOROUGH - FIRST WARD,President,,REP,Write-In,0,2,0,2
+Cambria,PATTON BOROUGH - FIRST WARD,Attorney General,,REP,Heather Heidelbaugh,74,16,0,90
+Cambria,PATTON BOROUGH - FIRST WARD,Attorney General,,REP,Write-In,1,1,0,2
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,REP,Timothy Defoor,71,16,0,87
+Cambria,PATTON BOROUGH - FIRST WARD,Auditor General,,REP,Write-In,2,1,0,3
+Cambria,PATTON BOROUGH - FIRST WARD,State Treasurer,,REP,Stacy L. Garrity,73,17,0,90
+Cambria,PATTON BOROUGH - FIRST WARD,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,PATTON BOROUGH - FIRST WARD,U.S. House,15,REP,Glenn Gt Thompson,75,19,0,94
+Cambria,PATTON BOROUGH - FIRST WARD,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - FIRST WARD,State Senator,35,REP,Wayne Langerholc Jr.,77,18,0,95
+Cambria,PATTON BOROUGH - FIRST WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - FIRST WARD,General Assembly,72,REP,Howard Terndrup,35,6,0,41
+Cambria,PATTON BOROUGH - FIRST WARD,General Assembly,72,REP,Jerry Carnicella,44,15,0,59
+Cambria,PATTON BOROUGH - FIRST WARD,General Assembly,72,REP,Write-In,3,0,0,3
+Cambria,PATTON BOROUGH - SECOND WARD,Registered Voters,,,,,,,556
+Cambria,PATTON BOROUGH - SECOND WARD,Registered Voters,,DEM,,,,,312
+Cambria,PATTON BOROUGH - SECOND WARD,Registered Voters,,REP,,,,,193
+Cambria,PATTON BOROUGH - SECOND WARD,Ballots Cast,,,,148,76,0,224
+Cambria,PATTON BOROUGH - SECOND WARD,Ballots Cast,,DEM,,84,64,0,148
+Cambria,PATTON BOROUGH - SECOND WARD,Ballots Cast,,REP,,64,12,0,76
+Cambria,PATTON BOROUGH - SECOND WARD,President,,DEM,Bernie Sanders,11,11,0,22
+Cambria,PATTON BOROUGH - SECOND WARD,President,,DEM,Joseph R. Biden,42,43,0,85
+Cambria,PATTON BOROUGH - SECOND WARD,President,,DEM,Tulsi Gabbard,11,6,0,17
+Cambria,PATTON BOROUGH - SECOND WARD,President,,DEM,Write-In,10,2,0,12
+Cambria,PATTON BOROUGH - SECOND WARD,Attorney General,,DEM,Josh Shapiro,71,57,0,128
+Cambria,PATTON BOROUGH - SECOND WARD,Attorney General,,DEM,Write-In,0,3,0,3
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,DEM,H. Scott Conklin,59,43,0,102
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,DEM,Michael Lamb,13,12,0,25
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,DEM,Tracie Fountain,1,1,0,2
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,3
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,DEM,Nina Ahmad,0,1,0,1
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,DEM,Christina M. Hartman,3,2,0,5
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,DEM,Write-In,0,2,0,2
+Cambria,PATTON BOROUGH - SECOND WARD,State Treasurer,,DEM,Joe Torsella,70,54,0,124
+Cambria,PATTON BOROUGH - SECOND WARD,State Treasurer,,DEM,Write-In,0,2,0,2
+Cambria,PATTON BOROUGH - SECOND WARD,U.S. House,15,DEM,Robert Williams,74,57,0,131
+Cambria,PATTON BOROUGH - SECOND WARD,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - SECOND WARD,State Senator,35,DEM,Shaun Dougherty,73,57,0,130
+Cambria,PATTON BOROUGH - SECOND WARD,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - SECOND WARD,General Assembly,72,DEM,Frank Burns,76,59,0,135
+Cambria,PATTON BOROUGH - SECOND WARD,General Assembly,72,DEM,Write-In,3,0,0,3
+Cambria,PATTON BOROUGH - SECOND WARD,President,,REP,Donald J. Trump,61,11,0,72
+Cambria,PATTON BOROUGH - SECOND WARD,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,PATTON BOROUGH - SECOND WARD,President,,REP,Bill Weld,1,0,0,1
+Cambria,PATTON BOROUGH - SECOND WARD,President,,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - SECOND WARD,Attorney General,,REP,Heather Heidelbaugh,57,11,0,68
+Cambria,PATTON BOROUGH - SECOND WARD,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,REP,Timothy Defoor,53,9,0,62
+Cambria,PATTON BOROUGH - SECOND WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - SECOND WARD,State Treasurer,,REP,Stacy L. Garrity,54,11,0,65
+Cambria,PATTON BOROUGH - SECOND WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - SECOND WARD,U.S. House,15,REP,Glenn Gt Thompson,56,11,0,67
+Cambria,PATTON BOROUGH - SECOND WARD,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - SECOND WARD,State Senator,35,REP,Wayne Langerholc Jr.,60,11,0,71
+Cambria,PATTON BOROUGH - SECOND WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,PATTON BOROUGH - SECOND WARD,General Assembly,72,REP,Howard Terndrup,44,10,0,54
+Cambria,PATTON BOROUGH - SECOND WARD,General Assembly,72,REP,Jerry Carnicella,19,2,0,21
+Cambria,PATTON BOROUGH - SECOND WARD,General Assembly,72,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - FIRST WARD,Registered Voters,,,,,,,314
+Cambria,PORTAGE BOROUGH - FIRST WARD,Registered Voters,,DEM,,,,,163
+Cambria,PORTAGE BOROUGH - FIRST WARD,Registered Voters,,REP,,,,,121
+Cambria,PORTAGE BOROUGH - FIRST WARD,Ballots Cast,,,,89,41,0,130
+Cambria,PORTAGE BOROUGH - FIRST WARD,Ballots Cast,,DEM,,47,32,0,79
+Cambria,PORTAGE BOROUGH - FIRST WARD,Ballots Cast,,REP,,42,9,0,51
+Cambria,PORTAGE BOROUGH - FIRST WARD,President,,DEM,Bernie Sanders,12,4,0,16
+Cambria,PORTAGE BOROUGH - FIRST WARD,President,,DEM,Joseph R. Biden,16,19,0,35
+Cambria,PORTAGE BOROUGH - FIRST WARD,President,,DEM,Tulsi Gabbard,5,3,0,8
+Cambria,PORTAGE BOROUGH - FIRST WARD,President,,DEM,Write-In,7,1,0,8
+Cambria,PORTAGE BOROUGH - FIRST WARD,Attorney General,,DEM,Josh Shapiro,38,32,0,70
+Cambria,PORTAGE BOROUGH - FIRST WARD,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,DEM,H. Scott Conklin,28,17,0,45
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,DEM,Michael Lamb,11,9,0,20
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,DEM,Nina Ahmad,3,2,0,5
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,DEM,Christina M. Hartman,1,2,0,3
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,State Treasurer,,DEM,Joe Torsella,37,29,0,66
+Cambria,PORTAGE BOROUGH - FIRST WARD,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,U.S. House,15,DEM,Robert Williams,38,29,0,67
+Cambria,PORTAGE BOROUGH - FIRST WARD,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,State Senator,35,DEM,Shaun Dougherty,39,28,0,67
+Cambria,PORTAGE BOROUGH - FIRST WARD,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,General Assembly,72,DEM,Frank Burns,46,32,0,78
+Cambria,PORTAGE BOROUGH - FIRST WARD,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,President,,REP,Donald J. Trump,39,9,0,48
+Cambria,PORTAGE BOROUGH - FIRST WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,PORTAGE BOROUGH - FIRST WARD,President,,REP,Bill Weld,2,0,0,2
+Cambria,PORTAGE BOROUGH - FIRST WARD,President,,REP,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - FIRST WARD,Attorney General,,REP,Heather Heidelbaugh,38,9,0,47
+Cambria,PORTAGE BOROUGH - FIRST WARD,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,REP,Timothy Defoor,37,9,0,46
+Cambria,PORTAGE BOROUGH - FIRST WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - FIRST WARD,State Treasurer,,REP,Stacy L. Garrity,36,9,0,45
+Cambria,PORTAGE BOROUGH - FIRST WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - FIRST WARD,U.S. House,15,REP,Glenn Gt Thompson,35,9,0,44
+Cambria,PORTAGE BOROUGH - FIRST WARD,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - FIRST WARD,State Senator,35,REP,Wayne Langerholc Jr.,38,9,0,47
+Cambria,PORTAGE BOROUGH - FIRST WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - FIRST WARD,General Assembly,72,REP,Howard Terndrup,23,6,0,29
+Cambria,PORTAGE BOROUGH - FIRST WARD,General Assembly,72,REP,Jerry Carnicella,12,3,0,15
+Cambria,PORTAGE BOROUGH - FIRST WARD,General Assembly,72,REP,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,Registered Voters,,,,,,,470
+Cambria,PORTAGE BOROUGH - SECOND WARD,Registered Voters,,DEM,,,,,210
+Cambria,PORTAGE BOROUGH - SECOND WARD,Registered Voters,,REP,,,,,204
+Cambria,PORTAGE BOROUGH - SECOND WARD,Ballots Cast,,,,97,71,0,168
+Cambria,PORTAGE BOROUGH - SECOND WARD,Ballots Cast,,DEM,,37,53,0,90
+Cambria,PORTAGE BOROUGH - SECOND WARD,Ballots Cast,,REP,,60,18,0,78
+Cambria,PORTAGE BOROUGH - SECOND WARD,President,,DEM,Bernie Sanders,7,8,0,15
+Cambria,PORTAGE BOROUGH - SECOND WARD,President,,DEM,Joseph R. Biden,19,33,0,52
+Cambria,PORTAGE BOROUGH - SECOND WARD,President,,DEM,Tulsi Gabbard,4,4,0,8
+Cambria,PORTAGE BOROUGH - SECOND WARD,President,,DEM,Write-In,4,1,0,5
+Cambria,PORTAGE BOROUGH - SECOND WARD,Attorney General,,DEM,Josh Shapiro,32,46,0,78
+Cambria,PORTAGE BOROUGH - SECOND WARD,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,DEM,H. Scott Conklin,17,25,0,42
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,DEM,Michael Lamb,12,18,0,30
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,DEM,Rose Rosie Marie Davis,1,5,0,6
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,DEM,Christina M. Hartman,4,3,0,7
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,DEM,Write-In,0,1,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,State Treasurer,,DEM,Joe Torsella,31,44,0,75
+Cambria,PORTAGE BOROUGH - SECOND WARD,State Treasurer,,DEM,Write-In,1,1,0,2
+Cambria,PORTAGE BOROUGH - SECOND WARD,U.S. House,15,DEM,Robert Williams,30,45,0,75
+Cambria,PORTAGE BOROUGH - SECOND WARD,U.S. House,15,DEM,Write-In,2,0,0,2
+Cambria,PORTAGE BOROUGH - SECOND WARD,State Senator,35,DEM,Shaun Dougherty,33,46,0,79
+Cambria,PORTAGE BOROUGH - SECOND WARD,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - SECOND WARD,General Assembly,72,DEM,Frank Burns,34,52,0,86
+Cambria,PORTAGE BOROUGH - SECOND WARD,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,President,,REP,Donald J. Trump,58,15,0,73
+Cambria,PORTAGE BOROUGH - SECOND WARD,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Cambria,PORTAGE BOROUGH - SECOND WARD,President,,REP,Bill Weld,1,0,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,President,,REP,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,Attorney General,,REP,Heather Heidelbaugh,57,16,0,73
+Cambria,PORTAGE BOROUGH - SECOND WARD,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,REP,Timothy Defoor,55,14,0,69
+Cambria,PORTAGE BOROUGH - SECOND WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - SECOND WARD,State Treasurer,,REP,Stacy L. Garrity,54,14,0,68
+Cambria,PORTAGE BOROUGH - SECOND WARD,State Treasurer,,REP,Write-In,2,0,0,2
+Cambria,PORTAGE BOROUGH - SECOND WARD,U.S. House,15,REP,Glenn Gt Thompson,56,16,0,72
+Cambria,PORTAGE BOROUGH - SECOND WARD,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,State Senator,35,REP,Wayne Langerholc Jr.,57,17,0,74
+Cambria,PORTAGE BOROUGH - SECOND WARD,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,PORTAGE BOROUGH - SECOND WARD,General Assembly,72,REP,Howard Terndrup,27,16,0,43
+Cambria,PORTAGE BOROUGH - SECOND WARD,General Assembly,72,REP,Jerry Carnicella,26,1,0,27
+Cambria,PORTAGE BOROUGH - SECOND WARD,General Assembly,72,REP,Write-In,5,0,0,5
+Cambria,PORTAGE BOROUGH - THIRD WARD,Registered Voters,,,,,,,475
+Cambria,PORTAGE BOROUGH - THIRD WARD,Registered Voters,,DEM,,,,,208
+Cambria,PORTAGE BOROUGH - THIRD WARD,Registered Voters,,REP,,,,,223
+Cambria,PORTAGE BOROUGH - THIRD WARD,Ballots Cast,,,,94,70,1,165
+Cambria,PORTAGE BOROUGH - THIRD WARD,Ballots Cast,,DEM,,35,45,0,80
+Cambria,PORTAGE BOROUGH - THIRD WARD,Ballots Cast,,REP,,59,25,1,85
+Cambria,PORTAGE BOROUGH - THIRD WARD,President,,DEM,Bernie Sanders,10,7,0,17
+Cambria,PORTAGE BOROUGH - THIRD WARD,President,,DEM,Joseph R. Biden,8,33,0,41
+Cambria,PORTAGE BOROUGH - THIRD WARD,President,,DEM,Tulsi Gabbard,3,3,0,6
+Cambria,PORTAGE BOROUGH - THIRD WARD,President,,DEM,Write-In,9,2,0,11
+Cambria,PORTAGE BOROUGH - THIRD WARD,Attorney General,,DEM,Josh Shapiro,32,42,0,74
+Cambria,PORTAGE BOROUGH - THIRD WARD,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,DEM,H. Scott Conklin,18,22,0,40
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,DEM,Michael Lamb,8,14,0,22
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,DEM,Tracie Fountain,2,0,0,2
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,0,4
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,DEM,Nina Ahmad,1,2,0,3
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,DEM,Christina M. Hartman,1,2,0,3
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,DEM,Write-In,0,1,0,1
+Cambria,PORTAGE BOROUGH - THIRD WARD,State Treasurer,,DEM,Joe Torsella,30,41,0,71
+Cambria,PORTAGE BOROUGH - THIRD WARD,State Treasurer,,DEM,Write-In,1,1,0,2
+Cambria,PORTAGE BOROUGH - THIRD WARD,U.S. House,15,DEM,Robert Williams,30,38,0,68
+Cambria,PORTAGE BOROUGH - THIRD WARD,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,PORTAGE BOROUGH - THIRD WARD,State Senator,35,DEM,Shaun Dougherty,29,40,0,69
+Cambria,PORTAGE BOROUGH - THIRD WARD,State Senator,35,DEM,Write-In,1,1,0,2
+Cambria,PORTAGE BOROUGH - THIRD WARD,General Assembly,72,DEM,Frank Burns,33,42,0,75
+Cambria,PORTAGE BOROUGH - THIRD WARD,General Assembly,72,DEM,Write-In,0,2,0,2
+Cambria,PORTAGE BOROUGH - THIRD WARD,President,,REP,Donald J. Trump,59,25,1,85
+Cambria,PORTAGE BOROUGH - THIRD WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,PORTAGE BOROUGH - THIRD WARD,President,,REP,Bill Weld,0,0,0,0
+Cambria,PORTAGE BOROUGH - THIRD WARD,President,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - THIRD WARD,Attorney General,,REP,Heather Heidelbaugh,56,23,1,80
+Cambria,PORTAGE BOROUGH - THIRD WARD,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,REP,Timothy Defoor,56,23,0,79
+Cambria,PORTAGE BOROUGH - THIRD WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - THIRD WARD,State Treasurer,,REP,Stacy L. Garrity,56,23,0,79
+Cambria,PORTAGE BOROUGH - THIRD WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - THIRD WARD,U.S. House,15,REP,Glenn Gt Thompson,56,24,0,80
+Cambria,PORTAGE BOROUGH - THIRD WARD,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - THIRD WARD,State Senator,35,REP,Wayne Langerholc Jr.,55,24,1,80
+Cambria,PORTAGE BOROUGH - THIRD WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,PORTAGE BOROUGH - THIRD WARD,General Assembly,72,REP,Howard Terndrup,27,11,0,38
+Cambria,PORTAGE BOROUGH - THIRD WARD,General Assembly,72,REP,Jerry Carnicella,26,13,0,39
+Cambria,PORTAGE BOROUGH - THIRD WARD,General Assembly,72,REP,Write-In,4,0,0,4
+Cambria,PORTAGE TOWNSHIP CENTER,Registered Voters,,,,,,,1040
+Cambria,PORTAGE TOWNSHIP CENTER,Registered Voters,,DEM,,,,,528
+Cambria,PORTAGE TOWNSHIP CENTER,Registered Voters,,REP,,,,,418
+Cambria,PORTAGE TOWNSHIP CENTER,Ballots Cast,,,,214,172,4,390
+Cambria,PORTAGE TOWNSHIP CENTER,Ballots Cast,,DEM,,100,137,1,238
+Cambria,PORTAGE TOWNSHIP CENTER,Ballots Cast,,REP,,114,35,3,152
+Cambria,PORTAGE TOWNSHIP CENTER,President,,DEM,Bernie Sanders,16,20,0,36
+Cambria,PORTAGE TOWNSHIP CENTER,President,,DEM,Joseph R. Biden,44,86,1,131
+Cambria,PORTAGE TOWNSHIP CENTER,President,,DEM,Tulsi Gabbard,14,8,0,22
+Cambria,PORTAGE TOWNSHIP CENTER,President,,DEM,Write-In,10,12,0,22
+Cambria,PORTAGE TOWNSHIP CENTER,Attorney General,,DEM,Josh Shapiro,85,129,1,215
+Cambria,PORTAGE TOWNSHIP CENTER,Attorney General,,DEM,Write-In,2,0,0,2
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,DEM,H. Scott Conklin,44,93,1,138
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,DEM,Michael Lamb,29,20,0,49
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,DEM,Tracie Fountain,6,4,0,10
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,DEM,Rose Rosie Marie Davis,4,6,0,10
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,DEM,Nina Ahmad,2,3,0,5
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,DEM,Christina M. Hartman,6,7,0,13
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,PORTAGE TOWNSHIP CENTER,State Treasurer,,DEM,Joe Torsella,83,129,1,213
+Cambria,PORTAGE TOWNSHIP CENTER,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,PORTAGE TOWNSHIP CENTER,U.S. House,15,DEM,Robert Williams,80,124,1,205
+Cambria,PORTAGE TOWNSHIP CENTER,U.S. House,15,DEM,Write-In,3,0,0,3
+Cambria,PORTAGE TOWNSHIP CENTER,State Senator,35,DEM,Shaun Dougherty,77,123,1,201
+Cambria,PORTAGE TOWNSHIP CENTER,State Senator,35,DEM,Write-In,2,2,0,4
+Cambria,PORTAGE TOWNSHIP CENTER,General Assembly,72,DEM,Frank Burns,96,133,1,230
+Cambria,PORTAGE TOWNSHIP CENTER,General Assembly,72,DEM,Write-In,3,2,0,5
+Cambria,PORTAGE TOWNSHIP CENTER,President,,REP,Donald J. Trump,112,31,3,146
+Cambria,PORTAGE TOWNSHIP CENTER,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,PORTAGE TOWNSHIP CENTER,President,,REP,Bill Weld,1,2,0,3
+Cambria,PORTAGE TOWNSHIP CENTER,President,,REP,Write-In,0,1,0,1
+Cambria,PORTAGE TOWNSHIP CENTER,Attorney General,,REP,Heather Heidelbaugh,103,33,3,139
+Cambria,PORTAGE TOWNSHIP CENTER,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,REP,Timothy Defoor,102,32,3,137
+Cambria,PORTAGE TOWNSHIP CENTER,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,PORTAGE TOWNSHIP CENTER,State Treasurer,,REP,Stacy L. Garrity,102,32,3,137
+Cambria,PORTAGE TOWNSHIP CENTER,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,PORTAGE TOWNSHIP CENTER,U.S. House,15,REP,Glenn Gt Thompson,106,33,3,142
+Cambria,PORTAGE TOWNSHIP CENTER,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,PORTAGE TOWNSHIP CENTER,State Senator,35,REP,Wayne Langerholc Jr.,106,35,3,144
+Cambria,PORTAGE TOWNSHIP CENTER,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,PORTAGE TOWNSHIP CENTER,General Assembly,72,REP,Howard Terndrup,64,20,1,85
+Cambria,PORTAGE TOWNSHIP CENTER,General Assembly,72,REP,Jerry Carnicella,40,14,2,56
+Cambria,PORTAGE TOWNSHIP CENTER,General Assembly,72,REP,Write-In,5,1,0,6
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Registered Voters,,,,,,,1115
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Registered Voters,,DEM,,,,,536
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Registered Voters,,REP,,,,,480
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Ballots Cast,,,,196,218,5,419
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Ballots Cast,,DEM,,83,142,2,227
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Ballots Cast,,REP,,113,76,3,192
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,President,,DEM,Bernie Sanders,18,13,0,31
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,President,,DEM,Joseph R. Biden,32,106,1,139
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,President,,DEM,Tulsi Gabbard,12,6,0,18
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,President,,DEM,Write-In,9,10,1,20
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Attorney General,,DEM,Josh Shapiro,67,134,2,203
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Attorney General,,DEM,Write-In,1,1,0,2
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,DEM,H. Scott Conklin,48,96,0,144
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,DEM,Michael Lamb,16,24,1,41
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,DEM,Tracie Fountain,0,5,0,5
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,DEM,Rose Rosie Marie Davis,5,4,0,9
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,DEM,Nina Ahmad,3,2,0,5
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,DEM,Christina M. Hartman,5,5,1,11
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,DEM,Write-In,1,2,0,3
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,State Treasurer,,DEM,Joe Torsella,64,129,2,195
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,State Treasurer,,DEM,Write-In,1,3,0,4
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,U.S. House,15,DEM,Robert Williams,69,125,2,196
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,U.S. House,15,DEM,Write-In,3,5,0,8
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,State Senator,35,DEM,Shaun Dougherty,66,128,2,196
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,State Senator,35,DEM,Write-In,1,3,0,4
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,General Assembly,72,DEM,Frank Burns,80,138,2,220
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,General Assembly,72,DEM,Write-In,1,2,0,3
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,President,,REP,Donald J. Trump,111,67,3,181
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,President,,REP,Bill Weld,1,3,0,4
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,President,,REP,Write-In,0,3,0,3
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Attorney General,,REP,Heather Heidelbaugh,100,65,3,168
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,REP,Timothy Defoor,98,67,3,168
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,State Treasurer,,REP,Stacy L. Garrity,103,66,3,172
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,U.S. House,15,REP,Glenn Gt Thompson,106,69,3,178
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,State Senator,35,REP,Wayne Langerholc Jr.,110,70,3,183
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,General Assembly,72,REP,Howard Terndrup,69,44,2,115
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,General Assembly,72,REP,Jerry Carnicella,36,27,1,64
+Cambria,PORTAGE TOWNSHIP - SOUTHWEST,General Assembly,72,REP,Write-In,4,2,0,6
+Cambria,READE TOWNSHIP,Registered Voters,,,,,,,826
+Cambria,READE TOWNSHIP,Registered Voters,,DEM,,,,,263
+Cambria,READE TOWNSHIP,Registered Voters,,REP,,,,,468
+Cambria,READE TOWNSHIP,Ballots Cast,,,,239,61,3,303
+Cambria,READE TOWNSHIP,Ballots Cast,,DEM,,67,27,0,94
+Cambria,READE TOWNSHIP,Ballots Cast,,REP,,172,34,3,209
+Cambria,READE TOWNSHIP,President,,DEM,Bernie Sanders,15,5,0,20
+Cambria,READE TOWNSHIP,President,,DEM,Joseph R. Biden,28,18,0,46
+Cambria,READE TOWNSHIP,President,,DEM,Tulsi Gabbard,5,0,0,5
+Cambria,READE TOWNSHIP,President,,DEM,Write-In,10,3,0,13
+Cambria,READE TOWNSHIP,Attorney General,,DEM,Josh Shapiro,49,26,0,75
+Cambria,READE TOWNSHIP,Attorney General,,DEM,Write-In,2,1,0,3
+Cambria,READE TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,37,23,0,60
+Cambria,READE TOWNSHIP,Auditor General,,DEM,Michael Lamb,6,1,0,7
+Cambria,READE TOWNSHIP,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Cambria,READE TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,6,0,0,6
+Cambria,READE TOWNSHIP,Auditor General,,DEM,Nina Ahmad,2,2,0,4
+Cambria,READE TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,4,0,0,4
+Cambria,READE TOWNSHIP,Auditor General,,DEM,Write-In,2,1,0,3
+Cambria,READE TOWNSHIP,State Treasurer,,DEM,Joe Torsella,54,26,0,80
+Cambria,READE TOWNSHIP,State Treasurer,,DEM,Write-In,2,1,0,3
+Cambria,READE TOWNSHIP,U.S. House,15,DEM,Robert Williams,46,22,0,68
+Cambria,READE TOWNSHIP,U.S. House,15,DEM,Write-In,6,3,0,9
+Cambria,READE TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,49,21,0,70
+Cambria,READE TOWNSHIP,State Senator,35,DEM,Write-In,2,1,0,3
+Cambria,READE TOWNSHIP,General Assembly,72,DEM,Frank Burns,59,26,0,85
+Cambria,READE TOWNSHIP,General Assembly,72,DEM,Write-In,0,1,0,1
+Cambria,READE TOWNSHIP,President,,REP,Donald J. Trump,169,31,3,203
+Cambria,READE TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,READE TOWNSHIP,President,,REP,Bill Weld,1,3,0,4
+Cambria,READE TOWNSHIP,President,,REP,Write-In,0,0,0,0
+Cambria,READE TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,156,30,1,187
+Cambria,READE TOWNSHIP,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,READE TOWNSHIP,Auditor General,,REP,Timothy Defoor,155,29,1,185
+Cambria,READE TOWNSHIP,Auditor General,,REP,Write-In,1,2,0,3
+Cambria,READE TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,157,30,1,188
+Cambria,READE TOWNSHIP,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,READE TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,159,32,1,192
+Cambria,READE TOWNSHIP,U.S. House,15,REP,Write-In,2,1,0,3
+Cambria,READE TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,158,30,1,189
+Cambria,READE TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,READE TOWNSHIP,General Assembly,72,REP,Howard Terndrup,68,11,0,79
+Cambria,READE TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,101,21,3,125
+Cambria,READE TOWNSHIP,General Assembly,72,REP,Write-In,1,1,0,2
+Cambria,RICHLAND TOWNSHIP NO. 1,Registered Voters,,,,,,,923
+Cambria,RICHLAND TOWNSHIP NO. 1,Registered Voters,,DEM,,,,,326
+Cambria,RICHLAND TOWNSHIP NO. 1,Registered Voters,,REP,,,,,504
+Cambria,RICHLAND TOWNSHIP NO. 1,Ballots Cast,,,,184,134,8,326
+Cambria,RICHLAND TOWNSHIP NO. 1,Ballots Cast,,DEM,,55,80,1,136
+Cambria,RICHLAND TOWNSHIP NO. 1,Ballots Cast,,REP,,129,54,7,190
+Cambria,RICHLAND TOWNSHIP NO. 1,President,,DEM,Bernie Sanders,13,10,0,23
+Cambria,RICHLAND TOWNSHIP NO. 1,President,,DEM,Joseph R. Biden,30,63,0,93
+Cambria,RICHLAND TOWNSHIP NO. 1,President,,DEM,Tulsi Gabbard,3,3,0,6
+Cambria,RICHLAND TOWNSHIP NO. 1,President,,DEM,Write-In,8,1,1,10
+Cambria,RICHLAND TOWNSHIP NO. 1,Attorney General,,DEM,Josh Shapiro,49,79,1,129
+Cambria,RICHLAND TOWNSHIP NO. 1,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,DEM,H. Scott Conklin,22,44,0,66
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,DEM,Michael Lamb,13,25,0,38
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,DEM,Tracie Fountain,1,2,1,4
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,0,4
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,DEM,Nina Ahmad,5,5,0,10
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,DEM,Christina M. Hartman,11,1,0,12
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 1,State Treasurer,,DEM,Joe Torsella,47,75,1,123
+Cambria,RICHLAND TOWNSHIP NO. 1,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,RICHLAND TOWNSHIP NO. 1,U.S. House,15,DEM,Robert Williams,51,74,1,126
+Cambria,RICHLAND TOWNSHIP NO. 1,U.S. House,15,DEM,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 1,State Senator,35,DEM,Shaun Dougherty,53,76,1,130
+Cambria,RICHLAND TOWNSHIP NO. 1,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 1,General Assembly,71,DEM,Write-In,6,12,0,18
+Cambria,RICHLAND TOWNSHIP NO. 1,President,,REP,Donald J. Trump,124,51,7,182
+Cambria,RICHLAND TOWNSHIP NO. 1,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Cambria,RICHLAND TOWNSHIP NO. 1,President,,REP,Bill Weld,2,2,0,4
+Cambria,RICHLAND TOWNSHIP NO. 1,President,,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 1,Attorney General,,REP,Heather Heidelbaugh,119,52,6,177
+Cambria,RICHLAND TOWNSHIP NO. 1,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,REP,Timothy Defoor,120,52,4,176
+Cambria,RICHLAND TOWNSHIP NO. 1,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 1,State Treasurer,,REP,Stacy L. Garrity,120,52,5,177
+Cambria,RICHLAND TOWNSHIP NO. 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 1,U.S. House,15,REP,Glenn Gt Thompson,119,52,6,177
+Cambria,RICHLAND TOWNSHIP NO. 1,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,126,52,6,184
+Cambria,RICHLAND TOWNSHIP NO. 1,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 1,General Assembly,71,REP,Jim Rigby,126,54,6,186
+Cambria,RICHLAND TOWNSHIP NO. 1,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 2,Registered Voters,,,,,,,1174
+Cambria,RICHLAND TOWNSHIP NO. 2,Registered Voters,,DEM,,,,,509
+Cambria,RICHLAND TOWNSHIP NO. 2,Registered Voters,,REP,,,,,566
+Cambria,RICHLAND TOWNSHIP NO. 2,Ballots Cast,,,,225,194,3,422
+Cambria,RICHLAND TOWNSHIP NO. 2,Ballots Cast,,DEM,,71,117,0,188
+Cambria,RICHLAND TOWNSHIP NO. 2,Ballots Cast,,REP,,154,77,3,234
+Cambria,RICHLAND TOWNSHIP NO. 2,President,,DEM,Bernie Sanders,12,14,0,26
+Cambria,RICHLAND TOWNSHIP NO. 2,President,,DEM,Joseph R. Biden,47,95,0,142
+Cambria,RICHLAND TOWNSHIP NO. 2,President,,DEM,Tulsi Gabbard,4,3,0,7
+Cambria,RICHLAND TOWNSHIP NO. 2,President,,DEM,Write-In,4,3,0,7
+Cambria,RICHLAND TOWNSHIP NO. 2,Attorney General,,DEM,Josh Shapiro,64,107,0,171
+Cambria,RICHLAND TOWNSHIP NO. 2,Attorney General,,DEM,Write-In,0,2,0,2
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,DEM,H. Scott Conklin,35,67,0,102
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,DEM,Michael Lamb,18,24,0,42
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,DEM,Tracie Fountain,0,6,0,6
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,DEM,Nina Ahmad,1,10,0,11
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,DEM,Christina M. Hartman,6,7,0,13
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 2,State Treasurer,,DEM,Joe Torsella,62,102,0,164
+Cambria,RICHLAND TOWNSHIP NO. 2,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,U.S. House,15,DEM,Robert Williams,63,102,0,165
+Cambria,RICHLAND TOWNSHIP NO. 2,U.S. House,15,DEM,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,State Senator,35,DEM,Shaun Dougherty,63,108,0,171
+Cambria,RICHLAND TOWNSHIP NO. 2,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,General Assembly,71,DEM,Write-In,5,10,0,15
+Cambria,RICHLAND TOWNSHIP NO. 2,President,,REP,Donald J. Trump,150,71,3,224
+Cambria,RICHLAND TOWNSHIP NO. 2,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Cambria,RICHLAND TOWNSHIP NO. 2,President,,REP,Bill Weld,3,3,0,6
+Cambria,RICHLAND TOWNSHIP NO. 2,President,,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,Attorney General,,REP,Heather Heidelbaugh,134,72,3,209
+Cambria,RICHLAND TOWNSHIP NO. 2,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,REP,Timothy Defoor,134,71,3,208
+Cambria,RICHLAND TOWNSHIP NO. 2,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,State Treasurer,,REP,Stacy L. Garrity,133,72,3,208
+Cambria,RICHLAND TOWNSHIP NO. 2,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,U.S. House,15,REP,Glenn Gt Thompson,140,75,3,218
+Cambria,RICHLAND TOWNSHIP NO. 2,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 2,State Senator,35,REP,Wayne Langerholc Jr.,148,75,3,226
+Cambria,RICHLAND TOWNSHIP NO. 2,State Senator,35,REP,Write-In,2,0,0,2
+Cambria,RICHLAND TOWNSHIP NO. 2,General Assembly,71,REP,Jim Rigby,148,76,3,227
+Cambria,RICHLAND TOWNSHIP NO. 2,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 3,Registered Voters,,,,,,,663
+Cambria,RICHLAND TOWNSHIP NO. 3,Registered Voters,,DEM,,,,,220
+Cambria,RICHLAND TOWNSHIP NO. 3,Registered Voters,,REP,,,,,396
+Cambria,RICHLAND TOWNSHIP NO. 3,Ballots Cast,,,,160,126,4,290
+Cambria,RICHLAND TOWNSHIP NO. 3,Ballots Cast,,DEM,,38,65,2,105
+Cambria,RICHLAND TOWNSHIP NO. 3,Ballots Cast,,REP,,122,61,2,185
+Cambria,RICHLAND TOWNSHIP NO. 3,President,,DEM,Bernie Sanders,7,4,0,11
+Cambria,RICHLAND TOWNSHIP NO. 3,President,,DEM,Joseph R. Biden,15,58,2,75
+Cambria,RICHLAND TOWNSHIP NO. 3,President,,DEM,Tulsi Gabbard,5,1,0,6
+Cambria,RICHLAND TOWNSHIP NO. 3,President,,DEM,Write-In,5,1,0,6
+Cambria,RICHLAND TOWNSHIP NO. 3,Attorney General,,DEM,Josh Shapiro,35,64,2,101
+Cambria,RICHLAND TOWNSHIP NO. 3,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,DEM,H. Scott Conklin,16,38,1,55
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,DEM,Michael Lamb,13,19,0,32
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,DEM,Tracie Fountain,4,1,1,6
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,DEM,Nina Ahmad,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,DEM,Christina M. Hartman,1,4,0,5
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 3,State Treasurer,,DEM,Joe Torsella,32,64,2,98
+Cambria,RICHLAND TOWNSHIP NO. 3,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 3,U.S. House,15,DEM,Robert Williams,32,63,2,97
+Cambria,RICHLAND TOWNSHIP NO. 3,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,RICHLAND TOWNSHIP NO. 3,State Senator,35,DEM,Shaun Dougherty,35,65,2,102
+Cambria,RICHLAND TOWNSHIP NO. 3,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 3,General Assembly,71,DEM,Write-In,2,7,1,10
+Cambria,RICHLAND TOWNSHIP NO. 3,President,,REP,Donald J. Trump,115,59,2,176
+Cambria,RICHLAND TOWNSHIP NO. 3,President,,REP,Roque Rocky De La Fuente,2,1,0,3
+Cambria,RICHLAND TOWNSHIP NO. 3,President,,REP,Bill Weld,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 3,President,,REP,Write-In,2,0,0,2
+Cambria,RICHLAND TOWNSHIP NO. 3,Attorney General,,REP,Heather Heidelbaugh,109,53,2,164
+Cambria,RICHLAND TOWNSHIP NO. 3,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,REP,Timothy Defoor,106,55,2,163
+Cambria,RICHLAND TOWNSHIP NO. 3,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 3,State Treasurer,,REP,Stacy L. Garrity,105,57,2,164
+Cambria,RICHLAND TOWNSHIP NO. 3,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,RICHLAND TOWNSHIP NO. 3,U.S. House,15,REP,Glenn Gt Thompson,110,57,2,169
+Cambria,RICHLAND TOWNSHIP NO. 3,U.S. House,15,REP,Write-In,2,0,0,2
+Cambria,RICHLAND TOWNSHIP NO. 3,State Senator,35,REP,Wayne Langerholc Jr.,116,60,2,178
+Cambria,RICHLAND TOWNSHIP NO. 3,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 3,General Assembly,71,REP,Jim Rigby,117,60,2,179
+Cambria,RICHLAND TOWNSHIP NO. 3,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 4,Registered Voters,,,,,,,881
+Cambria,RICHLAND TOWNSHIP NO. 4,Registered Voters,,DEM,,,,,335
+Cambria,RICHLAND TOWNSHIP NO. 4,Registered Voters,,REP,,,,,477
+Cambria,RICHLAND TOWNSHIP NO. 4,Ballots Cast,,,,161,208,6,375
+Cambria,RICHLAND TOWNSHIP NO. 4,Ballots Cast,,DEM,,53,101,1,155
+Cambria,RICHLAND TOWNSHIP NO. 4,Ballots Cast,,REP,,108,107,5,220
+Cambria,RICHLAND TOWNSHIP NO. 4,President,,DEM,Bernie Sanders,6,11,0,17
+Cambria,RICHLAND TOWNSHIP NO. 4,President,,DEM,Joseph R. Biden,34,79,1,114
+Cambria,RICHLAND TOWNSHIP NO. 4,President,,DEM,Tulsi Gabbard,5,4,0,9
+Cambria,RICHLAND TOWNSHIP NO. 4,President,,DEM,Write-In,6,4,0,10
+Cambria,RICHLAND TOWNSHIP NO. 4,Attorney General,,DEM,Josh Shapiro,47,96,1,144
+Cambria,RICHLAND TOWNSHIP NO. 4,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,DEM,H. Scott Conklin,23,41,0,64
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,DEM,Michael Lamb,18,30,1,49
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,DEM,Tracie Fountain,3,7,0,10
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,DEM,Rose Rosie Marie Davis,1,6,0,7
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,DEM,Nina Ahmad,2,4,0,6
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,DEM,Christina M. Hartman,3,8,0,11
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 4,State Treasurer,,DEM,Joe Torsella,43,91,1,135
+Cambria,RICHLAND TOWNSHIP NO. 4,State Treasurer,,DEM,Write-In,1,1,0,2
+Cambria,RICHLAND TOWNSHIP NO. 4,U.S. House,15,DEM,Robert Williams,46,90,1,137
+Cambria,RICHLAND TOWNSHIP NO. 4,U.S. House,15,DEM,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 4,State Senator,35,DEM,Shaun Dougherty,46,95,1,142
+Cambria,RICHLAND TOWNSHIP NO. 4,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 4,General Assembly,71,DEM,Write-In,2,10,0,12
+Cambria,RICHLAND TOWNSHIP NO. 4,President,,REP,Donald J. Trump,102,92,5,199
+Cambria,RICHLAND TOWNSHIP NO. 4,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 4,President,,REP,Bill Weld,2,8,0,10
+Cambria,RICHLAND TOWNSHIP NO. 4,President,,REP,Write-In,1,5,0,6
+Cambria,RICHLAND TOWNSHIP NO. 4,Attorney General,,REP,Heather Heidelbaugh,100,98,4,202
+Cambria,RICHLAND TOWNSHIP NO. 4,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,REP,Timothy Defoor,100,98,4,202
+Cambria,RICHLAND TOWNSHIP NO. 4,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 4,State Treasurer,,REP,Stacy L. Garrity,100,98,4,202
+Cambria,RICHLAND TOWNSHIP NO. 4,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 4,U.S. House,15,REP,Glenn Gt Thompson,101,99,5,205
+Cambria,RICHLAND TOWNSHIP NO. 4,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 4,State Senator,35,REP,Wayne Langerholc Jr.,106,104,4,214
+Cambria,RICHLAND TOWNSHIP NO. 4,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 4,General Assembly,71,REP,Jim Rigby,108,103,5,216
+Cambria,RICHLAND TOWNSHIP NO. 4,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 5,Registered Voters,,,,,,,1013
+Cambria,RICHLAND TOWNSHIP NO. 5,Registered Voters,,DEM,,,,,378
+Cambria,RICHLAND TOWNSHIP NO. 5,Registered Voters,,REP,,,,,503
+Cambria,RICHLAND TOWNSHIP NO. 5,Ballots Cast,,,,194,126,6,326
+Cambria,RICHLAND TOWNSHIP NO. 5,Ballots Cast,,DEM,,50,76,4,130
+Cambria,RICHLAND TOWNSHIP NO. 5,Ballots Cast,,REP,,144,50,2,196
+Cambria,RICHLAND TOWNSHIP NO. 5,President,,DEM,Bernie Sanders,11,13,0,24
+Cambria,RICHLAND TOWNSHIP NO. 5,President,,DEM,Joseph R. Biden,21,56,4,81
+Cambria,RICHLAND TOWNSHIP NO. 5,President,,DEM,Tulsi Gabbard,6,1,0,7
+Cambria,RICHLAND TOWNSHIP NO. 5,President,,DEM,Write-In,5,4,0,9
+Cambria,RICHLAND TOWNSHIP NO. 5,Attorney General,,DEM,Josh Shapiro,40,71,3,114
+Cambria,RICHLAND TOWNSHIP NO. 5,Attorney General,,DEM,Write-In,4,2,0,6
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,DEM,H. Scott Conklin,20,26,1,47
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,DEM,Michael Lamb,15,27,2,44
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,DEM,Tracie Fountain,2,2,0,4
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,DEM,Rose Rosie Marie Davis,0,6,0,6
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,DEM,Nina Ahmad,5,8,0,13
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,DEM,Christina M. Hartman,3,4,0,7
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,DEM,Write-In,4,1,0,5
+Cambria,RICHLAND TOWNSHIP NO. 5,State Treasurer,,DEM,Joe Torsella,37,71,3,111
+Cambria,RICHLAND TOWNSHIP NO. 5,State Treasurer,,DEM,Write-In,5,1,0,6
+Cambria,RICHLAND TOWNSHIP NO. 5,U.S. House,15,DEM,Robert Williams,37,68,3,108
+Cambria,RICHLAND TOWNSHIP NO. 5,U.S. House,15,DEM,Write-In,4,1,0,5
+Cambria,RICHLAND TOWNSHIP NO. 5,State Senator,35,DEM,Shaun Dougherty,40,68,0,108
+Cambria,RICHLAND TOWNSHIP NO. 5,State Senator,35,DEM,Write-In,5,1,0,6
+Cambria,RICHLAND TOWNSHIP NO. 5,General Assembly,71,DEM,Write-In,6,7,0,13
+Cambria,RICHLAND TOWNSHIP NO. 5,President,,REP,Donald J. Trump,141,43,2,186
+Cambria,RICHLAND TOWNSHIP NO. 5,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Cambria,RICHLAND TOWNSHIP NO. 5,President,,REP,Bill Weld,1,2,0,3
+Cambria,RICHLAND TOWNSHIP NO. 5,President,,REP,Write-In,0,3,0,3
+Cambria,RICHLAND TOWNSHIP NO. 5,Attorney General,,REP,Heather Heidelbaugh,125,47,2,174
+Cambria,RICHLAND TOWNSHIP NO. 5,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,REP,Timothy Defoor,124,44,2,170
+Cambria,RICHLAND TOWNSHIP NO. 5,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 5,State Treasurer,,REP,Stacy L. Garrity,126,47,2,175
+Cambria,RICHLAND TOWNSHIP NO. 5,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 5,U.S. House,15,REP,Glenn Gt Thompson,126,47,2,175
+Cambria,RICHLAND TOWNSHIP NO. 5,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 5,State Senator,35,REP,Wayne Langerholc Jr.,136,45,2,183
+Cambria,RICHLAND TOWNSHIP NO. 5,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 5,General Assembly,71,REP,Jim Rigby,137,49,2,188
+Cambria,RICHLAND TOWNSHIP NO. 5,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 6,Registered Voters,,,,,,,867
+Cambria,RICHLAND TOWNSHIP NO. 6,Registered Voters,,DEM,,,,,360
+Cambria,RICHLAND TOWNSHIP NO. 6,Registered Voters,,REP,,,,,406
+Cambria,RICHLAND TOWNSHIP NO. 6,Ballots Cast,,,,211,130,3,344
+Cambria,RICHLAND TOWNSHIP NO. 6,Ballots Cast,,DEM,,81,86,2,169
+Cambria,RICHLAND TOWNSHIP NO. 6,Ballots Cast,,REP,,130,44,1,175
+Cambria,RICHLAND TOWNSHIP NO. 6,President,,DEM,Bernie Sanders,11,15,0,26
+Cambria,RICHLAND TOWNSHIP NO. 6,President,,DEM,Joseph R. Biden,47,63,2,112
+Cambria,RICHLAND TOWNSHIP NO. 6,President,,DEM,Tulsi Gabbard,2,3,0,5
+Cambria,RICHLAND TOWNSHIP NO. 6,President,,DEM,Write-In,7,5,0,12
+Cambria,RICHLAND TOWNSHIP NO. 6,Attorney General,,DEM,Josh Shapiro,65,75,2,142
+Cambria,RICHLAND TOWNSHIP NO. 6,Attorney General,,DEM,Write-In,2,3,0,5
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,DEM,H. Scott Conklin,37,35,1,73
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,DEM,Michael Lamb,26,26,1,53
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,DEM,Tracie Fountain,2,7,0,9
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,0,6
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,DEM,Nina Ahmad,6,5,0,11
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,DEM,Christina M. Hartman,0,4,0,4
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,DEM,Write-In,0,3,0,3
+Cambria,RICHLAND TOWNSHIP NO. 6,State Treasurer,,DEM,Joe Torsella,62,74,2,138
+Cambria,RICHLAND TOWNSHIP NO. 6,State Treasurer,,DEM,Write-In,1,3,0,4
+Cambria,RICHLAND TOWNSHIP NO. 6,U.S. House,15,DEM,Robert Williams,63,81,2,146
+Cambria,RICHLAND TOWNSHIP NO. 6,U.S. House,15,DEM,Write-In,1,1,0,2
+Cambria,RICHLAND TOWNSHIP NO. 6,State Senator,35,DEM,Shaun Dougherty,67,78,2,147
+Cambria,RICHLAND TOWNSHIP NO. 6,State Senator,35,DEM,Write-In,2,4,0,6
+Cambria,RICHLAND TOWNSHIP NO. 6,General Assembly,71,DEM,Write-In,6,11,1,18
+Cambria,RICHLAND TOWNSHIP NO. 6,President,,REP,Donald J. Trump,127,34,1,162
+Cambria,RICHLAND TOWNSHIP NO. 6,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 6,President,,REP,Bill Weld,2,8,0,10
+Cambria,RICHLAND TOWNSHIP NO. 6,President,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 6,Attorney General,,REP,Heather Heidelbaugh,116,40,1,157
+Cambria,RICHLAND TOWNSHIP NO. 6,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,REP,Timothy Defoor,117,41,1,159
+Cambria,RICHLAND TOWNSHIP NO. 6,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 6,State Treasurer,,REP,Stacy L. Garrity,117,40,1,158
+Cambria,RICHLAND TOWNSHIP NO. 6,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 6,U.S. House,15,REP,Glenn Gt Thompson,124,40,1,165
+Cambria,RICHLAND TOWNSHIP NO. 6,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 6,State Senator,35,REP,Wayne Langerholc Jr.,128,38,1,167
+Cambria,RICHLAND TOWNSHIP NO. 6,State Senator,35,REP,Write-In,0,2,0,2
+Cambria,RICHLAND TOWNSHIP NO. 6,General Assembly,71,REP,Jim Rigby,127,41,1,169
+Cambria,RICHLAND TOWNSHIP NO. 6,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 7,Registered Voters,,,,,,,1050
+Cambria,RICHLAND TOWNSHIP NO. 7,Registered Voters,,DEM,,,,,390
+Cambria,RICHLAND TOWNSHIP NO. 7,Registered Voters,,REP,,,,,573
+Cambria,RICHLAND TOWNSHIP NO. 7,Ballots Cast,,,,200,188,12,400
+Cambria,RICHLAND TOWNSHIP NO. 7,Ballots Cast,,DEM,,63,110,3,176
+Cambria,RICHLAND TOWNSHIP NO. 7,Ballots Cast,,REP,,137,78,9,224
+Cambria,RICHLAND TOWNSHIP NO. 7,President,,DEM,Bernie Sanders,11,14,2,27
+Cambria,RICHLAND TOWNSHIP NO. 7,President,,DEM,Joseph R. Biden,36,84,0,120
+Cambria,RICHLAND TOWNSHIP NO. 7,President,,DEM,Tulsi Gabbard,7,5,1,13
+Cambria,RICHLAND TOWNSHIP NO. 7,President,,DEM,Write-In,7,6,0,13
+Cambria,RICHLAND TOWNSHIP NO. 7,Attorney General,,DEM,Josh Shapiro,57,97,3,157
+Cambria,RICHLAND TOWNSHIP NO. 7,Attorney General,,DEM,Write-In,2,0,0,2
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,DEM,H. Scott Conklin,29,46,0,75
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,DEM,Michael Lamb,18,37,1,56
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,DEM,Tracie Fountain,2,4,0,6
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,DEM,Rose Rosie Marie Davis,0,4,0,4
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,DEM,Nina Ahmad,3,7,2,12
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,DEM,Christina M. Hartman,4,3,0,7
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,RICHLAND TOWNSHIP NO. 7,State Treasurer,,DEM,Joe Torsella,55,95,3,153
+Cambria,RICHLAND TOWNSHIP NO. 7,State Treasurer,,DEM,Write-In,2,1,0,3
+Cambria,RICHLAND TOWNSHIP NO. 7,U.S. House,15,DEM,Robert Williams,51,93,3,147
+Cambria,RICHLAND TOWNSHIP NO. 7,U.S. House,15,DEM,Write-In,2,0,0,2
+Cambria,RICHLAND TOWNSHIP NO. 7,State Senator,35,DEM,Shaun Dougherty,52,98,2,152
+Cambria,RICHLAND TOWNSHIP NO. 7,State Senator,35,DEM,Write-In,4,0,1,5
+Cambria,RICHLAND TOWNSHIP NO. 7,General Assembly,71,DEM,Write-In,8,11,1,20
+Cambria,RICHLAND TOWNSHIP NO. 7,President,,REP,Donald J. Trump,133,70,9,212
+Cambria,RICHLAND TOWNSHIP NO. 7,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 7,President,,REP,Bill Weld,4,1,0,5
+Cambria,RICHLAND TOWNSHIP NO. 7,President,,REP,Write-In,0,2,0,2
+Cambria,RICHLAND TOWNSHIP NO. 7,Attorney General,,REP,Heather Heidelbaugh,125,71,9,205
+Cambria,RICHLAND TOWNSHIP NO. 7,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,REP,Timothy Defoor,125,70,9,204
+Cambria,RICHLAND TOWNSHIP NO. 7,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 7,State Treasurer,,REP,Stacy L. Garrity,125,70,9,204
+Cambria,RICHLAND TOWNSHIP NO. 7,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 7,U.S. House,15,REP,Glenn Gt Thompson,126,71,9,206
+Cambria,RICHLAND TOWNSHIP NO. 7,U.S. House,15,REP,Write-In,1,1,0,2
+Cambria,RICHLAND TOWNSHIP NO. 7,State Senator,35,REP,Wayne Langerholc Jr.,134,75,9,218
+Cambria,RICHLAND TOWNSHIP NO. 7,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 7,General Assembly,71,REP,Jim Rigby,134,73,9,216
+Cambria,RICHLAND TOWNSHIP NO. 7,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 8,Registered Voters,,,,,,,607
+Cambria,RICHLAND TOWNSHIP NO. 8,Registered Voters,,DEM,,,,,241
+Cambria,RICHLAND TOWNSHIP NO. 8,Registered Voters,,REP,,,,,302
+Cambria,RICHLAND TOWNSHIP NO. 8,Ballots Cast,,,,109,105,3,217
+Cambria,RICHLAND TOWNSHIP NO. 8,Ballots Cast,,DEM,,26,74,0,100
+Cambria,RICHLAND TOWNSHIP NO. 8,Ballots Cast,,REP,,83,31,3,117
+Cambria,RICHLAND TOWNSHIP NO. 8,President,,DEM,Bernie Sanders,2,12,0,14
+Cambria,RICHLAND TOWNSHIP NO. 8,President,,DEM,Joseph R. Biden,18,60,0,78
+Cambria,RICHLAND TOWNSHIP NO. 8,President,,DEM,Tulsi Gabbard,4,0,0,4
+Cambria,RICHLAND TOWNSHIP NO. 8,President,,DEM,Write-In,1,1,0,2
+Cambria,RICHLAND TOWNSHIP NO. 8,Attorney General,,DEM,Josh Shapiro,24,72,0,96
+Cambria,RICHLAND TOWNSHIP NO. 8,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,DEM,H. Scott Conklin,14,33,0,47
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,DEM,Michael Lamb,5,29,0,34
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,DEM,Tracie Fountain,2,1,0,3
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,2
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,DEM,Nina Ahmad,1,7,0,8
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,DEM,Christina M. Hartman,2,2,0,4
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,State Treasurer,,DEM,Joe Torsella,24,69,0,93
+Cambria,RICHLAND TOWNSHIP NO. 8,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,U.S. House,15,DEM,Robert Williams,24,69,0,93
+Cambria,RICHLAND TOWNSHIP NO. 8,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,State Senator,35,DEM,Shaun Dougherty,23,69,0,92
+Cambria,RICHLAND TOWNSHIP NO. 8,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,General Assembly,71,DEM,Write-In,0,5,0,5
+Cambria,RICHLAND TOWNSHIP NO. 8,President,,REP,Donald J. Trump,83,27,3,113
+Cambria,RICHLAND TOWNSHIP NO. 8,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 8,President,,REP,Bill Weld,0,2,0,2
+Cambria,RICHLAND TOWNSHIP NO. 8,President,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,Attorney General,,REP,Heather Heidelbaugh,78,28,1,107
+Cambria,RICHLAND TOWNSHIP NO. 8,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,REP,Timothy Defoor,76,27,1,104
+Cambria,RICHLAND TOWNSHIP NO. 8,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,State Treasurer,,REP,Stacy L. Garrity,78,27,1,106
+Cambria,RICHLAND TOWNSHIP NO. 8,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,U.S. House,15,REP,Glenn Gt Thompson,77,26,1,104
+Cambria,RICHLAND TOWNSHIP NO. 8,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 8,State Senator,35,REP,Wayne Langerholc Jr.,82,29,3,114
+Cambria,RICHLAND TOWNSHIP NO. 8,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 8,General Assembly,71,REP,Jim Rigby,82,27,3,112
+Cambria,RICHLAND TOWNSHIP NO. 8,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 9,Registered Voters,,,,,,,775
+Cambria,RICHLAND TOWNSHIP NO. 9,Registered Voters,,DEM,,,,,304
+Cambria,RICHLAND TOWNSHIP NO. 9,Registered Voters,,REP,,,,,405
+Cambria,RICHLAND TOWNSHIP NO. 9,Ballots Cast,,,,128,164,3,295
+Cambria,RICHLAND TOWNSHIP NO. 9,Ballots Cast,,DEM,,31,89,3,123
+Cambria,RICHLAND TOWNSHIP NO. 9,Ballots Cast,,REP,,97,75,0,172
+Cambria,RICHLAND TOWNSHIP NO. 9,President,,DEM,Bernie Sanders,6,7,0,13
+Cambria,RICHLAND TOWNSHIP NO. 9,President,,DEM,Joseph R. Biden,20,70,3,93
+Cambria,RICHLAND TOWNSHIP NO. 9,President,,DEM,Tulsi Gabbard,1,7,0,8
+Cambria,RICHLAND TOWNSHIP NO. 9,President,,DEM,Write-In,3,4,0,7
+Cambria,RICHLAND TOWNSHIP NO. 9,Attorney General,,DEM,Josh Shapiro,28,82,3,113
+Cambria,RICHLAND TOWNSHIP NO. 9,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,DEM,H. Scott Conklin,17,39,1,57
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,DEM,Michael Lamb,8,28,0,36
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,DEM,Tracie Fountain,1,10,0,11
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,0,4
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,DEM,Nina Ahmad,2,3,1,6
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,DEM,Christina M. Hartman,1,2,1,4
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,DEM,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 9,State Treasurer,,DEM,Joe Torsella,27,80,3,110
+Cambria,RICHLAND TOWNSHIP NO. 9,State Treasurer,,DEM,Write-In,0,2,0,2
+Cambria,RICHLAND TOWNSHIP NO. 9,U.S. House,15,DEM,Robert Williams,25,78,3,106
+Cambria,RICHLAND TOWNSHIP NO. 9,U.S. House,15,DEM,Write-In,0,2,0,2
+Cambria,RICHLAND TOWNSHIP NO. 9,State Senator,35,DEM,Shaun Dougherty,27,79,2,108
+Cambria,RICHLAND TOWNSHIP NO. 9,State Senator,35,DEM,Write-In,0,2,1,3
+Cambria,RICHLAND TOWNSHIP NO. 9,General Assembly,71,DEM,Write-In,2,4,0,6
+Cambria,RICHLAND TOWNSHIP NO. 9,President,,REP,Donald J. Trump,93,63,0,156
+Cambria,RICHLAND TOWNSHIP NO. 9,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Cambria,RICHLAND TOWNSHIP NO. 9,President,,REP,Bill Weld,2,5,0,7
+Cambria,RICHLAND TOWNSHIP NO. 9,President,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 9,Attorney General,,REP,Heather Heidelbaugh,86,63,0,149
+Cambria,RICHLAND TOWNSHIP NO. 9,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,REP,Timothy Defoor,84,63,0,147
+Cambria,RICHLAND TOWNSHIP NO. 9,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 9,State Treasurer,,REP,Stacy L. Garrity,87,62,0,149
+Cambria,RICHLAND TOWNSHIP NO. 9,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,RICHLAND TOWNSHIP NO. 9,U.S. House,15,REP,Glenn Gt Thompson,86,63,0,149
+Cambria,RICHLAND TOWNSHIP NO. 9,U.S. House,15,REP,Write-In,0,1,0,1
+Cambria,RICHLAND TOWNSHIP NO. 9,State Senator,35,REP,Wayne Langerholc Jr.,87,74,0,161
+Cambria,RICHLAND TOWNSHIP NO. 9,State Senator,35,REP,Write-In,2,0,0,2
+Cambria,RICHLAND TOWNSHIP NO. 9,General Assembly,71,REP,Jim Rigby,92,70,0,162
+Cambria,RICHLAND TOWNSHIP NO. 9,General Assembly,71,REP,Write-In,2,0,0,2
+Cambria,SANKERTOWN BOROUGH,Registered Voters,,,,,,,376
+Cambria,SANKERTOWN BOROUGH,Registered Voters,,DEM,,,,,180
+Cambria,SANKERTOWN BOROUGH,Registered Voters,,REP,,,,,153
+Cambria,SANKERTOWN BOROUGH,Ballots Cast,,,,105,37,1,143
+Cambria,SANKERTOWN BOROUGH,Ballots Cast,,DEM,,53,29,0,82
+Cambria,SANKERTOWN BOROUGH,Ballots Cast,,REP,,52,8,1,61
+Cambria,SANKERTOWN BOROUGH,President,,DEM,Bernie Sanders,13,3,0,16
+Cambria,SANKERTOWN BOROUGH,President,,DEM,Joseph R. Biden,21,23,0,44
+Cambria,SANKERTOWN BOROUGH,President,,DEM,Tulsi Gabbard,3,1,0,4
+Cambria,SANKERTOWN BOROUGH,President,,DEM,Write-In,8,1,0,9
+Cambria,SANKERTOWN BOROUGH,Attorney General,,DEM,Josh Shapiro,44,28,0,72
+Cambria,SANKERTOWN BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,Auditor General,,DEM,H. Scott Conklin,27,22,0,49
+Cambria,SANKERTOWN BOROUGH,Auditor General,,DEM,Michael Lamb,7,3,0,10
+Cambria,SANKERTOWN BOROUGH,Auditor General,,DEM,Tracie Fountain,3,1,0,4
+Cambria,SANKERTOWN BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,SANKERTOWN BOROUGH,Auditor General,,DEM,Nina Ahmad,1,2,0,3
+Cambria,SANKERTOWN BOROUGH,Auditor General,,DEM,Christina M. Hartman,8,1,0,9
+Cambria,SANKERTOWN BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,State Treasurer,,DEM,Joe Torsella,40,26,0,66
+Cambria,SANKERTOWN BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,SANKERTOWN BOROUGH,U.S. House,15,DEM,Robert Williams,41,28,0,69
+Cambria,SANKERTOWN BOROUGH,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,State Senator,35,DEM,Shaun Dougherty,41,28,0,69
+Cambria,SANKERTOWN BOROUGH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,General Assembly,72,DEM,Frank Burns,47,26,0,73
+Cambria,SANKERTOWN BOROUGH,General Assembly,72,DEM,Write-In,1,1,0,2
+Cambria,SANKERTOWN BOROUGH,President,,REP,Donald J. Trump,51,7,1,59
+Cambria,SANKERTOWN BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,President,,REP,Bill Weld,1,1,0,2
+Cambria,SANKERTOWN BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,Attorney General,,REP,Heather Heidelbaugh,51,7,1,59
+Cambria,SANKERTOWN BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,Auditor General,,REP,Timothy Defoor,49,7,1,57
+Cambria,SANKERTOWN BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,State Treasurer,,REP,Stacy L. Garrity,51,7,1,59
+Cambria,SANKERTOWN BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,51,7,1,59
+Cambria,SANKERTOWN BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,50,7,1,58
+Cambria,SANKERTOWN BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,SANKERTOWN BOROUGH,General Assembly,72,REP,Howard Terndrup,23,5,1,29
+Cambria,SANKERTOWN BOROUGH,General Assembly,72,REP,Jerry Carnicella,28,3,0,31
+Cambria,SANKERTOWN BOROUGH,General Assembly,72,REP,Write-In,1,0,0,1
+Cambria,SCALP LEVEL BOROUGH,Registered Voters,,,,,,,434
+Cambria,SCALP LEVEL BOROUGH,Registered Voters,,DEM,,,,,215
+Cambria,SCALP LEVEL BOROUGH,Registered Voters,,REP,,,,,170
+Cambria,SCALP LEVEL BOROUGH,Ballots Cast,,,,101,40,4,145
+Cambria,SCALP LEVEL BOROUGH,Ballots Cast,,DEM,,51,36,0,87
+Cambria,SCALP LEVEL BOROUGH,Ballots Cast,,REP,,50,4,4,58
+Cambria,SCALP LEVEL BOROUGH,President,,DEM,Bernie Sanders,11,7,0,18
+Cambria,SCALP LEVEL BOROUGH,President,,DEM,Joseph R. Biden,23,25,0,48
+Cambria,SCALP LEVEL BOROUGH,President,,DEM,Tulsi Gabbard,3,2,0,5
+Cambria,SCALP LEVEL BOROUGH,President,,DEM,Write-In,7,2,0,9
+Cambria,SCALP LEVEL BOROUGH,Attorney General,,DEM,Josh Shapiro,48,34,0,82
+Cambria,SCALP LEVEL BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,DEM,H. Scott Conklin,24,17,0,41
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,DEM,Michael Lamb,14,11,0,25
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,DEM,Tracie Fountain,2,3,0,5
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,1
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,DEM,Christina M. Hartman,8,3,0,11
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,State Treasurer,,DEM,Joe Torsella,49,32,0,81
+Cambria,SCALP LEVEL BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,U.S. House,15,DEM,Robert Williams,45,34,0,79
+Cambria,SCALP LEVEL BOROUGH,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,SCALP LEVEL BOROUGH,State Senator,35,DEM,Shaun Dougherty,50,32,0,82
+Cambria,SCALP LEVEL BOROUGH,State Senator,35,DEM,Write-In,0,2,0,2
+Cambria,SCALP LEVEL BOROUGH,General Assembly,71,DEM,Write-In,4,4,0,8
+Cambria,SCALP LEVEL BOROUGH,President,,REP,Donald J. Trump,46,4,4,54
+Cambria,SCALP LEVEL BOROUGH,President,,REP,Roque Rocky De La Fuente,2,0,0,2
+Cambria,SCALP LEVEL BOROUGH,President,,REP,Bill Weld,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,Attorney General,,REP,Heather Heidelbaugh,48,4,3,55
+Cambria,SCALP LEVEL BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,REP,Timothy Defoor,46,4,2,52
+Cambria,SCALP LEVEL BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,State Treasurer,,REP,Stacy L. Garrity,46,4,2,52
+Cambria,SCALP LEVEL BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,47,4,3,54
+Cambria,SCALP LEVEL BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,47,4,4,55
+Cambria,SCALP LEVEL BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,SCALP LEVEL BOROUGH,General Assembly,71,REP,Jim Rigby,48,4,3,55
+Cambria,SCALP LEVEL BOROUGH,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,Registered Voters,,,,,,,506
+Cambria,SOUTH FORK BOROUGH,Registered Voters,,DEM,,,,,233
+Cambria,SOUTH FORK BOROUGH,Registered Voters,,REP,,,,,211
+Cambria,SOUTH FORK BOROUGH,Ballots Cast,,,,120,27,0,147
+Cambria,SOUTH FORK BOROUGH,Ballots Cast,,DEM,,43,19,0,62
+Cambria,SOUTH FORK BOROUGH,Ballots Cast,,REP,,77,8,0,85
+Cambria,SOUTH FORK BOROUGH,President,,DEM,Bernie Sanders,12,3,0,15
+Cambria,SOUTH FORK BOROUGH,President,,DEM,Joseph R. Biden,15,16,0,31
+Cambria,SOUTH FORK BOROUGH,President,,DEM,Tulsi Gabbard,7,0,0,7
+Cambria,SOUTH FORK BOROUGH,President,,DEM,Write-In,5,0,0,5
+Cambria,SOUTH FORK BOROUGH,Attorney General,,DEM,Josh Shapiro,39,18,0,57
+Cambria,SOUTH FORK BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,Auditor General,,DEM,H. Scott Conklin,23,15,0,38
+Cambria,SOUTH FORK BOROUGH,Auditor General,,DEM,Michael Lamb,11,3,0,14
+Cambria,SOUTH FORK BOROUGH,Auditor General,,DEM,Tracie Fountain,2,0,0,2
+Cambria,SOUTH FORK BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,2
+Cambria,SOUTH FORK BOROUGH,Auditor General,,DEM,Nina Ahmad,1,1,0,2
+Cambria,SOUTH FORK BOROUGH,Auditor General,,DEM,Christina M. Hartman,1,0,0,1
+Cambria,SOUTH FORK BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,State Treasurer,,DEM,Joe Torsella,38,16,0,54
+Cambria,SOUTH FORK BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,U.S. House,15,DEM,Robert Williams,38,13,0,51
+Cambria,SOUTH FORK BOROUGH,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,State Senator,35,DEM,Shaun Dougherty,38,14,0,52
+Cambria,SOUTH FORK BOROUGH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,General Assembly,71,DEM,Write-In,4,0,0,4
+Cambria,SOUTH FORK BOROUGH,President,,REP,Donald J. Trump,75,7,0,82
+Cambria,SOUTH FORK BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,President,,REP,Bill Weld,1,1,0,2
+Cambria,SOUTH FORK BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,Attorney General,,REP,Heather Heidelbaugh,71,8,0,79
+Cambria,SOUTH FORK BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,Auditor General,,REP,Timothy Defoor,70,7,0,77
+Cambria,SOUTH FORK BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,State Treasurer,,REP,Stacy L. Garrity,67,8,0,75
+Cambria,SOUTH FORK BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,70,7,0,77
+Cambria,SOUTH FORK BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,SOUTH FORK BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,70,8,0,78
+Cambria,SOUTH FORK BOROUGH,State Senator,35,REP,Write-In,2,0,0,2
+Cambria,SOUTH FORK BOROUGH,General Assembly,71,REP,Jim Rigby,74,7,0,81
+Cambria,SOUTH FORK BOROUGH,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,SOUTHMONT BOROUGH NO. 1,Registered Voters,,,,,,,1038
+Cambria,SOUTHMONT BOROUGH NO. 1,Registered Voters,,DEM,,,,,431
+Cambria,SOUTHMONT BOROUGH NO. 1,Registered Voters,,REP,,,,,491
+Cambria,SOUTHMONT BOROUGH NO. 1,Ballots Cast,,,,186,209,9,404
+Cambria,SOUTHMONT BOROUGH NO. 1,Ballots Cast,,DEM,,71,130,6,207
+Cambria,SOUTHMONT BOROUGH NO. 1,Ballots Cast,,REP,,115,79,3,197
+Cambria,SOUTHMONT BOROUGH NO. 1,President,,DEM,Bernie Sanders,15,17,1,33
+Cambria,SOUTHMONT BOROUGH NO. 1,President,,DEM,Joseph R. Biden,40,107,5,152
+Cambria,SOUTHMONT BOROUGH NO. 1,President,,DEM,Tulsi Gabbard,10,1,0,11
+Cambria,SOUTHMONT BOROUGH NO. 1,President,,DEM,Write-In,3,1,0,4
+Cambria,SOUTHMONT BOROUGH NO. 1,Attorney General,,DEM,Josh Shapiro,62,120,6,188
+Cambria,SOUTHMONT BOROUGH NO. 1,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,DEM,H. Scott Conklin,34,57,2,93
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,DEM,Michael Lamb,21,43,3,67
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,DEM,Tracie Fountain,2,5,0,7
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,0,4
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,DEM,Nina Ahmad,3,8,0,11
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,DEM,Christina M. Hartman,3,9,1,13
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 1,State Treasurer,,DEM,Joe Torsella,60,121,6,187
+Cambria,SOUTHMONT BOROUGH NO. 1,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,SOUTHMONT BOROUGH NO. 1,U.S. House,13,DEM,Todd Rowley,59,119,6,184
+Cambria,SOUTHMONT BOROUGH NO. 1,U.S. House,13,DEM,Write-In,1,2,0,3
+Cambria,SOUTHMONT BOROUGH NO. 1,State Senator,35,DEM,Shaun Dougherty,57,122,6,185
+Cambria,SOUTHMONT BOROUGH NO. 1,State Senator,35,DEM,Write-In,4,1,0,5
+Cambria,SOUTHMONT BOROUGH NO. 1,General Assembly,71,DEM,Write-In,9,12,0,21
+Cambria,SOUTHMONT BOROUGH NO. 1,President,,REP,Donald J. Trump,108,59,3,170
+Cambria,SOUTHMONT BOROUGH NO. 1,President,,REP,Roque Rocky De La Fuente,2,3,0,5
+Cambria,SOUTHMONT BOROUGH NO. 1,President,,REP,Bill Weld,2,8,0,10
+Cambria,SOUTHMONT BOROUGH NO. 1,President,,REP,Write-In,1,4,0,5
+Cambria,SOUTHMONT BOROUGH NO. 1,Attorney General,,REP,Heather Heidelbaugh,103,70,2,175
+Cambria,SOUTHMONT BOROUGH NO. 1,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,REP,Timothy Defoor,102,70,2,174
+Cambria,SOUTHMONT BOROUGH NO. 1,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,SOUTHMONT BOROUGH NO. 1,State Treasurer,,REP,Stacy L. Garrity,102,68,2,172
+Cambria,SOUTHMONT BOROUGH NO. 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 1,U.S. House,13,REP,John Joyce,108,74,2,184
+Cambria,SOUTHMONT BOROUGH NO. 1,U.S. House,13,REP,Write-In,1,0,0,1
+Cambria,SOUTHMONT BOROUGH NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,111,77,2,190
+Cambria,SOUTHMONT BOROUGH NO. 1,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,SOUTHMONT BOROUGH NO. 1,General Assembly,71,REP,Jim Rigby,112,75,2,189
+Cambria,SOUTHMONT BOROUGH NO. 1,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,SOUTHMONT BOROUGH NO. 2,Registered Voters,,,,,,,470
+Cambria,SOUTHMONT BOROUGH NO. 2,Registered Voters,,DEM,,,,,184
+Cambria,SOUTHMONT BOROUGH NO. 2,Registered Voters,,REP,,,,,217
+Cambria,SOUTHMONT BOROUGH NO. 2,Ballots Cast,,,,83,71,2,156
+Cambria,SOUTHMONT BOROUGH NO. 2,Ballots Cast,,DEM,,25,41,2,68
+Cambria,SOUTHMONT BOROUGH NO. 2,Ballots Cast,,REP,,58,30,0,88
+Cambria,SOUTHMONT BOROUGH NO. 2,President,,DEM,Bernie Sanders,8,2,1,11
+Cambria,SOUTHMONT BOROUGH NO. 2,President,,DEM,Joseph R. Biden,12,36,1,49
+Cambria,SOUTHMONT BOROUGH NO. 2,President,,DEM,Tulsi Gabbard,2,1,0,3
+Cambria,SOUTHMONT BOROUGH NO. 2,President,,DEM,Write-In,2,2,0,4
+Cambria,SOUTHMONT BOROUGH NO. 2,Attorney General,,DEM,Josh Shapiro,21,40,1,62
+Cambria,SOUTHMONT BOROUGH NO. 2,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,DEM,H. Scott Conklin,11,13,0,24
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,DEM,Michael Lamb,4,16,0,20
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,DEM,Tracie Fountain,1,2,0,3
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,0,4
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,DEM,Nina Ahmad,4,4,0,8
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,DEM,Christina M. Hartman,0,3,1,4
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 2,State Treasurer,,DEM,Joe Torsella,20,41,0,61
+Cambria,SOUTHMONT BOROUGH NO. 2,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 2,U.S. House,13,DEM,Todd Rowley,18,39,1,58
+Cambria,SOUTHMONT BOROUGH NO. 2,U.S. House,13,DEM,Write-In,0,1,0,1
+Cambria,SOUTHMONT BOROUGH NO. 2,State Senator,35,DEM,Shaun Dougherty,23,38,2,63
+Cambria,SOUTHMONT BOROUGH NO. 2,State Senator,35,DEM,Write-In,0,3,0,3
+Cambria,SOUTHMONT BOROUGH NO. 2,General Assembly,71,DEM,Write-In,1,8,0,9
+Cambria,SOUTHMONT BOROUGH NO. 2,President,,REP,Donald J. Trump,56,23,0,79
+Cambria,SOUTHMONT BOROUGH NO. 2,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 2,President,,REP,Bill Weld,2,3,0,5
+Cambria,SOUTHMONT BOROUGH NO. 2,President,,REP,Write-In,0,3,0,3
+Cambria,SOUTHMONT BOROUGH NO. 2,Attorney General,,REP,Heather Heidelbaugh,49,25,0,74
+Cambria,SOUTHMONT BOROUGH NO. 2,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,REP,Timothy Defoor,50,24,0,74
+Cambria,SOUTHMONT BOROUGH NO. 2,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 2,State Treasurer,,REP,Stacy L. Garrity,50,25,0,75
+Cambria,SOUTHMONT BOROUGH NO. 2,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 2,U.S. House,13,REP,John Joyce,51,23,0,74
+Cambria,SOUTHMONT BOROUGH NO. 2,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,SOUTHMONT BOROUGH NO. 2,State Senator,35,REP,Wayne Langerholc Jr.,56,28,0,84
+Cambria,SOUTHMONT BOROUGH NO. 2,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,SOUTHMONT BOROUGH NO. 2,General Assembly,71,REP,Jim Rigby,58,27,0,85
+Cambria,SOUTHMONT BOROUGH NO. 2,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Registered Voters,,,,,,,531
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Registered Voters,,DEM,,,,,227
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Registered Voters,,REP,,,,,259
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Ballots Cast,,,,120,80,3,203
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Ballots Cast,,DEM,,38,42,1,81
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Ballots Cast,,REP,,82,38,2,122
+Cambria,STONYCREEK TOWNSHIP - WARD 1,President,,DEM,Bernie Sanders,6,11,0,17
+Cambria,STONYCREEK TOWNSHIP - WARD 1,President,,DEM,Joseph R. Biden,26,30,1,57
+Cambria,STONYCREEK TOWNSHIP - WARD 1,President,,DEM,Tulsi Gabbard,3,0,0,3
+Cambria,STONYCREEK TOWNSHIP - WARD 1,President,,DEM,Write-In,1,1,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Attorney General,,DEM,Josh Shapiro,36,38,1,75
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,DEM,H. Scott Conklin,22,12,1,35
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,DEM,Michael Lamb,9,17,0,26
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,DEM,Tracie Fountain,2,3,0,5
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,DEM,Nina Ahmad,1,3,0,4
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,DEM,Christina M. Hartman,3,4,0,7
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 1,State Treasurer,,DEM,Joe Torsella,34,40,1,75
+Cambria,STONYCREEK TOWNSHIP - WARD 1,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 1,U.S. House,13,DEM,Todd Rowley,35,39,1,75
+Cambria,STONYCREEK TOWNSHIP - WARD 1,U.S. House,13,DEM,Write-In,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 1,State Senator,35,DEM,Shaun Dougherty,36,40,1,77
+Cambria,STONYCREEK TOWNSHIP - WARD 1,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 1,General Assembly,71,DEM,Write-In,3,4,1,8
+Cambria,STONYCREEK TOWNSHIP - WARD 1,President,,REP,Donald J. Trump,77,29,2,108
+Cambria,STONYCREEK TOWNSHIP - WARD 1,President,,REP,Roque Rocky De La Fuente,1,1,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 1,President,,REP,Bill Weld,1,4,0,5
+Cambria,STONYCREEK TOWNSHIP - WARD 1,President,,REP,Write-In,1,3,0,4
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Attorney General,,REP,Heather Heidelbaugh,75,35,2,112
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,REP,Timothy Defoor,73,35,2,110
+Cambria,STONYCREEK TOWNSHIP - WARD 1,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 1,State Treasurer,,REP,Stacy L. Garrity,75,35,1,111
+Cambria,STONYCREEK TOWNSHIP - WARD 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 1,U.S. House,13,REP,John Joyce,76,36,2,114
+Cambria,STONYCREEK TOWNSHIP - WARD 1,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 1,State Senator,35,REP,Wayne Langerholc Jr.,78,38,2,118
+Cambria,STONYCREEK TOWNSHIP - WARD 1,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 1,General Assembly,71,REP,Jim Rigby,78,38,2,118
+Cambria,STONYCREEK TOWNSHIP - WARD 1,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Registered Voters,,,,,,,256
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Registered Voters,,DEM,,,,,108
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Registered Voters,,REP,,,,,119
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Ballots Cast,,,,71,36,1,108
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Ballots Cast,,DEM,,26,21,0,47
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Ballots Cast,,REP,,45,15,1,61
+Cambria,STONYCREEK TOWNSHIP - WARD 2,President,,DEM,Bernie Sanders,6,3,0,9
+Cambria,STONYCREEK TOWNSHIP - WARD 2,President,,DEM,Joseph R. Biden,14,17,0,31
+Cambria,STONYCREEK TOWNSHIP - WARD 2,President,,DEM,Tulsi Gabbard,2,0,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 2,President,,DEM,Write-In,4,0,0,4
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Attorney General,,DEM,Josh Shapiro,25,20,0,45
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Attorney General,,DEM,Write-In,1,1,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,DEM,H. Scott Conklin,12,8,0,20
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,DEM,Michael Lamb,8,6,0,14
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,DEM,Tracie Fountain,0,2,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,0,4
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,DEM,Nina Ahmad,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,DEM,Christina M. Hartman,2,2,0,4
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 2,State Treasurer,,DEM,Joe Torsella,22,19,0,41
+Cambria,STONYCREEK TOWNSHIP - WARD 2,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 2,U.S. House,13,DEM,Todd Rowley,22,19,0,41
+Cambria,STONYCREEK TOWNSHIP - WARD 2,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 2,State Senator,35,DEM,Shaun Dougherty,24,20,0,44
+Cambria,STONYCREEK TOWNSHIP - WARD 2,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 2,General Assembly,71,DEM,Write-In,7,0,0,7
+Cambria,STONYCREEK TOWNSHIP - WARD 2,President,,REP,Donald J. Trump,43,12,1,56
+Cambria,STONYCREEK TOWNSHIP - WARD 2,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 2,President,,REP,Bill Weld,2,2,0,4
+Cambria,STONYCREEK TOWNSHIP - WARD 2,President,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Attorney General,,REP,Heather Heidelbaugh,43,13,1,57
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,REP,Timothy Defoor,43,13,1,57
+Cambria,STONYCREEK TOWNSHIP - WARD 2,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 2,State Treasurer,,REP,Stacy L. Garrity,44,13,1,58
+Cambria,STONYCREEK TOWNSHIP - WARD 2,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 2,U.S. House,13,REP,John Joyce,43,14,1,58
+Cambria,STONYCREEK TOWNSHIP - WARD 2,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 2,State Senator,35,REP,Wayne Langerholc Jr.,44,12,1,57
+Cambria,STONYCREEK TOWNSHIP - WARD 2,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 2,General Assembly,71,REP,Jim Rigby,45,15,1,61
+Cambria,STONYCREEK TOWNSHIP - WARD 2,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Registered Voters,,,,,,,597
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Registered Voters,,DEM,,,,,280
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Registered Voters,,REP,,,,,253
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Ballots Cast,,,,77,77,4,158
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Ballots Cast,,DEM,,30,45,1,76
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Ballots Cast,,REP,,47,32,3,82
+Cambria,STONYCREEK TOWNSHIP - WARD 3,President,,DEM,Bernie Sanders,10,13,1,24
+Cambria,STONYCREEK TOWNSHIP - WARD 3,President,,DEM,Joseph R. Biden,15,27,0,42
+Cambria,STONYCREEK TOWNSHIP - WARD 3,President,,DEM,Tulsi Gabbard,2,3,0,5
+Cambria,STONYCREEK TOWNSHIP - WARD 3,President,,DEM,Write-In,3,1,0,4
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Attorney General,,DEM,Josh Shapiro,25,40,1,66
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Attorney General,,DEM,Write-In,2,0,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,DEM,H. Scott Conklin,7,18,0,25
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,DEM,Michael Lamb,13,9,1,23
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,DEM,Tracie Fountain,0,5,0,5
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,3
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,DEM,Nina Ahmad,2,7,0,9
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,DEM,Christina M. Hartman,2,4,0,6
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 3,State Treasurer,,DEM,Joe Torsella,25,40,1,66
+Cambria,STONYCREEK TOWNSHIP - WARD 3,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 3,U.S. House,13,DEM,Todd Rowley,26,41,1,68
+Cambria,STONYCREEK TOWNSHIP - WARD 3,U.S. House,13,DEM,Write-In,2,0,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 3,State Senator,35,DEM,Shaun Dougherty,25,41,1,67
+Cambria,STONYCREEK TOWNSHIP - WARD 3,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 3,General Assembly,71,DEM,Write-In,4,6,0,10
+Cambria,STONYCREEK TOWNSHIP - WARD 3,President,,REP,Donald J. Trump,41,25,3,69
+Cambria,STONYCREEK TOWNSHIP - WARD 3,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 3,President,,REP,Bill Weld,1,2,0,3
+Cambria,STONYCREEK TOWNSHIP - WARD 3,President,,REP,Write-In,4,2,0,6
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Attorney General,,REP,Heather Heidelbaugh,43,27,2,72
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,REP,Timothy Defoor,44,28,2,74
+Cambria,STONYCREEK TOWNSHIP - WARD 3,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 3,State Treasurer,,REP,Stacy L. Garrity,42,28,2,72
+Cambria,STONYCREEK TOWNSHIP - WARD 3,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 3,U.S. House,13,REP,John Joyce,42,29,2,73
+Cambria,STONYCREEK TOWNSHIP - WARD 3,U.S. House,13,REP,Write-In,1,0,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 3,State Senator,35,REP,Wayne Langerholc Jr.,45,31,2,78
+Cambria,STONYCREEK TOWNSHIP - WARD 3,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 3,General Assembly,71,REP,Jim Rigby,44,32,2,78
+Cambria,STONYCREEK TOWNSHIP - WARD 3,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Registered Voters,,,,,,,538
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Registered Voters,,DEM,,,,,226
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Registered Voters,,REP,,,,,254
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Ballots Cast,,,,122,102,5,229
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Ballots Cast,,DEM,,34,70,0,104
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Ballots Cast,,REP,,88,32,5,125
+Cambria,STONYCREEK TOWNSHIP - WARD 4,President,,DEM,Bernie Sanders,8,5,0,13
+Cambria,STONYCREEK TOWNSHIP - WARD 4,President,,DEM,Joseph R. Biden,20,59,0,79
+Cambria,STONYCREEK TOWNSHIP - WARD 4,President,,DEM,Tulsi Gabbard,0,5,0,5
+Cambria,STONYCREEK TOWNSHIP - WARD 4,President,,DEM,Write-In,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Attorney General,,DEM,Josh Shapiro,34,69,0,103
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,DEM,H. Scott Conklin,18,37,0,55
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,DEM,Michael Lamb,10,25,0,35
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,DEM,Tracie Fountain,1,2,0,3
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,DEM,Rose Rosie Marie Davis,0,2,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,DEM,Nina Ahmad,0,1,0,1
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,DEM,Christina M. Hartman,4,2,0,6
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,State Treasurer,,DEM,Joe Torsella,28,65,0,93
+Cambria,STONYCREEK TOWNSHIP - WARD 4,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,U.S. House,13,DEM,Todd Rowley,31,64,0,95
+Cambria,STONYCREEK TOWNSHIP - WARD 4,U.S. House,13,DEM,Write-In,0,3,0,3
+Cambria,STONYCREEK TOWNSHIP - WARD 4,State Senator,35,DEM,Shaun Dougherty,31,65,0,96
+Cambria,STONYCREEK TOWNSHIP - WARD 4,State Senator,35,DEM,Write-In,0,2,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 4,General Assembly,71,DEM,Write-In,0,11,0,11
+Cambria,STONYCREEK TOWNSHIP - WARD 4,President,,REP,Donald J. Trump,86,26,4,116
+Cambria,STONYCREEK TOWNSHIP - WARD 4,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,President,,REP,Bill Weld,1,2,0,3
+Cambria,STONYCREEK TOWNSHIP - WARD 4,President,,REP,Write-In,1,1,0,2
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Attorney General,,REP,Heather Heidelbaugh,77,27,4,108
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,REP,Timothy Defoor,76,27,4,107
+Cambria,STONYCREEK TOWNSHIP - WARD 4,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,State Treasurer,,REP,Stacy L. Garrity,75,28,3,106
+Cambria,STONYCREEK TOWNSHIP - WARD 4,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,U.S. House,13,REP,John Joyce,83,28,5,116
+Cambria,STONYCREEK TOWNSHIP - WARD 4,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,State Senator,35,REP,Wayne Langerholc Jr.,87,29,4,120
+Cambria,STONYCREEK TOWNSHIP - WARD 4,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,STONYCREEK TOWNSHIP - WARD 4,General Assembly,71,REP,Jim Rigby,85,30,5,120
+Cambria,STONYCREEK TOWNSHIP - WARD 4,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL BOROUGH,Registered Voters,,,,,,,323
+Cambria,SUMMERHILL BOROUGH,Registered Voters,,DEM,,,,,153
+Cambria,SUMMERHILL BOROUGH,Registered Voters,,REP,,,,,147
+Cambria,SUMMERHILL BOROUGH,Ballots Cast,,,,79,49,3,131
+Cambria,SUMMERHILL BOROUGH,Ballots Cast,,DEM,,33,28,0,61
+Cambria,SUMMERHILL BOROUGH,Ballots Cast,,REP,,46,21,3,70
+Cambria,SUMMERHILL BOROUGH,President,,DEM,Bernie Sanders,5,1,0,6
+Cambria,SUMMERHILL BOROUGH,President,,DEM,Joseph R. Biden,15,22,0,37
+Cambria,SUMMERHILL BOROUGH,President,,DEM,Tulsi Gabbard,3,2,0,5
+Cambria,SUMMERHILL BOROUGH,President,,DEM,Write-In,5,2,0,7
+Cambria,SUMMERHILL BOROUGH,Attorney General,,DEM,Josh Shapiro,29,25,0,54
+Cambria,SUMMERHILL BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,SUMMERHILL BOROUGH,Auditor General,,DEM,H. Scott Conklin,21,14,0,35
+Cambria,SUMMERHILL BOROUGH,Auditor General,,DEM,Michael Lamb,5,5,0,10
+Cambria,SUMMERHILL BOROUGH,Auditor General,,DEM,Tracie Fountain,1,2,0,3
+Cambria,SUMMERHILL BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,1
+Cambria,SUMMERHILL BOROUGH,Auditor General,,DEM,Nina Ahmad,1,1,0,2
+Cambria,SUMMERHILL BOROUGH,Auditor General,,DEM,Christina M. Hartman,1,4,0,5
+Cambria,SUMMERHILL BOROUGH,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,SUMMERHILL BOROUGH,State Treasurer,,DEM,Joe Torsella,24,23,0,47
+Cambria,SUMMERHILL BOROUGH,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,SUMMERHILL BOROUGH,U.S. House,15,DEM,Robert Williams,25,24,0,49
+Cambria,SUMMERHILL BOROUGH,U.S. House,15,DEM,Write-In,2,0,0,2
+Cambria,SUMMERHILL BOROUGH,State Senator,35,DEM,Shaun Dougherty,26,26,0,52
+Cambria,SUMMERHILL BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,SUMMERHILL BOROUGH,General Assembly,71,DEM,Write-In,2,4,0,6
+Cambria,SUMMERHILL BOROUGH,President,,REP,Donald J. Trump,43,17,3,63
+Cambria,SUMMERHILL BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,SUMMERHILL BOROUGH,President,,REP,Bill Weld,0,1,0,1
+Cambria,SUMMERHILL BOROUGH,President,,REP,Write-In,1,1,0,2
+Cambria,SUMMERHILL BOROUGH,Attorney General,,REP,Heather Heidelbaugh,40,17,3,60
+Cambria,SUMMERHILL BOROUGH,Attorney General,,REP,Write-In,1,1,0,2
+Cambria,SUMMERHILL BOROUGH,Auditor General,,REP,Timothy Defoor,39,15,3,57
+Cambria,SUMMERHILL BOROUGH,Auditor General,,REP,Write-In,1,1,0,2
+Cambria,SUMMERHILL BOROUGH,State Treasurer,,REP,Stacy L. Garrity,39,17,3,59
+Cambria,SUMMERHILL BOROUGH,State Treasurer,,REP,Write-In,1,1,0,2
+Cambria,SUMMERHILL BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,39,17,3,59
+Cambria,SUMMERHILL BOROUGH,U.S. House,15,REP,Write-In,1,1,0,2
+Cambria,SUMMERHILL BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,43,19,3,65
+Cambria,SUMMERHILL BOROUGH,State Senator,35,REP,Write-In,1,1,0,2
+Cambria,SUMMERHILL BOROUGH,General Assembly,71,REP,Jim Rigby,44,20,3,67
+Cambria,SUMMERHILL BOROUGH,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Registered Voters,,,,,,,717
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Registered Voters,,DEM,,,,,288
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Registered Voters,,REP,,,,,366
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Ballots Cast,,,,184,88,0,272
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Ballots Cast,,DEM,,65,47,0,112
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Ballots Cast,,REP,,119,41,0,160
+Cambria,SUMMERHILL TOWNSHIP - NORTH,President,,DEM,Bernie Sanders,14,4,0,18
+Cambria,SUMMERHILL TOWNSHIP - NORTH,President,,DEM,Joseph R. Biden,26,31,0,57
+Cambria,SUMMERHILL TOWNSHIP - NORTH,President,,DEM,Tulsi Gabbard,12,4,0,16
+Cambria,SUMMERHILL TOWNSHIP - NORTH,President,,DEM,Write-In,5,6,0,11
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Attorney General,,DEM,Josh Shapiro,56,43,0,99
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Attorney General,,DEM,Write-In,1,1,0,2
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,DEM,H. Scott Conklin,38,30,0,68
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,DEM,Michael Lamb,13,11,0,24
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,2
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,DEM,Nina Ahmad,0,1,0,1
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,DEM,Christina M. Hartman,6,1,0,7
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,DEM,Write-In,1,2,0,3
+Cambria,SUMMERHILL TOWNSHIP - NORTH,State Treasurer,,DEM,Joe Torsella,55,42,0,97
+Cambria,SUMMERHILL TOWNSHIP - NORTH,State Treasurer,,DEM,Write-In,2,2,0,4
+Cambria,SUMMERHILL TOWNSHIP - NORTH,U.S. House,15,DEM,Robert Williams,54,42,0,96
+Cambria,SUMMERHILL TOWNSHIP - NORTH,U.S. House,15,DEM,Write-In,3,3,0,6
+Cambria,SUMMERHILL TOWNSHIP - NORTH,State Senator,35,DEM,Shaun Dougherty,58,42,0,100
+Cambria,SUMMERHILL TOWNSHIP - NORTH,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,SUMMERHILL TOWNSHIP - NORTH,General Assembly,72,DEM,Frank Burns,58,46,0,104
+Cambria,SUMMERHILL TOWNSHIP - NORTH,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,SUMMERHILL TOWNSHIP - NORTH,President,,REP,Donald J. Trump,118,39,0,157
+Cambria,SUMMERHILL TOWNSHIP - NORTH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - NORTH,President,,REP,Bill Weld,1,2,0,3
+Cambria,SUMMERHILL TOWNSHIP - NORTH,President,,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Attorney General,,REP,Heather Heidelbaugh,104,37,0,141
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,REP,Timothy Defoor,102,35,0,137
+Cambria,SUMMERHILL TOWNSHIP - NORTH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - NORTH,State Treasurer,,REP,Stacy L. Garrity,102,35,0,137
+Cambria,SUMMERHILL TOWNSHIP - NORTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - NORTH,U.S. House,15,REP,Glenn Gt Thompson,106,36,0,142
+Cambria,SUMMERHILL TOWNSHIP - NORTH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - NORTH,State Senator,35,REP,Wayne Langerholc Jr.,108,40,0,148
+Cambria,SUMMERHILL TOWNSHIP - NORTH,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,SUMMERHILL TOWNSHIP - NORTH,General Assembly,72,REP,Howard Terndrup,64,30,0,94
+Cambria,SUMMERHILL TOWNSHIP - NORTH,General Assembly,72,REP,Jerry Carnicella,48,8,0,56
+Cambria,SUMMERHILL TOWNSHIP - NORTH,General Assembly,72,REP,Write-In,1,1,0,2
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Registered Voters,,,,,,,728
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Registered Voters,,DEM,,,,,349
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Registered Voters,,REP,,,,,294
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Ballots Cast,,,,205,59,2,266
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Ballots Cast,,DEM,,87,43,1,131
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Ballots Cast,,REP,,118,16,1,135
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,President,,DEM,Bernie Sanders,14,6,0,20
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,President,,DEM,Joseph R. Biden,43,32,1,76
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,President,,DEM,Tulsi Gabbard,13,1,0,14
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,President,,DEM,Write-In,8,2,0,10
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Attorney General,,DEM,Josh Shapiro,75,41,1,117
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Attorney General,,DEM,Write-In,3,0,0,3
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,DEM,H. Scott Conklin,45,19,0,64
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,DEM,Michael Lamb,11,14,0,25
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,0,6
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,DEM,Nina Ahmad,7,2,0,9
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,DEM,Christina M. Hartman,10,3,1,14
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,DEM,Write-In,3,0,0,3
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,State Treasurer,,DEM,Joe Torsella,74,39,1,114
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,State Treasurer,,DEM,Write-In,3,0,0,3
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,U.S. House,15,DEM,Robert Williams,73,40,1,114
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,U.S. House,15,DEM,Write-In,4,1,0,5
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,State Senator,35,DEM,Shaun Dougherty,74,40,1,115
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,State Senator,35,DEM,Write-In,2,1,0,3
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,General Assembly,72,DEM,Frank Burns,81,41,1,123
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,General Assembly,72,DEM,Write-In,2,0,0,2
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,President,,REP,Donald J. Trump,118,15,1,134
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,President,,REP,Bill Weld,0,1,0,1
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,President,,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Attorney General,,REP,Heather Heidelbaugh,106,13,1,120
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,REP,Timothy Defoor,106,13,1,120
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,State Treasurer,,REP,Stacy L. Garrity,104,14,1,119
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,U.S. House,15,REP,Glenn Gt Thompson,107,16,1,124
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,State Senator,35,REP,Wayne Langerholc Jr.,115,15,1,131
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,General Assembly,72,REP,Howard Terndrup,59,9,0,68
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,General Assembly,72,REP,Jerry Carnicella,53,7,1,61
+Cambria,SUMMERHILL TOWNSHIP - SOUTH,General Assembly,72,REP,Write-In,2,0,0,2
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Registered Voters,,,,,,,667
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Registered Voters,,DEM,,,,,281
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Registered Voters,,REP,,,,,311
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Ballots Cast,,,,169,76,4,249
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Ballots Cast,,DEM,,65,52,3,120
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Ballots Cast,,REP,,104,24,1,129
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,President,,DEM,Bernie Sanders,7,3,1,11
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,President,,DEM,Joseph R. Biden,27,36,1,64
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,President,,DEM,Tulsi Gabbard,11,5,1,17
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,President,,DEM,Write-In,12,4,0,16
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Attorney General,,DEM,Josh Shapiro,48,46,3,97
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Attorney General,,DEM,Write-In,2,0,0,2
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,DEM,H. Scott Conklin,41,35,2,78
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,DEM,Michael Lamb,12,5,1,18
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,DEM,Tracie Fountain,1,5,0,6
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,DEM,Nina Ahmad,2,1,0,3
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,DEM,Christina M. Hartman,1,3,0,4
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,State Treasurer,,DEM,Joe Torsella,50,44,3,97
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,U.S. House,15,DEM,Robert Williams,55,45,3,103
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,U.S. House,15,DEM,Write-In,2,0,0,2
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,State Senator,35,DEM,Shaun Dougherty,49,45,3,97
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,State Senator,35,DEM,Write-In,1,1,0,2
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,General Assembly,73,DEM,Write-In,4,6,0,10
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,President,,REP,Donald J. Trump,102,24,1,127
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,President,,REP,Bill Weld,2,0,0,2
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,President,,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Attorney General,,REP,Heather Heidelbaugh,98,20,1,119
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,REP,Timothy Defoor,92,21,1,114
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,Auditor General,,REP,Write-In,2,0,0,2
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,State Treasurer,,REP,Stacy L. Garrity,94,22,1,117
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,U.S. House,15,REP,Glenn Gt Thompson,98,22,1,121
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,State Senator,35,REP,Wayne Langerholc Jr.,99,22,1,122
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,General Assembly,73,REP,Tommy Sankey,100,23,1,124
+Cambria,SUSQUEHANNA TOWNSHIP - NORTH,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Registered Voters,,,,,,,472
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Registered Voters,,DEM,,,,,227
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Registered Voters,,REP,,,,,208
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Ballots Cast,,,,124,61,0,185
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Ballots Cast,,DEM,,50,39,0,89
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Ballots Cast,,REP,,74,22,0,96
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,President,,DEM,Bernie Sanders,3,2,0,5
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,President,,DEM,Joseph R. Biden,21,34,0,55
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,President,,DEM,Tulsi Gabbard,5,2,0,7
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,President,,DEM,Write-In,7,0,0,7
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Attorney General,,DEM,Josh Shapiro,43,34,0,77
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,DEM,H. Scott Conklin,27,30,0,57
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,DEM,Michael Lamb,8,5,0,13
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,DEM,Tracie Fountain,2,1,0,3
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,DEM,Christina M. Hartman,4,0,0,4
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,State Treasurer,,DEM,Joe Torsella,37,33,0,70
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,U.S. House,15,DEM,Robert Williams,38,32,0,70
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,State Senator,35,DEM,Shaun Dougherty,39,33,0,72
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,General Assembly,73,DEM,Write-In,4,0,0,4
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,President,,REP,Donald J. Trump,73,21,0,94
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,President,,REP,Bill Weld,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,President,,REP,Write-In,0,1,0,1
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Attorney General,,REP,Heather Heidelbaugh,64,19,0,83
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,REP,Timothy Defoor,60,19,0,79
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,State Treasurer,,REP,Stacy L. Garrity,62,19,0,81
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,U.S. House,15,REP,Glenn Gt Thompson,63,18,0,81
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,State Senator,35,REP,Wayne Langerholc Jr.,66,19,0,85
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,General Assembly,73,REP,Tommy Sankey,65,20,0,85
+Cambria,SUSQUEHANNA TOWNSHIP - SOUTH,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,Registered Voters,,,,,,,130
+Cambria,TUNNELHILL BOROUGH,Registered Voters,,DEM,,,,,63
+Cambria,TUNNELHILL BOROUGH,Registered Voters,,REP,,,,,54
+Cambria,TUNNELHILL BOROUGH,Ballots Cast,,,,36,5,0,41
+Cambria,TUNNELHILL BOROUGH,Ballots Cast,,DEM,,20,3,0,23
+Cambria,TUNNELHILL BOROUGH,Ballots Cast,,REP,,16,2,0,18
+Cambria,TUNNELHILL BOROUGH,President,,DEM,Bernie Sanders,4,1,0,5
+Cambria,TUNNELHILL BOROUGH,President,,DEM,Joseph R. Biden,5,1,0,6
+Cambria,TUNNELHILL BOROUGH,President,,DEM,Tulsi Gabbard,2,0,0,2
+Cambria,TUNNELHILL BOROUGH,President,,DEM,Write-In,3,0,0,3
+Cambria,TUNNELHILL BOROUGH,Attorney General,,DEM,Josh Shapiro,19,2,0,21
+Cambria,TUNNELHILL BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,Auditor General,,DEM,H. Scott Conklin,10,1,0,11
+Cambria,TUNNELHILL BOROUGH,Auditor General,,DEM,Michael Lamb,4,1,0,5
+Cambria,TUNNELHILL BOROUGH,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Cambria,TUNNELHILL BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,Auditor General,,DEM,Nina Ahmad,1,1,0,2
+Cambria,TUNNELHILL BOROUGH,Auditor General,,DEM,Christina M. Hartman,4,0,0,4
+Cambria,TUNNELHILL BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,State Treasurer,,DEM,Joe Torsella,16,2,0,18
+Cambria,TUNNELHILL BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,U.S. House,15,DEM,Robert Williams,18,2,0,20
+Cambria,TUNNELHILL BOROUGH,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,State Senator,35,DEM,Shaun Dougherty,17,2,0,19
+Cambria,TUNNELHILL BOROUGH,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,General Assembly,72,DEM,Frank Burns,19,3,0,22
+Cambria,TUNNELHILL BOROUGH,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,President,,REP,Donald J. Trump,16,2,0,18
+Cambria,TUNNELHILL BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,President,,REP,Bill Weld,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,Attorney General,,REP,Heather Heidelbaugh,14,2,0,16
+Cambria,TUNNELHILL BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,Auditor General,,REP,Timothy Defoor,13,2,0,15
+Cambria,TUNNELHILL BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,State Treasurer,,REP,Stacy L. Garrity,14,2,0,16
+Cambria,TUNNELHILL BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,12,2,0,14
+Cambria,TUNNELHILL BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,14,2,0,16
+Cambria,TUNNELHILL BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,TUNNELHILL BOROUGH,General Assembly,72,REP,Howard Terndrup,5,1,0,6
+Cambria,TUNNELHILL BOROUGH,General Assembly,72,REP,Jerry Carnicella,8,1,0,9
+Cambria,TUNNELHILL BOROUGH,General Assembly,72,REP,Write-In,3,0,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 1,Registered Voters,,,,,,,1151
+Cambria,UPPER YODER TOWNSHIP NO. 1,Registered Voters,,DEM,,,,,426
+Cambria,UPPER YODER TOWNSHIP NO. 1,Registered Voters,,REP,,,,,622
+Cambria,UPPER YODER TOWNSHIP NO. 1,Ballots Cast,,,,227,205,5,437
+Cambria,UPPER YODER TOWNSHIP NO. 1,Ballots Cast,,DEM,,76,116,4,196
+Cambria,UPPER YODER TOWNSHIP NO. 1,Ballots Cast,,REP,,151,89,1,241
+Cambria,UPPER YODER TOWNSHIP NO. 1,President,,DEM,Bernie Sanders,12,17,0,29
+Cambria,UPPER YODER TOWNSHIP NO. 1,President,,DEM,Joseph R. Biden,40,83,3,126
+Cambria,UPPER YODER TOWNSHIP NO. 1,President,,DEM,Tulsi Gabbard,9,4,1,14
+Cambria,UPPER YODER TOWNSHIP NO. 1,President,,DEM,Write-In,7,7,0,14
+Cambria,UPPER YODER TOWNSHIP NO. 1,Attorney General,,DEM,Josh Shapiro,62,107,4,173
+Cambria,UPPER YODER TOWNSHIP NO. 1,Attorney General,,DEM,Write-In,2,2,0,4
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,DEM,H. Scott Conklin,30,45,2,77
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,DEM,Michael Lamb,20,39,1,60
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,DEM,Tracie Fountain,3,3,0,6
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,0,6
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,DEM,Nina Ahmad,4,10,1,15
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,DEM,Christina M. Hartman,5,3,0,8
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,DEM,Write-In,1,3,0,4
+Cambria,UPPER YODER TOWNSHIP NO. 1,State Treasurer,,DEM,Joe Torsella,61,101,4,166
+Cambria,UPPER YODER TOWNSHIP NO. 1,State Treasurer,,DEM,Write-In,1,2,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 1,U.S. House,13,DEM,Todd Rowley,58,98,4,160
+Cambria,UPPER YODER TOWNSHIP NO. 1,U.S. House,13,DEM,Write-In,1,5,0,6
+Cambria,UPPER YODER TOWNSHIP NO. 1,State Senator,35,DEM,Shaun Dougherty,66,108,3,177
+Cambria,UPPER YODER TOWNSHIP NO. 1,State Senator,35,DEM,Write-In,2,1,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 1,General Assembly,72,DEM,Frank Burns,69,108,4,181
+Cambria,UPPER YODER TOWNSHIP NO. 1,General Assembly,72,DEM,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 1,President,,REP,Donald J. Trump,141,75,1,217
+Cambria,UPPER YODER TOWNSHIP NO. 1,President,,REP,Roque Rocky De La Fuente,3,1,0,4
+Cambria,UPPER YODER TOWNSHIP NO. 1,President,,REP,Bill Weld,2,6,0,8
+Cambria,UPPER YODER TOWNSHIP NO. 1,President,,REP,Write-In,1,3,0,4
+Cambria,UPPER YODER TOWNSHIP NO. 1,Attorney General,,REP,Heather Heidelbaugh,137,80,1,218
+Cambria,UPPER YODER TOWNSHIP NO. 1,Attorney General,,REP,Write-In,1,2,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,REP,Timothy Defoor,136,79,1,216
+Cambria,UPPER YODER TOWNSHIP NO. 1,Auditor General,,REP,Write-In,1,2,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 1,State Treasurer,,REP,Stacy L. Garrity,138,81,1,220
+Cambria,UPPER YODER TOWNSHIP NO. 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 1,U.S. House,13,REP,John Joyce,140,83,1,224
+Cambria,UPPER YODER TOWNSHIP NO. 1,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,144,83,1,228
+Cambria,UPPER YODER TOWNSHIP NO. 1,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 1,General Assembly,72,REP,Howard Terndrup,77,65,1,143
+Cambria,UPPER YODER TOWNSHIP NO. 1,General Assembly,72,REP,Jerry Carnicella,65,21,0,86
+Cambria,UPPER YODER TOWNSHIP NO. 1,General Assembly,72,REP,Write-In,3,1,0,4
+Cambria,UPPER YODER TOWNSHIP NO. 2,Registered Voters,,,,,,,617
+Cambria,UPPER YODER TOWNSHIP NO. 2,Registered Voters,,DEM,,,,,265
+Cambria,UPPER YODER TOWNSHIP NO. 2,Registered Voters,,REP,,,,,288
+Cambria,UPPER YODER TOWNSHIP NO. 2,Ballots Cast,,,,144,91,3,238
+Cambria,UPPER YODER TOWNSHIP NO. 2,Ballots Cast,,DEM,,67,62,0,129
+Cambria,UPPER YODER TOWNSHIP NO. 2,Ballots Cast,,REP,,77,29,3,109
+Cambria,UPPER YODER TOWNSHIP NO. 2,President,,DEM,Bernie Sanders,9,13,0,22
+Cambria,UPPER YODER TOWNSHIP NO. 2,President,,DEM,Joseph R. Biden,40,45,0,85
+Cambria,UPPER YODER TOWNSHIP NO. 2,President,,DEM,Tulsi Gabbard,9,2,0,11
+Cambria,UPPER YODER TOWNSHIP NO. 2,President,,DEM,Write-In,9,1,0,10
+Cambria,UPPER YODER TOWNSHIP NO. 2,Attorney General,,DEM,Josh Shapiro,65,56,0,121
+Cambria,UPPER YODER TOWNSHIP NO. 2,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,DEM,H. Scott Conklin,33,29,0,62
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Michael Lamb,23,23,0,46
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Tracie Fountain,3,3,0,6
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,2
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Nina Ahmad,2,1,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Christina M. Hartman,3,3,0,6
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 2,State Treasurer,,DEM,Joe Torsella,64,54,0,118
+Cambria,UPPER YODER TOWNSHIP NO. 2,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 2,U.S. House,13,DEM,Todd Rowley,63,56,0,119
+Cambria,UPPER YODER TOWNSHIP NO. 2,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 2,State Senator,35,DEM,Shaun Dougherty,63,60,0,123
+Cambria,UPPER YODER TOWNSHIP NO. 2,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,UPPER YODER TOWNSHIP NO. 2,General Assembly,72,DEM,Frank Burns,67,60,0,127
+Cambria,UPPER YODER TOWNSHIP NO. 2,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 2,President,,REP,Donald J. Trump,76,26,1,103
+Cambria,UPPER YODER TOWNSHIP NO. 2,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 2,President,,REP,Bill Weld,0,0,1,1
+Cambria,UPPER YODER TOWNSHIP NO. 2,President,,REP,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 2,Attorney General,,REP,Heather Heidelbaugh,71,27,3,101
+Cambria,UPPER YODER TOWNSHIP NO. 2,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,REP,Timothy Defoor,67,26,2,95
+Cambria,UPPER YODER TOWNSHIP NO. 2,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 2,State Treasurer,,REP,Stacy L. Garrity,71,26,3,100
+Cambria,UPPER YODER TOWNSHIP NO. 2,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 2,U.S. House,13,REP,John Joyce,73,28,3,104
+Cambria,UPPER YODER TOWNSHIP NO. 2,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 2,State Senator,35,REP,Wayne Langerholc Jr.,73,29,2,104
+Cambria,UPPER YODER TOWNSHIP NO. 2,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 2,General Assembly,72,REP,Howard Terndrup,45,22,3,70
+Cambria,UPPER YODER TOWNSHIP NO. 2,General Assembly,72,REP,Jerry Carnicella,28,6,0,34
+Cambria,UPPER YODER TOWNSHIP NO. 2,General Assembly,72,REP,Write-In,2,0,0,2
+Cambria,UPPER YODER TOWNSHIP NO. 3,Registered Voters,,,,,,,788
+Cambria,UPPER YODER TOWNSHIP NO. 3,Registered Voters,,DEM,,,,,342
+Cambria,UPPER YODER TOWNSHIP NO. 3,Registered Voters,,REP,,,,,353
+Cambria,UPPER YODER TOWNSHIP NO. 3,Ballots Cast,,,,142,189,6,337
+Cambria,UPPER YODER TOWNSHIP NO. 3,Ballots Cast,,DEM,,52,125,1,178
+Cambria,UPPER YODER TOWNSHIP NO. 3,Ballots Cast,,REP,,90,64,5,159
+Cambria,UPPER YODER TOWNSHIP NO. 3,President,,DEM,Bernie Sanders,7,23,1,31
+Cambria,UPPER YODER TOWNSHIP NO. 3,President,,DEM,Joseph R. Biden,34,84,0,118
+Cambria,UPPER YODER TOWNSHIP NO. 3,President,,DEM,Tulsi Gabbard,4,6,0,10
+Cambria,UPPER YODER TOWNSHIP NO. 3,President,,DEM,Write-In,3,3,0,6
+Cambria,UPPER YODER TOWNSHIP NO. 3,Attorney General,,DEM,Josh Shapiro,51,118,1,170
+Cambria,UPPER YODER TOWNSHIP NO. 3,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,DEM,H. Scott Conklin,32,51,0,83
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,DEM,Michael Lamb,16,34,1,51
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,DEM,Tracie Fountain,0,6,0,6
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,DEM,Rose Rosie Marie Davis,0,5,0,5
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,DEM,Nina Ahmad,1,10,0,11
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,DEM,Christina M. Hartman,3,9,0,12
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 3,State Treasurer,,DEM,Joe Torsella,49,108,1,158
+Cambria,UPPER YODER TOWNSHIP NO. 3,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 3,U.S. House,13,DEM,Todd Rowley,46,108,1,155
+Cambria,UPPER YODER TOWNSHIP NO. 3,U.S. House,13,DEM,Write-In,1,1,0,2
+Cambria,UPPER YODER TOWNSHIP NO. 3,State Senator,35,DEM,Shaun Dougherty,47,115,1,163
+Cambria,UPPER YODER TOWNSHIP NO. 3,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 3,General Assembly,72,DEM,Frank Burns,47,114,1,162
+Cambria,UPPER YODER TOWNSHIP NO. 3,General Assembly,72,DEM,Write-In,1,0,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 3,President,,REP,Donald J. Trump,88,57,5,150
+Cambria,UPPER YODER TOWNSHIP NO. 3,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 3,President,,REP,Bill Weld,0,4,0,4
+Cambria,UPPER YODER TOWNSHIP NO. 3,President,,REP,Write-In,1,1,0,2
+Cambria,UPPER YODER TOWNSHIP NO. 3,Attorney General,,REP,Heather Heidelbaugh,82,59,5,146
+Cambria,UPPER YODER TOWNSHIP NO. 3,Attorney General,,REP,Write-In,0,2,0,2
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,REP,Timothy Defoor,79,57,5,141
+Cambria,UPPER YODER TOWNSHIP NO. 3,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 3,State Treasurer,,REP,Stacy L. Garrity,79,57,5,141
+Cambria,UPPER YODER TOWNSHIP NO. 3,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,UPPER YODER TOWNSHIP NO. 3,U.S. House,13,REP,John Joyce,84,61,5,150
+Cambria,UPPER YODER TOWNSHIP NO. 3,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 3,State Senator,35,REP,Wayne Langerholc Jr.,86,62,5,153
+Cambria,UPPER YODER TOWNSHIP NO. 3,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 3,General Assembly,72,REP,Howard Terndrup,59,43,4,106
+Cambria,UPPER YODER TOWNSHIP NO. 3,General Assembly,72,REP,Jerry Carnicella,30,18,0,48
+Cambria,UPPER YODER TOWNSHIP NO. 3,General Assembly,72,REP,Write-In,0,2,1,3
+Cambria,UPPER YODER TOWNSHIP NO. 4,Registered Voters,,,,,,,745
+Cambria,UPPER YODER TOWNSHIP NO. 4,Registered Voters,,DEM,,,,,354
+Cambria,UPPER YODER TOWNSHIP NO. 4,Registered Voters,,REP,,,,,308
+Cambria,UPPER YODER TOWNSHIP NO. 4,Ballots Cast,,,,158,150,0,308
+Cambria,UPPER YODER TOWNSHIP NO. 4,Ballots Cast,,DEM,,64,110,0,174
+Cambria,UPPER YODER TOWNSHIP NO. 4,Ballots Cast,,REP,,94,40,0,134
+Cambria,UPPER YODER TOWNSHIP NO. 4,President,,DEM,Bernie Sanders,15,15,0,30
+Cambria,UPPER YODER TOWNSHIP NO. 4,President,,DEM,Joseph R. Biden,30,82,0,112
+Cambria,UPPER YODER TOWNSHIP NO. 4,President,,DEM,Tulsi Gabbard,9,2,0,11
+Cambria,UPPER YODER TOWNSHIP NO. 4,President,,DEM,Write-In,4,6,0,10
+Cambria,UPPER YODER TOWNSHIP NO. 4,Attorney General,,DEM,Josh Shapiro,54,101,0,155
+Cambria,UPPER YODER TOWNSHIP NO. 4,Attorney General,,DEM,Write-In,3,2,0,5
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,DEM,H. Scott Conklin,22,63,0,85
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,DEM,Michael Lamb,24,23,0,47
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,DEM,Tracie Fountain,0,5,0,5
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,0,5
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,DEM,Nina Ahmad,4,6,0,10
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,DEM,Christina M. Hartman,2,6,0,8
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,DEM,Write-In,2,1,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 4,State Treasurer,,DEM,Joe Torsella,53,104,0,157
+Cambria,UPPER YODER TOWNSHIP NO. 4,State Treasurer,,DEM,Write-In,2,1,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 4,U.S. House,13,DEM,Todd Rowley,51,100,0,151
+Cambria,UPPER YODER TOWNSHIP NO. 4,U.S. House,13,DEM,Write-In,3,1,0,4
+Cambria,UPPER YODER TOWNSHIP NO. 4,State Senator,35,DEM,Shaun Dougherty,53,96,0,149
+Cambria,UPPER YODER TOWNSHIP NO. 4,State Senator,35,DEM,Write-In,3,3,0,6
+Cambria,UPPER YODER TOWNSHIP NO. 4,General Assembly,72,DEM,Frank Burns,57,101,0,158
+Cambria,UPPER YODER TOWNSHIP NO. 4,General Assembly,72,DEM,Write-In,2,1,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 4,President,,REP,Donald J. Trump,92,30,0,122
+Cambria,UPPER YODER TOWNSHIP NO. 4,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Cambria,UPPER YODER TOWNSHIP NO. 4,President,,REP,Bill Weld,1,3,0,4
+Cambria,UPPER YODER TOWNSHIP NO. 4,President,,REP,Write-In,0,3,0,3
+Cambria,UPPER YODER TOWNSHIP NO. 4,Attorney General,,REP,Heather Heidelbaugh,90,35,0,125
+Cambria,UPPER YODER TOWNSHIP NO. 4,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,REP,Timothy Defoor,89,33,0,122
+Cambria,UPPER YODER TOWNSHIP NO. 4,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 4,State Treasurer,,REP,Stacy L. Garrity,89,37,0,126
+Cambria,UPPER YODER TOWNSHIP NO. 4,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 4,U.S. House,13,REP,John Joyce,91,34,0,125
+Cambria,UPPER YODER TOWNSHIP NO. 4,U.S. House,13,REP,Write-In,0,2,0,2
+Cambria,UPPER YODER TOWNSHIP NO. 4,State Senator,35,REP,Wayne Langerholc Jr.,94,37,0,131
+Cambria,UPPER YODER TOWNSHIP NO. 4,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,UPPER YODER TOWNSHIP NO. 4,General Assembly,72,REP,Howard Terndrup,54,26,0,80
+Cambria,UPPER YODER TOWNSHIP NO. 4,General Assembly,72,REP,Jerry Carnicella,36,11,0,47
+Cambria,UPPER YODER TOWNSHIP NO. 4,General Assembly,72,REP,Write-In,3,3,0,6
+Cambria,VINTONDALE BOROUGH,Registered Voters,,,,,,,250
+Cambria,VINTONDALE BOROUGH,Registered Voters,,DEM,,,,,123
+Cambria,VINTONDALE BOROUGH,Registered Voters,,REP,,,,,109
+Cambria,VINTONDALE BOROUGH,Ballots Cast,,,,60,24,0,84
+Cambria,VINTONDALE BOROUGH,Ballots Cast,,DEM,,24,18,0,42
+Cambria,VINTONDALE BOROUGH,Ballots Cast,,REP,,36,6,0,42
+Cambria,VINTONDALE BOROUGH,President,,DEM,Bernie Sanders,6,2,0,8
+Cambria,VINTONDALE BOROUGH,President,,DEM,Joseph R. Biden,9,15,0,24
+Cambria,VINTONDALE BOROUGH,President,,DEM,Tulsi Gabbard,2,1,0,3
+Cambria,VINTONDALE BOROUGH,President,,DEM,Write-In,3,0,0,3
+Cambria,VINTONDALE BOROUGH,Attorney General,,DEM,Josh Shapiro,16,18,0,34
+Cambria,VINTONDALE BOROUGH,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,Auditor General,,DEM,H. Scott Conklin,11,5,0,16
+Cambria,VINTONDALE BOROUGH,Auditor General,,DEM,Michael Lamb,6,6,0,12
+Cambria,VINTONDALE BOROUGH,Auditor General,,DEM,Tracie Fountain,0,2,0,2
+Cambria,VINTONDALE BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,VINTONDALE BOROUGH,Auditor General,,DEM,Nina Ahmad,1,3,0,4
+Cambria,VINTONDALE BOROUGH,Auditor General,,DEM,Christina M. Hartman,2,2,0,4
+Cambria,VINTONDALE BOROUGH,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,State Treasurer,,DEM,Joe Torsella,19,18,0,37
+Cambria,VINTONDALE BOROUGH,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,U.S. House,15,DEM,Robert Williams,20,18,0,38
+Cambria,VINTONDALE BOROUGH,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,State Senator,35,DEM,Shaun Dougherty,20,18,0,38
+Cambria,VINTONDALE BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,VINTONDALE BOROUGH,General Assembly,73,DEM,Write-In,3,1,0,4
+Cambria,VINTONDALE BOROUGH,President,,REP,Donald J. Trump,36,6,0,42
+Cambria,VINTONDALE BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,VINTONDALE BOROUGH,President,,REP,Bill Weld,0,0,0,0
+Cambria,VINTONDALE BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,Attorney General,,REP,Heather Heidelbaugh,32,6,0,38
+Cambria,VINTONDALE BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,Auditor General,,REP,Timothy Defoor,32,5,0,37
+Cambria,VINTONDALE BOROUGH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,State Treasurer,,REP,Stacy L. Garrity,34,6,0,40
+Cambria,VINTONDALE BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,34,6,0,40
+Cambria,VINTONDALE BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,33,6,0,39
+Cambria,VINTONDALE BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,VINTONDALE BOROUGH,General Assembly,73,REP,Tommy Sankey,31,6,0,37
+Cambria,VINTONDALE BOROUGH,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,Registered Voters,,,,,,,559
+Cambria,WASHINGTON TOWNSHIP,Registered Voters,,DEM,,,,,285
+Cambria,WASHINGTON TOWNSHIP,Registered Voters,,REP,,,,,226
+Cambria,WASHINGTON TOWNSHIP,Ballots Cast,,,,134,69,0,203
+Cambria,WASHINGTON TOWNSHIP,Ballots Cast,,DEM,,74,54,0,128
+Cambria,WASHINGTON TOWNSHIP,Ballots Cast,,REP,,60,15,0,75
+Cambria,WASHINGTON TOWNSHIP,President,,DEM,Bernie Sanders,23,7,0,30
+Cambria,WASHINGTON TOWNSHIP,President,,DEM,Joseph R. Biden,28,41,0,69
+Cambria,WASHINGTON TOWNSHIP,President,,DEM,Tulsi Gabbard,12,0,0,12
+Cambria,WASHINGTON TOWNSHIP,President,,DEM,Write-In,3,2,0,5
+Cambria,WASHINGTON TOWNSHIP,Attorney General,,DEM,Josh Shapiro,66,48,0,114
+Cambria,WASHINGTON TOWNSHIP,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,43,32,0,75
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,DEM,Michael Lamb,7,11,0,18
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,DEM,Tracie Fountain,3,0,0,3
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,0,4
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,DEM,Nina Ahmad,4,2,0,6
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,6,3,0,9
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,State Treasurer,,DEM,Joe Torsella,61,46,0,107
+Cambria,WASHINGTON TOWNSHIP,State Treasurer,,DEM,Write-In,1,1,0,2
+Cambria,WASHINGTON TOWNSHIP,U.S. House,15,DEM,Robert Williams,62,46,0,108
+Cambria,WASHINGTON TOWNSHIP,U.S. House,15,DEM,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,63,45,0,108
+Cambria,WASHINGTON TOWNSHIP,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,WASHINGTON TOWNSHIP,General Assembly,72,DEM,Frank Burns,70,51,0,121
+Cambria,WASHINGTON TOWNSHIP,General Assembly,72,DEM,Write-In,1,1,0,2
+Cambria,WASHINGTON TOWNSHIP,President,,REP,Donald J. Trump,59,15,0,74
+Cambria,WASHINGTON TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,President,,REP,Bill Weld,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,President,,REP,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,58,13,0,71
+Cambria,WASHINGTON TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,REP,Timothy Defoor,57,13,0,70
+Cambria,WASHINGTON TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,55,13,0,68
+Cambria,WASHINGTON TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,57,15,0,72
+Cambria,WASHINGTON TOWNSHIP,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,59,14,0,73
+Cambria,WASHINGTON TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,WASHINGTON TOWNSHIP,General Assembly,72,REP,Howard Terndrup,42,7,0,49
+Cambria,WASHINGTON TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,12,7,0,19
+Cambria,WASHINGTON TOWNSHIP,General Assembly,72,REP,Write-In,4,1,0,5
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Registered Voters,,,,,,,318
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Registered Voters,,DEM,,,,,154
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Registered Voters,,REP,,,,,131
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Ballots Cast,,,,103,25,2,130
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Ballots Cast,,DEM,,62,15,0,77
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Ballots Cast,,REP,,41,10,2,53
+Cambria,WEST CARROLL TOWNSHIP - NORTH,President,,DEM,Bernie Sanders,6,0,0,6
+Cambria,WEST CARROLL TOWNSHIP - NORTH,President,,DEM,Joseph R. Biden,33,14,0,47
+Cambria,WEST CARROLL TOWNSHIP - NORTH,President,,DEM,Tulsi Gabbard,4,1,0,5
+Cambria,WEST CARROLL TOWNSHIP - NORTH,President,,DEM,Write-In,9,0,0,9
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Attorney General,,DEM,Josh Shapiro,44,15,0,59
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Attorney General,,DEM,Write-In,3,0,0,3
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,H. Scott Conklin,31,8,0,39
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Michael Lamb,15,4,0,19
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Tracie Fountain,0,2,0,2
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,3
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Christina M. Hartman,3,0,0,3
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,WEST CARROLL TOWNSHIP - NORTH,State Treasurer,,DEM,Joe Torsella,42,15,0,57
+Cambria,WEST CARROLL TOWNSHIP - NORTH,State Treasurer,,DEM,Write-In,2,0,0,2
+Cambria,WEST CARROLL TOWNSHIP - NORTH,U.S. House,15,DEM,Robert Williams,46,15,0,61
+Cambria,WEST CARROLL TOWNSHIP - NORTH,U.S. House,15,DEM,Write-In,2,0,0,2
+Cambria,WEST CARROLL TOWNSHIP - NORTH,State Senator,35,DEM,Shaun Dougherty,44,15,0,59
+Cambria,WEST CARROLL TOWNSHIP - NORTH,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,WEST CARROLL TOWNSHIP - NORTH,General Assembly,73,DEM,Write-In,7,4,0,11
+Cambria,WEST CARROLL TOWNSHIP - NORTH,President,,REP,Donald J. Trump,40,10,2,52
+Cambria,WEST CARROLL TOWNSHIP - NORTH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - NORTH,President,,REP,Bill Weld,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - NORTH,President,,REP,Write-In,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Attorney General,,REP,Heather Heidelbaugh,37,9,1,47
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,REP,Timothy Defoor,39,8,2,49
+Cambria,WEST CARROLL TOWNSHIP - NORTH,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - NORTH,State Treasurer,,REP,Stacy L. Garrity,38,8,2,48
+Cambria,WEST CARROLL TOWNSHIP - NORTH,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - NORTH,U.S. House,15,REP,Glenn Gt Thompson,38,9,2,49
+Cambria,WEST CARROLL TOWNSHIP - NORTH,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - NORTH,State Senator,35,REP,Wayne Langerholc Jr.,38,10,2,50
+Cambria,WEST CARROLL TOWNSHIP - NORTH,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - NORTH,General Assembly,73,REP,Tommy Sankey,38,9,2,49
+Cambria,WEST CARROLL TOWNSHIP - NORTH,General Assembly,73,REP,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Registered Voters,,,,,,,414
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Registered Voters,,DEM,,,,,224
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Registered Voters,,REP,,,,,147
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Ballots Cast,,,,77,44,1,122
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Ballots Cast,,DEM,,36,39,0,75
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Ballots Cast,,REP,,41,5,1,47
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,President,,DEM,Bernie Sanders,14,2,0,16
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,President,,DEM,Joseph R. Biden,14,35,0,49
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,President,,DEM,Tulsi Gabbard,1,1,0,2
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,President,,DEM,Write-In,5,0,0,5
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Attorney General,,DEM,Josh Shapiro,26,36,0,62
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,H. Scott Conklin,20,24,0,44
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Michael Lamb,4,8,0,12
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Tracie Fountain,1,2,0,3
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Nina Ahmad,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Christina M. Hartman,2,2,0,4
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,State Treasurer,,DEM,Joe Torsella,25,35,0,60
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,U.S. House,15,DEM,Robert Williams,26,35,0,61
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,State Senator,35,DEM,Shaun Dougherty,26,34,0,60
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,General Assembly,73,DEM,Write-In,1,1,0,2
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,President,,REP,Donald J. Trump,40,4,1,45
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,President,,REP,Bill Weld,1,1,0,2
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,President,,REP,Write-In,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Attorney General,,REP,Heather Heidelbaugh,38,3,1,42
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,REP,Timothy Defoor,38,3,1,42
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,State Treasurer,,REP,Stacy L. Garrity,38,5,1,44
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,U.S. House,15,REP,Glenn Gt Thompson,36,5,1,42
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,State Senator,35,REP,Wayne Langerholc Jr.,38,5,1,44
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,General Assembly,73,REP,Tommy Sankey,39,5,1,45
+Cambria,WEST CARROLL TOWNSHIP - SOUTH,General Assembly,73,REP,Write-In,0,0,0,0
+Cambria,WESTMONT BOROUGH NO. 1,Registered Voters,,,,,,,1155
+Cambria,WESTMONT BOROUGH NO. 1,Registered Voters,,DEM,,,,,504
+Cambria,WESTMONT BOROUGH NO. 1,Registered Voters,,REP,,,,,499
+Cambria,WESTMONT BOROUGH NO. 1,Ballots Cast,,,,192,194,3,389
+Cambria,WESTMONT BOROUGH NO. 1,Ballots Cast,,DEM,,78,133,1,212
+Cambria,WESTMONT BOROUGH NO. 1,Ballots Cast,,REP,,114,61,2,177
+Cambria,WESTMONT BOROUGH NO. 1,President,,DEM,Bernie Sanders,19,20,0,39
+Cambria,WESTMONT BOROUGH NO. 1,President,,DEM,Joseph R. Biden,37,104,0,141
+Cambria,WESTMONT BOROUGH NO. 1,President,,DEM,Tulsi Gabbard,11,5,0,16
+Cambria,WESTMONT BOROUGH NO. 1,President,,DEM,Write-In,9,3,1,13
+Cambria,WESTMONT BOROUGH NO. 1,Attorney General,,DEM,Josh Shapiro,69,124,1,194
+Cambria,WESTMONT BOROUGH NO. 1,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,DEM,H. Scott Conklin,22,52,1,75
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,DEM,Michael Lamb,31,39,0,70
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,DEM,Tracie Fountain,2,7,0,9
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,4,8,0,12
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,DEM,Nina Ahmad,11,12,0,23
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,DEM,Christina M. Hartman,4,5,0,9
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,WESTMONT BOROUGH NO. 1,State Treasurer,,DEM,Joe Torsella,67,120,1,188
+Cambria,WESTMONT BOROUGH NO. 1,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,WESTMONT BOROUGH NO. 1,U.S. House,13,DEM,Todd Rowley,66,118,1,185
+Cambria,WESTMONT BOROUGH NO. 1,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,WESTMONT BOROUGH NO. 1,State Senator,35,DEM,Shaun Dougherty,68,122,1,191
+Cambria,WESTMONT BOROUGH NO. 1,State Senator,35,DEM,Write-In,3,1,0,4
+Cambria,WESTMONT BOROUGH NO. 1,General Assembly,71,DEM,Write-In,15,10,0,25
+Cambria,WESTMONT BOROUGH NO. 1,President,,REP,Donald J. Trump,106,56,2,164
+Cambria,WESTMONT BOROUGH NO. 1,President,,REP,Roque Rocky De La Fuente,2,2,0,4
+Cambria,WESTMONT BOROUGH NO. 1,President,,REP,Bill Weld,3,0,0,3
+Cambria,WESTMONT BOROUGH NO. 1,President,,REP,Write-In,1,3,0,4
+Cambria,WESTMONT BOROUGH NO. 1,Attorney General,,REP,Heather Heidelbaugh,103,59,1,163
+Cambria,WESTMONT BOROUGH NO. 1,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,REP,Timothy Defoor,99,56,1,156
+Cambria,WESTMONT BOROUGH NO. 1,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,WESTMONT BOROUGH NO. 1,State Treasurer,,REP,Stacy L. Garrity,101,57,1,159
+Cambria,WESTMONT BOROUGH NO. 1,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,WESTMONT BOROUGH NO. 1,U.S. House,13,REP,John Joyce,100,59,2,161
+Cambria,WESTMONT BOROUGH NO. 1,U.S. House,13,REP,Write-In,2,0,0,2
+Cambria,WESTMONT BOROUGH NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,107,60,2,169
+Cambria,WESTMONT BOROUGH NO. 1,State Senator,35,REP,Write-In,3,0,0,3
+Cambria,WESTMONT BOROUGH NO. 1,General Assembly,71,REP,Jim Rigby,107,60,2,169
+Cambria,WESTMONT BOROUGH NO. 1,General Assembly,71,REP,Write-In,3,0,0,3
+Cambria,WESTMONT BOROUGH NO. 2,Registered Voters,,,,,,,1395
+Cambria,WESTMONT BOROUGH NO. 2,Registered Voters,,DEM,,,,,508
+Cambria,WESTMONT BOROUGH NO. 2,Registered Voters,,REP,,,,,743
+Cambria,WESTMONT BOROUGH NO. 2,Ballots Cast,,,,230,300,8,538
+Cambria,WESTMONT BOROUGH NO. 2,Ballots Cast,,DEM,,66,176,2,244
+Cambria,WESTMONT BOROUGH NO. 2,Ballots Cast,,REP,,164,124,6,294
+Cambria,WESTMONT BOROUGH NO. 2,President,,DEM,Bernie Sanders,10,17,1,28
+Cambria,WESTMONT BOROUGH NO. 2,President,,DEM,Joseph R. Biden,39,145,0,184
+Cambria,WESTMONT BOROUGH NO. 2,President,,DEM,Tulsi Gabbard,8,3,1,12
+Cambria,WESTMONT BOROUGH NO. 2,President,,DEM,Write-In,7,5,0,12
+Cambria,WESTMONT BOROUGH NO. 2,Attorney General,,DEM,Josh Shapiro,52,166,2,220
+Cambria,WESTMONT BOROUGH NO. 2,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,DEM,H. Scott Conklin,26,63,1,90
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,DEM,Michael Lamb,20,72,0,92
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,DEM,Tracie Fountain,2,5,0,7
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,0,6
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,DEM,Nina Ahmad,4,14,0,18
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,DEM,Christina M. Hartman,3,10,0,13
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,WESTMONT BOROUGH NO. 2,State Treasurer,,DEM,Joe Torsella,51,153,1,205
+Cambria,WESTMONT BOROUGH NO. 2,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,WESTMONT BOROUGH NO. 2,U.S. House,13,DEM,Todd Rowley,49,155,2,206
+Cambria,WESTMONT BOROUGH NO. 2,U.S. House,13,DEM,Write-In,1,1,0,2
+Cambria,WESTMONT BOROUGH NO. 2,State Senator,35,DEM,Shaun Dougherty,58,159,2,219
+Cambria,WESTMONT BOROUGH NO. 2,State Senator,35,DEM,Write-In,1,1,0,2
+Cambria,WESTMONT BOROUGH NO. 2,General Assembly,71,DEM,Write-In,6,13,0,19
+Cambria,WESTMONT BOROUGH NO. 2,President,,REP,Donald J. Trump,156,96,6,258
+Cambria,WESTMONT BOROUGH NO. 2,President,,REP,Roque Rocky De La Fuente,1,3,0,4
+Cambria,WESTMONT BOROUGH NO. 2,President,,REP,Bill Weld,3,12,0,15
+Cambria,WESTMONT BOROUGH NO. 2,President,,REP,Write-In,2,6,0,8
+Cambria,WESTMONT BOROUGH NO. 2,Attorney General,,REP,Heather Heidelbaugh,144,112,6,262
+Cambria,WESTMONT BOROUGH NO. 2,Attorney General,,REP,Write-In,0,2,0,2
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,REP,Timothy Defoor,146,112,6,264
+Cambria,WESTMONT BOROUGH NO. 2,Auditor General,,REP,Write-In,0,2,0,2
+Cambria,WESTMONT BOROUGH NO. 2,State Treasurer,,REP,Stacy L. Garrity,142,114,6,262
+Cambria,WESTMONT BOROUGH NO. 2,State Treasurer,,REP,Write-In,0,2,0,2
+Cambria,WESTMONT BOROUGH NO. 2,U.S. House,13,REP,John Joyce,150,111,6,267
+Cambria,WESTMONT BOROUGH NO. 2,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,WESTMONT BOROUGH NO. 2,State Senator,35,REP,Wayne Langerholc Jr.,153,117,6,276
+Cambria,WESTMONT BOROUGH NO. 2,State Senator,35,REP,Write-In,2,1,0,3
+Cambria,WESTMONT BOROUGH NO. 2,General Assembly,71,REP,Jim Rigby,158,115,6,279
+Cambria,WESTMONT BOROUGH NO. 2,General Assembly,71,REP,Write-In,0,5,0,5
+Cambria,WESTMONT BOROUGH NO. 3,Registered Voters,,,,,,,1320
+Cambria,WESTMONT BOROUGH NO. 3,Registered Voters,,DEM,,,,,549
+Cambria,WESTMONT BOROUGH NO. 3,Registered Voters,,REP,,,,,638
+Cambria,WESTMONT BOROUGH NO. 3,Ballots Cast,,,,247,271,4,522
+Cambria,WESTMONT BOROUGH NO. 3,Ballots Cast,,DEM,,96,164,2,262
+Cambria,WESTMONT BOROUGH NO. 3,Ballots Cast,,REP,,151,107,2,260
+Cambria,WESTMONT BOROUGH NO. 3,President,,DEM,Bernie Sanders,23,23,2,48
+Cambria,WESTMONT BOROUGH NO. 3,President,,DEM,Joseph R. Biden,51,133,0,184
+Cambria,WESTMONT BOROUGH NO. 3,President,,DEM,Tulsi Gabbard,7,4,0,11
+Cambria,WESTMONT BOROUGH NO. 3,President,,DEM,Write-In,9,1,0,10
+Cambria,WESTMONT BOROUGH NO. 3,Attorney General,,DEM,Josh Shapiro,86,154,2,242
+Cambria,WESTMONT BOROUGH NO. 3,Attorney General,,DEM,Write-In,3,2,0,5
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,DEM,H. Scott Conklin,36,61,1,98
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,DEM,Michael Lamb,35,64,0,99
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,DEM,Tracie Fountain,1,6,0,7
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,DEM,Rose Rosie Marie Davis,4,3,0,7
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,DEM,Nina Ahmad,7,16,1,24
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,DEM,Christina M. Hartman,5,2,0,7
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,WESTMONT BOROUGH NO. 3,State Treasurer,,DEM,Joe Torsella,83,147,2,232
+Cambria,WESTMONT BOROUGH NO. 3,State Treasurer,,DEM,Write-In,1,1,0,2
+Cambria,WESTMONT BOROUGH NO. 3,U.S. House,13,DEM,Todd Rowley,79,147,2,228
+Cambria,WESTMONT BOROUGH NO. 3,U.S. House,13,DEM,Write-In,2,2,0,4
+Cambria,WESTMONT BOROUGH NO. 3,State Senator,35,DEM,Shaun Dougherty,82,155,2,239
+Cambria,WESTMONT BOROUGH NO. 3,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,WESTMONT BOROUGH NO. 3,General Assembly,71,DEM,Write-In,7,17,0,24
+Cambria,WESTMONT BOROUGH NO. 3,President,,REP,Donald J. Trump,148,86,2,236
+Cambria,WESTMONT BOROUGH NO. 3,President,,REP,Roque Rocky De La Fuente,0,3,0,3
+Cambria,WESTMONT BOROUGH NO. 3,President,,REP,Bill Weld,2,6,0,8
+Cambria,WESTMONT BOROUGH NO. 3,President,,REP,Write-In,0,7,0,7
+Cambria,WESTMONT BOROUGH NO. 3,Attorney General,,REP,Heather Heidelbaugh,135,92,2,229
+Cambria,WESTMONT BOROUGH NO. 3,Attorney General,,REP,Write-In,0,3,0,3
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,REP,Timothy Defoor,136,92,2,230
+Cambria,WESTMONT BOROUGH NO. 3,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,WESTMONT BOROUGH NO. 3,State Treasurer,,REP,Stacy L. Garrity,133,93,2,228
+Cambria,WESTMONT BOROUGH NO. 3,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,WESTMONT BOROUGH NO. 3,U.S. House,13,REP,John Joyce,147,97,2,246
+Cambria,WESTMONT BOROUGH NO. 3,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,WESTMONT BOROUGH NO. 3,State Senator,35,REP,Wayne Langerholc Jr.,149,99,2,250
+Cambria,WESTMONT BOROUGH NO. 3,State Senator,35,REP,Write-In,0,2,0,2
+Cambria,WESTMONT BOROUGH NO. 3,General Assembly,71,REP,Jim Rigby,150,102,2,254
+Cambria,WESTMONT BOROUGH NO. 3,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,Registered Voters,,,,,,,474
+Cambria,WEST TAYLOR TOWNSHIP,Registered Voters,,DEM,,,,,233
+Cambria,WEST TAYLOR TOWNSHIP,Registered Voters,,REP,,,,,180
+Cambria,WEST TAYLOR TOWNSHIP,Ballots Cast,,,,90,53,4,147
+Cambria,WEST TAYLOR TOWNSHIP,Ballots Cast,,DEM,,44,29,1,74
+Cambria,WEST TAYLOR TOWNSHIP,Ballots Cast,,REP,,46,24,3,73
+Cambria,WEST TAYLOR TOWNSHIP,President,,DEM,Bernie Sanders,8,0,0,8
+Cambria,WEST TAYLOR TOWNSHIP,President,,DEM,Joseph R. Biden,16,24,0,40
+Cambria,WEST TAYLOR TOWNSHIP,President,,DEM,Tulsi Gabbard,1,0,0,1
+Cambria,WEST TAYLOR TOWNSHIP,President,,DEM,Write-In,9,3,0,12
+Cambria,WEST TAYLOR TOWNSHIP,Attorney General,,DEM,Josh Shapiro,39,22,1,62
+Cambria,WEST TAYLOR TOWNSHIP,Attorney General,,DEM,Write-In,1,3,0,4
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,15,18,1,34
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,DEM,Michael Lamb,18,7,0,25
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,DEM,Tracie Fountain,0,1,0,1
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,0,4
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,DEM,Nina Ahmad,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,3,0,0,3
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,State Treasurer,,DEM,Joe Torsella,29,23,1,53
+Cambria,WEST TAYLOR TOWNSHIP,State Treasurer,,DEM,Write-In,1,3,0,4
+Cambria,WEST TAYLOR TOWNSHIP,U.S. House,13,DEM,Todd Rowley,28,26,1,55
+Cambria,WEST TAYLOR TOWNSHIP,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,29,23,1,53
+Cambria,WEST TAYLOR TOWNSHIP,State Senator,35,DEM,Write-In,2,1,0,3
+Cambria,WEST TAYLOR TOWNSHIP,General Assembly,71,DEM,Write-In,3,5,0,8
+Cambria,WEST TAYLOR TOWNSHIP,President,,REP,Donald J. Trump,46,24,3,73
+Cambria,WEST TAYLOR TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,President,,REP,Bill Weld,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,President,,REP,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,41,24,3,68
+Cambria,WEST TAYLOR TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,REP,Timothy Defoor,38,23,3,64
+Cambria,WEST TAYLOR TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,38,23,3,64
+Cambria,WEST TAYLOR TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,U.S. House,13,REP,John Joyce,41,24,3,68
+Cambria,WEST TAYLOR TOWNSHIP,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,44,24,3,71
+Cambria,WEST TAYLOR TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,WEST TAYLOR TOWNSHIP,General Assembly,71,REP,Jim Rigby,44,24,3,71
+Cambria,WEST TAYLOR TOWNSHIP,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,Registered Voters,,,,,,,609
+Cambria,WHITE TOWNSHIP,Registered Voters,,DEM,,,,,198
+Cambria,WHITE TOWNSHIP,Registered Voters,,REP,,,,,335
+Cambria,WHITE TOWNSHIP,Ballots Cast,,,,160,63,0,223
+Cambria,WHITE TOWNSHIP,Ballots Cast,,DEM,,34,36,0,70
+Cambria,WHITE TOWNSHIP,Ballots Cast,,REP,,126,27,0,153
+Cambria,WHITE TOWNSHIP,President,,DEM,Bernie Sanders,5,7,0,12
+Cambria,WHITE TOWNSHIP,President,,DEM,Joseph R. Biden,19,27,0,46
+Cambria,WHITE TOWNSHIP,President,,DEM,Tulsi Gabbard,6,1,0,7
+Cambria,WHITE TOWNSHIP,President,,DEM,Write-In,1,0,0,1
+Cambria,WHITE TOWNSHIP,Attorney General,,DEM,Josh Shapiro,31,35,0,66
+Cambria,WHITE TOWNSHIP,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,Auditor General,,DEM,H. Scott Conklin,25,22,0,47
+Cambria,WHITE TOWNSHIP,Auditor General,,DEM,Michael Lamb,4,5,0,9
+Cambria,WHITE TOWNSHIP,Auditor General,,DEM,Tracie Fountain,3,1,0,4
+Cambria,WHITE TOWNSHIP,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,0,3
+Cambria,WHITE TOWNSHIP,Auditor General,,DEM,Nina Ahmad,0,1,0,1
+Cambria,WHITE TOWNSHIP,Auditor General,,DEM,Christina M. Hartman,0,4,0,4
+Cambria,WHITE TOWNSHIP,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,State Treasurer,,DEM,Joe Torsella,33,34,0,67
+Cambria,WHITE TOWNSHIP,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,U.S. House,15,DEM,Robert Williams,31,35,0,66
+Cambria,WHITE TOWNSHIP,U.S. House,15,DEM,Write-In,1,0,0,1
+Cambria,WHITE TOWNSHIP,State Senator,35,DEM,Shaun Dougherty,33,35,0,68
+Cambria,WHITE TOWNSHIP,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,General Assembly,72,DEM,Frank Burns,33,34,0,67
+Cambria,WHITE TOWNSHIP,General Assembly,72,DEM,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,President,,REP,Donald J. Trump,124,26,0,150
+Cambria,WHITE TOWNSHIP,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,WHITE TOWNSHIP,President,,REP,Bill Weld,0,1,0,1
+Cambria,WHITE TOWNSHIP,President,,REP,Write-In,1,0,0,1
+Cambria,WHITE TOWNSHIP,Attorney General,,REP,Heather Heidelbaugh,121,25,0,146
+Cambria,WHITE TOWNSHIP,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,Auditor General,,REP,Timothy Defoor,120,25,0,145
+Cambria,WHITE TOWNSHIP,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,State Treasurer,,REP,Stacy L. Garrity,119,25,0,144
+Cambria,WHITE TOWNSHIP,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,U.S. House,15,REP,Glenn Gt Thompson,117,26,0,143
+Cambria,WHITE TOWNSHIP,U.S. House,15,REP,Write-In,1,0,0,1
+Cambria,WHITE TOWNSHIP,State Senator,35,REP,Wayne Langerholc Jr.,121,26,0,147
+Cambria,WHITE TOWNSHIP,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,WHITE TOWNSHIP,General Assembly,72,REP,Howard Terndrup,59,14,0,73
+Cambria,WHITE TOWNSHIP,General Assembly,72,REP,Jerry Carnicella,61,13,0,74
+Cambria,WHITE TOWNSHIP,General Assembly,72,REP,Write-In,4,0,0,4
+Cambria,WILMORE BOROUGH,Registered Voters,,,,,,,135
+Cambria,WILMORE BOROUGH,Registered Voters,,DEM,,,,,52
+Cambria,WILMORE BOROUGH,Registered Voters,,REP,,,,,74
+Cambria,WILMORE BOROUGH,Ballots Cast,,,,31,16,0,47
+Cambria,WILMORE BOROUGH,Ballots Cast,,DEM,,5,7,0,12
+Cambria,WILMORE BOROUGH,Ballots Cast,,REP,,26,9,0,35
+Cambria,WILMORE BOROUGH,President,,DEM,Bernie Sanders,0,0,0,0
+Cambria,WILMORE BOROUGH,President,,DEM,Joseph R. Biden,3,7,0,10
+Cambria,WILMORE BOROUGH,President,,DEM,Tulsi Gabbard,0,0,0,0
+Cambria,WILMORE BOROUGH,President,,DEM,Write-In,2,0,0,2
+Cambria,WILMORE BOROUGH,Attorney General,,DEM,Josh Shapiro,4,7,0,11
+Cambria,WILMORE BOROUGH,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,WILMORE BOROUGH,Auditor General,,DEM,H. Scott Conklin,1,4,0,5
+Cambria,WILMORE BOROUGH,Auditor General,,DEM,Michael Lamb,2,0,0,2
+Cambria,WILMORE BOROUGH,Auditor General,,DEM,Tracie Fountain,0,0,0,0
+Cambria,WILMORE BOROUGH,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,WILMORE BOROUGH,Auditor General,,DEM,Nina Ahmad,0,2,0,2
+Cambria,WILMORE BOROUGH,Auditor General,,DEM,Christina M. Hartman,0,1,0,1
+Cambria,WILMORE BOROUGH,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,WILMORE BOROUGH,State Treasurer,,DEM,Joe Torsella,4,6,0,10
+Cambria,WILMORE BOROUGH,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,WILMORE BOROUGH,U.S. House,15,DEM,Robert Williams,3,6,0,9
+Cambria,WILMORE BOROUGH,U.S. House,15,DEM,Write-In,2,0,0,2
+Cambria,WILMORE BOROUGH,State Senator,35,DEM,Shaun Dougherty,3,7,0,10
+Cambria,WILMORE BOROUGH,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,WILMORE BOROUGH,General Assembly,72,DEM,Frank Burns,4,6,0,10
+Cambria,WILMORE BOROUGH,General Assembly,72,DEM,Write-In,1,1,0,2
+Cambria,WILMORE BOROUGH,President,,REP,Donald J. Trump,24,7,0,31
+Cambria,WILMORE BOROUGH,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,WILMORE BOROUGH,President,,REP,Bill Weld,1,1,0,2
+Cambria,WILMORE BOROUGH,President,,REP,Write-In,0,0,0,0
+Cambria,WILMORE BOROUGH,Attorney General,,REP,Heather Heidelbaugh,24,8,0,32
+Cambria,WILMORE BOROUGH,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,WILMORE BOROUGH,Auditor General,,REP,Timothy Defoor,22,8,0,30
+Cambria,WILMORE BOROUGH,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,WILMORE BOROUGH,State Treasurer,,REP,Stacy L. Garrity,24,8,0,32
+Cambria,WILMORE BOROUGH,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,WILMORE BOROUGH,U.S. House,15,REP,Glenn Gt Thompson,21,9,0,30
+Cambria,WILMORE BOROUGH,U.S. House,15,REP,Write-In,0,0,0,0
+Cambria,WILMORE BOROUGH,State Senator,35,REP,Wayne Langerholc Jr.,24,9,0,33
+Cambria,WILMORE BOROUGH,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,WILMORE BOROUGH,General Assembly,72,REP,Howard Terndrup,13,7,0,20
+Cambria,WILMORE BOROUGH,General Assembly,72,REP,Jerry Carnicella,10,0,0,10
+Cambria,WILMORE BOROUGH,General Assembly,72,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - CENTER TOWN,Registered Voters,,,,,,,713
+Cambria,JOHNSTOWN - CENTER TOWN,Registered Voters,,DEM,,,,,435
+Cambria,JOHNSTOWN - CENTER TOWN,Registered Voters,,REP,,,,,162
+Cambria,JOHNSTOWN - CENTER TOWN,Ballots Cast,,,,60,98,3,161
+Cambria,JOHNSTOWN - CENTER TOWN,Ballots Cast,,DEM,,42,71,2,115
+Cambria,JOHNSTOWN - CENTER TOWN,Ballots Cast,,REP,,18,27,1,46
+Cambria,JOHNSTOWN - CENTER TOWN,President,,DEM,Bernie Sanders,11,10,0,21
+Cambria,JOHNSTOWN - CENTER TOWN,President,,DEM,Joseph R. Biden,24,54,2,80
+Cambria,JOHNSTOWN - CENTER TOWN,President,,DEM,Tulsi Gabbard,3,4,0,7
+Cambria,JOHNSTOWN - CENTER TOWN,President,,DEM,Write-In,1,1,0,2
+Cambria,JOHNSTOWN - CENTER TOWN,Attorney General,,DEM,Josh Shapiro,39,62,2,103
+Cambria,JOHNSTOWN - CENTER TOWN,Attorney General,,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,DEM,H. Scott Conklin,13,29,1,43
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,DEM,Michael Lamb,14,27,0,41
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,DEM,Tracie Fountain,0,4,0,4
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,2
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,DEM,Nina Ahmad,8,1,0,9
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,DEM,Christina M. Hartman,3,3,0,6
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CENTER TOWN,State Treasurer,,DEM,Joe Torsella,38,60,2,100
+Cambria,JOHNSTOWN - CENTER TOWN,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - CENTER TOWN,U.S. House,13,DEM,Todd Rowley,37,61,1,99
+Cambria,JOHNSTOWN - CENTER TOWN,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - CENTER TOWN,State Senator,35,DEM,Shaun Dougherty,39,62,1,102
+Cambria,JOHNSTOWN - CENTER TOWN,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CENTER TOWN,General Assembly,71,DEM,Write-In,4,11,0,15
+Cambria,JOHNSTOWN - CENTER TOWN,President,,REP,Donald J. Trump,17,23,0,40
+Cambria,JOHNSTOWN - CENTER TOWN,President,,REP,Roque Rocky De La Fuente,0,2,0,2
+Cambria,JOHNSTOWN - CENTER TOWN,President,,REP,Bill Weld,1,0,0,1
+Cambria,JOHNSTOWN - CENTER TOWN,President,,REP,Write-In,0,1,1,2
+Cambria,JOHNSTOWN - CENTER TOWN,Attorney General,,REP,Heather Heidelbaugh,16,22,1,39
+Cambria,JOHNSTOWN - CENTER TOWN,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,REP,Timothy Defoor,15,22,1,38
+Cambria,JOHNSTOWN - CENTER TOWN,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - CENTER TOWN,State Treasurer,,REP,Stacy L. Garrity,14,22,1,37
+Cambria,JOHNSTOWN - CENTER TOWN,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - CENTER TOWN,U.S. House,13,REP,John Joyce,13,25,1,39
+Cambria,JOHNSTOWN - CENTER TOWN,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CENTER TOWN,State Senator,35,REP,Wayne Langerholc Jr.,17,26,1,44
+Cambria,JOHNSTOWN - CENTER TOWN,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CENTER TOWN,General Assembly,71,REP,Jim Rigby,18,25,1,44
+Cambria,JOHNSTOWN - CENTER TOWN,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - KERNVILLE,Registered Voters,,,,,,,415
+Cambria,JOHNSTOWN - KERNVILLE,Registered Voters,,DEM,,,,,255
+Cambria,JOHNSTOWN - KERNVILLE,Registered Voters,,REP,,,,,86
+Cambria,JOHNSTOWN - KERNVILLE,Ballots Cast,,,,73,43,2,118
+Cambria,JOHNSTOWN - KERNVILLE,Ballots Cast,,DEM,,50,30,2,82
+Cambria,JOHNSTOWN - KERNVILLE,Ballots Cast,,REP,,23,13,0,36
+Cambria,JOHNSTOWN - KERNVILLE,President,,DEM,Bernie Sanders,5,4,0,9
+Cambria,JOHNSTOWN - KERNVILLE,President,,DEM,Joseph R. Biden,41,22,2,65
+Cambria,JOHNSTOWN - KERNVILLE,President,,DEM,Tulsi Gabbard,1,2,0,3
+Cambria,JOHNSTOWN - KERNVILLE,President,,DEM,Write-In,2,2,0,4
+Cambria,JOHNSTOWN - KERNVILLE,Attorney General,,DEM,Josh Shapiro,46,28,2,76
+Cambria,JOHNSTOWN - KERNVILLE,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,DEM,H. Scott Conklin,20,12,0,32
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,DEM,Michael Lamb,13,5,1,19
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,DEM,Tracie Fountain,6,1,0,7
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,0,4
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,DEM,Nina Ahmad,5,3,1,9
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,DEM,Christina M. Hartman,3,3,0,6
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - KERNVILLE,State Treasurer,,DEM,Joe Torsella,44,28,2,74
+Cambria,JOHNSTOWN - KERNVILLE,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - KERNVILLE,U.S. House,13,DEM,Todd Rowley,43,27,2,72
+Cambria,JOHNSTOWN - KERNVILLE,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - KERNVILLE,State Senator,35,DEM,Shaun Dougherty,38,26,2,66
+Cambria,JOHNSTOWN - KERNVILLE,State Senator,35,DEM,Write-In,2,0,0,2
+Cambria,JOHNSTOWN - KERNVILLE,General Assembly,71,DEM,Write-In,4,3,0,7
+Cambria,JOHNSTOWN - KERNVILLE,President,,REP,Donald J. Trump,19,9,0,28
+Cambria,JOHNSTOWN - KERNVILLE,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,JOHNSTOWN - KERNVILLE,President,,REP,Bill Weld,3,1,0,4
+Cambria,JOHNSTOWN - KERNVILLE,President,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - KERNVILLE,Attorney General,,REP,Heather Heidelbaugh,21,12,0,33
+Cambria,JOHNSTOWN - KERNVILLE,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,REP,Timothy Defoor,21,11,0,32
+Cambria,JOHNSTOWN - KERNVILLE,Auditor General,,REP,Write-In,0,2,0,2
+Cambria,JOHNSTOWN - KERNVILLE,State Treasurer,,REP,Stacy L. Garrity,22,12,0,34
+Cambria,JOHNSTOWN - KERNVILLE,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - KERNVILLE,U.S. House,13,REP,John Joyce,20,12,0,32
+Cambria,JOHNSTOWN - KERNVILLE,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - KERNVILLE,State Senator,35,REP,Wayne Langerholc Jr.,21,12,0,33
+Cambria,JOHNSTOWN - KERNVILLE,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - KERNVILLE,General Assembly,71,REP,Jim Rigby,23,12,0,35
+Cambria,JOHNSTOWN - KERNVILLE,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - SEVENTH WARD,Registered Voters,,,,,,,913
+Cambria,JOHNSTOWN - SEVENTH WARD,Registered Voters,,DEM,,,,,598
+Cambria,JOHNSTOWN - SEVENTH WARD,Registered Voters,,REP,,,,,180
+Cambria,JOHNSTOWN - SEVENTH WARD,Ballots Cast,,,,124,71,6,201
+Cambria,JOHNSTOWN - SEVENTH WARD,Ballots Cast,,DEM,,98,56,2,156
+Cambria,JOHNSTOWN - SEVENTH WARD,Ballots Cast,,REP,,26,15,4,45
+Cambria,JOHNSTOWN - SEVENTH WARD,President,,DEM,Bernie Sanders,15,8,1,24
+Cambria,JOHNSTOWN - SEVENTH WARD,President,,DEM,Joseph R. Biden,74,43,1,118
+Cambria,JOHNSTOWN - SEVENTH WARD,President,,DEM,Tulsi Gabbard,2,0,0,2
+Cambria,JOHNSTOWN - SEVENTH WARD,President,,DEM,Write-In,5,1,0,6
+Cambria,JOHNSTOWN - SEVENTH WARD,Attorney General,,DEM,Josh Shapiro,82,52,2,136
+Cambria,JOHNSTOWN - SEVENTH WARD,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,DEM,H. Scott Conklin,25,22,0,47
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,DEM,Michael Lamb,29,19,0,48
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,DEM,Tracie Fountain,4,3,0,7
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,1,7
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,DEM,Nina Ahmad,13,3,1,17
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,DEM,Christina M. Hartman,7,1,0,8
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - SEVENTH WARD,State Treasurer,,DEM,Joe Torsella,80,48,2,130
+Cambria,JOHNSTOWN - SEVENTH WARD,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - SEVENTH WARD,U.S. House,13,DEM,Todd Rowley,79,49,2,130
+Cambria,JOHNSTOWN - SEVENTH WARD,U.S. House,13,DEM,Write-In,2,0,0,2
+Cambria,JOHNSTOWN - SEVENTH WARD,State Senator,35,DEM,Shaun Dougherty,82,51,2,135
+Cambria,JOHNSTOWN - SEVENTH WARD,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - SEVENTH WARD,General Assembly,71,DEM,Write-In,10,5,0,15
+Cambria,JOHNSTOWN - SEVENTH WARD,President,,REP,Donald J. Trump,25,10,3,38
+Cambria,JOHNSTOWN - SEVENTH WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN - SEVENTH WARD,President,,REP,Bill Weld,0,3,0,3
+Cambria,JOHNSTOWN - SEVENTH WARD,President,,REP,Write-In,0,0,1,1
+Cambria,JOHNSTOWN - SEVENTH WARD,Attorney General,,REP,Heather Heidelbaugh,24,14,4,42
+Cambria,JOHNSTOWN - SEVENTH WARD,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,REP,Timothy Defoor,23,14,3,40
+Cambria,JOHNSTOWN - SEVENTH WARD,Auditor General,,REP,Write-In,0,0,1,1
+Cambria,JOHNSTOWN - SEVENTH WARD,State Treasurer,,REP,Stacy L. Garrity,24,14,4,42
+Cambria,JOHNSTOWN - SEVENTH WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - SEVENTH WARD,U.S. House,13,REP,John Joyce,24,15,4,43
+Cambria,JOHNSTOWN - SEVENTH WARD,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - SEVENTH WARD,State Senator,35,REP,Wayne Langerholc Jr.,26,15,4,45
+Cambria,JOHNSTOWN - SEVENTH WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - SEVENTH WARD,General Assembly,71,REP,Jim Rigby,26,15,4,45
+Cambria,JOHNSTOWN - SEVENTH WARD,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Registered Voters,,,,,,,466
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Registered Voters,,DEM,,,,,243
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Registered Voters,,REP,,,,,175
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Ballots Cast,,,,58,83,5,146
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Ballots Cast,,DEM,,27,50,0,77
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Ballots Cast,,REP,,31,33,5,69
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,President,,DEM,Bernie Sanders,7,9,0,16
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,President,,DEM,Joseph R. Biden,14,37,0,51
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,President,,DEM,Tulsi Gabbard,4,2,0,6
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,President,,DEM,Write-In,1,2,0,3
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Attorney General,,DEM,Josh Shapiro,24,46,0,70
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,DEM,H. Scott Conklin,7,25,0,32
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,DEM,Michael Lamb,9,9,0,18
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,DEM,Tracie Fountain,1,1,0,2
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,2
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,DEM,Nina Ahmad,4,4,0,8
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,DEM,Christina M. Hartman,1,6,0,7
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,State Treasurer,,DEM,Joe Torsella,23,48,0,71
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,U.S. House,13,DEM,Todd Rowley,22,46,0,68
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,State Senator,35,DEM,Shaun Dougherty,26,46,0,72
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,General Assembly,71,DEM,Write-In,3,10,0,13
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,President,,REP,Donald J. Trump,29,29,5,63
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,President,,REP,Bill Weld,2,3,0,5
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,President,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Attorney General,,REP,Heather Heidelbaugh,26,29,5,60
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,REP,Timothy Defoor,27,30,5,62
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,State Treasurer,,REP,Stacy L. Garrity,26,31,5,62
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,U.S. House,13,REP,John Joyce,29,31,5,65
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,State Senator,35,REP,Wayne Langerholc Jr.,29,32,5,66
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,General Assembly,71,REP,Jim Rigby,29,32,5,66
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 1,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Registered Voters,,,,,,,1032
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Registered Voters,,DEM,,,,,514
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Registered Voters,,REP,,,,,407
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Ballots Cast,,,,192,160,3,355
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Ballots Cast,,DEM,,86,124,2,212
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Ballots Cast,,REP,,106,36,1,143
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,President,,DEM,Bernie Sanders,9,26,0,35
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,President,,DEM,Joseph R. Biden,60,93,2,155
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,President,,DEM,Tulsi Gabbard,3,4,0,7
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,President,,DEM,Write-In,9,1,0,10
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Attorney General,,DEM,Josh Shapiro,77,114,2,193
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Attorney General,,DEM,Write-In,3,1,0,4
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,DEM,H. Scott Conklin,38,59,1,98
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,DEM,Michael Lamb,28,33,0,61
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,DEM,Tracie Fountain,3,9,0,12
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,DEM,Rose Rosie Marie Davis,5,6,0,11
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,DEM,Nina Ahmad,2,11,1,14
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,DEM,Christina M. Hartman,2,3,0,5
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,DEM,Write-In,1,1,0,2
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,State Treasurer,,DEM,Joe Torsella,73,110,2,185
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,State Treasurer,,DEM,Write-In,3,1,0,4
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,U.S. House,13,DEM,Todd Rowley,76,112,2,190
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,U.S. House,13,DEM,Write-In,3,1,0,4
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,State Senator,35,DEM,Shaun Dougherty,68,114,2,184
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,State Senator,35,DEM,Write-In,5,1,0,6
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,General Assembly,71,DEM,Write-In,7,18,0,25
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,President,,REP,Donald J. Trump,105,25,1,131
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,President,,REP,Bill Weld,0,4,0,4
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,President,,REP,Write-In,0,2,0,2
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Attorney General,,REP,Heather Heidelbaugh,96,33,1,130
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,REP,Timothy Defoor,97,31,1,129
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,State Treasurer,,REP,Stacy L. Garrity,96,31,1,128
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,U.S. House,13,REP,John Joyce,98,32,1,131
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,State Senator,35,REP,Wayne Langerholc Jr.,101,33,1,135
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,General Assembly,71,REP,Jim Rigby,103,32,1,136
+Cambria,JOHNSTOWN - EIGHTH WARD NO. 3,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Registered Voters,,,,,,,654
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Registered Voters,,DEM,,,,,414
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Registered Voters,,REP,,,,,154
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Ballots Cast,,,,101,63,6,170
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Ballots Cast,,DEM,,71,54,0,125
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Ballots Cast,,REP,,30,9,6,45
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,President,,DEM,Bernie Sanders,13,9,0,22
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,President,,DEM,Joseph R. Biden,47,41,0,88
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,President,,DEM,Tulsi Gabbard,3,2,0,5
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,President,,DEM,Write-In,5,0,0,5
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Attorney General,,DEM,Josh Shapiro,66,51,0,117
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,DEM,H. Scott Conklin,28,30,0,58
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,DEM,Michael Lamb,29,15,0,44
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,DEM,Tracie Fountain,2,1,0,3
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,0,4
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,DEM,Nina Ahmad,7,0,0,7
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,DEM,Christina M. Hartman,2,3,0,5
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,State Treasurer,,DEM,Joe Torsella,65,45,0,110
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,U.S. House,13,DEM,Todd Rowley,64,46,0,110
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,State Senator,35,DEM,Shaun Dougherty,62,46,0,108
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,General Assembly,71,DEM,Write-In,2,4,0,6
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,President,,REP,Donald J. Trump,29,9,5,43
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,President,,REP,Bill Weld,1,0,0,1
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,President,,REP,Write-In,0,0,1,1
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Attorney General,,REP,Heather Heidelbaugh,28,8,6,42
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,REP,Timothy Defoor,29,8,6,43
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,State Treasurer,,REP,Stacy L. Garrity,29,8,6,43
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,U.S. House,13,REP,John Joyce,29,9,6,44
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,State Senator,35,REP,Wayne Langerholc Jr.,30,9,6,45
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,General Assembly,71,REP,Jim Rigby,29,9,6,44
+Cambria,JOHNSTOWN - OLD CONEMAUGH/WOODVALE,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - PROSPECT,Registered Voters,,,,,,,339
+Cambria,JOHNSTOWN - PROSPECT,Registered Voters,,DEM,,,,,262
+Cambria,JOHNSTOWN - PROSPECT,Registered Voters,,REP,,,,,34
+Cambria,JOHNSTOWN - PROSPECT,Ballots Cast,,,,64,22,1,87
+Cambria,JOHNSTOWN - PROSPECT,Ballots Cast,,DEM,,53,20,1,74
+Cambria,JOHNSTOWN - PROSPECT,Ballots Cast,,REP,,11,2,0,13
+Cambria,JOHNSTOWN - PROSPECT,President,,DEM,Bernie Sanders,10,2,0,12
+Cambria,JOHNSTOWN - PROSPECT,President,,DEM,Joseph R. Biden,42,17,1,60
+Cambria,JOHNSTOWN - PROSPECT,President,,DEM,Tulsi Gabbard,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,President,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - PROSPECT,Attorney General,,DEM,Josh Shapiro,42,20,1,63
+Cambria,JOHNSTOWN - PROSPECT,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,DEM,H. Scott Conklin,14,8,0,22
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,DEM,Michael Lamb,7,7,0,14
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,DEM,Tracie Fountain,1,3,0,4
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,0,4
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,DEM,Nina Ahmad,10,2,0,12
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,DEM,Christina M. Hartman,4,0,1,5
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,State Treasurer,,DEM,Joe Torsella,37,20,1,58
+Cambria,JOHNSTOWN - PROSPECT,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,U.S. House,13,DEM,Todd Rowley,38,20,1,59
+Cambria,JOHNSTOWN - PROSPECT,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,State Senator,35,DEM,Shaun Dougherty,38,20,1,59
+Cambria,JOHNSTOWN - PROSPECT,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,General Assembly,71,DEM,Write-In,4,0,0,4
+Cambria,JOHNSTOWN - PROSPECT,President,,REP,Donald J. Trump,9,2,0,11
+Cambria,JOHNSTOWN - PROSPECT,President,,REP,Roque Rocky De La Fuente,1,0,0,1
+Cambria,JOHNSTOWN - PROSPECT,President,,REP,Bill Weld,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,President,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,Attorney General,,REP,Heather Heidelbaugh,8,2,0,10
+Cambria,JOHNSTOWN - PROSPECT,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,REP,Timothy Defoor,8,2,0,10
+Cambria,JOHNSTOWN - PROSPECT,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,State Treasurer,,REP,Stacy L. Garrity,8,2,0,10
+Cambria,JOHNSTOWN - PROSPECT,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,U.S. House,13,REP,John Joyce,9,2,0,11
+Cambria,JOHNSTOWN - PROSPECT,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,State Senator,35,REP,Wayne Langerholc Jr.,10,2,0,12
+Cambria,JOHNSTOWN - PROSPECT,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - PROSPECT,General Assembly,71,REP,Jim Rigby,10,2,0,12
+Cambria,JOHNSTOWN - PROSPECT,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - CAMBRIA CITY,Registered Voters,,,,,,,244
+Cambria,JOHNSTOWN - CAMBRIA CITY,Registered Voters,,DEM,,,,,144
+Cambria,JOHNSTOWN - CAMBRIA CITY,Registered Voters,,REP,,,,,71
+Cambria,JOHNSTOWN - CAMBRIA CITY,Ballots Cast,,,,41,29,0,70
+Cambria,JOHNSTOWN - CAMBRIA CITY,Ballots Cast,,DEM,,26,21,0,47
+Cambria,JOHNSTOWN - CAMBRIA CITY,Ballots Cast,,REP,,15,8,0,23
+Cambria,JOHNSTOWN - CAMBRIA CITY,President,,DEM,Bernie Sanders,9,1,0,10
+Cambria,JOHNSTOWN - CAMBRIA CITY,President,,DEM,Joseph R. Biden,10,20,0,30
+Cambria,JOHNSTOWN - CAMBRIA CITY,President,,DEM,Tulsi Gabbard,3,0,0,3
+Cambria,JOHNSTOWN - CAMBRIA CITY,President,,DEM,Write-In,2,0,0,2
+Cambria,JOHNSTOWN - CAMBRIA CITY,Attorney General,,DEM,Josh Shapiro,24,21,0,45
+Cambria,JOHNSTOWN - CAMBRIA CITY,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,DEM,H. Scott Conklin,13,12,0,25
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,DEM,Michael Lamb,8,8,0,16
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,DEM,Tracie Fountain,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,3
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,DEM,Nina Ahmad,1,0,0,1
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,DEM,Christina M. Hartman,2,0,0,2
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,State Treasurer,,DEM,Joe Torsella,24,20,0,44
+Cambria,JOHNSTOWN - CAMBRIA CITY,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,U.S. House,13,DEM,Todd Rowley,23,21,0,44
+Cambria,JOHNSTOWN - CAMBRIA CITY,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,State Senator,35,DEM,Shaun Dougherty,25,21,0,46
+Cambria,JOHNSTOWN - CAMBRIA CITY,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,General Assembly,71,DEM,Write-In,2,3,0,5
+Cambria,JOHNSTOWN - CAMBRIA CITY,President,,REP,Donald J. Trump,14,8,0,22
+Cambria,JOHNSTOWN - CAMBRIA CITY,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,President,,REP,Bill Weld,1,0,0,1
+Cambria,JOHNSTOWN - CAMBRIA CITY,President,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,Attorney General,,REP,Heather Heidelbaugh,14,7,0,21
+Cambria,JOHNSTOWN - CAMBRIA CITY,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,REP,Timothy Defoor,14,7,0,21
+Cambria,JOHNSTOWN - CAMBRIA CITY,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - CAMBRIA CITY,State Treasurer,,REP,Stacy L. Garrity,14,8,0,22
+Cambria,JOHNSTOWN - CAMBRIA CITY,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,U.S. House,13,REP,John Joyce,15,8,0,23
+Cambria,JOHNSTOWN - CAMBRIA CITY,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,State Senator,35,REP,Wayne Langerholc Jr.,15,8,0,23
+Cambria,JOHNSTOWN - CAMBRIA CITY,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - CAMBRIA CITY,General Assembly,71,REP,Jim Rigby,15,7,0,22
+Cambria,JOHNSTOWN - CAMBRIA CITY,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN -17TH WARD 1,Registered Voters,,,,,,,604
+Cambria,JOHNSTOWN -17TH WARD 1,Registered Voters,,DEM,,,,,354
+Cambria,JOHNSTOWN -17TH WARD 1,Registered Voters,,REP,,,,,164
+Cambria,JOHNSTOWN -17TH WARD 1,Ballots Cast,,,,113,63,3,179
+Cambria,JOHNSTOWN -17TH WARD 1,Ballots Cast,,DEM,,75,45,2,122
+Cambria,JOHNSTOWN -17TH WARD 1,Ballots Cast,,REP,,38,18,1,57
+Cambria,JOHNSTOWN -17TH WARD 1,President,,DEM,Bernie Sanders,13,5,2,20
+Cambria,JOHNSTOWN -17TH WARD 1,President,,DEM,Joseph R. Biden,50,36,0,86
+Cambria,JOHNSTOWN -17TH WARD 1,President,,DEM,Tulsi Gabbard,5,1,0,6
+Cambria,JOHNSTOWN -17TH WARD 1,President,,DEM,Write-In,4,1,0,5
+Cambria,JOHNSTOWN -17TH WARD 1,Attorney General,,DEM,Josh Shapiro,70,41,2,113
+Cambria,JOHNSTOWN -17TH WARD 1,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,DEM,H. Scott Conklin,31,18,0,49
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,DEM,Michael Lamb,20,14,1,35
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,DEM,Tracie Fountain,4,2,0,6
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,0,6
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,DEM,Nina Ahmad,10,2,1,13
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,DEM,Christina M. Hartman,4,4,0,8
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 1,State Treasurer,,DEM,Joe Torsella,66,38,2,106
+Cambria,JOHNSTOWN -17TH WARD 1,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 1,U.S. House,13,DEM,Todd Rowley,67,38,2,107
+Cambria,JOHNSTOWN -17TH WARD 1,U.S. House,13,DEM,Write-In,2,1,0,3
+Cambria,JOHNSTOWN -17TH WARD 1,State Senator,35,DEM,Shaun Dougherty,67,41,2,110
+Cambria,JOHNSTOWN -17TH WARD 1,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 1,General Assembly,71,DEM,Write-In,12,6,0,18
+Cambria,JOHNSTOWN -17TH WARD 1,President,,REP,Donald J. Trump,34,15,1,50
+Cambria,JOHNSTOWN -17TH WARD 1,President,,REP,Roque Rocky De La Fuente,1,2,0,3
+Cambria,JOHNSTOWN -17TH WARD 1,President,,REP,Bill Weld,1,1,0,2
+Cambria,JOHNSTOWN -17TH WARD 1,President,,REP,Write-In,2,0,0,2
+Cambria,JOHNSTOWN -17TH WARD 1,Attorney General,,REP,Heather Heidelbaugh,36,18,1,55
+Cambria,JOHNSTOWN -17TH WARD 1,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,REP,Timothy Defoor,35,18,0,53
+Cambria,JOHNSTOWN -17TH WARD 1,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 1,State Treasurer,,REP,Stacy L. Garrity,36,18,1,55
+Cambria,JOHNSTOWN -17TH WARD 1,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 1,U.S. House,13,REP,John Joyce,36,18,1,55
+Cambria,JOHNSTOWN -17TH WARD 1,U.S. House,13,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 1,State Senator,35,REP,Wayne Langerholc Jr.,36,17,1,54
+Cambria,JOHNSTOWN -17TH WARD 1,State Senator,35,REP,Write-In,2,0,0,2
+Cambria,JOHNSTOWN -17TH WARD 1,General Assembly,71,REP,Jim Rigby,36,17,1,54
+Cambria,JOHNSTOWN -17TH WARD 1,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 2,Registered Voters,,,,,,,764
+Cambria,JOHNSTOWN -17TH WARD 2,Registered Voters,,DEM,,,,,424
+Cambria,JOHNSTOWN -17TH WARD 2,Registered Voters,,REP,,,,,217
+Cambria,JOHNSTOWN -17TH WARD 2,Ballots Cast,,,,114,67,5,186
+Cambria,JOHNSTOWN -17TH WARD 2,Ballots Cast,,DEM,,61,49,4,114
+Cambria,JOHNSTOWN -17TH WARD 2,Ballots Cast,,REP,,53,18,1,72
+Cambria,JOHNSTOWN -17TH WARD 2,President,,DEM,Bernie Sanders,9,8,1,18
+Cambria,JOHNSTOWN -17TH WARD 2,President,,DEM,Joseph R. Biden,42,38,3,83
+Cambria,JOHNSTOWN -17TH WARD 2,President,,DEM,Tulsi Gabbard,5,2,0,7
+Cambria,JOHNSTOWN -17TH WARD 2,President,,DEM,Write-In,2,1,0,3
+Cambria,JOHNSTOWN -17TH WARD 2,Attorney General,,DEM,Josh Shapiro,54,41,3,98
+Cambria,JOHNSTOWN -17TH WARD 2,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,DEM,H. Scott Conklin,24,12,0,36
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,DEM,Michael Lamb,16,15,2,33
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,DEM,Tracie Fountain,4,2,0,6
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,0,3
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,DEM,Nina Ahmad,8,9,1,18
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,DEM,Christina M. Hartman,2,3,1,6
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,State Treasurer,,DEM,Joe Torsella,53,41,3,97
+Cambria,JOHNSTOWN -17TH WARD 2,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,U.S. House,13,DEM,Todd Rowley,50,42,3,95
+Cambria,JOHNSTOWN -17TH WARD 2,U.S. House,13,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 2,State Senator,35,DEM,Shaun Dougherty,52,41,3,96
+Cambria,JOHNSTOWN -17TH WARD 2,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,General Assembly,71,DEM,Write-In,8,6,0,14
+Cambria,JOHNSTOWN -17TH WARD 2,President,,REP,Donald J. Trump,49,18,1,68
+Cambria,JOHNSTOWN -17TH WARD 2,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,President,,REP,Bill Weld,3,0,0,3
+Cambria,JOHNSTOWN -17TH WARD 2,President,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 2,Attorney General,,REP,Heather Heidelbaugh,50,16,1,67
+Cambria,JOHNSTOWN -17TH WARD 2,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,REP,Timothy Defoor,50,16,1,67
+Cambria,JOHNSTOWN -17TH WARD 2,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,State Treasurer,,REP,Stacy L. Garrity,51,16,1,68
+Cambria,JOHNSTOWN -17TH WARD 2,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,U.S. House,13,REP,John Joyce,50,18,1,69
+Cambria,JOHNSTOWN -17TH WARD 2,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 2,State Senator,35,REP,Wayne Langerholc Jr.,51,18,1,70
+Cambria,JOHNSTOWN -17TH WARD 2,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 2,General Assembly,71,REP,Jim Rigby,52,18,1,71
+Cambria,JOHNSTOWN -17TH WARD 2,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 3,Registered Voters,,,,,,,681
+Cambria,JOHNSTOWN -17TH WARD 3,Registered Voters,,DEM,,,,,407
+Cambria,JOHNSTOWN -17TH WARD 3,Registered Voters,,REP,,,,,188
+Cambria,JOHNSTOWN -17TH WARD 3,Ballots Cast,,,,84,42,4,130
+Cambria,JOHNSTOWN -17TH WARD 3,Ballots Cast,,DEM,,39,22,3,64
+Cambria,JOHNSTOWN -17TH WARD 3,Ballots Cast,,REP,,45,20,1,66
+Cambria,JOHNSTOWN -17TH WARD 3,President,,DEM,Bernie Sanders,14,4,0,18
+Cambria,JOHNSTOWN -17TH WARD 3,President,,DEM,Joseph R. Biden,18,16,3,37
+Cambria,JOHNSTOWN -17TH WARD 3,President,,DEM,Tulsi Gabbard,0,1,0,1
+Cambria,JOHNSTOWN -17TH WARD 3,President,,DEM,Write-In,5,1,0,6
+Cambria,JOHNSTOWN -17TH WARD 3,Attorney General,,DEM,Josh Shapiro,33,21,3,57
+Cambria,JOHNSTOWN -17TH WARD 3,Attorney General,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,DEM,H. Scott Conklin,16,10,0,26
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,DEM,Michael Lamb,6,5,1,12
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,DEM,Tracie Fountain,3,2,0,5
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,DEM,Rose Rosie Marie Davis,0,3,1,4
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,DEM,Nina Ahmad,6,1,1,8
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,DEM,Christina M. Hartman,3,0,0,3
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 3,State Treasurer,,DEM,Joe Torsella,33,21,2,56
+Cambria,JOHNSTOWN -17TH WARD 3,State Treasurer,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 3,U.S. House,13,DEM,Todd Rowley,31,20,3,54
+Cambria,JOHNSTOWN -17TH WARD 3,U.S. House,13,DEM,Write-In,2,0,0,2
+Cambria,JOHNSTOWN -17TH WARD 3,State Senator,35,DEM,Shaun Dougherty,34,19,3,56
+Cambria,JOHNSTOWN -17TH WARD 3,State Senator,35,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 3,General Assembly,71,DEM,Write-In,3,1,0,4
+Cambria,JOHNSTOWN -17TH WARD 3,President,,REP,Donald J. Trump,37,19,1,57
+Cambria,JOHNSTOWN -17TH WARD 3,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 3,President,,REP,Bill Weld,3,1,0,4
+Cambria,JOHNSTOWN -17TH WARD 3,President,,REP,Write-In,4,0,0,4
+Cambria,JOHNSTOWN -17TH WARD 3,Attorney General,,REP,Heather Heidelbaugh,42,19,1,62
+Cambria,JOHNSTOWN -17TH WARD 3,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,REP,Timothy Defoor,42,18,1,61
+Cambria,JOHNSTOWN -17TH WARD 3,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 3,State Treasurer,,REP,Stacy L. Garrity,42,19,1,62
+Cambria,JOHNSTOWN -17TH WARD 3,State Treasurer,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 3,U.S. House,13,REP,John Joyce,42,19,1,62
+Cambria,JOHNSTOWN -17TH WARD 3,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 3,State Senator,35,REP,Wayne Langerholc Jr.,44,19,1,64
+Cambria,JOHNSTOWN -17TH WARD 3,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 3,General Assembly,71,REP,Jim Rigby,45,19,1,65
+Cambria,JOHNSTOWN -17TH WARD 3,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,Registered Voters,,,,,,,368
+Cambria,JOHNSTOWN -17TH WARD 4,Registered Voters,,DEM,,,,,192
+Cambria,JOHNSTOWN -17TH WARD 4,Registered Voters,,REP,,,,,127
+Cambria,JOHNSTOWN -17TH WARD 4,Ballots Cast,,,,57,46,5,108
+Cambria,JOHNSTOWN -17TH WARD 4,Ballots Cast,,DEM,,30,31,2,63
+Cambria,JOHNSTOWN -17TH WARD 4,Ballots Cast,,REP,,27,15,3,45
+Cambria,JOHNSTOWN -17TH WARD 4,President,,DEM,Bernie Sanders,8,7,1,16
+Cambria,JOHNSTOWN -17TH WARD 4,President,,DEM,Joseph R. Biden,18,21,1,40
+Cambria,JOHNSTOWN -17TH WARD 4,President,,DEM,Tulsi Gabbard,1,2,0,3
+Cambria,JOHNSTOWN -17TH WARD 4,President,,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN -17TH WARD 4,Attorney General,,DEM,Josh Shapiro,30,29,2,61
+Cambria,JOHNSTOWN -17TH WARD 4,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,DEM,H. Scott Conklin,12,12,1,25
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,DEM,Michael Lamb,9,9,0,18
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,DEM,Tracie Fountain,2,0,0,2
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,DEM,Nina Ahmad,7,9,1,17
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,DEM,Christina M. Hartman,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,State Treasurer,,DEM,Joe Torsella,27,27,2,56
+Cambria,JOHNSTOWN -17TH WARD 4,State Treasurer,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,U.S. House,13,DEM,Todd Rowley,28,28,2,58
+Cambria,JOHNSTOWN -17TH WARD 4,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,State Senator,35,DEM,Shaun Dougherty,27,28,2,57
+Cambria,JOHNSTOWN -17TH WARD 4,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN -17TH WARD 4,General Assembly,71,DEM,Write-In,3,5,0,8
+Cambria,JOHNSTOWN -17TH WARD 4,President,,REP,Donald J. Trump,25,13,3,41
+Cambria,JOHNSTOWN -17TH WARD 4,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,President,,REP,Bill Weld,2,0,0,2
+Cambria,JOHNSTOWN -17TH WARD 4,President,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN -17TH WARD 4,Attorney General,,REP,Heather Heidelbaugh,26,13,3,42
+Cambria,JOHNSTOWN -17TH WARD 4,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,REP,Timothy Defoor,26,13,3,42
+Cambria,JOHNSTOWN -17TH WARD 4,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,State Treasurer,,REP,Stacy L. Garrity,26,13,3,42
+Cambria,JOHNSTOWN -17TH WARD 4,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,U.S. House,13,REP,John Joyce,27,15,3,45
+Cambria,JOHNSTOWN -17TH WARD 4,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,State Senator,35,REP,Wayne Langerholc Jr.,26,15,3,44
+Cambria,JOHNSTOWN -17TH WARD 4,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN -17TH WARD 4,General Assembly,71,REP,Jim Rigby,25,15,3,43
+Cambria,JOHNSTOWN -17TH WARD 4,General Assembly,71,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Registered Voters,,,,,,,535
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Registered Voters,,DEM,,,,,303
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Registered Voters,,REP,,,,,160
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Ballots Cast,,,,82,67,0,149
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Ballots Cast,,DEM,,43,46,0,89
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Ballots Cast,,REP,,39,21,0,60
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,President,,DEM,Bernie Sanders,6,10,0,16
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,President,,DEM,Joseph R. Biden,22,32,0,54
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,President,,DEM,Tulsi Gabbard,6,1,0,7
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,President,,DEM,Write-In,5,2,0,7
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Attorney General,,DEM,Josh Shapiro,34,38,0,72
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Attorney General,,DEM,Write-In,1,2,0,3
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,DEM,H. Scott Conklin,16,17,0,33
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,DEM,Michael Lamb,16,16,0,32
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,DEM,Tracie Fountain,1,1,0,2
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,1,4,0,5
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,DEM,Nina Ahmad,4,1,0,5
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,DEM,Christina M. Hartman,3,2,0,5
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,State Treasurer,,DEM,Joe Torsella,33,40,0,73
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,U.S. House,13,DEM,Todd Rowley,37,39,0,76
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,U.S. House,13,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,State Senator,35,DEM,Shaun Dougherty,37,39,0,76
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,State Senator,35,DEM,Write-In,1,2,0,3
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,General Assembly,71,DEM,Write-In,4,11,0,15
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,President,,REP,Donald J. Trump,37,18,0,55
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,President,,REP,Bill Weld,0,2,0,2
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,President,,REP,Write-In,2,1,0,3
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Attorney General,,REP,Heather Heidelbaugh,34,18,0,52
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Attorney General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,REP,Timothy Defoor,31,17,0,48
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,Auditor General,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,State Treasurer,,REP,Stacy L. Garrity,33,17,0,50
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,State Treasurer,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,U.S. House,13,REP,John Joyce,34,17,0,51
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,U.S. House,13,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,State Senator,35,REP,Wayne Langerholc Jr.,35,19,0,54
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,State Senator,35,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,General Assembly,71,REP,Jim Rigby,35,20,0,55
+Cambria,JOHNSTOWN - EIGHTEENTH WARD,General Assembly,71,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - NINETEENTH WARD,Registered Voters,,,,,,,603
+Cambria,JOHNSTOWN - NINETEENTH WARD,Registered Voters,,DEM,,,,,349
+Cambria,JOHNSTOWN - NINETEENTH WARD,Registered Voters,,REP,,,,,177
+Cambria,JOHNSTOWN - NINETEENTH WARD,Ballots Cast,,,,112,99,0,211
+Cambria,JOHNSTOWN - NINETEENTH WARD,Ballots Cast,,DEM,,76,63,0,139
+Cambria,JOHNSTOWN - NINETEENTH WARD,Ballots Cast,,REP,,36,36,0,72
+Cambria,JOHNSTOWN - NINETEENTH WARD,President,,DEM,Bernie Sanders,17,8,0,25
+Cambria,JOHNSTOWN - NINETEENTH WARD,President,,DEM,Joseph R. Biden,49,48,0,97
+Cambria,JOHNSTOWN - NINETEENTH WARD,President,,DEM,Tulsi Gabbard,3,2,0,5
+Cambria,JOHNSTOWN - NINETEENTH WARD,President,,DEM,Write-In,3,2,0,5
+Cambria,JOHNSTOWN - NINETEENTH WARD,Attorney General,,DEM,Josh Shapiro,71,60,0,131
+Cambria,JOHNSTOWN - NINETEENTH WARD,Attorney General,,DEM,Write-In,1,1,0,2
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,DEM,H. Scott Conklin,26,28,0,54
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,DEM,Michael Lamb,28,19,0,47
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,DEM,Tracie Fountain,2,2,0,4
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,DEM,Rose Rosie Marie Davis,5,6,0,11
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,DEM,Nina Ahmad,8,4,0,12
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,DEM,Christina M. Hartman,4,3,0,7
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - NINETEENTH WARD,State Treasurer,,DEM,Joe Torsella,69,58,0,127
+Cambria,JOHNSTOWN - NINETEENTH WARD,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - NINETEENTH WARD,U.S. House,13,DEM,Todd Rowley,68,57,0,125
+Cambria,JOHNSTOWN - NINETEENTH WARD,U.S. House,13,DEM,Write-In,1,2,0,3
+Cambria,JOHNSTOWN - NINETEENTH WARD,State Senator,35,DEM,Shaun Dougherty,70,56,0,126
+Cambria,JOHNSTOWN - NINETEENTH WARD,State Senator,35,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - NINETEENTH WARD,General Assembly,71,DEM,Write-In,7,9,0,16
+Cambria,JOHNSTOWN - NINETEENTH WARD,President,,REP,Donald J. Trump,33,32,0,65
+Cambria,JOHNSTOWN - NINETEENTH WARD,President,,REP,Roque Rocky De La Fuente,0,1,0,1
+Cambria,JOHNSTOWN - NINETEENTH WARD,President,,REP,Bill Weld,0,1,0,1
+Cambria,JOHNSTOWN - NINETEENTH WARD,President,,REP,Write-In,0,1,0,1
+Cambria,JOHNSTOWN - NINETEENTH WARD,Attorney General,,REP,Heather Heidelbaugh,32,34,0,66
+Cambria,JOHNSTOWN - NINETEENTH WARD,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,REP,Timothy Defoor,30,34,0,64
+Cambria,JOHNSTOWN - NINETEENTH WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - NINETEENTH WARD,State Treasurer,,REP,Stacy L. Garrity,31,34,0,65
+Cambria,JOHNSTOWN - NINETEENTH WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - NINETEENTH WARD,U.S. House,13,REP,John Joyce,29,35,0,64
+Cambria,JOHNSTOWN - NINETEENTH WARD,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - NINETEENTH WARD,State Senator,35,REP,Wayne Langerholc Jr.,35,36,0,71
+Cambria,JOHNSTOWN - NINETEENTH WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - NINETEENTH WARD,General Assembly,71,REP,Jim Rigby,34,36,0,70
+Cambria,JOHNSTOWN - NINETEENTH WARD,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 1,Registered Voters,,,,,,,807
+Cambria,JOHNSTOWN-20TH WARD 1,Registered Voters,,DEM,,,,,499
+Cambria,JOHNSTOWN-20TH WARD 1,Registered Voters,,REP,,,,,216
+Cambria,JOHNSTOWN-20TH WARD 1,Ballots Cast,,,,139,107,7,253
+Cambria,JOHNSTOWN-20TH WARD 1,Ballots Cast,,DEM,,91,79,5,175
+Cambria,JOHNSTOWN-20TH WARD 1,Ballots Cast,,REP,,48,28,2,78
+Cambria,JOHNSTOWN-20TH WARD 1,President,,DEM,Bernie Sanders,21,7,1,29
+Cambria,JOHNSTOWN-20TH WARD 1,President,,DEM,Joseph R. Biden,45,59,2,106
+Cambria,JOHNSTOWN-20TH WARD 1,President,,DEM,Tulsi Gabbard,4,8,2,14
+Cambria,JOHNSTOWN-20TH WARD 1,President,,DEM,Write-In,11,3,0,14
+Cambria,JOHNSTOWN-20TH WARD 1,Attorney General,,DEM,Josh Shapiro,83,73,5,161
+Cambria,JOHNSTOWN-20TH WARD 1,Attorney General,,DEM,Write-In,2,2,0,4
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,DEM,H. Scott Conklin,37,40,1,78
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,DEM,Michael Lamb,23,24,3,50
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,DEM,Tracie Fountain,4,4,0,8
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,DEM,Rose Rosie Marie Davis,4,1,0,5
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,DEM,Nina Ahmad,10,6,0,16
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,DEM,Christina M. Hartman,4,4,1,9
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,DEM,Write-In,2,0,0,2
+Cambria,JOHNSTOWN-20TH WARD 1,State Treasurer,,DEM,Joe Torsella,80,75,3,158
+Cambria,JOHNSTOWN-20TH WARD 1,State Treasurer,,DEM,Write-In,3,0,0,3
+Cambria,JOHNSTOWN-20TH WARD 1,U.S. House,13,DEM,Todd Rowley,82,75,4,161
+Cambria,JOHNSTOWN-20TH WARD 1,U.S. House,13,DEM,Write-In,1,1,0,2
+Cambria,JOHNSTOWN-20TH WARD 1,State Senator,35,DEM,Shaun Dougherty,81,72,5,158
+Cambria,JOHNSTOWN-20TH WARD 1,State Senator,35,DEM,Write-In,1,3,0,4
+Cambria,JOHNSTOWN-20TH WARD 1,General Assembly,71,DEM,Write-In,13,13,0,26
+Cambria,JOHNSTOWN-20TH WARD 1,President,,REP,Donald J. Trump,48,23,2,73
+Cambria,JOHNSTOWN-20TH WARD 1,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 1,President,,REP,Bill Weld,0,3,0,3
+Cambria,JOHNSTOWN-20TH WARD 1,President,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 1,Attorney General,,REP,Heather Heidelbaugh,45,27,2,74
+Cambria,JOHNSTOWN-20TH WARD 1,Attorney General,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,REP,Timothy Defoor,44,27,1,72
+Cambria,JOHNSTOWN-20TH WARD 1,Auditor General,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN-20TH WARD 1,State Treasurer,,REP,Stacy L. Garrity,45,27,2,74
+Cambria,JOHNSTOWN-20TH WARD 1,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 1,U.S. House,13,REP,John Joyce,47,28,1,76
+Cambria,JOHNSTOWN-20TH WARD 1,U.S. House,13,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN-20TH WARD 1,State Senator,35,REP,Wayne Langerholc Jr.,46,27,2,75
+Cambria,JOHNSTOWN-20TH WARD 1,State Senator,35,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN-20TH WARD 1,General Assembly,71,REP,Jim Rigby,48,27,2,77
+Cambria,JOHNSTOWN-20TH WARD 1,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,Registered Voters,,,,,,,793
+Cambria,JOHNSTOWN-20TH WARD 2,Registered Voters,,DEM,,,,,490
+Cambria,JOHNSTOWN-20TH WARD 2,Registered Voters,,REP,,,,,173
+Cambria,JOHNSTOWN-20TH WARD 2,Ballots Cast,,,,85,77,1,163
+Cambria,JOHNSTOWN-20TH WARD 2,Ballots Cast,,DEM,,47,56,1,104
+Cambria,JOHNSTOWN-20TH WARD 2,Ballots Cast,,REP,,38,21,0,59
+Cambria,JOHNSTOWN-20TH WARD 2,President,,DEM,Bernie Sanders,10,8,1,19
+Cambria,JOHNSTOWN-20TH WARD 2,President,,DEM,Joseph R. Biden,31,42,0,73
+Cambria,JOHNSTOWN-20TH WARD 2,President,,DEM,Tulsi Gabbard,2,0,0,2
+Cambria,JOHNSTOWN-20TH WARD 2,President,,DEM,Write-In,1,3,0,4
+Cambria,JOHNSTOWN-20TH WARD 2,Attorney General,,DEM,Josh Shapiro,40,50,1,91
+Cambria,JOHNSTOWN-20TH WARD 2,Attorney General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,DEM,H. Scott Conklin,14,22,0,36
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,DEM,Michael Lamb,11,19,0,30
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,DEM,Tracie Fountain,1,0,0,1
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,DEM,Rose Rosie Marie Davis,4,2,0,6
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,DEM,Nina Ahmad,11,4,1,16
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,DEM,Christina M. Hartman,2,2,0,4
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,State Treasurer,,DEM,Joe Torsella,41,47,1,89
+Cambria,JOHNSTOWN-20TH WARD 2,State Treasurer,,DEM,Write-In,0,1,0,1
+Cambria,JOHNSTOWN-20TH WARD 2,U.S. House,13,DEM,Todd Rowley,39,48,1,88
+Cambria,JOHNSTOWN-20TH WARD 2,U.S. House,13,DEM,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,State Senator,35,DEM,Shaun Dougherty,41,49,1,91
+Cambria,JOHNSTOWN-20TH WARD 2,State Senator,35,DEM,Write-In,1,0,0,1
+Cambria,JOHNSTOWN-20TH WARD 2,General Assembly,71,DEM,Write-In,5,9,0,14
+Cambria,JOHNSTOWN-20TH WARD 2,President,,REP,Donald J. Trump,38,21,0,59
+Cambria,JOHNSTOWN-20TH WARD 2,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,President,,REP,Bill Weld,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,President,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,Attorney General,,REP,Heather Heidelbaugh,35,17,0,52
+Cambria,JOHNSTOWN-20TH WARD 2,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,REP,Timothy Defoor,35,16,0,51
+Cambria,JOHNSTOWN-20TH WARD 2,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,State Treasurer,,REP,Stacy L. Garrity,35,16,0,51
+Cambria,JOHNSTOWN-20TH WARD 2,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,U.S. House,13,REP,John Joyce,37,16,0,53
+Cambria,JOHNSTOWN-20TH WARD 2,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,State Senator,35,REP,Wayne Langerholc Jr.,36,21,0,57
+Cambria,JOHNSTOWN-20TH WARD 2,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN-20TH WARD 2,General Assembly,71,REP,Jim Rigby,38,21,0,59
+Cambria,JOHNSTOWN-20TH WARD 2,General Assembly,71,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Registered Voters,,,,,,,435
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Registered Voters,,DEM,,,,,252
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Registered Voters,,REP,,,,,129
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Ballots Cast,,,,84,58,2,144
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Ballots Cast,,DEM,,55,27,1,83
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Ballots Cast,,REP,,29,31,1,61
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,President,,DEM,Bernie Sanders,13,4,0,17
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,President,,DEM,Joseph R. Biden,24,21,0,45
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,President,,DEM,Tulsi Gabbard,4,1,0,5
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,President,,DEM,Write-In,5,0,1,6
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Attorney General,,DEM,Josh Shapiro,40,20,0,60
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Attorney General,,DEM,Write-In,0,0,1,1
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,DEM,H. Scott Conklin,21,12,0,33
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,DEM,Michael Lamb,9,7,0,16
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,DEM,Tracie Fountain,2,0,0,2
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,0,4
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,DEM,Nina Ahmad,5,0,0,5
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,DEM,Christina M. Hartman,6,1,0,7
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,DEM,Write-In,0,0,1,1
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,State Treasurer,,DEM,Joe Torsella,39,20,0,59
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,State Treasurer,,DEM,Write-In,0,0,1,1
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,U.S. House,13,DEM,Todd Rowley,37,20,0,57
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,U.S. House,13,DEM,Write-In,0,0,1,1
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,State Senator,35,DEM,Shaun Dougherty,36,23,0,59
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,State Senator,35,DEM,Write-In,0,1,1,2
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,General Assembly,71,DEM,Write-In,3,2,1,6
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,President,,REP,Donald J. Trump,28,31,1,60
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,President,,REP,Roque Rocky De La Fuente,0,0,0,0
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,President,,REP,Bill Weld,0,0,0,0
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,President,,REP,Write-In,1,0,0,1
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Attorney General,,REP,Heather Heidelbaugh,27,30,1,58
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Attorney General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,REP,Timothy Defoor,26,30,1,57
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,Auditor General,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,State Treasurer,,REP,Stacy L. Garrity,26,30,1,57
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,State Treasurer,,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,U.S. House,13,REP,John Joyce,28,30,1,59
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,U.S. House,13,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,State Senator,35,REP,Wayne Langerholc Jr.,29,30,1,60
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,State Senator,35,REP,Write-In,0,0,0,0
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,General Assembly,71,REP,Jim Rigby,28,30,1,59
+Cambria,JOHNSTOWN - TWENTY-FIRST WARD,General Assembly,71,REP,Write-In,0,0,0,0

--- a/2020/20200602__pa__primary__lackawanna__precinct.csv
+++ b/2020/20200602__pa__primary__lackawanna__precinct.csv
@@ -1,0 +1,7283 @@
+county,precinct,office,district,party,candidate,election_day,mail_in,absentee,provisional,votes
+Lackawanna,Waverly Township W-00 P-00,Registered Voters,,,,,,,,1321
+Lackawanna,Waverly Township W-00 P-00,Registered Voters,,DEM,,,,,,715
+Lackawanna,Waverly Township W-00 P-00,Registered Voters,,REP,,,,,,606
+Lackawanna,Waverly Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Waverly Township W-00 P-00,Ballots Cast,,,,228,266,86,9,589
+Lackawanna,Waverly Township W-00 P-00,Ballots Cast,,DEM,,102,206,59,6,373
+Lackawanna,Waverly Township W-00 P-00,Ballots Cast,,REP,,126,60,27,3,216
+Lackawanna,Waverly Township W-00 P-00,President,,DEM,Bernie Sanders,13,16,8,1,38
+Lackawanna,Waverly Township W-00 P-00,President,,DEM,Joseph R. Biden,76,184,50,5,315
+Lackawanna,Waverly Township W-00 P-00,President,,DEM,Tulsi Gabbard,8,3,1,0,12
+Lackawanna,Waverly Township W-00 P-00,President,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Waverly Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,79,185,54,6,324
+Lackawanna,Waverly Township W-00 P-00,Attorney General,,DEM,Write-in,3,4,0,0,7
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,5,9,4,0,18
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,DEM,Michael Lamb,17,23,11,1,52
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,5,15,3,0,23
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,11,34,12,3,60
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,35,46,16,2,99
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,10,32,6,0,48
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Waverly Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,76,176,56,6,314
+Lackawanna,Waverly Township W-00 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,88,200,58,6,352
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,DEM,Write-in,3,1,0,0,4
+Lackawanna,Waverly Township W-00 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,90,199,59,6,354
+Lackawanna,Waverly Township W-00 P-00,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Waverly Township W-00 P-00,President,,REP,Donald J. Trump,108,47,16,2,173
+Lackawanna,Waverly Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,2,1,2,0,5
+Lackawanna,Waverly Township W-00 P-00,President,,REP,Bill Weld,7,3,5,1,16
+Lackawanna,Waverly Township W-00 P-00,President,,REP,Write-in,5,3,2,0,10
+Lackawanna,Waverly Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,107,48,22,2,179
+Lackawanna,Waverly Township W-00 P-00,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,105,45,23,2,175
+Lackawanna,Waverly Township W-00 P-00,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Waverly Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,103,44,21,2,170
+Lackawanna,Waverly Township W-00 P-00,State Treasurer,,REP,Write-in,2,1,0,0,3
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,REP,Harry Haas,3,2,0,0,5
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,24,2,3,1,30
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,REP,Jim Bognet,32,10,3,0,45
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,1,0,1,0,2
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,15,3,3,1,22
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,REP,Earl Granville,45,32,15,0,92
+Lackawanna,Waverly Township W-00 P-00,U.S. House,8,REP,Write-in,0,1,0,1,2
+Lackawanna,Waverly Township W-00 P-00,General Assembly,114,REP,James May,107,48,23,2,180
+Lackawanna,Waverly Township W-00 P-00,General Assembly,114,REP,Write-in,2,2,0,0,4
+Lackawanna,Archbald W-01 P-01,Registered Voters,,,,,,,,1158
+Lackawanna,Archbald W-01 P-01,Registered Voters,,DEM,,,,,,837
+Lackawanna,Archbald W-01 P-01,Registered Voters,,REP,,,,,,321
+Lackawanna,Archbald W-01 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Archbald W-01 P-01,Ballots Cast,,,,210,297,44,8,559
+Lackawanna,Archbald W-01 P-01,Ballots Cast,,DEM,,124,258,37,5,424
+Lackawanna,Archbald W-01 P-01,Ballots Cast,,REP,,86,39,7,3,135
+Lackawanna,Archbald W-01 P-01,President,,DEM,Bernie Sanders,15,21,2,2,40
+Lackawanna,Archbald W-01 P-01,President,,DEM,Joseph R. Biden,80,218,29,2,329
+Lackawanna,Archbald W-01 P-01,President,,DEM,Tulsi Gabbard,9,6,2,0,17
+Lackawanna,Archbald W-01 P-01,President,,DEM,Write-in,12,5,1,1,19
+Lackawanna,Archbald W-01 P-01,Attorney General,,DEM,Josh Shapiro,88,234,30,5,357
+Lackawanna,Archbald W-01 P-01,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Archbald W-01 P-01,Auditor General,,DEM,H. Scott Conklin,6,12,3,0,21
+Lackawanna,Archbald W-01 P-01,Auditor General,,DEM,Michael Lamb,20,44,5,0,69
+Lackawanna,Archbald W-01 P-01,Auditor General,,DEM,Tracie Fountain,7,20,3,0,30
+Lackawanna,Archbald W-01 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,13,66,6,1,86
+Lackawanna,Archbald W-01 P-01,Auditor General,,DEM,Nina Ahmad,40,49,5,3,97
+Lackawanna,Archbald W-01 P-01,Auditor General,,DEM,Christina M. Hartman,16,31,7,0,54
+Lackawanna,Archbald W-01 P-01,Auditor General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Archbald W-01 P-01,State Treasurer,,DEM,Joe Torsella,80,228,29,4,341
+Lackawanna,Archbald W-01 P-01,State Treasurer,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Archbald W-01 P-01,U.S. House,8,DEM,Matt Cartwright,94,242,34,4,374
+Lackawanna,Archbald W-01 P-01,U.S. House,8,DEM,Write-in,10,2,0,0,12
+Lackawanna,Archbald W-01 P-01,General Assembly,112,DEM,Kyle J. Mullins,105,249,32,4,390
+Lackawanna,Archbald W-01 P-01,General Assembly,112,DEM,Write-in,4,1,0,0,5
+Lackawanna,Archbald W-01 P-01,President,,REP,Donald J. Trump,80,37,7,3,127
+Lackawanna,Archbald W-01 P-01,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Archbald W-01 P-01,President,,REP,Bill Weld,4,0,0,0,4
+Lackawanna,Archbald W-01 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-01 P-01,Attorney General,,REP,Heather Heidelbaugh,65,25,5,2,97
+Lackawanna,Archbald W-01 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-01 P-01,Auditor General,,REP,Timothy DeFoor,61,24,6,2,93
+Lackawanna,Archbald W-01 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-01 P-01,State Treasurer,,REP,Stacy L. Garrity,62,24,6,2,94
+Lackawanna,Archbald W-01 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-01 P-01,U.S. House,8,REP,Harry Haas,2,0,1,0,3
+Lackawanna,Archbald W-01 P-01,U.S. House,8,REP,Teddy Daniels,14,2,0,0,16
+Lackawanna,Archbald W-01 P-01,U.S. House,8,REP,Jim Bognet,15,2,2,0,19
+Lackawanna,Archbald W-01 P-01,U.S. House,8,REP,Mike Cammisa,0,2,0,0,2
+Lackawanna,Archbald W-01 P-01,U.S. House,8,REP,Mike Marsicano,9,0,0,0,9
+Lackawanna,Archbald W-01 P-01,U.S. House,8,REP,Earl Granville,42,32,4,3,81
+Lackawanna,Archbald W-01 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-01 P-01,General Assembly,112,REP,Write-in,13,3,1,2,19
+Lackawanna,Archbald W-01 P-02,Registered Voters,,,,,,,,1263
+Lackawanna,Archbald W-01 P-02,Registered Voters,,DEM,,,,,,951
+Lackawanna,Archbald W-01 P-02,Registered Voters,,REP,,,,,,312
+Lackawanna,Archbald W-01 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Archbald W-01 P-02,Ballots Cast,,,,202,291,62,4,559
+Lackawanna,Archbald W-01 P-02,Ballots Cast,,DEM,,119,269,53,2,443
+Lackawanna,Archbald W-01 P-02,Ballots Cast,,REP,,83,22,9,2,116
+Lackawanna,Archbald W-01 P-02,President,,DEM,Bernie Sanders,14,22,6,0,42
+Lackawanna,Archbald W-01 P-02,President,,DEM,Joseph R. Biden,73,227,41,2,343
+Lackawanna,Archbald W-01 P-02,President,,DEM,Tulsi Gabbard,9,6,2,0,17
+Lackawanna,Archbald W-01 P-02,President,,DEM,Write-in,17,5,2,0,24
+Lackawanna,Archbald W-01 P-02,Attorney General,,DEM,Josh Shapiro,94,224,40,2,360
+Lackawanna,Archbald W-01 P-02,Attorney General,,DEM,Write-in,5,1,1,0,7
+Lackawanna,Archbald W-01 P-02,Auditor General,,DEM,H. Scott Conklin,4,7,5,0,16
+Lackawanna,Archbald W-01 P-02,Auditor General,,DEM,Michael Lamb,18,41,5,0,64
+Lackawanna,Archbald W-01 P-02,Auditor General,,DEM,Tracie Fountain,2,11,3,0,16
+Lackawanna,Archbald W-01 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,10,59,11,0,80
+Lackawanna,Archbald W-01 P-02,Auditor General,,DEM,Nina Ahmad,49,64,18,1,132
+Lackawanna,Archbald W-01 P-02,Auditor General,,DEM,Christina M. Hartman,13,32,2,1,48
+Lackawanna,Archbald W-01 P-02,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-01 P-02,State Treasurer,,DEM,Joe Torsella,85,210,42,2,339
+Lackawanna,Archbald W-01 P-02,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-01 P-02,U.S. House,8,DEM,Matt Cartwright,93,250,49,2,394
+Lackawanna,Archbald W-01 P-02,U.S. House,8,DEM,Write-in,7,2,1,0,10
+Lackawanna,Archbald W-01 P-02,General Assembly,112,DEM,Kyle J. Mullins,100,249,46,2,397
+Lackawanna,Archbald W-01 P-02,General Assembly,112,DEM,Write-in,2,1,0,0,3
+Lackawanna,Archbald W-01 P-02,President,,REP,Donald J. Trump,77,17,9,1,104
+Lackawanna,Archbald W-01 P-02,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Archbald W-01 P-02,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Archbald W-01 P-02,President,,REP,Write-in,2,1,0,0,3
+Lackawanna,Archbald W-01 P-02,Attorney General,,REP,Heather Heidelbaugh,61,15,8,1,85
+Lackawanna,Archbald W-01 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-01 P-02,Auditor General,,REP,Timothy DeFoor,62,15,8,1,86
+Lackawanna,Archbald W-01 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-01 P-02,State Treasurer,,REP,Stacy L. Garrity,60,15,8,1,84
+Lackawanna,Archbald W-01 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-01 P-02,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Archbald W-01 P-02,U.S. House,8,REP,Teddy Daniels,15,1,0,0,16
+Lackawanna,Archbald W-01 P-02,U.S. House,8,REP,Jim Bognet,15,2,2,1,20
+Lackawanna,Archbald W-01 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Archbald W-01 P-02,U.S. House,8,REP,Mike Marsicano,10,0,0,0,10
+Lackawanna,Archbald W-01 P-02,U.S. House,8,REP,Earl Granville,40,17,7,1,65
+Lackawanna,Archbald W-01 P-02,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Archbald W-01 P-02,General Assembly,112,REP,Write-in,19,6,5,0,30
+Lackawanna,Archbald W-02 P-01,Registered Voters,,,,,,,,737
+Lackawanna,Archbald W-02 P-01,Registered Voters,,DEM,,,,,,578
+Lackawanna,Archbald W-02 P-01,Registered Voters,,REP,,,,,,159
+Lackawanna,Archbald W-02 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Archbald W-02 P-01,Ballots Cast,,,,132,175,29,3,339
+Lackawanna,Archbald W-02 P-01,Ballots Cast,,DEM,,92,167,27,2,288
+Lackawanna,Archbald W-02 P-01,Ballots Cast,,REP,,40,8,2,1,51
+Lackawanna,Archbald W-02 P-01,President,,DEM,Bernie Sanders,23,13,1,1,38
+Lackawanna,Archbald W-02 P-01,President,,DEM,Joseph R. Biden,52,145,25,1,223
+Lackawanna,Archbald W-02 P-01,President,,DEM,Tulsi Gabbard,7,2,0,0,9
+Lackawanna,Archbald W-02 P-01,President,,DEM,Write-in,4,3,1,0,8
+Lackawanna,Archbald W-02 P-01,Attorney General,,DEM,Josh Shapiro,59,135,21,0,215
+Lackawanna,Archbald W-02 P-01,Attorney General,,DEM,Write-in,2,0,1,0,3
+Lackawanna,Archbald W-02 P-01,Auditor General,,DEM,H. Scott Conklin,2,11,1,0,14
+Lackawanna,Archbald W-02 P-01,Auditor General,,DEM,Michael Lamb,8,13,1,0,22
+Lackawanna,Archbald W-02 P-01,Auditor General,,DEM,Tracie Fountain,2,5,1,0,8
+Lackawanna,Archbald W-02 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,19,44,4,0,67
+Lackawanna,Archbald W-02 P-01,Auditor General,,DEM,Nina Ahmad,28,38,8,2,76
+Lackawanna,Archbald W-02 P-01,Auditor General,,DEM,Christina M. Hartman,9,27,8,0,44
+Lackawanna,Archbald W-02 P-01,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Archbald W-02 P-01,State Treasurer,,DEM,Joe Torsella,54,125,22,0,201
+Lackawanna,Archbald W-02 P-01,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Archbald W-02 P-01,U.S. House,8,DEM,Matt Cartwright,70,156,24,1,251
+Lackawanna,Archbald W-02 P-01,U.S. House,8,DEM,Write-in,6,0,1,0,7
+Lackawanna,Archbald W-02 P-01,General Assembly,112,DEM,Kyle J. Mullins,74,148,26,1,249
+Lackawanna,Archbald W-02 P-01,General Assembly,112,DEM,Write-in,1,2,0,0,3
+Lackawanna,Archbald W-02 P-01,President,,REP,Donald J. Trump,38,6,2,1,47
+Lackawanna,Archbald W-02 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Archbald W-02 P-01,President,,REP,Bill Weld,1,2,0,0,3
+Lackawanna,Archbald W-02 P-01,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Archbald W-02 P-01,Attorney General,,REP,Heather Heidelbaugh,27,6,0,1,34
+Lackawanna,Archbald W-02 P-01,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Archbald W-02 P-01,Auditor General,,REP,Timothy DeFoor,26,7,0,1,34
+Lackawanna,Archbald W-02 P-01,Auditor General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Archbald W-02 P-01,State Treasurer,,REP,Stacy L. Garrity,25,7,0,1,33
+Lackawanna,Archbald W-02 P-01,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Archbald W-02 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Archbald W-02 P-01,U.S. House,8,REP,Teddy Daniels,8,0,0,1,9
+Lackawanna,Archbald W-02 P-01,U.S. House,8,REP,Jim Bognet,10,2,0,0,12
+Lackawanna,Archbald W-02 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Archbald W-02 P-01,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Archbald W-02 P-01,U.S. House,8,REP,Earl Granville,19,6,1,0,26
+Lackawanna,Archbald W-02 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-02 P-01,General Assembly,112,REP,Write-in,6,2,0,0,8
+Lackawanna,Archbald W-03 P-00,Registered Voters,,,,,,,,438
+Lackawanna,Archbald W-03 P-00,Registered Voters,,DEM,,,,,,332
+Lackawanna,Archbald W-03 P-00,Registered Voters,,REP,,,,,,106
+Lackawanna,Archbald W-03 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Archbald W-03 P-00,Ballots Cast,,,,73,83,21,4,181
+Lackawanna,Archbald W-03 P-00,Ballots Cast,,DEM,,49,69,21,2,141
+Lackawanna,Archbald W-03 P-00,Ballots Cast,,REP,,24,14,0,2,40
+Lackawanna,Archbald W-03 P-00,President,,DEM,Bernie Sanders,8,8,6,0,22
+Lackawanna,Archbald W-03 P-00,President,,DEM,Joseph R. Biden,29,54,15,2,100
+Lackawanna,Archbald W-03 P-00,President,,DEM,Tulsi Gabbard,3,3,0,0,6
+Lackawanna,Archbald W-03 P-00,President,,DEM,Write-in,3,2,0,0,5
+Lackawanna,Archbald W-03 P-00,Attorney General,,DEM,Josh Shapiro,37,60,20,2,119
+Lackawanna,Archbald W-03 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,Auditor General,,DEM,H. Scott Conklin,3,2,1,0,6
+Lackawanna,Archbald W-03 P-00,Auditor General,,DEM,Michael Lamb,10,9,2,0,21
+Lackawanna,Archbald W-03 P-00,Auditor General,,DEM,Tracie Fountain,4,4,2,0,10
+Lackawanna,Archbald W-03 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,2,21,3,0,26
+Lackawanna,Archbald W-03 P-00,Auditor General,,DEM,Nina Ahmad,19,13,4,1,37
+Lackawanna,Archbald W-03 P-00,Auditor General,,DEM,Christina M. Hartman,5,12,7,0,24
+Lackawanna,Archbald W-03 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,State Treasurer,,DEM,Joe Torsella,34,59,20,1,114
+Lackawanna,Archbald W-03 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,U.S. House,8,DEM,Matt Cartwright,38,65,21,2,126
+Lackawanna,Archbald W-03 P-00,U.S. House,8,DEM,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,General Assembly,112,DEM,Kyle J. Mullins,43,67,21,2,133
+Lackawanna,Archbald W-03 P-00,General Assembly,112,DEM,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,President,,REP,Donald J. Trump,23,11,0,2,36
+Lackawanna,Archbald W-03 P-00,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Archbald W-03 P-00,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Archbald W-03 P-00,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-03 P-00,Attorney General,,REP,Heather Heidelbaugh,21,13,0,2,36
+Lackawanna,Archbald W-03 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,Auditor General,,REP,Timothy DeFoor,20,13,0,2,35
+Lackawanna,Archbald W-03 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,State Treasurer,,REP,Stacy L. Garrity,19,13,0,2,34
+Lackawanna,Archbald W-03 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,U.S. House,8,REP,Harry Haas,1,1,0,0,2
+Lackawanna,Archbald W-03 P-00,U.S. House,8,REP,Teddy Daniels,6,2,0,1,9
+Lackawanna,Archbald W-03 P-00,U.S. House,8,REP,Jim Bognet,4,2,0,0,6
+Lackawanna,Archbald W-03 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,U.S. House,8,REP,Mike Marsicano,5,0,0,0,5
+Lackawanna,Archbald W-03 P-00,U.S. House,8,REP,Earl Granville,8,8,0,1,17
+Lackawanna,Archbald W-03 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-03 P-00,General Assembly,112,REP,Write-in,1,2,0,1,4
+Lackawanna,Archbald W-04 P-01,Registered Voters,,,,,,,,1315
+Lackawanna,Archbald W-04 P-01,Registered Voters,,DEM,,,,,,1004
+Lackawanna,Archbald W-04 P-01,Registered Voters,,REP,,,,,,311
+Lackawanna,Archbald W-04 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Archbald W-04 P-01,Ballots Cast,,,,236,357,48,10,651
+Lackawanna,Archbald W-04 P-01,Ballots Cast,,DEM,,150,323,45,7,525
+Lackawanna,Archbald W-04 P-01,Ballots Cast,,REP,,86,34,3,3,126
+Lackawanna,Archbald W-04 P-01,President,,DEM,Bernie Sanders,25,27,4,1,57
+Lackawanna,Archbald W-04 P-01,President,,DEM,Joseph R. Biden,90,273,32,6,401
+Lackawanna,Archbald W-04 P-01,President,,DEM,Tulsi Gabbard,8,8,4,0,20
+Lackawanna,Archbald W-04 P-01,President,,DEM,Write-in,10,6,3,0,19
+Lackawanna,Archbald W-04 P-01,Attorney General,,DEM,Josh Shapiro,103,274,35,6,418
+Lackawanna,Archbald W-04 P-01,Attorney General,,DEM,Write-in,7,3,2,0,12
+Lackawanna,Archbald W-04 P-01,Auditor General,,DEM,H. Scott Conklin,6,18,1,3,28
+Lackawanna,Archbald W-04 P-01,Auditor General,,DEM,Michael Lamb,22,37,5,2,66
+Lackawanna,Archbald W-04 P-01,Auditor General,,DEM,Tracie Fountain,5,14,3,0,22
+Lackawanna,Archbald W-04 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,17,73,10,1,101
+Lackawanna,Archbald W-04 P-01,Auditor General,,DEM,Nina Ahmad,43,91,12,1,147
+Lackawanna,Archbald W-04 P-01,Auditor General,,DEM,Christina M. Hartman,18,35,7,0,60
+Lackawanna,Archbald W-04 P-01,Auditor General,,DEM,Write-in,4,2,0,0,6
+Lackawanna,Archbald W-04 P-01,State Treasurer,,DEM,Joe Torsella,96,262,39,5,402
+Lackawanna,Archbald W-04 P-01,State Treasurer,,DEM,Write-in,6,1,0,0,7
+Lackawanna,Archbald W-04 P-01,U.S. House,8,DEM,Matt Cartwright,115,304,36,7,462
+Lackawanna,Archbald W-04 P-01,U.S. House,8,DEM,Write-in,12,3,4,0,19
+Lackawanna,Archbald W-04 P-01,General Assembly,112,DEM,Kyle J. Mullins,129,310,42,7,488
+Lackawanna,Archbald W-04 P-01,General Assembly,112,DEM,Write-in,6,0,0,0,6
+Lackawanna,Archbald W-04 P-01,President,,REP,Donald J. Trump,83,23,3,3,112
+Lackawanna,Archbald W-04 P-01,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Lackawanna,Archbald W-04 P-01,President,,REP,Bill Weld,0,5,0,0,5
+Lackawanna,Archbald W-04 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-04 P-01,Attorney General,,REP,Heather Heidelbaugh,51,25,1,2,79
+Lackawanna,Archbald W-04 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-04 P-01,Auditor General,,REP,Timothy DeFoor,50,25,1,2,78
+Lackawanna,Archbald W-04 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-04 P-01,State Treasurer,,REP,Stacy L. Garrity,48,26,1,2,77
+Lackawanna,Archbald W-04 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-04 P-01,U.S. House,8,REP,Harry Haas,0,1,0,0,1
+Lackawanna,Archbald W-04 P-01,U.S. House,8,REP,Teddy Daniels,19,0,0,1,20
+Lackawanna,Archbald W-04 P-01,U.S. House,8,REP,Jim Bognet,20,3,0,0,23
+Lackawanna,Archbald W-04 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,1,1
+Lackawanna,Archbald W-04 P-01,U.S. House,8,REP,Mike Marsicano,5,5,0,0,10
+Lackawanna,Archbald W-04 P-01,U.S. House,8,REP,Earl Granville,37,23,1,1,62
+Lackawanna,Archbald W-04 P-01,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-04 P-01,General Assembly,112,REP,Write-in,4,6,0,2,12
+Lackawanna,Archbald W-04 P-02,Registered Voters,,,,,,,,227
+Lackawanna,Archbald W-04 P-02,Registered Voters,,DEM,,,,,,165
+Lackawanna,Archbald W-04 P-02,Registered Voters,,REP,,,,,,62
+Lackawanna,Archbald W-04 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Archbald W-04 P-02,Ballots Cast,,,,50,52,7,2,111
+Lackawanna,Archbald W-04 P-02,Ballots Cast,,DEM,,30,45,4,2,81
+Lackawanna,Archbald W-04 P-02,Ballots Cast,,REP,,20,7,3,0,30
+Lackawanna,Archbald W-04 P-02,President,,DEM,Bernie Sanders,10,2,1,1,14
+Lackawanna,Archbald W-04 P-02,President,,DEM,Joseph R. Biden,19,39,3,1,62
+Lackawanna,Archbald W-04 P-02,President,,DEM,Tulsi Gabbard,0,1,0,0,1
+Lackawanna,Archbald W-04 P-02,President,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Archbald W-04 P-02,Attorney General,,DEM,Josh Shapiro,25,41,4,2,72
+Lackawanna,Archbald W-04 P-02,Attorney General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-04 P-02,Auditor General,,DEM,H. Scott Conklin,4,1,0,0,5
+Lackawanna,Archbald W-04 P-02,Auditor General,,DEM,Michael Lamb,9,15,1,0,25
+Lackawanna,Archbald W-04 P-02,Auditor General,,DEM,Tracie Fountain,0,4,2,0,6
+Lackawanna,Archbald W-04 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,4,4,1,1,10
+Lackawanna,Archbald W-04 P-02,Auditor General,,DEM,Nina Ahmad,6,16,0,0,22
+Lackawanna,Archbald W-04 P-02,Auditor General,,DEM,Christina M. Hartman,3,3,0,0,6
+Lackawanna,Archbald W-04 P-02,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-04 P-02,State Treasurer,,DEM,Joe Torsella,24,42,4,1,71
+Lackawanna,Archbald W-04 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-04 P-02,U.S. House,8,DEM,Matt Cartwright,23,41,4,2,70
+Lackawanna,Archbald W-04 P-02,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Archbald W-04 P-02,General Assembly,112,DEM,Kyle J. Mullins,27,41,4,2,74
+Lackawanna,Archbald W-04 P-02,General Assembly,112,DEM,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-04 P-02,President,,REP,Donald J. Trump,19,4,3,0,26
+Lackawanna,Archbald W-04 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Archbald W-04 P-02,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Archbald W-04 P-02,President,,REP,Write-in,0,2,0,0,2
+Lackawanna,Archbald W-04 P-02,Attorney General,,REP,Heather Heidelbaugh,15,6,2,0,23
+Lackawanna,Archbald W-04 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Archbald W-04 P-02,Auditor General,,REP,Timothy DeFoor,15,6,2,0,23
+Lackawanna,Archbald W-04 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-04 P-02,State Treasurer,,REP,Stacy L. Garrity,16,6,2,0,24
+Lackawanna,Archbald W-04 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Archbald W-04 P-02,U.S. House,8,REP,Harry Haas,0,0,1,0,1
+Lackawanna,Archbald W-04 P-02,U.S. House,8,REP,Teddy Daniels,10,1,0,0,11
+Lackawanna,Archbald W-04 P-02,U.S. House,8,REP,Jim Bognet,4,0,0,0,4
+Lackawanna,Archbald W-04 P-02,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Archbald W-04 P-02,U.S. House,8,REP,Mike Marsicano,0,0,1,0,1
+Lackawanna,Archbald W-04 P-02,U.S. House,8,REP,Earl Granville,5,5,0,0,10
+Lackawanna,Archbald W-04 P-02,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Archbald W-04 P-02,General Assembly,112,REP,Write-in,1,2,0,0,3
+Lackawanna,Benton Township W-00 P-00,Registered Voters,,,,,,,,1209
+Lackawanna,Benton Township W-00 P-00,Registered Voters,,DEM,,,,,,481
+Lackawanna,Benton Township W-00 P-00,Registered Voters,,REP,,,,,,728
+Lackawanna,Benton Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Benton Township W-00 P-00,Ballots Cast,,,,248,224,39,9,520
+Lackawanna,Benton Township W-00 P-00,Ballots Cast,,DEM,,56,139,26,3,224
+Lackawanna,Benton Township W-00 P-00,Ballots Cast,,REP,,192,85,13,6,296
+Lackawanna,Benton Township W-00 P-00,President,,DEM,Bernie Sanders,11,15,3,1,30
+Lackawanna,Benton Township W-00 P-00,President,,DEM,Joseph R. Biden,41,120,23,2,186
+Lackawanna,Benton Township W-00 P-00,President,,DEM,Tulsi Gabbard,3,1,0,0,4
+Lackawanna,Benton Township W-00 P-00,President,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Benton Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,47,128,23,3,201
+Lackawanna,Benton Township W-00 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Benton Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,5,8,4,0,17
+Lackawanna,Benton Township W-00 P-00,Auditor General,,DEM,Michael Lamb,12,25,4,0,41
+Lackawanna,Benton Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,1,16,2,0,19
+Lackawanna,Benton Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,6,21,4,3,34
+Lackawanna,Benton Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,19,25,1,0,45
+Lackawanna,Benton Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,6,24,5,0,35
+Lackawanna,Benton Township W-00 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Benton Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,48,120,22,2,192
+Lackawanna,Benton Township W-00 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,53,132,23,3,211
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,DEM,Write-in,0,1,1,0,2
+Lackawanna,Benton Township W-00 P-00,General Assembly,117,DEM,Write-in,3,11,1,0,15
+Lackawanna,Benton Township W-00 P-00,President,,REP,Donald J. Trump,172,50,10,6,238
+Lackawanna,Benton Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,6,7,1,0,14
+Lackawanna,Benton Township W-00 P-00,President,,REP,Bill Weld,7,18,2,0,27
+Lackawanna,Benton Township W-00 P-00,President,,REP,Write-in,1,5,0,0,6
+Lackawanna,Benton Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,148,68,11,5,232
+Lackawanna,Benton Township W-00 P-00,Attorney General,,REP,Write-in,2,2,0,0,4
+Lackawanna,Benton Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,149,69,10,5,233
+Lackawanna,Benton Township W-00 P-00,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Benton Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,149,68,10,5,232
+Lackawanna,Benton Township W-00 P-00,State Treasurer,,REP,Write-in,1,2,0,0,3
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,REP,Harry Haas,11,4,0,0,15
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,29,5,3,2,39
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,REP,Jim Bognet,45,13,2,1,61
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,1,2,0,0,3
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,13,5,0,0,18
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,REP,Earl Granville,83,53,7,2,145
+Lackawanna,Benton Township W-00 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Benton Township W-00 P-00,General Assembly,117,REP,Karen Boback,163,72,10,2,247
+Lackawanna,Benton Township W-00 P-00,General Assembly,117,REP,Write-in,1,4,0,0,5
+Lackawanna,Blakely W-01 P-01,Registered Voters,,,,,,,,808
+Lackawanna,Blakely W-01 P-01,Registered Voters,,DEM,,,,,,560
+Lackawanna,Blakely W-01 P-01,Registered Voters,,REP,,,,,,248
+Lackawanna,Blakely W-01 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Blakely W-01 P-01,Ballots Cast,,,,205,142,28,6,381
+Lackawanna,Blakely W-01 P-01,Ballots Cast,,DEM,,130,125,24,4,283
+Lackawanna,Blakely W-01 P-01,Ballots Cast,,REP,,75,17,4,2,98
+Lackawanna,Blakely W-01 P-01,President,,DEM,Bernie Sanders,21,14,6,2,43
+Lackawanna,Blakely W-01 P-01,President,,DEM,Joseph R. Biden,86,105,17,2,210
+Lackawanna,Blakely W-01 P-01,President,,DEM,Tulsi Gabbard,10,2,0,0,12
+Lackawanna,Blakely W-01 P-01,President,,DEM,Write-in,6,3,0,0,9
+Lackawanna,Blakely W-01 P-01,Attorney General,,DEM,Josh Shapiro,100,105,18,4,227
+Lackawanna,Blakely W-01 P-01,Attorney General,,DEM,Write-in,2,2,2,0,6
+Lackawanna,Blakely W-01 P-01,Auditor General,,DEM,H. Scott Conklin,5,9,1,0,15
+Lackawanna,Blakely W-01 P-01,Auditor General,,DEM,Michael Lamb,17,13,1,0,31
+Lackawanna,Blakely W-01 P-01,Auditor General,,DEM,Tracie Fountain,5,9,0,0,14
+Lackawanna,Blakely W-01 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,15,24,10,0,49
+Lackawanna,Blakely W-01 P-01,Auditor General,,DEM,Nina Ahmad,54,36,6,2,98
+Lackawanna,Blakely W-01 P-01,Auditor General,,DEM,Christina M. Hartman,16,17,3,1,37
+Lackawanna,Blakely W-01 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Blakely W-01 P-01,State Treasurer,,DEM,Joe Torsella,96,105,17,3,221
+Lackawanna,Blakely W-01 P-01,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Blakely W-01 P-01,U.S. House,8,DEM,Matt Cartwright,105,117,24,4,250
+Lackawanna,Blakely W-01 P-01,U.S. House,8,DEM,Write-in,4,0,0,0,4
+Lackawanna,Blakely W-01 P-01,General Assembly,112,DEM,Kyle J. Mullins,116,118,24,3,261
+Lackawanna,Blakely W-01 P-01,General Assembly,112,DEM,Write-in,4,0,0,0,4
+Lackawanna,Blakely W-01 P-01,President,,REP,Donald J. Trump,68,13,4,0,85
+Lackawanna,Blakely W-01 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Blakely W-01 P-01,President,,REP,Bill Weld,3,2,0,1,6
+Lackawanna,Blakely W-01 P-01,President,,REP,Write-in,0,1,0,1,2
+Lackawanna,Blakely W-01 P-01,Attorney General,,REP,Heather Heidelbaugh,56,14,4,2,76
+Lackawanna,Blakely W-01 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-01 P-01,Auditor General,,REP,Timothy DeFoor,55,14,4,2,75
+Lackawanna,Blakely W-01 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-01 P-01,State Treasurer,,REP,Stacy L. Garrity,52,14,4,2,72
+Lackawanna,Blakely W-01 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-01 P-01,U.S. House,8,REP,Harry Haas,2,0,1,0,3
+Lackawanna,Blakely W-01 P-01,U.S. House,8,REP,Teddy Daniels,11,4,0,0,15
+Lackawanna,Blakely W-01 P-01,U.S. House,8,REP,Jim Bognet,10,2,1,1,14
+Lackawanna,Blakely W-01 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Blakely W-01 P-01,U.S. House,8,REP,Mike Marsicano,8,0,0,0,8
+Lackawanna,Blakely W-01 P-01,U.S. House,8,REP,Earl Granville,39,10,2,1,52
+Lackawanna,Blakely W-01 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-01 P-01,General Assembly,112,REP,Write-in,9,6,1,0,16
+Lackawanna,Blakely W-02 P-01,Registered Voters,,,,,,,,1002
+Lackawanna,Blakely W-02 P-01,Registered Voters,,DEM,,,,,,672
+Lackawanna,Blakely W-02 P-01,Registered Voters,,REP,,,,,,330
+Lackawanna,Blakely W-02 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Blakely W-02 P-01,Ballots Cast,,,,234,167,26,3,430
+Lackawanna,Blakely W-02 P-01,Ballots Cast,,DEM,,127,141,20,0,288
+Lackawanna,Blakely W-02 P-01,Ballots Cast,,REP,,107,26,6,3,142
+Lackawanna,Blakely W-02 P-01,President,,DEM,Bernie Sanders,31,13,5,0,49
+Lackawanna,Blakely W-02 P-01,President,,DEM,Joseph R. Biden,73,122,14,0,209
+Lackawanna,Blakely W-02 P-01,President,,DEM,Tulsi Gabbard,3,5,1,0,9
+Lackawanna,Blakely W-02 P-01,President,,DEM,Write-in,11,0,0,0,11
+Lackawanna,Blakely W-02 P-01,Attorney General,,DEM,Josh Shapiro,89,127,18,0,234
+Lackawanna,Blakely W-02 P-01,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Blakely W-02 P-01,Auditor General,,DEM,H. Scott Conklin,9,9,0,0,18
+Lackawanna,Blakely W-02 P-01,Auditor General,,DEM,Michael Lamb,16,22,3,0,41
+Lackawanna,Blakely W-02 P-01,Auditor General,,DEM,Tracie Fountain,10,9,1,0,20
+Lackawanna,Blakely W-02 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,15,32,1,0,48
+Lackawanna,Blakely W-02 P-01,Auditor General,,DEM,Nina Ahmad,29,28,10,0,67
+Lackawanna,Blakely W-02 P-01,Auditor General,,DEM,Christina M. Hartman,22,24,1,0,47
+Lackawanna,Blakely W-02 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Blakely W-02 P-01,State Treasurer,,DEM,Joe Torsella,87,118,18,0,223
+Lackawanna,Blakely W-02 P-01,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Blakely W-02 P-01,U.S. House,8,DEM,Matt Cartwright,99,133,20,0,252
+Lackawanna,Blakely W-02 P-01,U.S. House,8,DEM,Write-in,8,1,0,0,9
+Lackawanna,Blakely W-02 P-01,General Assembly,112,DEM,Kyle J. Mullins,98,135,20,0,253
+Lackawanna,Blakely W-02 P-01,General Assembly,112,DEM,Write-in,13,0,0,0,13
+Lackawanna,Blakely W-02 P-01,President,,REP,Donald J. Trump,99,18,5,3,125
+Lackawanna,Blakely W-02 P-01,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Blakely W-02 P-01,President,,REP,Bill Weld,2,2,0,0,4
+Lackawanna,Blakely W-02 P-01,President,,REP,Write-in,3,5,1,0,9
+Lackawanna,Blakely W-02 P-01,Attorney General,,REP,Heather Heidelbaugh,68,20,5,2,95
+Lackawanna,Blakely W-02 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-02 P-01,Auditor General,,REP,Timothy DeFoor,69,19,4,2,94
+Lackawanna,Blakely W-02 P-01,Auditor General,,REP,Write-in,0,0,1,0,1
+Lackawanna,Blakely W-02 P-01,State Treasurer,,REP,Stacy L. Garrity,69,20,5,2,96
+Lackawanna,Blakely W-02 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-02 P-01,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Blakely W-02 P-01,U.S. House,8,REP,Teddy Daniels,35,1,0,0,36
+Lackawanna,Blakely W-02 P-01,U.S. House,8,REP,Jim Bognet,15,2,2,0,19
+Lackawanna,Blakely W-02 P-01,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Blakely W-02 P-01,U.S. House,8,REP,Mike Marsicano,12,0,0,0,12
+Lackawanna,Blakely W-02 P-01,U.S. House,8,REP,Earl Granville,41,21,4,3,69
+Lackawanna,Blakely W-02 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-02 P-01,General Assembly,112,REP,Write-in,32,5,3,1,41
+Lackawanna,Blakely W-03 P-01,Registered Voters,,,,,,,,1080
+Lackawanna,Blakely W-03 P-01,Registered Voters,,DEM,,,,,,774
+Lackawanna,Blakely W-03 P-01,Registered Voters,,REP,,,,,,306
+Lackawanna,Blakely W-03 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Blakely W-03 P-01,Ballots Cast,,,,196,232,38,6,472
+Lackawanna,Blakely W-03 P-01,Ballots Cast,,DEM,,110,199,33,3,345
+Lackawanna,Blakely W-03 P-01,Ballots Cast,,REP,,86,33,5,3,127
+Lackawanna,Blakely W-03 P-01,President,,DEM,Bernie Sanders,15,20,4,0,39
+Lackawanna,Blakely W-03 P-01,President,,DEM,Joseph R. Biden,74,161,28,2,265
+Lackawanna,Blakely W-03 P-01,President,,DEM,Tulsi Gabbard,2,7,0,0,9
+Lackawanna,Blakely W-03 P-01,President,,DEM,Write-in,13,4,0,1,18
+Lackawanna,Blakely W-03 P-01,Attorney General,,DEM,Josh Shapiro,81,177,29,3,290
+Lackawanna,Blakely W-03 P-01,Attorney General,,DEM,Write-in,5,1,0,0,6
+Lackawanna,Blakely W-03 P-01,Auditor General,,DEM,H. Scott Conklin,8,6,1,0,15
+Lackawanna,Blakely W-03 P-01,Auditor General,,DEM,Michael Lamb,18,40,5,0,63
+Lackawanna,Blakely W-03 P-01,Auditor General,,DEM,Tracie Fountain,3,9,4,0,16
+Lackawanna,Blakely W-03 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,13,44,8,1,66
+Lackawanna,Blakely W-03 P-01,Auditor General,,DEM,Nina Ahmad,37,37,4,2,80
+Lackawanna,Blakely W-03 P-01,Auditor General,,DEM,Christina M. Hartman,10,34,6,0,50
+Lackawanna,Blakely W-03 P-01,Auditor General,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Blakely W-03 P-01,State Treasurer,,DEM,Joe Torsella,80,171,29,3,283
+Lackawanna,Blakely W-03 P-01,State Treasurer,,DEM,Write-in,4,1,0,0,5
+Lackawanna,Blakely W-03 P-01,U.S. House,8,DEM,Matt Cartwright,92,187,31,2,312
+Lackawanna,Blakely W-03 P-01,U.S. House,8,DEM,Write-in,8,2,0,1,11
+Lackawanna,Blakely W-03 P-01,General Assembly,112,DEM,Kyle J. Mullins,100,190,31,3,324
+Lackawanna,Blakely W-03 P-01,General Assembly,112,DEM,Write-in,3,1,0,0,4
+Lackawanna,Blakely W-03 P-01,President,,REP,Donald J. Trump,82,20,4,3,109
+Lackawanna,Blakely W-03 P-01,President,,REP,Roque Rocky De La Fuente,1,2,1,0,4
+Lackawanna,Blakely W-03 P-01,President,,REP,Bill Weld,0,7,0,0,7
+Lackawanna,Blakely W-03 P-01,President,,REP,Write-in,3,3,0,0,6
+Lackawanna,Blakely W-03 P-01,Attorney General,,REP,Heather Heidelbaugh,65,27,5,3,100
+Lackawanna,Blakely W-03 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-03 P-01,Auditor General,,REP,Timothy DeFoor,64,27,5,3,99
+Lackawanna,Blakely W-03 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-03 P-01,State Treasurer,,REP,Stacy L. Garrity,66,26,5,3,100
+Lackawanna,Blakely W-03 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-03 P-01,U.S. House,8,REP,Harry Haas,3,1,0,0,4
+Lackawanna,Blakely W-03 P-01,U.S. House,8,REP,Teddy Daniels,23,1,0,2,26
+Lackawanna,Blakely W-03 P-01,U.S. House,8,REP,Jim Bognet,15,7,0,1,23
+Lackawanna,Blakely W-03 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Blakely W-03 P-01,U.S. House,8,REP,Mike Marsicano,4,0,1,0,5
+Lackawanna,Blakely W-03 P-01,U.S. House,8,REP,Earl Granville,40,23,4,0,67
+Lackawanna,Blakely W-03 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-03 P-01,General Assembly,112,REP,Write-in,15,4,2,0,21
+Lackawanna,Blakely W-03 P-02,Registered Voters,,,,,,,,1281
+Lackawanna,Blakely W-03 P-02,Registered Voters,,DEM,,,,,,899
+Lackawanna,Blakely W-03 P-02,Registered Voters,,REP,,,,,,382
+Lackawanna,Blakely W-03 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Blakely W-03 P-02,Ballots Cast,,,,259,275,60,17,611
+Lackawanna,Blakely W-03 P-02,Ballots Cast,,DEM,,151,239,57,5,452
+Lackawanna,Blakely W-03 P-02,Ballots Cast,,REP,,108,36,3,12,159
+Lackawanna,Blakely W-03 P-02,President,,DEM,Bernie Sanders,22,21,5,1,49
+Lackawanna,Blakely W-03 P-02,President,,DEM,Joseph R. Biden,97,206,49,3,355
+Lackawanna,Blakely W-03 P-02,President,,DEM,Tulsi Gabbard,10,5,0,1,16
+Lackawanna,Blakely W-03 P-02,President,,DEM,Write-in,6,3,2,0,11
+Lackawanna,Blakely W-03 P-02,Attorney General,,DEM,Josh Shapiro,114,220,45,3,382
+Lackawanna,Blakely W-03 P-02,Attorney General,,DEM,Write-in,1,2,1,0,4
+Lackawanna,Blakely W-03 P-02,Auditor General,,DEM,H. Scott Conklin,8,9,4,0,21
+Lackawanna,Blakely W-03 P-02,Auditor General,,DEM,Michael Lamb,30,32,17,1,80
+Lackawanna,Blakely W-03 P-02,Auditor General,,DEM,Tracie Fountain,3,23,2,0,28
+Lackawanna,Blakely W-03 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,22,51,12,1,86
+Lackawanna,Blakely W-03 P-02,Auditor General,,DEM,Nina Ahmad,47,56,9,1,113
+Lackawanna,Blakely W-03 P-02,Auditor General,,DEM,Christina M. Hartman,20,33,6,0,59
+Lackawanna,Blakely W-03 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-03 P-02,State Treasurer,,DEM,Joe Torsella,110,208,49,3,370
+Lackawanna,Blakely W-03 P-02,State Treasurer,,DEM,Write-in,0,1,1,0,2
+Lackawanna,Blakely W-03 P-02,U.S. House,8,DEM,Matt Cartwright,122,227,48,4,401
+Lackawanna,Blakely W-03 P-02,U.S. House,8,DEM,Write-in,4,1,2,1,8
+Lackawanna,Blakely W-03 P-02,General Assembly,112,DEM,Kyle J. Mullins,136,229,56,4,425
+Lackawanna,Blakely W-03 P-02,General Assembly,112,DEM,Write-in,1,2,0,1,4
+Lackawanna,Blakely W-03 P-02,President,,REP,Donald J. Trump,103,22,3,12,140
+Lackawanna,Blakely W-03 P-02,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Blakely W-03 P-02,President,,REP,Bill Weld,1,6,0,0,7
+Lackawanna,Blakely W-03 P-02,President,,REP,Write-in,2,2,0,0,4
+Lackawanna,Blakely W-03 P-02,Attorney General,,REP,Heather Heidelbaugh,80,24,3,10,117
+Lackawanna,Blakely W-03 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Blakely W-03 P-02,Auditor General,,REP,Timothy DeFoor,79,24,3,10,116
+Lackawanna,Blakely W-03 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-03 P-02,State Treasurer,,REP,Stacy L. Garrity,81,25,3,10,119
+Lackawanna,Blakely W-03 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Blakely W-03 P-02,U.S. House,8,REP,Harry Haas,5,0,0,0,5
+Lackawanna,Blakely W-03 P-02,U.S. House,8,REP,Teddy Daniels,28,3,2,4,37
+Lackawanna,Blakely W-03 P-02,U.S. House,8,REP,Jim Bognet,14,4,0,4,22
+Lackawanna,Blakely W-03 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Blakely W-03 P-02,U.S. House,8,REP,Mike Marsicano,6,2,0,2,10
+Lackawanna,Blakely W-03 P-02,U.S. House,8,REP,Earl Granville,51,24,1,2,78
+Lackawanna,Blakely W-03 P-02,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Blakely W-03 P-02,General Assembly,112,REP,Write-in,36,3,1,4,44
+Lackawanna,Carbondale W-01 P-01,Registered Voters,,,,,,,,845
+Lackawanna,Carbondale W-01 P-01,Registered Voters,,DEM,,,,,,564
+Lackawanna,Carbondale W-01 P-01,Registered Voters,,REP,,,,,,281
+Lackawanna,Carbondale W-01 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-01 P-01,Ballots Cast,,,,186,119,31,2,338
+Lackawanna,Carbondale W-01 P-01,Ballots Cast,,DEM,,102,101,24,0,227
+Lackawanna,Carbondale W-01 P-01,Ballots Cast,,REP,,84,18,7,2,111
+Lackawanna,Carbondale W-01 P-01,President,,DEM,Bernie Sanders,22,12,3,0,37
+Lackawanna,Carbondale W-01 P-01,President,,DEM,Joseph R. Biden,71,84,20,0,175
+Lackawanna,Carbondale W-01 P-01,President,,DEM,Tulsi Gabbard,3,0,1,0,4
+Lackawanna,Carbondale W-01 P-01,President,,DEM,Write-in,2,3,0,0,5
+Lackawanna,Carbondale W-01 P-01,Attorney General,,DEM,Josh Shapiro,83,98,21,0,202
+Lackawanna,Carbondale W-01 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,Auditor General,,DEM,H. Scott Conklin,6,6,1,0,13
+Lackawanna,Carbondale W-01 P-01,Auditor General,,DEM,Michael Lamb,20,16,4,0,40
+Lackawanna,Carbondale W-01 P-01,Auditor General,,DEM,Tracie Fountain,4,9,1,0,14
+Lackawanna,Carbondale W-01 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,19,20,5,0,44
+Lackawanna,Carbondale W-01 P-01,Auditor General,,DEM,Nina Ahmad,24,20,5,0,49
+Lackawanna,Carbondale W-01 P-01,Auditor General,,DEM,Christina M. Hartman,10,14,5,0,29
+Lackawanna,Carbondale W-01 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,State Treasurer,,DEM,Joe Torsella,84,88,20,0,192
+Lackawanna,Carbondale W-01 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,DEM,Matt Cartwright,83,101,20,0,204
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,DEM,Write-in,5,0,1,0,6
+Lackawanna,Carbondale W-01 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,86,91,23,0,200
+Lackawanna,Carbondale W-01 P-01,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,President,,REP,Donald J. Trump,80,14,7,2,103
+Lackawanna,Carbondale W-01 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,President,,REP,Bill Weld,2,2,0,0,4
+Lackawanna,Carbondale W-01 P-01,President,,REP,Write-in,2,1,0,0,3
+Lackawanna,Carbondale W-01 P-01,Attorney General,,REP,Heather Heidelbaugh,55,13,5,2,75
+Lackawanna,Carbondale W-01 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,Auditor General,,REP,Timothy DeFoor,53,11,4,2,70
+Lackawanna,Carbondale W-01 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,State Treasurer,,REP,Stacy L. Garrity,57,12,5,2,76
+Lackawanna,Carbondale W-01 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,REP,Harry Haas,8,1,1,0,10
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,REP,Teddy Daniels,9,3,1,0,13
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,REP,Jim Bognet,9,1,1,0,11
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,REP,Earl Granville,53,12,4,2,71
+Lackawanna,Carbondale W-01 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-01,General Assembly,114,REP,James May,68,12,5,2,87
+Lackawanna,Carbondale W-01 P-01,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-02,Registered Voters,,,,,,,,454
+Lackawanna,Carbondale W-01 P-02,Registered Voters,,DEM,,,,,,324
+Lackawanna,Carbondale W-01 P-02,Registered Voters,,REP,,,,,,130
+Lackawanna,Carbondale W-01 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-01 P-02,Ballots Cast,,,,91,85,18,4,198
+Lackawanna,Carbondale W-01 P-02,Ballots Cast,,DEM,,59,67,14,3,143
+Lackawanna,Carbondale W-01 P-02,Ballots Cast,,REP,,32,18,4,1,55
+Lackawanna,Carbondale W-01 P-02,President,,DEM,Bernie Sanders,11,6,1,2,20
+Lackawanna,Carbondale W-01 P-02,President,,DEM,Joseph R. Biden,34,55,11,1,101
+Lackawanna,Carbondale W-01 P-02,President,,DEM,Tulsi Gabbard,3,2,0,0,5
+Lackawanna,Carbondale W-01 P-02,President,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Carbondale W-01 P-02,Attorney General,,DEM,Josh Shapiro,49,58,10,0,117
+Lackawanna,Carbondale W-01 P-02,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-01 P-02,Auditor General,,DEM,H. Scott Conklin,15,14,2,0,31
+Lackawanna,Carbondale W-01 P-02,Auditor General,,DEM,Michael Lamb,5,8,3,0,16
+Lackawanna,Carbondale W-01 P-02,Auditor General,,DEM,Tracie Fountain,4,1,1,0,6
+Lackawanna,Carbondale W-01 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,7,16,3,0,26
+Lackawanna,Carbondale W-01 P-02,Auditor General,,DEM,Nina Ahmad,10,8,2,0,20
+Lackawanna,Carbondale W-01 P-02,Auditor General,,DEM,Christina M. Hartman,8,10,2,0,20
+Lackawanna,Carbondale W-01 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-01 P-02,State Treasurer,,DEM,Joe Torsella,47,58,10,0,115
+Lackawanna,Carbondale W-01 P-02,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,DEM,Matt Cartwright,48,57,12,2,119
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,DEM,Write-in,4,2,1,0,7
+Lackawanna,Carbondale W-01 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,49,56,9,2,116
+Lackawanna,Carbondale W-01 P-02,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-01 P-02,President,,REP,Donald J. Trump,30,15,2,1,48
+Lackawanna,Carbondale W-01 P-02,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Lackawanna,Carbondale W-01 P-02,President,,REP,Bill Weld,1,0,1,0,2
+Lackawanna,Carbondale W-01 P-02,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Carbondale W-01 P-02,Attorney General,,REP,Heather Heidelbaugh,15,10,2,1,28
+Lackawanna,Carbondale W-01 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-02,Auditor General,,REP,Timothy DeFoor,14,10,2,1,27
+Lackawanna,Carbondale W-01 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-02,State Treasurer,,REP,Stacy L. Garrity,16,10,2,0,28
+Lackawanna,Carbondale W-01 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,REP,Teddy Daniels,3,2,0,0,5
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,REP,Jim Bognet,4,0,0,0,4
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,REP,Mike Marsicano,1,0,1,0,2
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,REP,Earl Granville,22,16,3,1,42
+Lackawanna,Carbondale W-01 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-01 P-02,General Assembly,114,REP,James May,16,10,3,0,29
+Lackawanna,Carbondale W-01 P-02,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,Registered Voters,,,,,,,,258
+Lackawanna,Carbondale W-03 P-01,Registered Voters,,DEM,,,,,,176
+Lackawanna,Carbondale W-03 P-01,Registered Voters,,REP,,,,,,82
+Lackawanna,Carbondale W-03 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-03 P-01,Ballots Cast,,,,46,57,8,2,113
+Lackawanna,Carbondale W-03 P-01,Ballots Cast,,DEM,,25,44,8,1,78
+Lackawanna,Carbondale W-03 P-01,Ballots Cast,,REP,,21,13,0,1,35
+Lackawanna,Carbondale W-03 P-01,President,,DEM,Bernie Sanders,1,3,0,0,4
+Lackawanna,Carbondale W-03 P-01,President,,DEM,Joseph R. Biden,20,40,8,0,68
+Lackawanna,Carbondale W-03 P-01,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Lackawanna,Carbondale W-03 P-01,President,,DEM,Write-in,3,1,0,1,5
+Lackawanna,Carbondale W-03 P-01,Attorney General,,DEM,Josh Shapiro,18,36,7,1,62
+Lackawanna,Carbondale W-03 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,Auditor General,,DEM,H. Scott Conklin,2,3,1,0,6
+Lackawanna,Carbondale W-03 P-01,Auditor General,,DEM,Michael Lamb,2,9,1,0,12
+Lackawanna,Carbondale W-03 P-01,Auditor General,,DEM,Tracie Fountain,3,1,0,0,4
+Lackawanna,Carbondale W-03 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,5,7,0,0,12
+Lackawanna,Carbondale W-03 P-01,Auditor General,,DEM,Nina Ahmad,2,6,2,1,11
+Lackawanna,Carbondale W-03 P-01,Auditor General,,DEM,Christina M. Hartman,3,11,2,0,16
+Lackawanna,Carbondale W-03 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,State Treasurer,,DEM,Joe Torsella,17,39,7,1,64
+Lackawanna,Carbondale W-03 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,DEM,Matt Cartwright,20,44,5,1,70
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,DEM,Write-in,3,0,2,0,5
+Lackawanna,Carbondale W-03 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,19,41,7,1,68
+Lackawanna,Carbondale W-03 P-01,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-03 P-01,President,,REP,Donald J. Trump,17,12,0,1,30
+Lackawanna,Carbondale W-03 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,President,,REP,Bill Weld,2,1,0,0,3
+Lackawanna,Carbondale W-03 P-01,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-03 P-01,Attorney General,,REP,Heather Heidelbaugh,15,9,0,1,25
+Lackawanna,Carbondale W-03 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,Auditor General,,REP,Timothy DeFoor,15,9,0,0,24
+Lackawanna,Carbondale W-03 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,State Treasurer,,REP,Stacy L. Garrity,14,9,0,0,23
+Lackawanna,Carbondale W-03 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,REP,Harry Haas,4,1,0,0,5
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,REP,Teddy Daniels,1,1,0,0,2
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,REP,Jim Bognet,1,1,0,0,2
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,REP,Mike Marsicano,2,1,0,0,3
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,REP,Earl Granville,13,9,0,1,23
+Lackawanna,Carbondale W-03 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-01,General Assembly,114,REP,James May,16,10,0,1,27
+Lackawanna,Carbondale W-03 P-01,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-02,Registered Voters,,,,,,,,482
+Lackawanna,Carbondale W-03 P-02,Registered Voters,,DEM,,,,,,316
+Lackawanna,Carbondale W-03 P-02,Registered Voters,,REP,,,,,,166
+Lackawanna,Carbondale W-03 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-03 P-02,Ballots Cast,,,,114,73,13,2,202
+Lackawanna,Carbondale W-03 P-02,Ballots Cast,,DEM,,56,58,11,1,126
+Lackawanna,Carbondale W-03 P-02,Ballots Cast,,REP,,58,15,2,1,76
+Lackawanna,Carbondale W-03 P-02,President,,DEM,Bernie Sanders,12,5,2,0,19
+Lackawanna,Carbondale W-03 P-02,President,,DEM,Joseph R. Biden,35,49,8,1,93
+Lackawanna,Carbondale W-03 P-02,President,,DEM,Tulsi Gabbard,0,2,0,0,2
+Lackawanna,Carbondale W-03 P-02,President,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Carbondale W-03 P-02,Attorney General,,DEM,Josh Shapiro,39,48,10,1,98
+Lackawanna,Carbondale W-03 P-02,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Carbondale W-03 P-02,Auditor General,,DEM,H. Scott Conklin,4,9,0,0,13
+Lackawanna,Carbondale W-03 P-02,Auditor General,,DEM,Michael Lamb,8,4,3,0,15
+Lackawanna,Carbondale W-03 P-02,Auditor General,,DEM,Tracie Fountain,0,1,1,0,2
+Lackawanna,Carbondale W-03 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,9,20,3,0,32
+Lackawanna,Carbondale W-03 P-02,Auditor General,,DEM,Nina Ahmad,16,8,1,1,26
+Lackawanna,Carbondale W-03 P-02,Auditor General,,DEM,Christina M. Hartman,11,12,1,0,24
+Lackawanna,Carbondale W-03 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-03 P-02,State Treasurer,,DEM,Joe Torsella,44,49,10,1,104
+Lackawanna,Carbondale W-03 P-02,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,DEM,Matt Cartwright,44,57,9,1,111
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Carbondale W-03 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,47,55,9,1,112
+Lackawanna,Carbondale W-03 P-02,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-03 P-02,President,,REP,Donald J. Trump,55,14,2,1,72
+Lackawanna,Carbondale W-03 P-02,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Carbondale W-03 P-02,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-02,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-03 P-02,Attorney General,,REP,Heather Heidelbaugh,43,9,2,1,55
+Lackawanna,Carbondale W-03 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-02,Auditor General,,REP,Timothy DeFoor,43,8,2,1,54
+Lackawanna,Carbondale W-03 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-02,State Treasurer,,REP,Stacy L. Garrity,41,9,2,1,53
+Lackawanna,Carbondale W-03 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,REP,Teddy Daniels,14,0,0,0,14
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,REP,Jim Bognet,3,2,0,0,5
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,REP,Mike Marsicano,2,0,0,0,2
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,REP,Earl Granville,39,13,2,1,55
+Lackawanna,Carbondale W-03 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-02,General Assembly,114,REP,James May,44,10,2,1,57
+Lackawanna,Carbondale W-03 P-02,General Assembly,114,REP,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-03 P-03,Registered Voters,,,,,,,,716
+Lackawanna,Carbondale W-03 P-03,Registered Voters,,DEM,,,,,,470
+Lackawanna,Carbondale W-03 P-03,Registered Voters,,REP,,,,,,246
+Lackawanna,Carbondale W-03 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-03 P-03,Ballots Cast,,,,131,110,25,2,268
+Lackawanna,Carbondale W-03 P-03,Ballots Cast,,DEM,,59,91,22,0,172
+Lackawanna,Carbondale W-03 P-03,Ballots Cast,,REP,,72,19,3,2,96
+Lackawanna,Carbondale W-03 P-03,President,,DEM,Bernie Sanders,8,13,4,0,25
+Lackawanna,Carbondale W-03 P-03,President,,DEM,Joseph R. Biden,42,68,17,0,127
+Lackawanna,Carbondale W-03 P-03,President,,DEM,Tulsi Gabbard,2,2,1,0,5
+Lackawanna,Carbondale W-03 P-03,President,,DEM,Write-in,5,5,0,0,10
+Lackawanna,Carbondale W-03 P-03,Attorney General,,DEM,Josh Shapiro,45,78,21,0,144
+Lackawanna,Carbondale W-03 P-03,Attorney General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Carbondale W-03 P-03,Auditor General,,DEM,H. Scott Conklin,4,4,1,0,9
+Lackawanna,Carbondale W-03 P-03,Auditor General,,DEM,Michael Lamb,13,17,2,0,32
+Lackawanna,Carbondale W-03 P-03,Auditor General,,DEM,Tracie Fountain,3,8,5,0,16
+Lackawanna,Carbondale W-03 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,7,21,5,0,33
+Lackawanna,Carbondale W-03 P-03,Auditor General,,DEM,Nina Ahmad,8,10,6,0,24
+Lackawanna,Carbondale W-03 P-03,Auditor General,,DEM,Christina M. Hartman,7,18,2,0,27
+Lackawanna,Carbondale W-03 P-03,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-03 P-03,State Treasurer,,DEM,Joe Torsella,43,76,20,0,139
+Lackawanna,Carbondale W-03 P-03,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,DEM,Matt Cartwright,49,80,22,0,151
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,DEM,Write-in,3,2,0,0,5
+Lackawanna,Carbondale W-03 P-03,General Assembly,114,DEM,Bridget Malloy Kosierowski,45,78,21,0,144
+Lackawanna,Carbondale W-03 P-03,General Assembly,114,DEM,Write-in,1,3,0,0,4
+Lackawanna,Carbondale W-03 P-03,President,,REP,Donald J. Trump,67,10,2,2,81
+Lackawanna,Carbondale W-03 P-03,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-03,President,,REP,Bill Weld,1,6,0,0,7
+Lackawanna,Carbondale W-03 P-03,President,,REP,Write-in,0,1,1,0,2
+Lackawanna,Carbondale W-03 P-03,Attorney General,,REP,Heather Heidelbaugh,52,13,2,0,67
+Lackawanna,Carbondale W-03 P-03,Attorney General,,REP,Write-in,0,0,1,0,1
+Lackawanna,Carbondale W-03 P-03,Auditor General,,REP,Timothy DeFoor,50,14,2,0,66
+Lackawanna,Carbondale W-03 P-03,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-03,State Treasurer,,REP,Stacy L. Garrity,50,15,2,0,67
+Lackawanna,Carbondale W-03 P-03,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,REP,Harry Haas,2,0,0,0,2
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,REP,Teddy Daniels,7,0,0,0,7
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,REP,Jim Bognet,3,1,0,0,4
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,REP,Mike Marsicano,1,1,0,0,2
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,REP,Earl Granville,57,13,2,2,74
+Lackawanna,Carbondale W-03 P-03,U.S. House,8,REP,Write-in,0,1,1,0,2
+Lackawanna,Carbondale W-03 P-03,General Assembly,114,REP,James May,51,15,2,1,69
+Lackawanna,Carbondale W-03 P-03,General Assembly,114,REP,Write-in,0,0,1,0,1
+Lackawanna,Carbondale W-04 P-01,Registered Voters,,,,,,,,563
+Lackawanna,Carbondale W-04 P-01,Registered Voters,,DEM,,,,,,390
+Lackawanna,Carbondale W-04 P-01,Registered Voters,,REP,,,,,,173
+Lackawanna,Carbondale W-04 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-04 P-01,Ballots Cast,,,,145,69,10,3,227
+Lackawanna,Carbondale W-04 P-01,Ballots Cast,,DEM,,79,63,10,1,153
+Lackawanna,Carbondale W-04 P-01,Ballots Cast,,REP,,66,6,0,2,74
+Lackawanna,Carbondale W-04 P-01,President,,DEM,Bernie Sanders,16,6,1,0,23
+Lackawanna,Carbondale W-04 P-01,President,,DEM,Joseph R. Biden,50,54,9,1,114
+Lackawanna,Carbondale W-04 P-01,President,,DEM,Tulsi Gabbard,2,3,0,0,5
+Lackawanna,Carbondale W-04 P-01,President,,DEM,Write-in,4,0,0,0,4
+Lackawanna,Carbondale W-04 P-01,Attorney General,,DEM,Josh Shapiro,62,59,9,0,130
+Lackawanna,Carbondale W-04 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-04 P-01,Auditor General,,DEM,H. Scott Conklin,5,2,0,0,7
+Lackawanna,Carbondale W-04 P-01,Auditor General,,DEM,Michael Lamb,19,5,0,1,25
+Lackawanna,Carbondale W-04 P-01,Auditor General,,DEM,Tracie Fountain,4,2,0,0,6
+Lackawanna,Carbondale W-04 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,17,16,2,0,35
+Lackawanna,Carbondale W-04 P-01,Auditor General,,DEM,Nina Ahmad,14,12,4,0,30
+Lackawanna,Carbondale W-04 P-01,Auditor General,,DEM,Christina M. Hartman,7,13,3,0,23
+Lackawanna,Carbondale W-04 P-01,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Carbondale W-04 P-01,State Treasurer,,DEM,Joe Torsella,55,54,9,0,118
+Lackawanna,Carbondale W-04 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,DEM,Matt Cartwright,65,60,10,1,136
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Carbondale W-04 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,59,53,9,0,121
+Lackawanna,Carbondale W-04 P-01,General Assembly,114,DEM,Write-in,2,1,0,0,3
+Lackawanna,Carbondale W-04 P-01,President,,REP,Donald J. Trump,66,5,0,1,72
+Lackawanna,Carbondale W-04 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Carbondale W-04 P-01,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Carbondale W-04 P-01,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-04 P-01,Attorney General,,REP,Heather Heidelbaugh,48,6,0,1,55
+Lackawanna,Carbondale W-04 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-04 P-01,Auditor General,,REP,Timothy DeFoor,41,6,0,1,48
+Lackawanna,Carbondale W-04 P-01,Auditor General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Carbondale W-04 P-01,State Treasurer,,REP,Stacy L. Garrity,45,6,0,1,52
+Lackawanna,Carbondale W-04 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,REP,Harry Haas,4,0,0,0,4
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,REP,Teddy Daniels,9,0,0,0,9
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,REP,Jim Bognet,1,0,0,0,1
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,REP,Mike Marsicano,5,0,0,1,6
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,REP,Earl Granville,47,6,0,1,54
+Lackawanna,Carbondale W-04 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-04 P-01,General Assembly,114,REP,James May,45,6,0,1,52
+Lackawanna,Carbondale W-04 P-01,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,Registered Voters,,,,,,,,358
+Lackawanna,Carbondale W-05 P-01,Registered Voters,,DEM,,,,,,226
+Lackawanna,Carbondale W-05 P-01,Registered Voters,,REP,,,,,,132
+Lackawanna,Carbondale W-05 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-05 P-01,Ballots Cast,,,,75,50,11,1,137
+Lackawanna,Carbondale W-05 P-01,Ballots Cast,,DEM,,28,38,11,0,77
+Lackawanna,Carbondale W-05 P-01,Ballots Cast,,REP,,47,12,0,1,60
+Lackawanna,Carbondale W-05 P-01,President,,DEM,Bernie Sanders,3,5,2,0,10
+Lackawanna,Carbondale W-05 P-01,President,,DEM,Joseph R. Biden,17,29,9,0,55
+Lackawanna,Carbondale W-05 P-01,President,,DEM,Tulsi Gabbard,5,3,0,0,8
+Lackawanna,Carbondale W-05 P-01,President,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Carbondale W-05 P-01,Attorney General,,DEM,Josh Shapiro,22,31,11,0,64
+Lackawanna,Carbondale W-05 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,Auditor General,,DEM,H. Scott Conklin,2,4,1,0,7
+Lackawanna,Carbondale W-05 P-01,Auditor General,,DEM,Michael Lamb,6,5,3,0,14
+Lackawanna,Carbondale W-05 P-01,Auditor General,,DEM,Tracie Fountain,2,4,0,0,6
+Lackawanna,Carbondale W-05 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,4,7,1,0,12
+Lackawanna,Carbondale W-05 P-01,Auditor General,,DEM,Nina Ahmad,6,5,1,0,12
+Lackawanna,Carbondale W-05 P-01,Auditor General,,DEM,Christina M. Hartman,6,6,4,0,16
+Lackawanna,Carbondale W-05 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,State Treasurer,,DEM,Joe Torsella,22,26,11,0,59
+Lackawanna,Carbondale W-05 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,DEM,Matt Cartwright,25,35,11,0,71
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,24,33,11,0,68
+Lackawanna,Carbondale W-05 P-01,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,President,,REP,Donald J. Trump,42,9,0,1,52
+Lackawanna,Carbondale W-05 P-01,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Carbondale W-05 P-01,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Carbondale W-05 P-01,President,,REP,Write-in,1,1,0,0,2
+Lackawanna,Carbondale W-05 P-01,Attorney General,,REP,Heather Heidelbaugh,32,8,0,0,40
+Lackawanna,Carbondale W-05 P-01,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Carbondale W-05 P-01,Auditor General,,REP,Timothy DeFoor,32,8,0,0,40
+Lackawanna,Carbondale W-05 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,State Treasurer,,REP,Stacy L. Garrity,33,8,0,0,41
+Lackawanna,Carbondale W-05 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,REP,Teddy Daniels,8,0,0,0,8
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,REP,Jim Bognet,2,0,0,0,2
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,REP,Mike Marsicano,7,0,0,0,7
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,REP,Earl Granville,29,12,0,1,42
+Lackawanna,Carbondale W-05 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-01,General Assembly,114,REP,James May,35,8,0,1,44
+Lackawanna,Carbondale W-05 P-01,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,Registered Voters,,,,,,,,367
+Lackawanna,Carbondale W-05 P-02,Registered Voters,,DEM,,,,,,255
+Lackawanna,Carbondale W-05 P-02,Registered Voters,,REP,,,,,,112
+Lackawanna,Carbondale W-05 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-05 P-02,Ballots Cast,,,,64,49,4,0,117
+Lackawanna,Carbondale W-05 P-02,Ballots Cast,,DEM,,34,41,4,0,79
+Lackawanna,Carbondale W-05 P-02,Ballots Cast,,REP,,30,8,0,0,38
+Lackawanna,Carbondale W-05 P-02,President,,DEM,Bernie Sanders,5,4,0,0,9
+Lackawanna,Carbondale W-05 P-02,President,,DEM,Joseph R. Biden,19,33,4,0,56
+Lackawanna,Carbondale W-05 P-02,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Lackawanna,Carbondale W-05 P-02,President,,DEM,Write-in,4,0,0,0,4
+Lackawanna,Carbondale W-05 P-02,Attorney General,,DEM,Josh Shapiro,22,38,3,0,63
+Lackawanna,Carbondale W-05 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,Auditor General,,DEM,H. Scott Conklin,5,2,0,0,7
+Lackawanna,Carbondale W-05 P-02,Auditor General,,DEM,Michael Lamb,5,10,0,0,15
+Lackawanna,Carbondale W-05 P-02,Auditor General,,DEM,Tracie Fountain,0,4,0,0,4
+Lackawanna,Carbondale W-05 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,4,10,1,0,15
+Lackawanna,Carbondale W-05 P-02,Auditor General,,DEM,Nina Ahmad,4,2,1,0,7
+Lackawanna,Carbondale W-05 P-02,Auditor General,,DEM,Christina M. Hartman,3,7,1,0,11
+Lackawanna,Carbondale W-05 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,State Treasurer,,DEM,Joe Torsella,21,35,2,0,58
+Lackawanna,Carbondale W-05 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,DEM,Matt Cartwright,23,37,4,0,64
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,DEM,Write-in,5,3,0,0,8
+Lackawanna,Carbondale W-05 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,24,35,3,0,62
+Lackawanna,Carbondale W-05 P-02,General Assembly,114,DEM,Write-in,1,1,0,0,2
+Lackawanna,Carbondale W-05 P-02,President,,REP,Donald J. Trump,29,7,0,0,36
+Lackawanna,Carbondale W-05 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,President,,REP,Bill Weld,1,0,0,0,1
+Lackawanna,Carbondale W-05 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,Attorney General,,REP,Heather Heidelbaugh,16,6,0,0,22
+Lackawanna,Carbondale W-05 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,Auditor General,,REP,Timothy DeFoor,16,6,0,0,22
+Lackawanna,Carbondale W-05 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,State Treasurer,,REP,Stacy L. Garrity,18,6,0,0,24
+Lackawanna,Carbondale W-05 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,REP,Teddy Daniels,4,0,0,0,4
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,REP,Jim Bognet,4,0,0,0,4
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,REP,Earl Granville,21,8,0,0,29
+Lackawanna,Carbondale W-05 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-05 P-02,General Assembly,114,REP,James May,18,7,0,0,25
+Lackawanna,Carbondale W-05 P-02,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-01,Registered Voters,,,,,,,,388
+Lackawanna,Carbondale W-06 P-01,Registered Voters,,DEM,,,,,,254
+Lackawanna,Carbondale W-06 P-01,Registered Voters,,REP,,,,,,134
+Lackawanna,Carbondale W-06 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-06 P-01,Ballots Cast,,,,76,53,30,0,159
+Lackawanna,Carbondale W-06 P-01,Ballots Cast,,DEM,,39,50,20,0,109
+Lackawanna,Carbondale W-06 P-01,Ballots Cast,,REP,,37,3,10,0,50
+Lackawanna,Carbondale W-06 P-01,President,,DEM,Bernie Sanders,7,7,1,0,15
+Lackawanna,Carbondale W-06 P-01,President,,DEM,Joseph R. Biden,25,41,15,0,81
+Lackawanna,Carbondale W-06 P-01,President,,DEM,Tulsi Gabbard,0,0,1,0,1
+Lackawanna,Carbondale W-06 P-01,President,,DEM,Write-in,1,1,3,0,5
+Lackawanna,Carbondale W-06 P-01,Attorney General,,DEM,Josh Shapiro,29,42,18,0,89
+Lackawanna,Carbondale W-06 P-01,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-06 P-01,Auditor General,,DEM,H. Scott Conklin,4,1,2,0,7
+Lackawanna,Carbondale W-06 P-01,Auditor General,,DEM,Michael Lamb,8,9,2,0,19
+Lackawanna,Carbondale W-06 P-01,Auditor General,,DEM,Tracie Fountain,1,5,0,0,6
+Lackawanna,Carbondale W-06 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,2,14,6,0,22
+Lackawanna,Carbondale W-06 P-01,Auditor General,,DEM,Nina Ahmad,3,1,1,0,5
+Lackawanna,Carbondale W-06 P-01,Auditor General,,DEM,Christina M. Hartman,5,7,4,0,16
+Lackawanna,Carbondale W-06 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-06 P-01,State Treasurer,,DEM,Joe Torsella,23,40,14,0,77
+Lackawanna,Carbondale W-06 P-01,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,DEM,Matt Cartwright,33,45,18,0,96
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,DEM,Write-in,2,0,1,0,3
+Lackawanna,Carbondale W-06 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,31,45,16,0,92
+Lackawanna,Carbondale W-06 P-01,General Assembly,114,DEM,Write-in,2,0,0,0,2
+Lackawanna,Carbondale W-06 P-01,President,,REP,Donald J. Trump,34,3,8,0,45
+Lackawanna,Carbondale W-06 P-01,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Carbondale W-06 P-01,President,,REP,Bill Weld,1,0,2,0,3
+Lackawanna,Carbondale W-06 P-01,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-01,Attorney General,,REP,Heather Heidelbaugh,28,2,9,0,39
+Lackawanna,Carbondale W-06 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-01,Auditor General,,REP,Timothy DeFoor,26,2,9,0,37
+Lackawanna,Carbondale W-06 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-01,State Treasurer,,REP,Stacy L. Garrity,27,2,9,0,38
+Lackawanna,Carbondale W-06 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,REP,Harry Haas,2,0,2,0,4
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,REP,Teddy Daniels,1,0,0,0,1
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,REP,Jim Bognet,3,1,0,0,4
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,REP,Mike Marsicano,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,REP,Earl Granville,31,2,8,0,41
+Lackawanna,Carbondale W-06 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-01,General Assembly,114,REP,James May,28,0,9,0,37
+Lackawanna,Carbondale W-06 P-01,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,Registered Voters,,,,,,,,229
+Lackawanna,Carbondale W-06 P-02,Registered Voters,,DEM,,,,,,154
+Lackawanna,Carbondale W-06 P-02,Registered Voters,,REP,,,,,,75
+Lackawanna,Carbondale W-06 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale W-06 P-02,Ballots Cast,,,,42,22,5,3,72
+Lackawanna,Carbondale W-06 P-02,Ballots Cast,,DEM,,23,15,2,3,43
+Lackawanna,Carbondale W-06 P-02,Ballots Cast,,REP,,19,7,3,0,29
+Lackawanna,Carbondale W-06 P-02,President,,DEM,Bernie Sanders,2,0,1,0,3
+Lackawanna,Carbondale W-06 P-02,President,,DEM,Joseph R. Biden,19,13,0,1,33
+Lackawanna,Carbondale W-06 P-02,President,,DEM,Tulsi Gabbard,0,2,0,0,2
+Lackawanna,Carbondale W-06 P-02,President,,DEM,Write-in,2,0,1,0,3
+Lackawanna,Carbondale W-06 P-02,Attorney General,,DEM,Josh Shapiro,17,14,2,2,35
+Lackawanna,Carbondale W-06 P-02,Attorney General,,DEM,Write-in,1,0,0,1,2
+Lackawanna,Carbondale W-06 P-02,Auditor General,,DEM,H. Scott Conklin,2,1,1,0,4
+Lackawanna,Carbondale W-06 P-02,Auditor General,,DEM,Michael Lamb,2,2,0,1,5
+Lackawanna,Carbondale W-06 P-02,Auditor General,,DEM,Tracie Fountain,1,0,1,0,2
+Lackawanna,Carbondale W-06 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,3,7,0,0,10
+Lackawanna,Carbondale W-06 P-02,Auditor General,,DEM,Nina Ahmad,9,1,0,2,12
+Lackawanna,Carbondale W-06 P-02,Auditor General,,DEM,Christina M. Hartman,3,4,0,0,7
+Lackawanna,Carbondale W-06 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-06 P-02,State Treasurer,,DEM,Joe Torsella,17,12,2,3,34
+Lackawanna,Carbondale W-06 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,DEM,Matt Cartwright,22,14,2,1,39
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,DEM,Write-in,1,0,0,2,3
+Lackawanna,Carbondale W-06 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,17,14,2,3,36
+Lackawanna,Carbondale W-06 P-02,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale W-06 P-02,President,,REP,Donald J. Trump,19,7,3,0,29
+Lackawanna,Carbondale W-06 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,Attorney General,,REP,Heather Heidelbaugh,17,7,3,0,27
+Lackawanna,Carbondale W-06 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,Auditor General,,REP,Timothy DeFoor,18,7,3,0,28
+Lackawanna,Carbondale W-06 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,State Treasurer,,REP,Stacy L. Garrity,18,7,3,0,28
+Lackawanna,Carbondale W-06 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,REP,Teddy Daniels,4,4,0,0,8
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,REP,Jim Bognet,0,0,1,0,1
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,REP,Mike Marsicano,2,0,0,0,2
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,REP,Earl Granville,13,3,2,0,18
+Lackawanna,Carbondale W-06 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale W-06 P-02,General Assembly,114,REP,James May,18,7,3,0,28
+Lackawanna,Carbondale W-06 P-02,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NE,Registered Voters,,,,,,,,298
+Lackawanna,Carbondale Twp. W-00 P-NE,Registered Voters,,DEM,,,,,,195
+Lackawanna,Carbondale Twp. W-00 P-NE,Registered Voters,,REP,,,,,,103
+Lackawanna,Carbondale Twp. W-00 P-NE,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale Twp. W-00 P-NE,Ballots Cast,,,,81,41,13,0,135
+Lackawanna,Carbondale Twp. W-00 P-NE,Ballots Cast,,DEM,,39,36,11,0,86
+Lackawanna,Carbondale Twp. W-00 P-NE,Ballots Cast,,REP,,42,5,2,0,49
+Lackawanna,Carbondale Twp. W-00 P-NE,President,,DEM,Bernie Sanders,6,8,1,0,15
+Lackawanna,Carbondale Twp. W-00 P-NE,President,,DEM,Joseph R. Biden,23,28,9,0,60
+Lackawanna,Carbondale Twp. W-00 P-NE,President,,DEM,Tulsi Gabbard,3,0,1,0,4
+Lackawanna,Carbondale Twp. W-00 P-NE,President,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Carbondale Twp. W-00 P-NE,Attorney General,,DEM,Josh Shapiro,32,30,9,0,71
+Lackawanna,Carbondale Twp. W-00 P-NE,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,DEM,H. Scott Conklin,2,1,0,0,3
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,DEM,Michael Lamb,7,0,3,0,10
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,DEM,Tracie Fountain,1,3,1,0,5
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,DEM,Rose Rosie Marie Davis,8,11,0,0,19
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,DEM,Nina Ahmad,3,8,3,0,14
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,DEM,Christina M. Hartman,11,7,2,0,20
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NE,State Treasurer,,DEM,Joe Torsella,30,29,10,0,69
+Lackawanna,Carbondale Twp. W-00 P-NE,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,DEM,Matt Cartwright,33,27,10,0,70
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,DEM,Write-in,1,1,0,0,2
+Lackawanna,Carbondale Twp. W-00 P-NE,General Assembly,114,DEM,Bridget Malloy Kosierowski,30,33,10,0,73
+Lackawanna,Carbondale Twp. W-00 P-NE,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NE,President,,REP,Donald J. Trump,38,4,1,0,43
+Lackawanna,Carbondale Twp. W-00 P-NE,President,,REP,Roque Rocky De La Fuente,1,0,1,0,2
+Lackawanna,Carbondale Twp. W-00 P-NE,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NE,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NE,Attorney General,,REP,Heather Heidelbaugh,31,3,1,0,35
+Lackawanna,Carbondale Twp. W-00 P-NE,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,REP,Timothy DeFoor,30,4,2,0,36
+Lackawanna,Carbondale Twp. W-00 P-NE,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NE,State Treasurer,,REP,Stacy L. Garrity,32,3,2,0,37
+Lackawanna,Carbondale Twp. W-00 P-NE,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,REP,Teddy Daniels,5,0,0,0,5
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,REP,Jim Bognet,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,REP,Mike Marsicano,2,1,0,0,3
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,REP,Earl Granville,31,3,2,0,36
+Lackawanna,Carbondale Twp. W-00 P-NE,U.S. House,8,REP,Write-in,1,1,0,0,2
+Lackawanna,Carbondale Twp. W-00 P-NE,General Assembly,114,REP,James May,34,4,2,0,40
+Lackawanna,Carbondale Twp. W-00 P-NE,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,Registered Voters,,,,,,,,165
+Lackawanna,Carbondale Twp. W-00 P-NW,Registered Voters,,DEM,,,,,,100
+Lackawanna,Carbondale Twp. W-00 P-NW,Registered Voters,,REP,,,,,,65
+Lackawanna,Carbondale Twp. W-00 P-NW,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale Twp. W-00 P-NW,Ballots Cast,,,,56,17,4,0,77
+Lackawanna,Carbondale Twp. W-00 P-NW,Ballots Cast,,DEM,,28,17,1,0,46
+Lackawanna,Carbondale Twp. W-00 P-NW,Ballots Cast,,REP,,28,0,3,0,31
+Lackawanna,Carbondale Twp. W-00 P-NW,President,,DEM,Bernie Sanders,7,2,0,0,9
+Lackawanna,Carbondale Twp. W-00 P-NW,President,,DEM,Joseph R. Biden,13,14,1,0,28
+Lackawanna,Carbondale Twp. W-00 P-NW,President,,DEM,Tulsi Gabbard,5,1,0,0,6
+Lackawanna,Carbondale Twp. W-00 P-NW,President,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NW,Attorney General,,DEM,Josh Shapiro,20,15,1,0,36
+Lackawanna,Carbondale Twp. W-00 P-NW,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,DEM,H. Scott Conklin,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,DEM,Michael Lamb,6,0,0,0,6
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,DEM,Tracie Fountain,0,1,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,DEM,Rose Rosie Marie Davis,8,3,0,0,11
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,DEM,Nina Ahmad,2,5,0,0,7
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,DEM,Christina M. Hartman,9,3,0,0,12
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,State Treasurer,,DEM,Joe Torsella,22,11,1,0,34
+Lackawanna,Carbondale Twp. W-00 P-NW,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,DEM,Matt Cartwright,20,16,1,0,37
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NW,General Assembly,114,DEM,Bridget Malloy Kosierowski,20,13,0,0,33
+Lackawanna,Carbondale Twp. W-00 P-NW,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NW,President,,REP,Donald J. Trump,26,0,2,0,28
+Lackawanna,Carbondale Twp. W-00 P-NW,President,,REP,Roque Rocky De La Fuente,1,0,1,0,2
+Lackawanna,Carbondale Twp. W-00 P-NW,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NW,Attorney General,,REP,Heather Heidelbaugh,25,0,3,0,28
+Lackawanna,Carbondale Twp. W-00 P-NW,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,REP,Timothy DeFoor,23,0,3,0,26
+Lackawanna,Carbondale Twp. W-00 P-NW,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,State Treasurer,,REP,Stacy L. Garrity,19,0,3,0,22
+Lackawanna,Carbondale Twp. W-00 P-NW,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,REP,Harry Haas,4,0,2,0,6
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,REP,Teddy Daniels,7,0,0,0,7
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,REP,Jim Bognet,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,REP,Earl Granville,14,0,1,0,15
+Lackawanna,Carbondale Twp. W-00 P-NW,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-NW,General Assembly,114,REP,James May,25,0,3,0,28
+Lackawanna,Carbondale Twp. W-00 P-NW,General Assembly,114,REP,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-SO,Registered Voters,,,,,,,,230
+Lackawanna,Carbondale Twp. W-00 P-SO,Registered Voters,,DEM,,,,,,156
+Lackawanna,Carbondale Twp. W-00 P-SO,Registered Voters,,REP,,,,,,74
+Lackawanna,Carbondale Twp. W-00 P-SO,Registered Voters,,NPA,,,,,,0
+Lackawanna,Carbondale Twp. W-00 P-SO,Ballots Cast,,,,58,41,9,1,109
+Lackawanna,Carbondale Twp. W-00 P-SO,Ballots Cast,,DEM,,28,36,9,1,74
+Lackawanna,Carbondale Twp. W-00 P-SO,Ballots Cast,,REP,,30,5,0,0,35
+Lackawanna,Carbondale Twp. W-00 P-SO,President,,DEM,Bernie Sanders,4,7,0,1,12
+Lackawanna,Carbondale Twp. W-00 P-SO,President,,DEM,Joseph R. Biden,21,29,9,0,59
+Lackawanna,Carbondale Twp. W-00 P-SO,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-SO,President,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,Attorney General,,DEM,Josh Shapiro,22,34,9,1,66
+Lackawanna,Carbondale Twp. W-00 P-SO,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,DEM,H. Scott Conklin,4,1,0,0,5
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,DEM,Michael Lamb,9,3,2,0,14
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,DEM,Tracie Fountain,0,5,2,0,7
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,DEM,Rose Rosie Marie Davis,4,12,2,0,18
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,DEM,Nina Ahmad,6,4,1,1,12
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,DEM,Christina M. Hartman,3,7,2,0,12
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,State Treasurer,,DEM,Joe Torsella,23,33,8,1,65
+Lackawanna,Carbondale Twp. W-00 P-SO,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,DEM,Matt Cartwright,21,35,8,1,65
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Carbondale Twp. W-00 P-SO,General Assembly,114,DEM,Bridget Malloy Kosierowski,22,34,8,1,65
+Lackawanna,Carbondale Twp. W-00 P-SO,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-SO,President,,REP,Donald J. Trump,29,4,0,0,33
+Lackawanna,Carbondale Twp. W-00 P-SO,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-SO,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,Attorney General,,REP,Heather Heidelbaugh,22,4,0,0,26
+Lackawanna,Carbondale Twp. W-00 P-SO,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,REP,Timothy DeFoor,22,4,0,0,26
+Lackawanna,Carbondale Twp. W-00 P-SO,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,State Treasurer,,REP,Stacy L. Garrity,22,4,0,0,26
+Lackawanna,Carbondale Twp. W-00 P-SO,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,REP,Teddy Daniels,5,0,0,0,5
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,REP,Jim Bognet,4,0,0,0,4
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,REP,Earl Granville,19,5,0,0,24
+Lackawanna,Carbondale Twp. W-00 P-SO,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Carbondale Twp. W-00 P-SO,General Assembly,114,REP,James May,28,4,0,0,32
+Lackawanna,Carbondale Twp. W-00 P-SO,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Clarks Green W-00 P-00,Registered Voters,,,,,,,,1126
+Lackawanna,Clarks Green W-00 P-00,Registered Voters,,DEM,,,,,,666
+Lackawanna,Clarks Green W-00 P-00,Registered Voters,,REP,,,,,,460
+Lackawanna,Clarks Green W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Clarks Green W-00 P-00,Ballots Cast,,,,208,284,56,12,560
+Lackawanna,Clarks Green W-00 P-00,Ballots Cast,,DEM,,99,234,43,6,382
+Lackawanna,Clarks Green W-00 P-00,Ballots Cast,,REP,,109,50,13,6,178
+Lackawanna,Clarks Green W-00 P-00,President,,DEM,Bernie Sanders,24,32,5,3,64
+Lackawanna,Clarks Green W-00 P-00,President,,DEM,Joseph R. Biden,71,190,38,3,302
+Lackawanna,Clarks Green W-00 P-00,President,,DEM,Tulsi Gabbard,3,3,0,0,6
+Lackawanna,Clarks Green W-00 P-00,President,,DEM,Write-in,0,7,0,0,7
+Lackawanna,Clarks Green W-00 P-00,Attorney General,,DEM,Josh Shapiro,79,207,36,5,327
+Lackawanna,Clarks Green W-00 P-00,Attorney General,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,DEM,H. Scott Conklin,5,8,5,0,18
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,DEM,Michael Lamb,13,46,5,1,65
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,DEM,Tracie Fountain,12,18,5,1,36
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,9,45,11,0,65
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,DEM,Nina Ahmad,27,59,7,3,96
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,DEM,Christina M. Hartman,15,19,1,1,36
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Clarks Green W-00 P-00,State Treasurer,,DEM,Joe Torsella,71,197,36,5,309
+Lackawanna,Clarks Green W-00 P-00,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,DEM,Matt Cartwright,83,223,43,6,355
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,DEM,Write-in,3,2,0,0,5
+Lackawanna,Clarks Green W-00 P-00,General Assembly,113,DEM,Marty Flynn,76,196,39,3,314
+Lackawanna,Clarks Green W-00 P-00,General Assembly,113,DEM,Write-in,7,5,0,0,12
+Lackawanna,Clarks Green W-00 P-00,President,,REP,Donald J. Trump,98,33,9,5,145
+Lackawanna,Clarks Green W-00 P-00,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Clarks Green W-00 P-00,President,,REP,Bill Weld,5,8,3,1,17
+Lackawanna,Clarks Green W-00 P-00,President,,REP,Write-in,0,5,0,0,5
+Lackawanna,Clarks Green W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,80,45,10,4,139
+Lackawanna,Clarks Green W-00 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,REP,Timothy DeFoor,81,41,10,3,135
+Lackawanna,Clarks Green W-00 P-00,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Clarks Green W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,77,44,10,4,135
+Lackawanna,Clarks Green W-00 P-00,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,REP,Harry Haas,3,4,1,1,9
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,REP,Teddy Daniels,25,2,1,1,29
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,REP,Jim Bognet,22,8,2,3,35
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,REP,Mike Marsicano,11,3,2,0,16
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,REP,Earl Granville,45,30,5,1,81
+Lackawanna,Clarks Green W-00 P-00,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Clarks Green W-00 P-00,General Assembly,113,REP,William Kresge,85,43,11,4,143
+Lackawanna,Clarks Green W-00 P-00,General Assembly,113,REP,Write-in,2,1,0,0,3
+Lackawanna,Clarks Summit W-00 P-01,Registered Voters,,,,,,,,750
+Lackawanna,Clarks Summit W-00 P-01,Registered Voters,,DEM,,,,,,435
+Lackawanna,Clarks Summit W-00 P-01,Registered Voters,,REP,,,,,,315
+Lackawanna,Clarks Summit W-00 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Clarks Summit W-00 P-01,Ballots Cast,,,,111,161,43,3,318
+Lackawanna,Clarks Summit W-00 P-01,Ballots Cast,,DEM,,44,123,36,2,205
+Lackawanna,Clarks Summit W-00 P-01,Ballots Cast,,REP,,67,38,7,1,113
+Lackawanna,Clarks Summit W-00 P-01,President,,DEM,Bernie Sanders,5,17,10,0,32
+Lackawanna,Clarks Summit W-00 P-01,President,,DEM,Joseph R. Biden,36,104,26,2,168
+Lackawanna,Clarks Summit W-00 P-01,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Lackawanna,Clarks Summit W-00 P-01,President,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Clarks Summit W-00 P-01,Attorney General,,DEM,Josh Shapiro,36,120,31,2,189
+Lackawanna,Clarks Summit W-00 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,DEM,H. Scott Conklin,5,7,1,0,13
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,DEM,Michael Lamb,7,11,1,1,20
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,DEM,Tracie Fountain,2,11,3,0,16
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,5,27,5,0,37
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,DEM,Nina Ahmad,15,36,15,1,67
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,DEM,Christina M. Hartman,1,17,7,0,25
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-01,State Treasurer,,DEM,Joe Torsella,33,109,32,2,176
+Lackawanna,Clarks Summit W-00 P-01,State Treasurer,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,DEM,Matt Cartwright,40,123,36,2,201
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Clarks Summit W-00 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,40,117,34,2,193
+Lackawanna,Clarks Summit W-00 P-01,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-01,President,,REP,Donald J. Trump,64,27,3,1,95
+Lackawanna,Clarks Summit W-00 P-01,President,,REP,Roque Rocky De La Fuente,1,0,2,0,3
+Lackawanna,Clarks Summit W-00 P-01,President,,REP,Bill Weld,1,7,2,0,10
+Lackawanna,Clarks Summit W-00 P-01,President,,REP,Write-in,1,4,0,0,5
+Lackawanna,Clarks Summit W-00 P-01,Attorney General,,REP,Heather Heidelbaugh,55,31,5,1,92
+Lackawanna,Clarks Summit W-00 P-01,Attorney General,,REP,Write-in,1,1,1,0,3
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,REP,Timothy DeFoor,56,28,5,1,90
+Lackawanna,Clarks Summit W-00 P-01,Auditor General,,REP,Write-in,0,1,1,0,2
+Lackawanna,Clarks Summit W-00 P-01,State Treasurer,,REP,Stacy L. Garrity,55,28,6,1,90
+Lackawanna,Clarks Summit W-00 P-01,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,REP,Harry Haas,3,4,0,1,8
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,REP,Teddy Daniels,12,0,0,0,12
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,REP,Jim Bognet,17,4,0,0,21
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,REP,Mike Cammisa,3,0,0,0,3
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,REP,Mike Marsicano,4,2,0,0,6
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,REP,Earl Granville,26,26,5,0,57
+Lackawanna,Clarks Summit W-00 P-01,U.S. House,8,REP,Write-in,0,0,1,0,1
+Lackawanna,Clarks Summit W-00 P-01,General Assembly,114,REP,James May,60,31,6,1,98
+Lackawanna,Clarks Summit W-00 P-01,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Clarks Summit W-00 P-02,Registered Voters,,,,,,,,962
+Lackawanna,Clarks Summit W-00 P-02,Registered Voters,,DEM,,,,,,498
+Lackawanna,Clarks Summit W-00 P-02,Registered Voters,,REP,,,,,,464
+Lackawanna,Clarks Summit W-00 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Clarks Summit W-00 P-02,Ballots Cast,,,,172,222,44,2,440
+Lackawanna,Clarks Summit W-00 P-02,Ballots Cast,,DEM,,60,162,37,1,260
+Lackawanna,Clarks Summit W-00 P-02,Ballots Cast,,REP,,112,60,7,1,180
+Lackawanna,Clarks Summit W-00 P-02,President,,DEM,Bernie Sanders,8,11,6,0,25
+Lackawanna,Clarks Summit W-00 P-02,President,,DEM,Joseph R. Biden,47,145,31,1,224
+Lackawanna,Clarks Summit W-00 P-02,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Lackawanna,Clarks Summit W-00 P-02,President,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Clarks Summit W-00 P-02,Attorney General,,DEM,Josh Shapiro,50,149,34,1,234
+Lackawanna,Clarks Summit W-00 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,DEM,H. Scott Conklin,4,8,2,0,14
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,DEM,Michael Lamb,10,28,4,1,43
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,DEM,Tracie Fountain,7,16,1,0,24
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,9,37,7,0,53
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,DEM,Nina Ahmad,13,24,10,0,47
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,DEM,Christina M. Hartman,4,25,8,0,37
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,DEM,Write-in,0,0,2,0,2
+Lackawanna,Clarks Summit W-00 P-02,State Treasurer,,DEM,Joe Torsella,47,145,31,1,224
+Lackawanna,Clarks Summit W-00 P-02,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,DEM,Matt Cartwright,53,152,36,1,242
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,DEM,Write-in,1,1,0,0,2
+Lackawanna,Clarks Summit W-00 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,58,151,35,1,245
+Lackawanna,Clarks Summit W-00 P-02,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-02,President,,REP,Donald J. Trump,108,46,5,1,160
+Lackawanna,Clarks Summit W-00 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-02,President,,REP,Bill Weld,2,9,1,0,12
+Lackawanna,Clarks Summit W-00 P-02,President,,REP,Write-in,1,1,0,0,2
+Lackawanna,Clarks Summit W-00 P-02,Attorney General,,REP,Heather Heidelbaugh,82,49,6,1,138
+Lackawanna,Clarks Summit W-00 P-02,Attorney General,,REP,Write-in,2,0,1,0,3
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,REP,Timothy DeFoor,82,48,5,1,136
+Lackawanna,Clarks Summit W-00 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-02,State Treasurer,,REP,Stacy L. Garrity,82,50,5,1,138
+Lackawanna,Clarks Summit W-00 P-02,State Treasurer,,REP,Write-in,0,1,1,0,2
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,REP,Harry Haas,5,3,0,1,9
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,REP,Teddy Daniels,24,5,1,0,30
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,REP,Jim Bognet,22,12,2,0,36
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,REP,Mike Marsicano,7,1,0,0,8
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,REP,Earl Granville,46,32,3,0,81
+Lackawanna,Clarks Summit W-00 P-02,U.S. House,8,REP,Write-in,1,0,1,0,2
+Lackawanna,Clarks Summit W-00 P-02,General Assembly,114,REP,James May,94,52,6,1,153
+Lackawanna,Clarks Summit W-00 P-02,General Assembly,114,REP,Write-in,2,1,1,0,4
+Lackawanna,Clarks Summit W-00 P-03,Registered Voters,,,,,,,,864
+Lackawanna,Clarks Summit W-00 P-03,Registered Voters,,DEM,,,,,,489
+Lackawanna,Clarks Summit W-00 P-03,Registered Voters,,REP,,,,,,375
+Lackawanna,Clarks Summit W-00 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Clarks Summit W-00 P-03,Ballots Cast,,,,156,219,38,6,419
+Lackawanna,Clarks Summit W-00 P-03,Ballots Cast,,DEM,,64,171,32,2,269
+Lackawanna,Clarks Summit W-00 P-03,Ballots Cast,,REP,,92,48,6,4,150
+Lackawanna,Clarks Summit W-00 P-03,President,,DEM,Bernie Sanders,18,17,3,0,38
+Lackawanna,Clarks Summit W-00 P-03,President,,DEM,Joseph R. Biden,37,151,28,2,218
+Lackawanna,Clarks Summit W-00 P-03,President,,DEM,Tulsi Gabbard,3,3,0,0,6
+Lackawanna,Clarks Summit W-00 P-03,President,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Clarks Summit W-00 P-03,Attorney General,,DEM,Josh Shapiro,48,145,27,2,222
+Lackawanna,Clarks Summit W-00 P-03,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,DEM,H. Scott Conklin,2,10,2,0,14
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,DEM,Michael Lamb,12,19,0,0,31
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,DEM,Tracie Fountain,1,15,1,1,18
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,10,41,11,0,62
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,DEM,Nina Ahmad,21,30,5,1,57
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,DEM,Christina M. Hartman,9,22,6,0,37
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Clarks Summit W-00 P-03,State Treasurer,,DEM,Joe Torsella,46,140,24,2,212
+Lackawanna,Clarks Summit W-00 P-03,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,DEM,Matt Cartwright,54,159,31,2,246
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,DEM,Write-in,1,1,0,0,2
+Lackawanna,Clarks Summit W-00 P-03,General Assembly,114,DEM,Bridget Malloy Kosierowski,59,153,26,2,240
+Lackawanna,Clarks Summit W-00 P-03,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-03,President,,REP,Donald J. Trump,82,34,5,3,124
+Lackawanna,Clarks Summit W-00 P-03,President,,REP,Roque Rocky De La Fuente,4,1,0,0,5
+Lackawanna,Clarks Summit W-00 P-03,President,,REP,Bill Weld,4,8,0,0,12
+Lackawanna,Clarks Summit W-00 P-03,President,,REP,Write-in,0,3,1,1,5
+Lackawanna,Clarks Summit W-00 P-03,Attorney General,,REP,Heather Heidelbaugh,70,40,6,1,117
+Lackawanna,Clarks Summit W-00 P-03,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,REP,Timothy DeFoor,68,41,5,2,116
+Lackawanna,Clarks Summit W-00 P-03,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Clarks Summit W-00 P-03,State Treasurer,,REP,Stacy L. Garrity,69,39,6,3,117
+Lackawanna,Clarks Summit W-00 P-03,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,REP,Harry Haas,2,1,0,0,3
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,REP,Teddy Daniels,20,1,0,1,22
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,REP,Jim Bognet,16,4,2,0,22
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,REP,Mike Cammisa,1,3,0,0,4
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,REP,Mike Marsicano,8,3,0,1,12
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,REP,Earl Granville,40,35,4,2,81
+Lackawanna,Clarks Summit W-00 P-03,U.S. House,8,REP,Write-in,2,0,0,0,2
+Lackawanna,Clarks Summit W-00 P-03,General Assembly,114,REP,James May,77,41,6,2,126
+Lackawanna,Clarks Summit W-00 P-03,General Assembly,114,REP,Write-in,2,3,0,0,5
+Lackawanna,Clarks Summit W-00 P-04,Registered Voters,,,,,,,,975
+Lackawanna,Clarks Summit W-00 P-04,Registered Voters,,DEM,,,,,,516
+Lackawanna,Clarks Summit W-00 P-04,Registered Voters,,REP,,,,,,459
+Lackawanna,Clarks Summit W-00 P-04,Registered Voters,,NPA,,,,,,0
+Lackawanna,Clarks Summit W-00 P-04,Ballots Cast,,,,205,224,53,7,489
+Lackawanna,Clarks Summit W-00 P-04,Ballots Cast,,DEM,,88,159,40,2,289
+Lackawanna,Clarks Summit W-00 P-04,Ballots Cast,,REP,,117,65,13,5,200
+Lackawanna,Clarks Summit W-00 P-04,President,,DEM,Bernie Sanders,9,18,7,1,35
+Lackawanna,Clarks Summit W-00 P-04,President,,DEM,Joseph R. Biden,70,136,33,1,240
+Lackawanna,Clarks Summit W-00 P-04,President,,DEM,Tulsi Gabbard,5,0,0,0,5
+Lackawanna,Clarks Summit W-00 P-04,President,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Clarks Summit W-00 P-04,Attorney General,,DEM,Josh Shapiro,66,141,37,1,245
+Lackawanna,Clarks Summit W-00 P-04,Attorney General,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,DEM,H. Scott Conklin,3,8,1,0,12
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,DEM,Michael Lamb,17,18,4,0,39
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,DEM,Tracie Fountain,5,17,3,1,26
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,DEM,Rose Rosie Marie Davis,14,32,3,0,49
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,DEM,Nina Ahmad,21,26,9,0,56
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,DEM,Christina M. Hartman,8,29,9,0,46
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Clarks Summit W-00 P-04,State Treasurer,,DEM,Joe Torsella,65,131,35,1,232
+Lackawanna,Clarks Summit W-00 P-04,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,DEM,Matt Cartwright,77,151,35,1,264
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,DEM,Write-in,2,1,0,0,3
+Lackawanna,Clarks Summit W-00 P-04,General Assembly,114,DEM,Bridget Malloy Kosierowski,77,152,39,2,270
+Lackawanna,Clarks Summit W-00 P-04,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Clarks Summit W-00 P-04,President,,REP,Donald J. Trump,107,45,11,5,168
+Lackawanna,Clarks Summit W-00 P-04,President,,REP,Roque Rocky De La Fuente,2,3,0,0,5
+Lackawanna,Clarks Summit W-00 P-04,President,,REP,Bill Weld,2,11,2,0,15
+Lackawanna,Clarks Summit W-00 P-04,President,,REP,Write-in,3,1,0,0,4
+Lackawanna,Clarks Summit W-00 P-04,Attorney General,,REP,Heather Heidelbaugh,85,55,11,2,153
+Lackawanna,Clarks Summit W-00 P-04,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,REP,Timothy DeFoor,79,53,12,2,146
+Lackawanna,Clarks Summit W-00 P-04,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Clarks Summit W-00 P-04,State Treasurer,,REP,Stacy L. Garrity,81,55,12,2,150
+Lackawanna,Clarks Summit W-00 P-04,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,REP,Harry Haas,4,3,1,0,8
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,REP,Teddy Daniels,26,1,1,0,28
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,REP,Jim Bognet,17,9,2,0,28
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,REP,Mike Cammisa,2,1,0,0,3
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,REP,Mike Marsicano,11,5,0,0,16
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,REP,Earl Granville,53,39,8,5,105
+Lackawanna,Clarks Summit W-00 P-04,U.S. House,8,REP,Write-in,1,3,0,0,4
+Lackawanna,Clarks Summit W-00 P-04,General Assembly,114,REP,James May,88,60,9,3,160
+Lackawanna,Clarks Summit W-00 P-04,General Assembly,114,REP,Write-in,3,0,0,0,3
+Lackawanna,Clifton Township W-00 P-00,Registered Voters,,,,,,,,861
+Lackawanna,Clifton Township W-00 P-00,Registered Voters,,DEM,,,,,,363
+Lackawanna,Clifton Township W-00 P-00,Registered Voters,,REP,,,,,,498
+Lackawanna,Clifton Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Clifton Township W-00 P-00,Ballots Cast,,,,165,89,31,9,294
+Lackawanna,Clifton Township W-00 P-00,Ballots Cast,,DEM,,47,64,18,4,133
+Lackawanna,Clifton Township W-00 P-00,Ballots Cast,,REP,,118,25,13,5,161
+Lackawanna,Clifton Township W-00 P-00,President,,DEM,Bernie Sanders,9,4,2,0,15
+Lackawanna,Clifton Township W-00 P-00,President,,DEM,Joseph R. Biden,26,60,16,4,106
+Lackawanna,Clifton Township W-00 P-00,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Clifton Township W-00 P-00,President,,DEM,Write-in,7,0,0,0,7
+Lackawanna,Clifton Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,34,54,18,4,110
+Lackawanna,Clifton Township W-00 P-00,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,1,0,0,0,1
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,DEM,Michael Lamb,6,5,0,0,11
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,0,8,3,2,13
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,11,27,12,0,50
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,10,5,2,1,18
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,3,9,1,1,14
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Clifton Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,31,49,16,4,100
+Lackawanna,Clifton Township W-00 P-00,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,32,62,17,4,115
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,DEM,Write-in,4,0,0,0,4
+Lackawanna,Clifton Township W-00 P-00,General Assembly,118,DEM,Mike Carroll,27,51,16,4,98
+Lackawanna,Clifton Township W-00 P-00,General Assembly,118,DEM,Write-in,1,1,0,0,2
+Lackawanna,Clifton Township W-00 P-00,President,,REP,Donald J. Trump,111,21,10,5,147
+Lackawanna,Clifton Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,2,0,2,0,4
+Lackawanna,Clifton Township W-00 P-00,President,,REP,Bill Weld,1,3,1,0,5
+Lackawanna,Clifton Township W-00 P-00,President,,REP,Write-in,3,1,0,0,4
+Lackawanna,Clifton Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,95,19,13,4,131
+Lackawanna,Clifton Township W-00 P-00,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,94,18,13,4,129
+Lackawanna,Clifton Township W-00 P-00,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Clifton Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,95,18,13,3,129
+Lackawanna,Clifton Township W-00 P-00,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,REP,Harry Haas,8,0,1,0,9
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,37,4,4,4,49
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,REP,Jim Bognet,23,7,0,1,31
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,8,1,0,0,9
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,REP,Earl Granville,36,10,8,0,54
+Lackawanna,Clifton Township W-00 P-00,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Clifton Township W-00 P-00,General Assembly,118,REP,Andrew Holter,94,17,12,4,127
+Lackawanna,Clifton Township W-00 P-00,General Assembly,118,REP,Write-in,2,0,0,0,2
+Lackawanna,Covington Township W-00 P-00,Registered Voters,,,,,,,,1468
+Lackawanna,Covington Township W-00 P-00,Registered Voters,,DEM,,,,,,669
+Lackawanna,Covington Township W-00 P-00,Registered Voters,,REP,,,,,,799
+Lackawanna,Covington Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Covington Township W-00 P-00,Ballots Cast,,,,324,267,44,5,640
+Lackawanna,Covington Township W-00 P-00,Ballots Cast,,DEM,,90,178,27,0,295
+Lackawanna,Covington Township W-00 P-00,Ballots Cast,,REP,,234,89,17,5,345
+Lackawanna,Covington Township W-00 P-00,President,,DEM,Bernie Sanders,14,26,5,0,45
+Lackawanna,Covington Township W-00 P-00,President,,DEM,Joseph R. Biden,60,142,21,0,223
+Lackawanna,Covington Township W-00 P-00,President,,DEM,Tulsi Gabbard,5,4,0,0,9
+Lackawanna,Covington Township W-00 P-00,President,,DEM,Write-in,9,6,0,0,15
+Lackawanna,Covington Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,76,154,22,0,252
+Lackawanna,Covington Township W-00 P-00,Attorney General,,DEM,Write-in,4,1,0,0,5
+Lackawanna,Covington Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,6,15,2,0,23
+Lackawanna,Covington Township W-00 P-00,Auditor General,,DEM,Michael Lamb,14,14,3,0,31
+Lackawanna,Covington Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,5,12,2,0,19
+Lackawanna,Covington Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,25,54,7,0,86
+Lackawanna,Covington Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,22,35,3,0,60
+Lackawanna,Covington Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,10,19,4,0,33
+Lackawanna,Covington Township W-00 P-00,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Covington Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,69,149,23,0,241
+Lackawanna,Covington Township W-00 P-00,State Treasurer,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,77,168,26,0,271
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,DEM,Write-in,6,1,0,0,7
+Lackawanna,Covington Township W-00 P-00,General Assembly,118,DEM,Mike Carroll,73,147,25,0,245
+Lackawanna,Covington Township W-00 P-00,General Assembly,118,DEM,Write-in,3,2,0,0,5
+Lackawanna,Covington Township W-00 P-00,President,,REP,Donald J. Trump,226,65,16,5,312
+Lackawanna,Covington Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,3,1,0,0,4
+Lackawanna,Covington Township W-00 P-00,President,,REP,Bill Weld,3,13,1,0,17
+Lackawanna,Covington Township W-00 P-00,President,,REP,Write-in,1,4,0,0,5
+Lackawanna,Covington Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,174,67,16,2,259
+Lackawanna,Covington Township W-00 P-00,Attorney General,,REP,Write-in,1,3,0,0,4
+Lackawanna,Covington Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,167,66,16,2,251
+Lackawanna,Covington Township W-00 P-00,Auditor General,,REP,Write-in,1,3,0,0,4
+Lackawanna,Covington Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,172,68,16,2,258
+Lackawanna,Covington Township W-00 P-00,State Treasurer,,REP,Write-in,0,3,0,0,3
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,REP,Harry Haas,3,1,2,0,6
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,98,8,1,2,109
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,REP,Jim Bognet,27,14,3,0,44
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,1,2,0,3
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,16,6,0,1,23
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,REP,Earl Granville,85,50,8,2,145
+Lackawanna,Covington Township W-00 P-00,U.S. House,8,REP,Write-in,1,1,0,0,2
+Lackawanna,Covington Township W-00 P-00,General Assembly,118,REP,Andrew Holter,169,64,13,2,248
+Lackawanna,Covington Township W-00 P-00,General Assembly,118,REP,Write-in,1,7,0,0,8
+Lackawanna,Dalton W-00 P-00,Registered Voters,,,,,,,,884
+Lackawanna,Dalton W-00 P-00,Registered Voters,,DEM,,,,,,433
+Lackawanna,Dalton W-00 P-00,Registered Voters,,REP,,,,,,451
+Lackawanna,Dalton W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dalton W-00 P-00,Ballots Cast,,,,189,186,27,10,412
+Lackawanna,Dalton W-00 P-00,Ballots Cast,,DEM,,84,140,19,4,247
+Lackawanna,Dalton W-00 P-00,Ballots Cast,,REP,,105,46,8,6,165
+Lackawanna,Dalton W-00 P-00,President,,DEM,Bernie Sanders,12,15,0,3,30
+Lackawanna,Dalton W-00 P-00,President,,DEM,Joseph R. Biden,63,121,17,1,202
+Lackawanna,Dalton W-00 P-00,President,,DEM,Tulsi Gabbard,4,3,1,0,8
+Lackawanna,Dalton W-00 P-00,President,,DEM,Write-in,3,1,1,0,5
+Lackawanna,Dalton W-00 P-00,Attorney General,,DEM,Josh Shapiro,69,123,14,3,209
+Lackawanna,Dalton W-00 P-00,Attorney General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Dalton W-00 P-00,Auditor General,,DEM,H. Scott Conklin,10,6,0,1,17
+Lackawanna,Dalton W-00 P-00,Auditor General,,DEM,Michael Lamb,8,26,1,1,36
+Lackawanna,Dalton W-00 P-00,Auditor General,,DEM,Tracie Fountain,2,20,0,0,22
+Lackawanna,Dalton W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,7,16,3,0,26
+Lackawanna,Dalton W-00 P-00,Auditor General,,DEM,Nina Ahmad,25,22,3,2,52
+Lackawanna,Dalton W-00 P-00,Auditor General,,DEM,Christina M. Hartman,13,28,6,0,47
+Lackawanna,Dalton W-00 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dalton W-00 P-00,State Treasurer,,DEM,Joe Torsella,67,121,14,4,206
+Lackawanna,Dalton W-00 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dalton W-00 P-00,U.S. House,8,DEM,Matt Cartwright,74,134,14,3,225
+Lackawanna,Dalton W-00 P-00,U.S. House,8,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dalton W-00 P-00,General Assembly,117,DEM,Write-in,5,7,1,0,13
+Lackawanna,Dalton W-00 P-00,President,,REP,Donald J. Trump,95,25,3,3,126
+Lackawanna,Dalton W-00 P-00,President,,REP,Roque Rocky De La Fuente,0,1,0,1,2
+Lackawanna,Dalton W-00 P-00,President,,REP,Bill Weld,5,10,1,1,17
+Lackawanna,Dalton W-00 P-00,President,,REP,Write-in,2,5,2,0,9
+Lackawanna,Dalton W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,85,35,6,2,128
+Lackawanna,Dalton W-00 P-00,Attorney General,,REP,Write-in,0,2,0,0,2
+Lackawanna,Dalton W-00 P-00,Auditor General,,REP,Timothy DeFoor,83,35,6,3,127
+Lackawanna,Dalton W-00 P-00,Auditor General,,REP,Write-in,1,2,0,0,3
+Lackawanna,Dalton W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,81,35,6,2,124
+Lackawanna,Dalton W-00 P-00,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dalton W-00 P-00,U.S. House,8,REP,Harry Haas,2,2,0,0,4
+Lackawanna,Dalton W-00 P-00,U.S. House,8,REP,Teddy Daniels,14,5,0,0,19
+Lackawanna,Dalton W-00 P-00,U.S. House,8,REP,Jim Bognet,25,5,1,0,31
+Lackawanna,Dalton W-00 P-00,U.S. House,8,REP,Mike Cammisa,1,3,0,0,4
+Lackawanna,Dalton W-00 P-00,U.S. House,8,REP,Mike Marsicano,10,5,0,1,16
+Lackawanna,Dalton W-00 P-00,U.S. House,8,REP,Earl Granville,49,22,7,5,83
+Lackawanna,Dalton W-00 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Dalton W-00 P-00,General Assembly,117,REP,Karen Boback,93,38,7,5,143
+Lackawanna,Dalton W-00 P-00,General Assembly,117,REP,Write-in,0,1,0,0,1
+Lackawanna,Dickson City W-01 P-01,Registered Voters,,,,,,,,583
+Lackawanna,Dickson City W-01 P-01,Registered Voters,,DEM,,,,,,407
+Lackawanna,Dickson City W-01 P-01,Registered Voters,,REP,,,,,,176
+Lackawanna,Dickson City W-01 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dickson City W-01 P-01,Ballots Cast,,,,97,116,27,1,241
+Lackawanna,Dickson City W-01 P-01,Ballots Cast,,DEM,,52,97,25,1,175
+Lackawanna,Dickson City W-01 P-01,Ballots Cast,,REP,,45,19,2,0,66
+Lackawanna,Dickson City W-01 P-01,President,,DEM,Bernie Sanders,6,4,3,0,13
+Lackawanna,Dickson City W-01 P-01,President,,DEM,Joseph R. Biden,33,85,21,1,140
+Lackawanna,Dickson City W-01 P-01,President,,DEM,Tulsi Gabbard,3,4,1,0,8
+Lackawanna,Dickson City W-01 P-01,President,,DEM,Write-in,5,2,0,0,7
+Lackawanna,Dickson City W-01 P-01,Attorney General,,DEM,Josh Shapiro,38,79,22,1,140
+Lackawanna,Dickson City W-01 P-01,Attorney General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dickson City W-01 P-01,Auditor General,,DEM,H. Scott Conklin,3,9,0,0,12
+Lackawanna,Dickson City W-01 P-01,Auditor General,,DEM,Michael Lamb,10,12,4,0,26
+Lackawanna,Dickson City W-01 P-01,Auditor General,,DEM,Tracie Fountain,0,7,1,0,8
+Lackawanna,Dickson City W-01 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,8,25,6,0,39
+Lackawanna,Dickson City W-01 P-01,Auditor General,,DEM,Nina Ahmad,13,12,3,1,29
+Lackawanna,Dickson City W-01 P-01,Auditor General,,DEM,Christina M. Hartman,9,12,9,0,30
+Lackawanna,Dickson City W-01 P-01,Auditor General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Dickson City W-01 P-01,State Treasurer,,DEM,Joe Torsella,38,83,22,1,144
+Lackawanna,Dickson City W-01 P-01,State Treasurer,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,DEM,Matt Cartwright,42,91,24,1,158
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,DEM,Write-in,5,1,0,0,6
+Lackawanna,Dickson City W-01 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,43,85,23,1,152
+Lackawanna,Dickson City W-01 P-01,General Assembly,114,DEM,Write-in,3,1,0,0,4
+Lackawanna,Dickson City W-01 P-01,President,,REP,Donald J. Trump,43,16,2,0,61
+Lackawanna,Dickson City W-01 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-01,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Dickson City W-01 P-01,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Dickson City W-01 P-01,Attorney General,,REP,Heather Heidelbaugh,30,16,2,0,48
+Lackawanna,Dickson City W-01 P-01,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Dickson City W-01 P-01,Auditor General,,REP,Timothy DeFoor,31,16,2,0,49
+Lackawanna,Dickson City W-01 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-01,State Treasurer,,REP,Stacy L. Garrity,30,15,1,0,46
+Lackawanna,Dickson City W-01 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,REP,Teddy Daniels,9,3,1,0,13
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,REP,Jim Bognet,11,3,0,0,14
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,REP,Mike Marsicano,2,1,0,0,3
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,REP,Earl Granville,17,11,1,0,29
+Lackawanna,Dickson City W-01 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-01,General Assembly,114,REP,James May,32,16,2,0,50
+Lackawanna,Dickson City W-01 P-01,General Assembly,114,REP,Write-in,2,0,0,0,2
+Lackawanna,Dickson City W-01 P-02,Registered Voters,,,,,,,,794
+Lackawanna,Dickson City W-01 P-02,Registered Voters,,DEM,,,,,,589
+Lackawanna,Dickson City W-01 P-02,Registered Voters,,REP,,,,,,205
+Lackawanna,Dickson City W-01 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dickson City W-01 P-02,Ballots Cast,,,,135,146,19,0,300
+Lackawanna,Dickson City W-01 P-02,Ballots Cast,,DEM,,92,130,16,0,238
+Lackawanna,Dickson City W-01 P-02,Ballots Cast,,REP,,43,16,3,0,62
+Lackawanna,Dickson City W-01 P-02,President,,DEM,Bernie Sanders,18,13,0,0,31
+Lackawanna,Dickson City W-01 P-02,President,,DEM,Joseph R. Biden,57,110,15,0,182
+Lackawanna,Dickson City W-01 P-02,President,,DEM,Tulsi Gabbard,1,4,0,0,5
+Lackawanna,Dickson City W-01 P-02,President,,DEM,Write-in,10,0,0,0,10
+Lackawanna,Dickson City W-01 P-02,Attorney General,,DEM,Josh Shapiro,74,112,16,0,202
+Lackawanna,Dickson City W-01 P-02,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Dickson City W-01 P-02,Auditor General,,DEM,H. Scott Conklin,9,6,2,0,17
+Lackawanna,Dickson City W-01 P-02,Auditor General,,DEM,Michael Lamb,19,21,1,0,41
+Lackawanna,Dickson City W-01 P-02,Auditor General,,DEM,Tracie Fountain,9,9,3,0,21
+Lackawanna,Dickson City W-01 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,11,27,2,0,40
+Lackawanna,Dickson City W-01 P-02,Auditor General,,DEM,Nina Ahmad,19,17,3,0,39
+Lackawanna,Dickson City W-01 P-02,Auditor General,,DEM,Christina M. Hartman,7,24,5,0,36
+Lackawanna,Dickson City W-01 P-02,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dickson City W-01 P-02,State Treasurer,,DEM,Joe Torsella,70,106,14,0,190
+Lackawanna,Dickson City W-01 P-02,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,DEM,Matt Cartwright,78,119,16,0,213
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,DEM,Write-in,6,1,0,0,7
+Lackawanna,Dickson City W-01 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,72,111,15,0,198
+Lackawanna,Dickson City W-01 P-02,General Assembly,114,DEM,Write-in,2,0,0,0,2
+Lackawanna,Dickson City W-01 P-02,President,,REP,Donald J. Trump,43,13,3,0,59
+Lackawanna,Dickson City W-01 P-02,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Dickson City W-01 P-02,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-02,Attorney General,,REP,Heather Heidelbaugh,27,13,3,0,43
+Lackawanna,Dickson City W-01 P-02,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Dickson City W-01 P-02,Auditor General,,REP,Timothy DeFoor,27,13,3,0,43
+Lackawanna,Dickson City W-01 P-02,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Dickson City W-01 P-02,State Treasurer,,REP,Stacy L. Garrity,28,13,3,0,44
+Lackawanna,Dickson City W-01 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,REP,Teddy Daniels,8,2,0,0,10
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,REP,Jim Bognet,1,2,0,0,3
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,REP,Mike Marsicano,5,1,0,0,6
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,REP,Earl Granville,25,10,3,0,38
+Lackawanna,Dickson City W-01 P-02,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Dickson City W-01 P-02,General Assembly,114,REP,James May,36,15,3,0,54
+Lackawanna,Dickson City W-01 P-02,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-02 P-01,Registered Voters,,,,,,,,749
+Lackawanna,Dickson City W-02 P-01,Registered Voters,,DEM,,,,,,520
+Lackawanna,Dickson City W-02 P-01,Registered Voters,,REP,,,,,,229
+Lackawanna,Dickson City W-02 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dickson City W-02 P-01,Ballots Cast,,,,113,113,26,2,254
+Lackawanna,Dickson City W-02 P-01,Ballots Cast,,DEM,,55,97,18,2,172
+Lackawanna,Dickson City W-02 P-01,Ballots Cast,,REP,,58,16,8,0,82
+Lackawanna,Dickson City W-02 P-01,President,,DEM,Bernie Sanders,10,8,1,2,21
+Lackawanna,Dickson City W-02 P-01,President,,DEM,Joseph R. Biden,33,86,14,0,133
+Lackawanna,Dickson City W-02 P-01,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Dickson City W-02 P-01,President,,DEM,Write-in,5,0,3,0,8
+Lackawanna,Dickson City W-02 P-01,Attorney General,,DEM,Josh Shapiro,41,73,13,2,129
+Lackawanna,Dickson City W-02 P-01,Attorney General,,DEM,Write-in,1,0,3,0,4
+Lackawanna,Dickson City W-02 P-01,Auditor General,,DEM,H. Scott Conklin,3,4,0,0,7
+Lackawanna,Dickson City W-02 P-01,Auditor General,,DEM,Michael Lamb,15,10,2,1,28
+Lackawanna,Dickson City W-02 P-01,Auditor General,,DEM,Tracie Fountain,1,6,4,0,11
+Lackawanna,Dickson City W-02 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,6,22,0,0,28
+Lackawanna,Dickson City W-02 P-01,Auditor General,,DEM,Nina Ahmad,11,18,5,1,35
+Lackawanna,Dickson City W-02 P-01,Auditor General,,DEM,Christina M. Hartman,7,13,1,0,21
+Lackawanna,Dickson City W-02 P-01,Auditor General,,DEM,Write-in,2,0,3,0,5
+Lackawanna,Dickson City W-02 P-01,State Treasurer,,DEM,Joe Torsella,40,73,12,2,127
+Lackawanna,Dickson City W-02 P-01,State Treasurer,,DEM,Write-in,1,0,2,0,3
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,DEM,Matt Cartwright,42,90,14,2,148
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,DEM,Write-in,3,2,3,0,8
+Lackawanna,Dickson City W-02 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,44,80,13,2,139
+Lackawanna,Dickson City W-02 P-01,General Assembly,114,DEM,Write-in,1,0,3,0,4
+Lackawanna,Dickson City W-02 P-01,President,,REP,Donald J. Trump,54,15,6,0,75
+Lackawanna,Dickson City W-02 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Dickson City W-02 P-01,President,,REP,Bill Weld,0,1,1,0,2
+Lackawanna,Dickson City W-02 P-01,President,,REP,Write-in,2,0,1,0,3
+Lackawanna,Dickson City W-02 P-01,Attorney General,,REP,Heather Heidelbaugh,42,15,7,0,64
+Lackawanna,Dickson City W-02 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-02 P-01,Auditor General,,REP,Timothy DeFoor,40,15,7,0,62
+Lackawanna,Dickson City W-02 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-02 P-01,State Treasurer,,REP,Stacy L. Garrity,41,15,7,0,63
+Lackawanna,Dickson City W-02 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,REP,Harry Haas,2,0,0,0,2
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,REP,Teddy Daniels,20,4,1,0,25
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,REP,Jim Bognet,9,5,1,0,15
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,REP,Mike Marsicano,8,0,0,0,8
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,REP,Earl Granville,14,6,4,0,24
+Lackawanna,Dickson City W-02 P-01,U.S. House,8,REP,Write-in,2,0,0,0,2
+Lackawanna,Dickson City W-02 P-01,General Assembly,114,REP,James May,41,15,7,0,63
+Lackawanna,Dickson City W-02 P-01,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-01,Registered Voters,,,,,,,,472
+Lackawanna,Dickson City W-03 P-01,Registered Voters,,DEM,,,,,,348
+Lackawanna,Dickson City W-03 P-01,Registered Voters,,REP,,,,,,124
+Lackawanna,Dickson City W-03 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dickson City W-03 P-01,Ballots Cast,,,,112,81,17,2,212
+Lackawanna,Dickson City W-03 P-01,Ballots Cast,,DEM,,72,74,16,1,163
+Lackawanna,Dickson City W-03 P-01,Ballots Cast,,REP,,40,7,1,1,49
+Lackawanna,Dickson City W-03 P-01,President,,DEM,Bernie Sanders,12,5,3,0,20
+Lackawanna,Dickson City W-03 P-01,President,,DEM,Joseph R. Biden,42,63,13,1,119
+Lackawanna,Dickson City W-03 P-01,President,,DEM,Tulsi Gabbard,5,2,0,0,7
+Lackawanna,Dickson City W-03 P-01,President,,DEM,Write-in,6,3,0,0,9
+Lackawanna,Dickson City W-03 P-01,Attorney General,,DEM,Josh Shapiro,64,62,13,1,140
+Lackawanna,Dickson City W-03 P-01,Attorney General,,DEM,Write-in,0,4,0,0,4
+Lackawanna,Dickson City W-03 P-01,Auditor General,,DEM,H. Scott Conklin,4,2,2,0,8
+Lackawanna,Dickson City W-03 P-01,Auditor General,,DEM,Michael Lamb,16,8,0,0,24
+Lackawanna,Dickson City W-03 P-01,Auditor General,,DEM,Tracie Fountain,1,3,1,0,5
+Lackawanna,Dickson City W-03 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,4,20,3,0,27
+Lackawanna,Dickson City W-03 P-01,Auditor General,,DEM,Nina Ahmad,22,12,1,0,35
+Lackawanna,Dickson City W-03 P-01,Auditor General,,DEM,Christina M. Hartman,8,13,5,1,27
+Lackawanna,Dickson City W-03 P-01,Auditor General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Dickson City W-03 P-01,State Treasurer,,DEM,Joe Torsella,52,55,11,1,119
+Lackawanna,Dickson City W-03 P-01,State Treasurer,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,DEM,Matt Cartwright,62,68,15,1,146
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,DEM,Write-in,1,3,0,0,4
+Lackawanna,Dickson City W-03 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,56,59,13,1,129
+Lackawanna,Dickson City W-03 P-01,General Assembly,114,DEM,Write-in,1,2,0,0,3
+Lackawanna,Dickson City W-03 P-01,President,,REP,Donald J. Trump,38,3,1,1,43
+Lackawanna,Dickson City W-03 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-01,President,,REP,Bill Weld,1,0,0,0,1
+Lackawanna,Dickson City W-03 P-01,President,,REP,Write-in,0,2,0,0,2
+Lackawanna,Dickson City W-03 P-01,Attorney General,,REP,Heather Heidelbaugh,29,6,0,1,36
+Lackawanna,Dickson City W-03 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-01,Auditor General,,REP,Timothy DeFoor,29,6,0,1,36
+Lackawanna,Dickson City W-03 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-01,State Treasurer,,REP,Stacy L. Garrity,30,6,1,0,37
+Lackawanna,Dickson City W-03 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,REP,Harry Haas,2,0,0,0,2
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,REP,Teddy Daniels,7,0,0,0,7
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,REP,Jim Bognet,9,0,1,0,10
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,REP,Mike Marsicano,4,1,0,0,5
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,REP,Earl Granville,17,5,0,1,23
+Lackawanna,Dickson City W-03 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-01,General Assembly,114,REP,James May,29,5,1,1,36
+Lackawanna,Dickson City W-03 P-01,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Dickson City W-03 P-02,Registered Voters,,,,,,,,690
+Lackawanna,Dickson City W-03 P-02,Registered Voters,,DEM,,,,,,516
+Lackawanna,Dickson City W-03 P-02,Registered Voters,,REP,,,,,,174
+Lackawanna,Dickson City W-03 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dickson City W-03 P-02,Ballots Cast,,,,127,169,24,5,325
+Lackawanna,Dickson City W-03 P-02,Ballots Cast,,DEM,,72,146,22,4,244
+Lackawanna,Dickson City W-03 P-02,Ballots Cast,,REP,,55,23,2,1,81
+Lackawanna,Dickson City W-03 P-02,President,,DEM,Bernie Sanders,10,10,4,0,24
+Lackawanna,Dickson City W-03 P-02,President,,DEM,Joseph R. Biden,45,125,16,3,189
+Lackawanna,Dickson City W-03 P-02,President,,DEM,Tulsi Gabbard,10,7,0,1,18
+Lackawanna,Dickson City W-03 P-02,President,,DEM,Write-in,4,2,2,0,8
+Lackawanna,Dickson City W-03 P-02,Attorney General,,DEM,Josh Shapiro,57,132,17,3,209
+Lackawanna,Dickson City W-03 P-02,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Dickson City W-03 P-02,Auditor General,,DEM,H. Scott Conklin,2,9,2,0,13
+Lackawanna,Dickson City W-03 P-02,Auditor General,,DEM,Michael Lamb,21,16,5,1,43
+Lackawanna,Dickson City W-03 P-02,Auditor General,,DEM,Tracie Fountain,2,6,2,0,10
+Lackawanna,Dickson City W-03 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,11,45,3,0,59
+Lackawanna,Dickson City W-03 P-02,Auditor General,,DEM,Nina Ahmad,24,20,3,2,49
+Lackawanna,Dickson City W-03 P-02,Auditor General,,DEM,Christina M. Hartman,4,22,3,0,29
+Lackawanna,Dickson City W-03 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-02,State Treasurer,,DEM,Joe Torsella,58,120,15,3,196
+Lackawanna,Dickson City W-03 P-02,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,DEM,Matt Cartwright,60,133,21,4,218
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,DEM,Write-in,5,1,1,0,7
+Lackawanna,Dickson City W-03 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,60,132,16,4,212
+Lackawanna,Dickson City W-03 P-02,General Assembly,114,DEM,Write-in,2,1,0,0,3
+Lackawanna,Dickson City W-03 P-02,President,,REP,Donald J. Trump,53,19,0,1,73
+Lackawanna,Dickson City W-03 P-02,President,,REP,Roque Rocky De La Fuente,2,0,2,0,4
+Lackawanna,Dickson City W-03 P-02,President,,REP,Bill Weld,0,3,0,0,3
+Lackawanna,Dickson City W-03 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-02,Attorney General,,REP,Heather Heidelbaugh,40,23,2,1,66
+Lackawanna,Dickson City W-03 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-02,Auditor General,,REP,Timothy DeFoor,39,23,2,1,65
+Lackawanna,Dickson City W-03 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-02,State Treasurer,,REP,Stacy L. Garrity,40,23,2,1,66
+Lackawanna,Dickson City W-03 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,REP,Teddy Daniels,16,5,0,1,22
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,REP,Jim Bognet,9,1,0,0,10
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,REP,Mike Marsicano,3,0,1,0,4
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,REP,Earl Granville,24,16,1,0,41
+Lackawanna,Dickson City W-03 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-02,General Assembly,114,REP,James May,44,23,2,1,70
+Lackawanna,Dickson City W-03 P-02,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-03,Registered Voters,,,,,,,,554
+Lackawanna,Dickson City W-03 P-03,Registered Voters,,DEM,,,,,,406
+Lackawanna,Dickson City W-03 P-03,Registered Voters,,REP,,,,,,148
+Lackawanna,Dickson City W-03 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dickson City W-03 P-03,Ballots Cast,,,,106,124,22,0,252
+Lackawanna,Dickson City W-03 P-03,Ballots Cast,,DEM,,60,107,16,0,183
+Lackawanna,Dickson City W-03 P-03,Ballots Cast,,REP,,46,17,6,0,69
+Lackawanna,Dickson City W-03 P-03,President,,DEM,Bernie Sanders,8,16,4,0,28
+Lackawanna,Dickson City W-03 P-03,President,,DEM,Joseph R. Biden,32,86,11,0,129
+Lackawanna,Dickson City W-03 P-03,President,,DEM,Tulsi Gabbard,6,1,1,0,8
+Lackawanna,Dickson City W-03 P-03,President,,DEM,Write-in,6,3,0,0,9
+Lackawanna,Dickson City W-03 P-03,Attorney General,,DEM,Josh Shapiro,44,92,13,0,149
+Lackawanna,Dickson City W-03 P-03,Attorney General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Dickson City W-03 P-03,Auditor General,,DEM,H. Scott Conklin,5,6,0,0,11
+Lackawanna,Dickson City W-03 P-03,Auditor General,,DEM,Michael Lamb,13,15,0,0,28
+Lackawanna,Dickson City W-03 P-03,Auditor General,,DEM,Tracie Fountain,2,8,0,0,10
+Lackawanna,Dickson City W-03 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,5,24,6,0,35
+Lackawanna,Dickson City W-03 P-03,Auditor General,,DEM,Nina Ahmad,17,20,3,0,40
+Lackawanna,Dickson City W-03 P-03,Auditor General,,DEM,Christina M. Hartman,8,15,3,0,26
+Lackawanna,Dickson City W-03 P-03,Auditor General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Dickson City W-03 P-03,State Treasurer,,DEM,Joe Torsella,42,83,14,0,139
+Lackawanna,Dickson City W-03 P-03,State Treasurer,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,DEM,Matt Cartwright,44,95,14,0,153
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,DEM,Write-in,2,1,0,0,3
+Lackawanna,Dickson City W-03 P-03,General Assembly,114,DEM,Bridget Malloy Kosierowski,47,95,13,0,155
+Lackawanna,Dickson City W-03 P-03,General Assembly,114,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dickson City W-03 P-03,President,,REP,Donald J. Trump,43,10,4,0,57
+Lackawanna,Dickson City W-03 P-03,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Dickson City W-03 P-03,President,,REP,Bill Weld,0,1,1,0,2
+Lackawanna,Dickson City W-03 P-03,President,,REP,Write-in,0,3,0,0,3
+Lackawanna,Dickson City W-03 P-03,Attorney General,,REP,Heather Heidelbaugh,32,15,4,0,51
+Lackawanna,Dickson City W-03 P-03,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dickson City W-03 P-03,Auditor General,,REP,Timothy DeFoor,33,15,2,0,50
+Lackawanna,Dickson City W-03 P-03,Auditor General,,REP,Write-in,0,1,1,0,2
+Lackawanna,Dickson City W-03 P-03,State Treasurer,,REP,Stacy L. Garrity,33,15,2,0,50
+Lackawanna,Dickson City W-03 P-03,State Treasurer,,REP,Write-in,0,1,1,0,2
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,REP,Harry Haas,0,3,1,0,4
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,REP,Teddy Daniels,6,0,1,0,7
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,REP,Jim Bognet,15,2,1,0,18
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,REP,Earl Granville,20,11,3,0,34
+Lackawanna,Dickson City W-03 P-03,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Dickson City W-03 P-03,General Assembly,114,REP,James May,36,15,4,0,55
+Lackawanna,Dickson City W-03 P-03,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-01,Registered Voters,,,,,,,,894
+Lackawanna,Dunmore W-01 P-01,Registered Voters,,DEM,,,,,,698
+Lackawanna,Dunmore W-01 P-01,Registered Voters,,REP,,,,,,196
+Lackawanna,Dunmore W-01 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-01 P-01,Ballots Cast,,,,97,246,28,4,375
+Lackawanna,Dunmore W-01 P-01,Ballots Cast,,DEM,,64,226,28,3,321
+Lackawanna,Dunmore W-01 P-01,Ballots Cast,,REP,,33,20,0,1,54
+Lackawanna,Dunmore W-01 P-01,President,,DEM,Bernie Sanders,10,17,1,0,28
+Lackawanna,Dunmore W-01 P-01,President,,DEM,Joseph R. Biden,48,204,27,3,282
+Lackawanna,Dunmore W-01 P-01,President,,DEM,Tulsi Gabbard,2,4,0,0,6
+Lackawanna,Dunmore W-01 P-01,President,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dunmore W-01 P-01,Attorney General,,DEM,Josh Shapiro,55,185,24,2,266
+Lackawanna,Dunmore W-01 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-01,Auditor General,,DEM,H. Scott Conklin,3,6,4,0,13
+Lackawanna,Dunmore W-01 P-01,Auditor General,,DEM,Michael Lamb,13,34,4,0,51
+Lackawanna,Dunmore W-01 P-01,Auditor General,,DEM,Tracie Fountain,2,18,4,0,24
+Lackawanna,Dunmore W-01 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,8,54,1,2,65
+Lackawanna,Dunmore W-01 P-01,Auditor General,,DEM,Nina Ahmad,25,38,8,1,72
+Lackawanna,Dunmore W-01 P-01,Auditor General,,DEM,Christina M. Hartman,4,25,4,0,33
+Lackawanna,Dunmore W-01 P-01,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-01,State Treasurer,,DEM,Joe Torsella,50,174,24,2,250
+Lackawanna,Dunmore W-01 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,DEM,Matt Cartwright,56,215,23,2,296
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,DEM,Write-in,3,2,1,0,6
+Lackawanna,Dunmore W-01 P-01,General Assembly,112,DEM,Kyle J. Mullins,54,205,23,2,284
+Lackawanna,Dunmore W-01 P-01,General Assembly,112,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dunmore W-01 P-01,President,,REP,Donald J. Trump,30,11,0,1,42
+Lackawanna,Dunmore W-01 P-01,President,,REP,Roque Rocky De La Fuente,2,1,0,0,3
+Lackawanna,Dunmore W-01 P-01,President,,REP,Bill Weld,1,3,0,0,4
+Lackawanna,Dunmore W-01 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-01,Attorney General,,REP,Heather Heidelbaugh,29,14,0,0,43
+Lackawanna,Dunmore W-01 P-01,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-01,Auditor General,,REP,Timothy DeFoor,29,15,0,0,44
+Lackawanna,Dunmore W-01 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-01,State Treasurer,,REP,Stacy L. Garrity,27,15,0,0,42
+Lackawanna,Dunmore W-01 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,REP,Harry Haas,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,REP,Teddy Daniels,10,1,0,0,11
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,REP,Jim Bognet,8,0,0,0,8
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,REP,Earl Granville,10,18,0,1,29
+Lackawanna,Dunmore W-01 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-01,General Assembly,112,REP,Write-in,9,8,0,0,17
+Lackawanna,Dunmore W-01 P-02,Registered Voters,,,,,,,,942
+Lackawanna,Dunmore W-01 P-02,Registered Voters,,DEM,,,,,,741
+Lackawanna,Dunmore W-01 P-02,Registered Voters,,REP,,,,,,201
+Lackawanna,Dunmore W-01 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-01 P-02,Ballots Cast,,,,210,237,41,10,498
+Lackawanna,Dunmore W-01 P-02,Ballots Cast,,DEM,,149,212,37,6,404
+Lackawanna,Dunmore W-01 P-02,Ballots Cast,,REP,,61,25,4,4,94
+Lackawanna,Dunmore W-01 P-02,President,,DEM,Bernie Sanders,25,15,3,1,44
+Lackawanna,Dunmore W-01 P-02,President,,DEM,Joseph R. Biden,96,178,33,4,311
+Lackawanna,Dunmore W-01 P-02,President,,DEM,Tulsi Gabbard,5,7,0,1,13
+Lackawanna,Dunmore W-01 P-02,President,,DEM,Write-in,14,2,0,0,16
+Lackawanna,Dunmore W-01 P-02,Attorney General,,DEM,Josh Shapiro,111,171,31,6,319
+Lackawanna,Dunmore W-01 P-02,Attorney General,,DEM,Write-in,5,2,1,0,8
+Lackawanna,Dunmore W-01 P-02,Auditor General,,DEM,H. Scott Conklin,6,12,1,0,19
+Lackawanna,Dunmore W-01 P-02,Auditor General,,DEM,Michael Lamb,23,19,7,2,51
+Lackawanna,Dunmore W-01 P-02,Auditor General,,DEM,Tracie Fountain,5,12,2,0,19
+Lackawanna,Dunmore W-01 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,22,50,11,0,83
+Lackawanna,Dunmore W-01 P-02,Auditor General,,DEM,Nina Ahmad,47,42,7,3,99
+Lackawanna,Dunmore W-01 P-02,Auditor General,,DEM,Christina M. Hartman,12,38,3,1,54
+Lackawanna,Dunmore W-01 P-02,Auditor General,,DEM,Write-in,4,0,0,0,4
+Lackawanna,Dunmore W-01 P-02,State Treasurer,,DEM,Joe Torsella,105,163,31,5,304
+Lackawanna,Dunmore W-01 P-02,State Treasurer,,DEM,Write-in,4,0,0,1,5
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,DEM,Matt Cartwright,118,192,35,4,349
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,DEM,Write-in,8,0,0,1,9
+Lackawanna,Dunmore W-01 P-02,General Assembly,112,DEM,Kyle J. Mullins,117,184,36,6,343
+Lackawanna,Dunmore W-01 P-02,General Assembly,112,DEM,Write-in,3,1,0,0,4
+Lackawanna,Dunmore W-01 P-02,President,,REP,Donald J. Trump,56,19,3,4,82
+Lackawanna,Dunmore W-01 P-02,President,,REP,Roque Rocky De La Fuente,3,1,1,0,5
+Lackawanna,Dunmore W-01 P-02,President,,REP,Bill Weld,2,3,0,0,5
+Lackawanna,Dunmore W-01 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-02,Attorney General,,REP,Heather Heidelbaugh,43,23,4,4,74
+Lackawanna,Dunmore W-01 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-02,Auditor General,,REP,Timothy DeFoor,42,23,4,4,73
+Lackawanna,Dunmore W-01 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-02,State Treasurer,,REP,Stacy L. Garrity,40,22,4,4,70
+Lackawanna,Dunmore W-01 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,REP,Harry Haas,3,0,0,0,3
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,REP,Teddy Daniels,14,5,0,2,21
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,REP,Jim Bognet,2,3,0,0,5
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,REP,Mike Marsicano,6,3,0,0,9
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,REP,Earl Granville,28,12,4,2,46
+Lackawanna,Dunmore W-01 P-02,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-02,General Assembly,112,REP,Write-in,9,9,1,1,20
+Lackawanna,Dunmore W-01 P-03,Registered Voters,,,,,,,,1154
+Lackawanna,Dunmore W-01 P-03,Registered Voters,,DEM,,,,,,870
+Lackawanna,Dunmore W-01 P-03,Registered Voters,,REP,,,,,,284
+Lackawanna,Dunmore W-01 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-01 P-03,Ballots Cast,,,,169,299,71,9,548
+Lackawanna,Dunmore W-01 P-03,Ballots Cast,,DEM,,123,254,66,5,448
+Lackawanna,Dunmore W-01 P-03,Ballots Cast,,REP,,46,45,5,4,100
+Lackawanna,Dunmore W-01 P-03,President,,DEM,Bernie Sanders,15,19,7,1,42
+Lackawanna,Dunmore W-01 P-03,President,,DEM,Joseph R. Biden,85,222,52,4,363
+Lackawanna,Dunmore W-01 P-03,President,,DEM,Tulsi Gabbard,12,11,6,0,29
+Lackawanna,Dunmore W-01 P-03,President,,DEM,Write-in,6,1,0,0,7
+Lackawanna,Dunmore W-01 P-03,Attorney General,,DEM,Josh Shapiro,91,226,51,4,372
+Lackawanna,Dunmore W-01 P-03,Attorney General,,DEM,Write-in,2,0,1,0,3
+Lackawanna,Dunmore W-01 P-03,Auditor General,,DEM,H. Scott Conklin,3,13,2,0,18
+Lackawanna,Dunmore W-01 P-03,Auditor General,,DEM,Michael Lamb,16,43,12,0,71
+Lackawanna,Dunmore W-01 P-03,Auditor General,,DEM,Tracie Fountain,6,20,2,1,29
+Lackawanna,Dunmore W-01 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,18,70,20,1,109
+Lackawanna,Dunmore W-01 P-03,Auditor General,,DEM,Nina Ahmad,33,43,13,3,92
+Lackawanna,Dunmore W-01 P-03,Auditor General,,DEM,Christina M. Hartman,15,35,3,0,53
+Lackawanna,Dunmore W-01 P-03,Auditor General,,DEM,Write-in,2,1,1,0,4
+Lackawanna,Dunmore W-01 P-03,State Treasurer,,DEM,Joe Torsella,77,215,45,3,340
+Lackawanna,Dunmore W-01 P-03,State Treasurer,,DEM,Write-in,3,1,1,0,5
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,DEM,Matt Cartwright,93,234,60,3,390
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,DEM,Write-in,6,1,2,0,9
+Lackawanna,Dunmore W-01 P-03,General Assembly,112,DEM,Kyle J. Mullins,92,229,52,3,376
+Lackawanna,Dunmore W-01 P-03,General Assembly,112,DEM,Write-in,1,2,3,0,6
+Lackawanna,Dunmore W-01 P-03,President,,REP,Donald J. Trump,41,32,5,3,81
+Lackawanna,Dunmore W-01 P-03,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Dunmore W-01 P-03,President,,REP,Bill Weld,1,6,0,1,8
+Lackawanna,Dunmore W-01 P-03,President,,REP,Write-in,1,4,0,0,5
+Lackawanna,Dunmore W-01 P-03,Attorney General,,REP,Heather Heidelbaugh,40,36,2,3,81
+Lackawanna,Dunmore W-01 P-03,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-03,Auditor General,,REP,Timothy DeFoor,40,36,2,3,81
+Lackawanna,Dunmore W-01 P-03,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-03,State Treasurer,,REP,Stacy L. Garrity,36,39,1,3,79
+Lackawanna,Dunmore W-01 P-03,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,REP,Harry Haas,4,1,0,2,7
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,REP,Teddy Daniels,6,1,0,0,7
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,REP,Jim Bognet,13,8,3,0,24
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,REP,Mike Cammisa,0,0,0,2,2
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,REP,Mike Marsicano,7,9,0,0,16
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,REP,Earl Granville,14,24,2,0,40
+Lackawanna,Dunmore W-01 P-03,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-01 P-03,General Assembly,112,REP,Write-in,2,7,1,0,10
+Lackawanna,Dunmore W-02 P-01,Registered Voters,,,,,,,,807
+Lackawanna,Dunmore W-02 P-01,Registered Voters,,DEM,,,,,,593
+Lackawanna,Dunmore W-02 P-01,Registered Voters,,REP,,,,,,214
+Lackawanna,Dunmore W-02 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-02 P-01,Ballots Cast,,,,119,160,30,2,311
+Lackawanna,Dunmore W-02 P-01,Ballots Cast,,DEM,,78,144,29,0,251
+Lackawanna,Dunmore W-02 P-01,Ballots Cast,,REP,,41,16,1,2,60
+Lackawanna,Dunmore W-02 P-01,President,,DEM,Bernie Sanders,15,23,3,0,41
+Lackawanna,Dunmore W-02 P-01,President,,DEM,Joseph R. Biden,41,114,26,0,181
+Lackawanna,Dunmore W-02 P-01,President,,DEM,Tulsi Gabbard,7,4,0,0,11
+Lackawanna,Dunmore W-02 P-01,President,,DEM,Write-in,4,1,0,0,5
+Lackawanna,Dunmore W-02 P-01,Attorney General,,DEM,Josh Shapiro,54,121,26,0,201
+Lackawanna,Dunmore W-02 P-01,Attorney General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-02 P-01,Auditor General,,DEM,H. Scott Conklin,4,4,2,0,10
+Lackawanna,Dunmore W-02 P-01,Auditor General,,DEM,Michael Lamb,15,24,8,0,47
+Lackawanna,Dunmore W-02 P-01,Auditor General,,DEM,Tracie Fountain,2,10,1,0,13
+Lackawanna,Dunmore W-02 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,9,45,7,0,61
+Lackawanna,Dunmore W-02 P-01,Auditor General,,DEM,Nina Ahmad,19,20,6,0,45
+Lackawanna,Dunmore W-02 P-01,Auditor General,,DEM,Christina M. Hartman,8,21,3,0,32
+Lackawanna,Dunmore W-02 P-01,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-02 P-01,State Treasurer,,DEM,Joe Torsella,46,119,26,0,191
+Lackawanna,Dunmore W-02 P-01,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,DEM,Matt Cartwright,58,130,26,0,214
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,DEM,Write-in,2,2,0,0,4
+Lackawanna,Dunmore W-02 P-01,General Assembly,112,DEM,Kyle J. Mullins,50,122,26,0,198
+Lackawanna,Dunmore W-02 P-01,General Assembly,112,DEM,Write-in,2,0,0,0,2
+Lackawanna,Dunmore W-02 P-01,President,,REP,Donald J. Trump,38,10,1,2,51
+Lackawanna,Dunmore W-02 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-01,President,,REP,Bill Weld,1,2,0,0,3
+Lackawanna,Dunmore W-02 P-01,President,,REP,Write-in,0,2,0,0,2
+Lackawanna,Dunmore W-02 P-01,Attorney General,,REP,Heather Heidelbaugh,30,11,1,1,43
+Lackawanna,Dunmore W-02 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-01,Auditor General,,REP,Timothy DeFoor,29,13,1,1,44
+Lackawanna,Dunmore W-02 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-01,State Treasurer,,REP,Stacy L. Garrity,27,13,1,1,42
+Lackawanna,Dunmore W-02 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,REP,Teddy Daniels,12,3,0,0,15
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,REP,Jim Bognet,10,1,0,2,13
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,REP,Mike Marsicano,2,0,0,0,2
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,REP,Earl Granville,15,12,1,0,28
+Lackawanna,Dunmore W-02 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-01,General Assembly,112,REP,Write-in,16,1,0,0,17
+Lackawanna,Dunmore W-02 P-02,Registered Voters,,,,,,,,914
+Lackawanna,Dunmore W-02 P-02,Registered Voters,,DEM,,,,,,689
+Lackawanna,Dunmore W-02 P-02,Registered Voters,,REP,,,,,,225
+Lackawanna,Dunmore W-02 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-02 P-02,Ballots Cast,,,,139,233,46,3,421
+Lackawanna,Dunmore W-02 P-02,Ballots Cast,,DEM,,93,208,40,2,343
+Lackawanna,Dunmore W-02 P-02,Ballots Cast,,REP,,46,25,6,1,78
+Lackawanna,Dunmore W-02 P-02,President,,DEM,Bernie Sanders,16,19,4,1,40
+Lackawanna,Dunmore W-02 P-02,President,,DEM,Joseph R. Biden,60,182,36,1,279
+Lackawanna,Dunmore W-02 P-02,President,,DEM,Tulsi Gabbard,8,3,0,0,11
+Lackawanna,Dunmore W-02 P-02,President,,DEM,Write-in,4,3,0,0,7
+Lackawanna,Dunmore W-02 P-02,Attorney General,,DEM,Josh Shapiro,59,178,32,2,271
+Lackawanna,Dunmore W-02 P-02,Attorney General,,DEM,Write-in,1,1,1,0,3
+Lackawanna,Dunmore W-02 P-02,Auditor General,,DEM,H. Scott Conklin,0,17,3,0,20
+Lackawanna,Dunmore W-02 P-02,Auditor General,,DEM,Michael Lamb,19,31,3,1,54
+Lackawanna,Dunmore W-02 P-02,Auditor General,,DEM,Tracie Fountain,4,8,6,0,18
+Lackawanna,Dunmore W-02 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,11,65,7,0,83
+Lackawanna,Dunmore W-02 P-02,Auditor General,,DEM,Nina Ahmad,25,23,7,0,55
+Lackawanna,Dunmore W-02 P-02,Auditor General,,DEM,Christina M. Hartman,7,18,10,1,36
+Lackawanna,Dunmore W-02 P-02,Auditor General,,DEM,Write-in,1,4,0,0,5
+Lackawanna,Dunmore W-02 P-02,State Treasurer,,DEM,Joe Torsella,50,172,32,2,256
+Lackawanna,Dunmore W-02 P-02,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,DEM,Matt Cartwright,75,192,34,2,303
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,DEM,Write-in,6,3,3,0,12
+Lackawanna,Dunmore W-02 P-02,General Assembly,112,DEM,Kyle J. Mullins,69,180,35,2,286
+Lackawanna,Dunmore W-02 P-02,General Assembly,112,DEM,Write-in,1,2,0,0,3
+Lackawanna,Dunmore W-02 P-02,President,,REP,Donald J. Trump,43,21,5,1,70
+Lackawanna,Dunmore W-02 P-02,President,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Lackawanna,Dunmore W-02 P-02,President,,REP,Bill Weld,1,4,0,0,5
+Lackawanna,Dunmore W-02 P-02,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-02 P-02,Attorney General,,REP,Heather Heidelbaugh,38,20,4,1,63
+Lackawanna,Dunmore W-02 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-02,Auditor General,,REP,Timothy DeFoor,35,21,2,1,59
+Lackawanna,Dunmore W-02 P-02,Auditor General,,REP,Write-in,2,0,1,0,3
+Lackawanna,Dunmore W-02 P-02,State Treasurer,,REP,Stacy L. Garrity,34,22,2,1,59
+Lackawanna,Dunmore W-02 P-02,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,REP,Harry Haas,3,0,0,0,3
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,REP,Teddy Daniels,16,2,0,0,18
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,REP,Jim Bognet,9,4,0,1,14
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,REP,Mike Marsicano,4,1,0,0,5
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,REP,Earl Granville,9,16,4,0,29
+Lackawanna,Dunmore W-02 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-02 P-02,General Assembly,112,REP,Write-in,13,2,2,1,18
+Lackawanna,Dunmore W-03 P-01,Registered Voters,,,,,,,,795
+Lackawanna,Dunmore W-03 P-01,Registered Voters,,DEM,,,,,,592
+Lackawanna,Dunmore W-03 P-01,Registered Voters,,REP,,,,,,203
+Lackawanna,Dunmore W-03 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-03 P-01,Ballots Cast,,,,164,155,34,1,354
+Lackawanna,Dunmore W-03 P-01,Ballots Cast,,DEM,,110,142,30,1,283
+Lackawanna,Dunmore W-03 P-01,Ballots Cast,,REP,,54,13,4,0,71
+Lackawanna,Dunmore W-03 P-01,President,,DEM,Bernie Sanders,22,13,9,1,45
+Lackawanna,Dunmore W-03 P-01,President,,DEM,Joseph R. Biden,64,120,21,0,205
+Lackawanna,Dunmore W-03 P-01,President,,DEM,Tulsi Gabbard,7,2,0,0,9
+Lackawanna,Dunmore W-03 P-01,President,,DEM,Write-in,8,3,0,0,11
+Lackawanna,Dunmore W-03 P-01,Attorney General,,DEM,Josh Shapiro,89,122,27,1,239
+Lackawanna,Dunmore W-03 P-01,Attorney General,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Dunmore W-03 P-01,Auditor General,,DEM,H. Scott Conklin,9,10,2,0,21
+Lackawanna,Dunmore W-03 P-01,Auditor General,,DEM,Michael Lamb,12,12,5,0,29
+Lackawanna,Dunmore W-03 P-01,Auditor General,,DEM,Tracie Fountain,8,7,0,1,16
+Lackawanna,Dunmore W-03 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,23,38,10,0,71
+Lackawanna,Dunmore W-03 P-01,Auditor General,,DEM,Nina Ahmad,25,30,7,0,62
+Lackawanna,Dunmore W-03 P-01,Auditor General,,DEM,Christina M. Hartman,10,15,3,0,28
+Lackawanna,Dunmore W-03 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-01,State Treasurer,,DEM,Joe Torsella,83,110,28,1,222
+Lackawanna,Dunmore W-03 P-01,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,DEM,Matt Cartwright,88,132,25,1,246
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,DEM,Write-in,7,2,0,0,9
+Lackawanna,Dunmore W-03 P-01,General Assembly,112,DEM,Kyle J. Mullins,85,122,28,1,236
+Lackawanna,Dunmore W-03 P-01,General Assembly,112,DEM,Write-in,1,1,0,0,2
+Lackawanna,Dunmore W-03 P-01,President,,REP,Donald J. Trump,51,11,3,0,65
+Lackawanna,Dunmore W-03 P-01,President,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Lackawanna,Dunmore W-03 P-01,President,,REP,Bill Weld,3,1,0,0,4
+Lackawanna,Dunmore W-03 P-01,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-03 P-01,Attorney General,,REP,Heather Heidelbaugh,41,11,4,0,56
+Lackawanna,Dunmore W-03 P-01,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Dunmore W-03 P-01,Auditor General,,REP,Timothy DeFoor,40,10,4,0,54
+Lackawanna,Dunmore W-03 P-01,Auditor General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Dunmore W-03 P-01,State Treasurer,,REP,Stacy L. Garrity,41,10,4,0,55
+Lackawanna,Dunmore W-03 P-01,State Treasurer,,REP,Write-in,2,0,0,0,2
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,REP,Teddy Daniels,16,0,1,0,17
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,REP,Jim Bognet,15,5,1,0,21
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,REP,Mike Marsicano,10,2,0,0,12
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,REP,Earl Granville,10,6,2,0,18
+Lackawanna,Dunmore W-03 P-01,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-01,General Assembly,112,REP,Write-in,9,4,1,0,14
+Lackawanna,Dunmore W-03 P-02,Registered Voters,,,,,,,,550
+Lackawanna,Dunmore W-03 P-02,Registered Voters,,DEM,,,,,,401
+Lackawanna,Dunmore W-03 P-02,Registered Voters,,REP,,,,,,149
+Lackawanna,Dunmore W-03 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-03 P-02,Ballots Cast,,,,88,120,10,9,227
+Lackawanna,Dunmore W-03 P-02,Ballots Cast,,DEM,,59,100,9,7,175
+Lackawanna,Dunmore W-03 P-02,Ballots Cast,,REP,,29,20,1,2,52
+Lackawanna,Dunmore W-03 P-02,President,,DEM,Bernie Sanders,9,10,2,3,24
+Lackawanna,Dunmore W-03 P-02,President,,DEM,Joseph R. Biden,41,83,7,3,134
+Lackawanna,Dunmore W-03 P-02,President,,DEM,Tulsi Gabbard,5,2,0,0,7
+Lackawanna,Dunmore W-03 P-02,President,,DEM,Write-in,2,3,0,1,6
+Lackawanna,Dunmore W-03 P-02,Attorney General,,DEM,Josh Shapiro,42,84,9,7,142
+Lackawanna,Dunmore W-03 P-02,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Dunmore W-03 P-02,Auditor General,,DEM,H. Scott Conklin,1,3,0,0,4
+Lackawanna,Dunmore W-03 P-02,Auditor General,,DEM,Michael Lamb,10,14,0,1,25
+Lackawanna,Dunmore W-03 P-02,Auditor General,,DEM,Tracie Fountain,3,10,1,1,15
+Lackawanna,Dunmore W-03 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,5,21,2,3,31
+Lackawanna,Dunmore W-03 P-02,Auditor General,,DEM,Nina Ahmad,25,16,3,0,44
+Lackawanna,Dunmore W-03 P-02,Auditor General,,DEM,Christina M. Hartman,7,10,2,2,21
+Lackawanna,Dunmore W-03 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-02,State Treasurer,,DEM,Joe Torsella,38,76,8,7,129
+Lackawanna,Dunmore W-03 P-02,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,DEM,Matt Cartwright,45,87,9,6,147
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,DEM,Write-in,3,3,0,0,6
+Lackawanna,Dunmore W-03 P-02,General Assembly,112,DEM,Kyle J. Mullins,44,85,8,7,144
+Lackawanna,Dunmore W-03 P-02,General Assembly,112,DEM,Write-in,3,1,0,0,4
+Lackawanna,Dunmore W-03 P-02,President,,REP,Donald J. Trump,26,18,1,2,47
+Lackawanna,Dunmore W-03 P-02,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Dunmore W-03 P-02,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Dunmore W-03 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-03 P-02,Attorney General,,REP,Heather Heidelbaugh,24,14,1,2,41
+Lackawanna,Dunmore W-03 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-02,Auditor General,,REP,Timothy DeFoor,24,13,1,2,40
+Lackawanna,Dunmore W-03 P-02,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-02,State Treasurer,,REP,Stacy L. Garrity,25,14,1,1,41
+Lackawanna,Dunmore W-03 P-02,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,REP,Teddy Daniels,7,2,0,0,9
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,REP,Jim Bognet,5,4,0,0,9
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,REP,Mike Marsicano,2,0,0,0,2
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,REP,Earl Granville,13,12,1,2,28
+Lackawanna,Dunmore W-03 P-02,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-03 P-02,General Assembly,112,REP,Write-in,9,1,0,0,10
+Lackawanna,Dunmore W-05 P-00,Registered Voters,,,,,,,,530
+Lackawanna,Dunmore W-05 P-00,Registered Voters,,DEM,,,,,,350
+Lackawanna,Dunmore W-05 P-00,Registered Voters,,REP,,,,,,180
+Lackawanna,Dunmore W-05 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-05 P-00,Ballots Cast,,,,66,94,27,2,189
+Lackawanna,Dunmore W-05 P-00,Ballots Cast,,DEM,,31,84,21,1,137
+Lackawanna,Dunmore W-05 P-00,Ballots Cast,,REP,,35,10,6,1,52
+Lackawanna,Dunmore W-05 P-00,President,,DEM,Bernie Sanders,6,8,2,0,16
+Lackawanna,Dunmore W-05 P-00,President,,DEM,Joseph R. Biden,17,74,17,1,109
+Lackawanna,Dunmore W-05 P-00,President,,DEM,Tulsi Gabbard,2,0,2,0,4
+Lackawanna,Dunmore W-05 P-00,President,,DEM,Write-in,4,2,0,0,6
+Lackawanna,Dunmore W-05 P-00,Attorney General,,DEM,Josh Shapiro,23,74,20,0,117
+Lackawanna,Dunmore W-05 P-00,Attorney General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-05 P-00,Auditor General,,DEM,H. Scott Conklin,2,2,0,0,4
+Lackawanna,Dunmore W-05 P-00,Auditor General,,DEM,Michael Lamb,3,8,4,0,15
+Lackawanna,Dunmore W-05 P-00,Auditor General,,DEM,Tracie Fountain,1,6,2,0,9
+Lackawanna,Dunmore W-05 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,4,25,8,0,37
+Lackawanna,Dunmore W-05 P-00,Auditor General,,DEM,Nina Ahmad,7,21,2,0,30
+Lackawanna,Dunmore W-05 P-00,Auditor General,,DEM,Christina M. Hartman,2,12,2,0,16
+Lackawanna,Dunmore W-05 P-00,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-05 P-00,State Treasurer,,DEM,Joe Torsella,20,72,18,1,111
+Lackawanna,Dunmore W-05 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,DEM,Matt Cartwright,24,77,19,1,121
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Dunmore W-05 P-00,General Assembly,112,DEM,Kyle J. Mullins,22,75,19,1,117
+Lackawanna,Dunmore W-05 P-00,General Assembly,112,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-05 P-00,President,,REP,Donald J. Trump,34,8,6,1,49
+Lackawanna,Dunmore W-05 P-00,President,,REP,Roque Rocky De La Fuente,0,2,0,0,2
+Lackawanna,Dunmore W-05 P-00,President,,REP,Bill Weld,1,0,0,0,1
+Lackawanna,Dunmore W-05 P-00,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-05 P-00,Attorney General,,REP,Heather Heidelbaugh,24,7,6,1,38
+Lackawanna,Dunmore W-05 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-05 P-00,Auditor General,,REP,Timothy DeFoor,24,7,5,1,37
+Lackawanna,Dunmore W-05 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-05 P-00,State Treasurer,,REP,Stacy L. Garrity,24,8,5,1,38
+Lackawanna,Dunmore W-05 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,REP,Harry Haas,1,1,0,0,2
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,REP,Teddy Daniels,11,0,0,0,11
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,REP,Jim Bognet,10,1,5,0,16
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,REP,Mike Marsicano,5,0,0,0,5
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,REP,Earl Granville,8,6,1,1,16
+Lackawanna,Dunmore W-05 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-05 P-00,General Assembly,112,REP,Write-in,10,1,2,0,13
+Lackawanna,Dunmore W-06 P-01,Registered Voters,,,,,,,,538
+Lackawanna,Dunmore W-06 P-01,Registered Voters,,DEM,,,,,,423
+Lackawanna,Dunmore W-06 P-01,Registered Voters,,REP,,,,,,115
+Lackawanna,Dunmore W-06 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-06 P-01,Ballots Cast,,,,85,139,18,2,244
+Lackawanna,Dunmore W-06 P-01,Ballots Cast,,DEM,,55,128,16,1,200
+Lackawanna,Dunmore W-06 P-01,Ballots Cast,,REP,,30,11,2,1,44
+Lackawanna,Dunmore W-06 P-01,President,,DEM,Bernie Sanders,10,16,1,0,27
+Lackawanna,Dunmore W-06 P-01,President,,DEM,Joseph R. Biden,38,108,15,1,162
+Lackawanna,Dunmore W-06 P-01,President,,DEM,Tulsi Gabbard,2,3,0,0,5
+Lackawanna,Dunmore W-06 P-01,President,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Dunmore W-06 P-01,Attorney General,,DEM,Josh Shapiro,39,114,11,1,165
+Lackawanna,Dunmore W-06 P-01,Attorney General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-06 P-01,Auditor General,,DEM,H. Scott Conklin,3,8,0,0,11
+Lackawanna,Dunmore W-06 P-01,Auditor General,,DEM,Michael Lamb,7,15,2,0,24
+Lackawanna,Dunmore W-06 P-01,Auditor General,,DEM,Tracie Fountain,1,12,2,0,15
+Lackawanna,Dunmore W-06 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,6,27,2,0,35
+Lackawanna,Dunmore W-06 P-01,Auditor General,,DEM,Nina Ahmad,15,24,4,0,43
+Lackawanna,Dunmore W-06 P-01,Auditor General,,DEM,Christina M. Hartman,8,12,3,0,23
+Lackawanna,Dunmore W-06 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-01,State Treasurer,,DEM,Joe Torsella,36,110,11,1,158
+Lackawanna,Dunmore W-06 P-01,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,DEM,Matt Cartwright,42,119,14,1,176
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,DEM,Write-in,2,3,0,0,5
+Lackawanna,Dunmore W-06 P-01,General Assembly,112,DEM,Kyle J. Mullins,36,116,14,1,167
+Lackawanna,Dunmore W-06 P-01,General Assembly,112,DEM,Write-in,4,2,0,0,6
+Lackawanna,Dunmore W-06 P-01,President,,REP,Donald J. Trump,25,9,2,1,37
+Lackawanna,Dunmore W-06 P-01,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Dunmore W-06 P-01,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Dunmore W-06 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-06 P-01,Attorney General,,REP,Heather Heidelbaugh,20,10,2,1,33
+Lackawanna,Dunmore W-06 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-01,Auditor General,,REP,Timothy DeFoor,20,9,2,1,32
+Lackawanna,Dunmore W-06 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-01,State Treasurer,,REP,Stacy L. Garrity,21,9,2,1,33
+Lackawanna,Dunmore W-06 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,REP,Harry Haas,2,0,0,0,2
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,REP,Teddy Daniels,6,0,0,0,6
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,REP,Jim Bognet,10,3,0,0,13
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,REP,Mike Marsicano,2,0,0,1,3
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,REP,Earl Granville,6,5,2,0,13
+Lackawanna,Dunmore W-06 P-01,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-06 P-01,General Assembly,112,REP,Write-in,10,5,2,1,18
+Lackawanna,Dunmore W-06 P-02,Registered Voters,,,,,,,,764
+Lackawanna,Dunmore W-06 P-02,Registered Voters,,DEM,,,,,,604
+Lackawanna,Dunmore W-06 P-02,Registered Voters,,REP,,,,,,160
+Lackawanna,Dunmore W-06 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-06 P-02,Ballots Cast,,,,130,236,55,5,426
+Lackawanna,Dunmore W-06 P-02,Ballots Cast,,DEM,,93,220,54,5,372
+Lackawanna,Dunmore W-06 P-02,Ballots Cast,,REP,,37,16,1,0,54
+Lackawanna,Dunmore W-06 P-02,President,,DEM,Bernie Sanders,20,17,8,0,45
+Lackawanna,Dunmore W-06 P-02,President,,DEM,Joseph R. Biden,63,199,44,5,311
+Lackawanna,Dunmore W-06 P-02,President,,DEM,Tulsi Gabbard,5,1,1,0,7
+Lackawanna,Dunmore W-06 P-02,President,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Dunmore W-06 P-02,Attorney General,,DEM,Josh Shapiro,75,180,45,3,303
+Lackawanna,Dunmore W-06 P-02,Attorney General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Dunmore W-06 P-02,Auditor General,,DEM,H. Scott Conklin,5,11,0,2,18
+Lackawanna,Dunmore W-06 P-02,Auditor General,,DEM,Michael Lamb,28,30,8,2,68
+Lackawanna,Dunmore W-06 P-02,Auditor General,,DEM,Tracie Fountain,1,13,7,0,21
+Lackawanna,Dunmore W-06 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,12,50,11,0,73
+Lackawanna,Dunmore W-06 P-02,Auditor General,,DEM,Nina Ahmad,29,57,17,0,103
+Lackawanna,Dunmore W-06 P-02,Auditor General,,DEM,Christina M. Hartman,11,19,4,0,34
+Lackawanna,Dunmore W-06 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-02,State Treasurer,,DEM,Joe Torsella,76,175,45,4,300
+Lackawanna,Dunmore W-06 P-02,State Treasurer,,DEM,Write-in,0,1,1,0,2
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,DEM,Matt Cartwright,81,201,45,5,332
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,DEM,Write-in,2,1,0,0,3
+Lackawanna,Dunmore W-06 P-02,General Assembly,112,DEM,Kyle J. Mullins,80,190,47,5,322
+Lackawanna,Dunmore W-06 P-02,General Assembly,112,DEM,Write-in,4,2,0,0,6
+Lackawanna,Dunmore W-06 P-02,President,,REP,Donald J. Trump,35,10,0,0,45
+Lackawanna,Dunmore W-06 P-02,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Lackawanna,Dunmore W-06 P-02,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Dunmore W-06 P-02,President,,REP,Write-in,1,1,0,0,2
+Lackawanna,Dunmore W-06 P-02,Attorney General,,REP,Heather Heidelbaugh,31,11,1,0,43
+Lackawanna,Dunmore W-06 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-02,Auditor General,,REP,Timothy DeFoor,31,11,0,0,42
+Lackawanna,Dunmore W-06 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-02,State Treasurer,,REP,Stacy L. Garrity,30,12,0,0,42
+Lackawanna,Dunmore W-06 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,REP,Harry Haas,0,4,0,0,4
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,REP,Teddy Daniels,14,0,0,0,14
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,REP,Jim Bognet,12,3,0,0,15
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,REP,Mike Marsicano,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,REP,Earl Granville,10,5,0,0,15
+Lackawanna,Dunmore W-06 P-02,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-06 P-02,General Assembly,112,REP,Write-in,17,2,0,0,19
+Lackawanna,Dunmore W-06 P-03,Registered Voters,,,,,,,,698
+Lackawanna,Dunmore W-06 P-03,Registered Voters,,DEM,,,,,,555
+Lackawanna,Dunmore W-06 P-03,Registered Voters,,REP,,,,,,143
+Lackawanna,Dunmore W-06 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-06 P-03,Ballots Cast,,,,98,140,25,1,264
+Lackawanna,Dunmore W-06 P-03,Ballots Cast,,DEM,,75,128,23,0,226
+Lackawanna,Dunmore W-06 P-03,Ballots Cast,,REP,,23,12,2,1,38
+Lackawanna,Dunmore W-06 P-03,President,,DEM,Bernie Sanders,5,12,5,0,22
+Lackawanna,Dunmore W-06 P-03,President,,DEM,Joseph R. Biden,61,111,18,0,190
+Lackawanna,Dunmore W-06 P-03,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Lackawanna,Dunmore W-06 P-03,President,,DEM,Write-in,3,3,0,0,6
+Lackawanna,Dunmore W-06 P-03,Attorney General,,DEM,Josh Shapiro,55,117,19,0,191
+Lackawanna,Dunmore W-06 P-03,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-03,Auditor General,,DEM,H. Scott Conklin,7,7,1,0,15
+Lackawanna,Dunmore W-06 P-03,Auditor General,,DEM,Michael Lamb,12,14,2,0,28
+Lackawanna,Dunmore W-06 P-03,Auditor General,,DEM,Tracie Fountain,2,10,4,0,16
+Lackawanna,Dunmore W-06 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,7,30,5,0,42
+Lackawanna,Dunmore W-06 P-03,Auditor General,,DEM,Nina Ahmad,19,25,5,0,49
+Lackawanna,Dunmore W-06 P-03,Auditor General,,DEM,Christina M. Hartman,9,28,2,0,39
+Lackawanna,Dunmore W-06 P-03,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-03,State Treasurer,,DEM,Joe Torsella,48,113,16,0,177
+Lackawanna,Dunmore W-06 P-03,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,DEM,Matt Cartwright,61,123,18,0,202
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,DEM,Write-in,2,1,0,0,3
+Lackawanna,Dunmore W-06 P-03,General Assembly,112,DEM,Kyle J. Mullins,60,117,17,0,194
+Lackawanna,Dunmore W-06 P-03,General Assembly,112,DEM,Write-in,3,0,0,0,3
+Lackawanna,Dunmore W-06 P-03,President,,REP,Donald J. Trump,19,12,2,1,34
+Lackawanna,Dunmore W-06 P-03,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Dunmore W-06 P-03,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-03,President,,REP,Write-in,2,0,0,0,2
+Lackawanna,Dunmore W-06 P-03,Attorney General,,REP,Heather Heidelbaugh,15,12,1,1,29
+Lackawanna,Dunmore W-06 P-03,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-03,Auditor General,,REP,Timothy DeFoor,15,12,1,1,29
+Lackawanna,Dunmore W-06 P-03,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-03,State Treasurer,,REP,Stacy L. Garrity,15,12,1,1,29
+Lackawanna,Dunmore W-06 P-03,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,REP,Harry Haas,1,1,0,0,2
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,REP,Teddy Daniels,4,1,1,0,6
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,REP,Jim Bognet,4,2,0,0,6
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,REP,Mike Marsicano,2,1,0,0,3
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,REP,Earl Granville,10,6,0,1,17
+Lackawanna,Dunmore W-06 P-03,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-03,General Assembly,112,REP,Write-in,8,5,0,0,13
+Lackawanna,Dunmore W-06 P-04,Registered Voters,,,,,,,,531
+Lackawanna,Dunmore W-06 P-04,Registered Voters,,DEM,,,,,,414
+Lackawanna,Dunmore W-06 P-04,Registered Voters,,REP,,,,,,117
+Lackawanna,Dunmore W-06 P-04,Registered Voters,,NPA,,,,,,0
+Lackawanna,Dunmore W-06 P-04,Ballots Cast,,,,92,148,21,10,271
+Lackawanna,Dunmore W-06 P-04,Ballots Cast,,DEM,,59,135,18,8,220
+Lackawanna,Dunmore W-06 P-04,Ballots Cast,,REP,,33,13,3,2,51
+Lackawanna,Dunmore W-06 P-04,President,,DEM,Bernie Sanders,6,17,3,0,26
+Lackawanna,Dunmore W-06 P-04,President,,DEM,Joseph R. Biden,44,113,15,6,178
+Lackawanna,Dunmore W-06 P-04,President,,DEM,Tulsi Gabbard,4,1,0,1,6
+Lackawanna,Dunmore W-06 P-04,President,,DEM,Write-in,3,2,0,0,5
+Lackawanna,Dunmore W-06 P-04,Attorney General,,DEM,Josh Shapiro,41,110,16,3,170
+Lackawanna,Dunmore W-06 P-04,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Dunmore W-06 P-04,Auditor General,,DEM,H. Scott Conklin,5,12,1,0,18
+Lackawanna,Dunmore W-06 P-04,Auditor General,,DEM,Michael Lamb,10,22,1,1,34
+Lackawanna,Dunmore W-06 P-04,Auditor General,,DEM,Tracie Fountain,2,6,0,0,8
+Lackawanna,Dunmore W-06 P-04,Auditor General,,DEM,Rose Rosie Marie Davis,5,22,6,3,36
+Lackawanna,Dunmore W-06 P-04,Auditor General,,DEM,Nina Ahmad,24,41,3,2,70
+Lackawanna,Dunmore W-06 P-04,Auditor General,,DEM,Christina M. Hartman,1,15,2,0,18
+Lackawanna,Dunmore W-06 P-04,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-04,State Treasurer,,DEM,Joe Torsella,37,109,14,5,165
+Lackawanna,Dunmore W-06 P-04,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,DEM,Matt Cartwright,47,127,16,6,196
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,DEM,Write-in,2,2,0,0,4
+Lackawanna,Dunmore W-06 P-04,General Assembly,112,DEM,Kyle J. Mullins,47,119,16,5,187
+Lackawanna,Dunmore W-06 P-04,General Assembly,112,DEM,Write-in,4,1,0,0,5
+Lackawanna,Dunmore W-06 P-04,President,,REP,Donald J. Trump,31,12,3,2,48
+Lackawanna,Dunmore W-06 P-04,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-04,President,,REP,Bill Weld,1,0,0,0,1
+Lackawanna,Dunmore W-06 P-04,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Dunmore W-06 P-04,Attorney General,,REP,Heather Heidelbaugh,28,10,2,2,42
+Lackawanna,Dunmore W-06 P-04,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Dunmore W-06 P-04,Auditor General,,REP,Timothy DeFoor,27,10,2,2,41
+Lackawanna,Dunmore W-06 P-04,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-04,State Treasurer,,REP,Stacy L. Garrity,26,10,2,2,40
+Lackawanna,Dunmore W-06 P-04,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,REP,Teddy Daniels,9,0,0,0,9
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,REP,Jim Bognet,9,1,0,0,10
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,REP,Mike Marsicano,5,2,0,0,7
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,REP,Earl Granville,8,9,3,1,21
+Lackawanna,Dunmore W-06 P-04,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Dunmore W-06 P-04,General Assembly,112,REP,Write-in,12,0,0,2,14
+Lackawanna,Elmhurst Township W-00 P-00,Registered Voters,,,,,,,,490
+Lackawanna,Elmhurst Township W-00 P-00,Registered Voters,,DEM,,,,,,238
+Lackawanna,Elmhurst Township W-00 P-00,Registered Voters,,REP,,,,,,252
+Lackawanna,Elmhurst Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Elmhurst Township W-00 P-00,Ballots Cast,,,,107,86,25,4,222
+Lackawanna,Elmhurst Township W-00 P-00,Ballots Cast,,DEM,,36,59,17,2,114
+Lackawanna,Elmhurst Township W-00 P-00,Ballots Cast,,REP,,71,27,8,2,108
+Lackawanna,Elmhurst Township W-00 P-00,President,,DEM,Bernie Sanders,5,9,0,0,14
+Lackawanna,Elmhurst Township W-00 P-00,President,,DEM,Joseph R. Biden,23,47,17,2,89
+Lackawanna,Elmhurst Township W-00 P-00,President,,DEM,Tulsi Gabbard,2,2,0,0,4
+Lackawanna,Elmhurst Township W-00 P-00,President,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Elmhurst Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,27,53,14,2,96
+Lackawanna,Elmhurst Township W-00 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,1,5,2,0,8
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,DEM,Michael Lamb,6,4,0,0,10
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,1,6,2,1,10
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,8,13,3,0,24
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,8,8,2,0,18
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,5,8,5,1,19
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Elmhurst Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,25,51,13,2,91
+Lackawanna,Elmhurst Township W-00 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,30,54,13,1,98
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,DEM,Write-in,0,1,0,0,1
+Lackawanna,Elmhurst Township W-00 P-00,General Assembly,118,DEM,Mike Carroll,24,47,14,2,87
+Lackawanna,Elmhurst Township W-00 P-00,General Assembly,118,DEM,Write-in,0,0,0,0,0
+Lackawanna,Elmhurst Township W-00 P-00,President,,REP,Donald J. Trump,66,18,8,2,94
+Lackawanna,Elmhurst Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,0,2,0,0,2
+Lackawanna,Elmhurst Township W-00 P-00,President,,REP,Bill Weld,3,0,0,0,3
+Lackawanna,Elmhurst Township W-00 P-00,President,,REP,Write-in,0,5,0,0,5
+Lackawanna,Elmhurst Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,52,19,8,1,80
+Lackawanna,Elmhurst Township W-00 P-00,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,54,17,8,1,80
+Lackawanna,Elmhurst Township W-00 P-00,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Elmhurst Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,53,20,8,1,82
+Lackawanna,Elmhurst Township W-00 P-00,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,REP,Harry Haas,4,3,0,0,7
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,22,1,1,1,25
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,REP,Jim Bognet,12,7,1,1,21
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,REP,Earl Granville,30,13,5,0,48
+Lackawanna,Elmhurst Township W-00 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Elmhurst Township W-00 P-00,General Assembly,118,REP,Andrew Holter,55,17,8,1,81
+Lackawanna,Elmhurst Township W-00 P-00,General Assembly,118,REP,Write-in,0,2,0,0,2
+Lackawanna,Fell Township W-00 P-01,Registered Voters,,,,,,,,466
+Lackawanna,Fell Township W-00 P-01,Registered Voters,,DEM,,,,,,292
+Lackawanna,Fell Township W-00 P-01,Registered Voters,,REP,,,,,,174
+Lackawanna,Fell Township W-00 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Fell Township W-00 P-01,Ballots Cast,,,,120,68,16,4,208
+Lackawanna,Fell Township W-00 P-01,Ballots Cast,,DEM,,63,51,9,2,125
+Lackawanna,Fell Township W-00 P-01,Ballots Cast,,REP,,57,17,7,2,83
+Lackawanna,Fell Township W-00 P-01,President,,DEM,Bernie Sanders,9,1,1,0,11
+Lackawanna,Fell Township W-00 P-01,President,,DEM,Joseph R. Biden,37,49,7,2,95
+Lackawanna,Fell Township W-00 P-01,President,,DEM,Tulsi Gabbard,6,0,1,0,7
+Lackawanna,Fell Township W-00 P-01,President,,DEM,Write-in,4,1,0,0,5
+Lackawanna,Fell Township W-00 P-01,Attorney General,,DEM,Josh Shapiro,46,47,7,2,102
+Lackawanna,Fell Township W-00 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-01,Auditor General,,DEM,H. Scott Conklin,6,2,1,0,9
+Lackawanna,Fell Township W-00 P-01,Auditor General,,DEM,Michael Lamb,13,9,2,0,24
+Lackawanna,Fell Township W-00 P-01,Auditor General,,DEM,Tracie Fountain,4,3,0,0,7
+Lackawanna,Fell Township W-00 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,10,12,3,0,25
+Lackawanna,Fell Township W-00 P-01,Auditor General,,DEM,Nina Ahmad,14,5,1,0,20
+Lackawanna,Fell Township W-00 P-01,Auditor General,,DEM,Christina M. Hartman,9,10,1,1,21
+Lackawanna,Fell Township W-00 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-01,State Treasurer,,DEM,Joe Torsella,50,40,8,2,100
+Lackawanna,Fell Township W-00 P-01,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,DEM,Matt Cartwright,50,50,9,2,111
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,DEM,Write-in,4,0,0,0,4
+Lackawanna,Fell Township W-00 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,55,41,9,2,107
+Lackawanna,Fell Township W-00 P-01,General Assembly,114,DEM,Write-in,1,1,0,0,2
+Lackawanna,Fell Township W-00 P-01,President,,REP,Donald J. Trump,55,12,7,2,76
+Lackawanna,Fell Township W-00 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-01,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Fell Township W-00 P-01,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Fell Township W-00 P-01,Attorney General,,REP,Heather Heidelbaugh,41,12,4,1,58
+Lackawanna,Fell Township W-00 P-01,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Fell Township W-00 P-01,Auditor General,,REP,Timothy DeFoor,42,12,4,1,59
+Lackawanna,Fell Township W-00 P-01,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Fell Township W-00 P-01,State Treasurer,,REP,Stacy L. Garrity,44,12,4,1,61
+Lackawanna,Fell Township W-00 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,REP,Harry Haas,0,1,0,0,1
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,REP,Teddy Daniels,10,2,1,0,13
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,REP,Jim Bognet,12,0,0,0,12
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,REP,Mike Marsicano,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,REP,Earl Granville,35,14,4,2,55
+Lackawanna,Fell Township W-00 P-01,U.S. House,8,REP,Write-in,0,0,2,0,2
+Lackawanna,Fell Township W-00 P-01,General Assembly,114,REP,James May,41,15,6,2,64
+Lackawanna,Fell Township W-00 P-01,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-02,Registered Voters,,,,,,,,450
+Lackawanna,Fell Township W-00 P-02,Registered Voters,,DEM,,,,,,269
+Lackawanna,Fell Township W-00 P-02,Registered Voters,,REP,,,,,,181
+Lackawanna,Fell Township W-00 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Fell Township W-00 P-02,Ballots Cast,,,,130,40,11,7,188
+Lackawanna,Fell Township W-00 P-02,Ballots Cast,,DEM,,60,33,6,0,99
+Lackawanna,Fell Township W-00 P-02,Ballots Cast,,REP,,70,7,5,7,89
+Lackawanna,Fell Township W-00 P-02,President,,DEM,Bernie Sanders,5,3,0,0,8
+Lackawanna,Fell Township W-00 P-02,President,,DEM,Joseph R. Biden,31,23,6,0,60
+Lackawanna,Fell Township W-00 P-02,President,,DEM,Tulsi Gabbard,10,2,0,0,12
+Lackawanna,Fell Township W-00 P-02,President,,DEM,Write-in,6,1,0,0,7
+Lackawanna,Fell Township W-00 P-02,Attorney General,,DEM,Josh Shapiro,44,28,6,0,78
+Lackawanna,Fell Township W-00 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-02,Auditor General,,DEM,H. Scott Conklin,9,1,1,0,11
+Lackawanna,Fell Township W-00 P-02,Auditor General,,DEM,Michael Lamb,10,2,0,0,12
+Lackawanna,Fell Township W-00 P-02,Auditor General,,DEM,Tracie Fountain,4,2,1,0,7
+Lackawanna,Fell Township W-00 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,7,10,3,0,20
+Lackawanna,Fell Township W-00 P-02,Auditor General,,DEM,Nina Ahmad,7,5,0,0,12
+Lackawanna,Fell Township W-00 P-02,Auditor General,,DEM,Christina M. Hartman,7,7,1,0,15
+Lackawanna,Fell Township W-00 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-02,State Treasurer,,DEM,Joe Torsella,35,31,6,0,72
+Lackawanna,Fell Township W-00 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,DEM,Matt Cartwright,40,31,6,0,77
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,DEM,Write-in,10,0,0,0,10
+Lackawanna,Fell Township W-00 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,39,30,6,0,75
+Lackawanna,Fell Township W-00 P-02,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-02,President,,REP,Donald J. Trump,66,5,3,7,81
+Lackawanna,Fell Township W-00 P-02,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-02,President,,REP,Bill Weld,1,1,1,0,3
+Lackawanna,Fell Township W-00 P-02,President,,REP,Write-in,0,0,1,0,1
+Lackawanna,Fell Township W-00 P-02,Attorney General,,REP,Heather Heidelbaugh,49,6,4,6,65
+Lackawanna,Fell Township W-00 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-02,Auditor General,,REP,Timothy DeFoor,48,6,3,6,63
+Lackawanna,Fell Township W-00 P-02,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-02,State Treasurer,,REP,Stacy L. Garrity,45,6,4,6,61
+Lackawanna,Fell Township W-00 P-02,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,REP,Harry Haas,5,0,0,1,6
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,REP,Teddy Daniels,8,3,1,1,13
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,REP,Jim Bognet,3,1,3,0,7
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,REP,Mike Marsicano,6,0,0,0,6
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,REP,Earl Granville,45,2,1,5,53
+Lackawanna,Fell Township W-00 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-02,General Assembly,114,REP,James May,54,7,4,7,72
+Lackawanna,Fell Township W-00 P-02,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,Registered Voters,,,,,,,,315
+Lackawanna,Fell Township W-00 P-03,Registered Voters,,DEM,,,,,,196
+Lackawanna,Fell Township W-00 P-03,Registered Voters,,REP,,,,,,119
+Lackawanna,Fell Township W-00 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Fell Township W-00 P-03,Ballots Cast,,,,75,35,5,3,118
+Lackawanna,Fell Township W-00 P-03,Ballots Cast,,DEM,,41,26,4,2,73
+Lackawanna,Fell Township W-00 P-03,Ballots Cast,,REP,,34,9,1,1,45
+Lackawanna,Fell Township W-00 P-03,President,,DEM,Bernie Sanders,6,0,0,0,6
+Lackawanna,Fell Township W-00 P-03,President,,DEM,Joseph R. Biden,28,24,4,2,58
+Lackawanna,Fell Township W-00 P-03,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-03,President,,DEM,Write-in,3,2,0,0,5
+Lackawanna,Fell Township W-00 P-03,Attorney General,,DEM,Josh Shapiro,31,26,3,1,61
+Lackawanna,Fell Township W-00 P-03,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,Auditor General,,DEM,H. Scott Conklin,3,3,0,0,6
+Lackawanna,Fell Township W-00 P-03,Auditor General,,DEM,Michael Lamb,7,3,1,0,11
+Lackawanna,Fell Township W-00 P-03,Auditor General,,DEM,Tracie Fountain,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,5,6,1,1,13
+Lackawanna,Fell Township W-00 P-03,Auditor General,,DEM,Nina Ahmad,9,6,0,0,15
+Lackawanna,Fell Township W-00 P-03,Auditor General,,DEM,Christina M. Hartman,8,7,0,1,16
+Lackawanna,Fell Township W-00 P-03,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,State Treasurer,,DEM,Joe Torsella,29,26,3,2,60
+Lackawanna,Fell Township W-00 P-03,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,DEM,Matt Cartwright,32,23,4,2,61
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,DEM,Write-in,5,3,0,0,8
+Lackawanna,Fell Township W-00 P-03,General Assembly,114,DEM,Bridget Malloy Kosierowski,28,26,4,2,60
+Lackawanna,Fell Township W-00 P-03,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,President,,REP,Donald J. Trump,31,8,1,1,41
+Lackawanna,Fell Township W-00 P-03,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,President,,REP,Bill Weld,2,1,0,0,3
+Lackawanna,Fell Township W-00 P-03,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,Attorney General,,REP,Heather Heidelbaugh,25,7,1,1,34
+Lackawanna,Fell Township W-00 P-03,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Fell Township W-00 P-03,Auditor General,,REP,Timothy DeFoor,25,8,1,1,35
+Lackawanna,Fell Township W-00 P-03,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-03,State Treasurer,,REP,Stacy L. Garrity,24,9,1,0,34
+Lackawanna,Fell Township W-00 P-03,State Treasurer,,REP,Write-in,1,0,0,1,2
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,REP,Teddy Daniels,7,4,0,1,12
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,REP,Jim Bognet,5,1,0,0,6
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,REP,Mike Marsicano,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,REP,Earl Granville,19,4,1,0,24
+Lackawanna,Fell Township W-00 P-03,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-03,General Assembly,114,REP,James May,28,8,1,1,38
+Lackawanna,Fell Township W-00 P-03,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Fell Township W-00 P-04,Registered Voters,,,,,,,,157
+Lackawanna,Fell Township W-00 P-04,Registered Voters,,DEM,,,,,,98
+Lackawanna,Fell Township W-00 P-04,Registered Voters,,REP,,,,,,59
+Lackawanna,Fell Township W-00 P-04,Registered Voters,,NPA,,,,,,0
+Lackawanna,Fell Township W-00 P-04,Ballots Cast,,,,47,25,4,0,76
+Lackawanna,Fell Township W-00 P-04,Ballots Cast,,DEM,,27,23,4,0,54
+Lackawanna,Fell Township W-00 P-04,Ballots Cast,,REP,,20,2,0,0,22
+Lackawanna,Fell Township W-00 P-04,President,,DEM,Bernie Sanders,8,1,0,0,9
+Lackawanna,Fell Township W-00 P-04,President,,DEM,Joseph R. Biden,9,20,4,0,33
+Lackawanna,Fell Township W-00 P-04,President,,DEM,Tulsi Gabbard,2,2,0,0,4
+Lackawanna,Fell Township W-00 P-04,President,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-04,Attorney General,,DEM,Josh Shapiro,20,19,4,0,43
+Lackawanna,Fell Township W-00 P-04,Attorney General,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Fell Township W-00 P-04,Auditor General,,DEM,H. Scott Conklin,1,2,0,0,3
+Lackawanna,Fell Township W-00 P-04,Auditor General,,DEM,Michael Lamb,0,2,1,0,3
+Lackawanna,Fell Township W-00 P-04,Auditor General,,DEM,Tracie Fountain,2,0,2,0,4
+Lackawanna,Fell Township W-00 P-04,Auditor General,,DEM,Rose Rosie Marie Davis,7,6,1,0,14
+Lackawanna,Fell Township W-00 P-04,Auditor General,,DEM,Nina Ahmad,7,2,0,0,9
+Lackawanna,Fell Township W-00 P-04,Auditor General,,DEM,Christina M. Hartman,3,7,0,0,10
+Lackawanna,Fell Township W-00 P-04,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-04,State Treasurer,,DEM,Joe Torsella,22,20,4,0,46
+Lackawanna,Fell Township W-00 P-04,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,DEM,Matt Cartwright,19,20,4,0,43
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-04,General Assembly,114,DEM,Bridget Malloy Kosierowski,21,20,4,0,45
+Lackawanna,Fell Township W-00 P-04,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-04,President,,REP,Donald J. Trump,19,1,0,0,20
+Lackawanna,Fell Township W-00 P-04,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Fell Township W-00 P-04,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-04,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-04,Attorney General,,REP,Heather Heidelbaugh,13,2,0,0,15
+Lackawanna,Fell Township W-00 P-04,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-04,Auditor General,,REP,Timothy DeFoor,13,2,0,0,15
+Lackawanna,Fell Township W-00 P-04,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-04,State Treasurer,,REP,Stacy L. Garrity,13,2,0,0,15
+Lackawanna,Fell Township W-00 P-04,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,REP,Teddy Daniels,6,0,0,0,6
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,REP,Jim Bognet,2,0,0,0,2
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,REP,Earl Granville,11,2,0,0,13
+Lackawanna,Fell Township W-00 P-04,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Fell Township W-00 P-04,General Assembly,114,REP,James May,15,2,0,0,17
+Lackawanna,Fell Township W-00 P-04,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Glenburn Township W-00 P-00,Registered Voters,,,,,,,,924
+Lackawanna,Glenburn Township W-00 P-00,Registered Voters,,DEM,,,,,,419
+Lackawanna,Glenburn Township W-00 P-00,Registered Voters,,REP,,,,,,505
+Lackawanna,Glenburn Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Glenburn Township W-00 P-00,Ballots Cast,,,,185,176,32,7,400
+Lackawanna,Glenburn Township W-00 P-00,Ballots Cast,,DEM,,70,125,24,4,223
+Lackawanna,Glenburn Township W-00 P-00,Ballots Cast,,REP,,115,51,8,3,177
+Lackawanna,Glenburn Township W-00 P-00,President,,DEM,Bernie Sanders,14,13,1,1,29
+Lackawanna,Glenburn Township W-00 P-00,President,,DEM,Joseph R. Biden,52,109,21,3,185
+Lackawanna,Glenburn Township W-00 P-00,President,,DEM,Tulsi Gabbard,3,2,2,0,7
+Lackawanna,Glenburn Township W-00 P-00,President,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Glenburn Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,59,110,20,2,191
+Lackawanna,Glenburn Township W-00 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,7,9,0,0,16
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,DEM,Michael Lamb,10,14,3,0,27
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,3,13,2,0,18
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,7,12,3,0,22
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,23,31,7,2,63
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,10,20,5,0,35
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Glenburn Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,59,103,18,2,182
+Lackawanna,Glenburn Township W-00 P-00,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,62,118,24,4,208
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,DEM,Write-in,0,0,0,0,0
+Lackawanna,Glenburn Township W-00 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,63,114,22,4,203
+Lackawanna,Glenburn Township W-00 P-00,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Glenburn Township W-00 P-00,President,,REP,Donald J. Trump,104,35,7,2,148
+Lackawanna,Glenburn Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Lackawanna,Glenburn Township W-00 P-00,President,,REP,Bill Weld,7,5,0,1,13
+Lackawanna,Glenburn Township W-00 P-00,President,,REP,Write-in,0,3,1,0,4
+Lackawanna,Glenburn Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,99,43,4,2,148
+Lackawanna,Glenburn Township W-00 P-00,Attorney General,,REP,Write-in,0,0,2,0,2
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,95,43,6,2,146
+Lackawanna,Glenburn Township W-00 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Glenburn Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,99,43,6,2,150
+Lackawanna,Glenburn Township W-00 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,REP,Harry Haas,4,1,0,0,5
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,33,4,0,0,37
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,REP,Jim Bognet,20,11,2,0,33
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,10,3,0,1,14
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,REP,Earl Granville,45,29,6,2,82
+Lackawanna,Glenburn Township W-00 P-00,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Glenburn Township W-00 P-00,General Assembly,114,REP,James May,105,45,5,2,157
+Lackawanna,Glenburn Township W-00 P-00,General Assembly,114,REP,Write-in,0,0,2,0,2
+Lackawanna,Greenfield Township W-00 P-00,Registered Voters,,,,,,,,1488
+Lackawanna,Greenfield Township W-00 P-00,Registered Voters,,DEM,,,,,,796
+Lackawanna,Greenfield Township W-00 P-00,Registered Voters,,REP,,,,,,692
+Lackawanna,Greenfield Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Greenfield Township W-00 P-00,Ballots Cast,,,,367,256,55,7,685
+Lackawanna,Greenfield Township W-00 P-00,Ballots Cast,,DEM,,126,185,40,4,355
+Lackawanna,Greenfield Township W-00 P-00,Ballots Cast,,REP,,241,71,15,3,330
+Lackawanna,Greenfield Township W-00 P-00,President,,DEM,Bernie Sanders,26,28,9,0,63
+Lackawanna,Greenfield Township W-00 P-00,President,,DEM,Joseph R. Biden,78,143,26,4,251
+Lackawanna,Greenfield Township W-00 P-00,President,,DEM,Tulsi Gabbard,4,7,1,0,12
+Lackawanna,Greenfield Township W-00 P-00,President,,DEM,Write-in,5,3,3,0,11
+Lackawanna,Greenfield Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,97,146,36,4,283
+Lackawanna,Greenfield Township W-00 P-00,Attorney General,,DEM,Write-in,2,5,1,0,8
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,18,5,5,0,28
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,DEM,Michael Lamb,25,32,3,1,61
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,2,11,4,0,17
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,21,48,9,1,79
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,31,19,3,2,55
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,11,32,10,0,53
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,DEM,Write-in,0,1,1,0,2
+Lackawanna,Greenfield Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,98,141,34,4,277
+Lackawanna,Greenfield Township W-00 P-00,State Treasurer,,DEM,Write-in,1,2,1,0,4
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,103,166,33,4,306
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,DEM,Write-in,7,6,5,0,18
+Lackawanna,Greenfield Township W-00 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,105,157,37,4,303
+Lackawanna,Greenfield Township W-00 P-00,General Assembly,114,DEM,Write-in,1,1,1,0,3
+Lackawanna,Greenfield Township W-00 P-00,President,,REP,Donald J. Trump,228,61,12,3,304
+Lackawanna,Greenfield Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Greenfield Township W-00 P-00,President,,REP,Bill Weld,8,5,1,0,14
+Lackawanna,Greenfield Township W-00 P-00,President,,REP,Write-in,0,3,1,0,4
+Lackawanna,Greenfield Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,171,58,11,3,243
+Lackawanna,Greenfield Township W-00 P-00,Attorney General,,REP,Write-in,4,0,0,0,4
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,170,58,10,3,241
+Lackawanna,Greenfield Township W-00 P-00,Auditor General,,REP,Write-in,3,0,0,0,3
+Lackawanna,Greenfield Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,173,58,10,3,244
+Lackawanna,Greenfield Township W-00 P-00,State Treasurer,,REP,Write-in,2,0,0,0,2
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,REP,Harry Haas,15,4,0,0,19
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,32,5,1,0,38
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,REP,Jim Bognet,27,4,0,1,32
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,13,1,0,1,15
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,REP,Earl Granville,152,57,14,1,224
+Lackawanna,Greenfield Township W-00 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Greenfield Township W-00 P-00,General Assembly,114,REP,James May,187,60,9,3,259
+Lackawanna,Greenfield Township W-00 P-00,General Assembly,114,REP,Write-in,1,0,1,0,2
+Lackawanna,Jefferson Township W-00 P-00,Registered Voters,,,,,,,,2506
+Lackawanna,Jefferson Township W-00 P-00,Registered Voters,,DEM,,,,,,1232
+Lackawanna,Jefferson Township W-00 P-00,Registered Voters,,REP,,,,,,1274
+Lackawanna,Jefferson Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Jefferson Township W-00 P-00,Ballots Cast,,,,553,448,80,17,1098
+Lackawanna,Jefferson Township W-00 P-00,Ballots Cast,,DEM,,182,320,61,5,568
+Lackawanna,Jefferson Township W-00 P-00,Ballots Cast,,REP,,371,128,19,12,530
+Lackawanna,Jefferson Township W-00 P-00,President,,DEM,Bernie Sanders,28,37,4,1,70
+Lackawanna,Jefferson Township W-00 P-00,President,,DEM,Joseph R. Biden,106,263,53,4,426
+Lackawanna,Jefferson Township W-00 P-00,President,,DEM,Tulsi Gabbard,13,7,1,0,21
+Lackawanna,Jefferson Township W-00 P-00,President,,DEM,Write-in,21,11,1,0,33
+Lackawanna,Jefferson Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,141,271,53,4,469
+Lackawanna,Jefferson Township W-00 P-00,Attorney General,,DEM,Write-in,3,2,0,0,5
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,15,16,4,0,35
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,DEM,Michael Lamb,30,46,7,1,84
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,5,32,7,0,44
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,32,83,17,1,133
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,37,44,10,2,93
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,26,43,8,0,77
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,DEM,Write-in,6,2,1,0,9
+Lackawanna,Jefferson Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,138,269,51,4,462
+Lackawanna,Jefferson Township W-00 P-00,State Treasurer,,DEM,Write-in,4,2,0,0,6
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,142,290,57,5,494
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,DEM,Write-in,20,3,1,0,24
+Lackawanna,Jefferson Township W-00 P-00,General Assembly,118,DEM,Mike Carroll,137,259,53,4,453
+Lackawanna,Jefferson Township W-00 P-00,General Assembly,118,DEM,Write-in,5,5,0,0,10
+Lackawanna,Jefferson Township W-00 P-00,President,,REP,Donald J. Trump,353,115,16,11,495
+Lackawanna,Jefferson Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Lackawanna,Jefferson Township W-00 P-00,President,,REP,Bill Weld,8,7,2,1,18
+Lackawanna,Jefferson Township W-00 P-00,President,,REP,Write-in,1,2,1,0,4
+Lackawanna,Jefferson Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,283,111,14,8,416
+Lackawanna,Jefferson Township W-00 P-00,Attorney General,,REP,Write-in,0,0,2,0,2
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,280,111,14,9,414
+Lackawanna,Jefferson Township W-00 P-00,Auditor General,,REP,Write-in,3,0,2,0,5
+Lackawanna,Jefferson Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,272,112,14,9,407
+Lackawanna,Jefferson Township W-00 P-00,State Treasurer,,REP,Write-in,1,0,2,0,3
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,REP,Harry Haas,8,3,1,0,12
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,148,20,1,4,173
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,REP,Jim Bognet,64,18,2,1,85
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,3,3,0,0,6
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,23,10,0,0,33
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,REP,Earl Granville,116,69,13,6,204
+Lackawanna,Jefferson Township W-00 P-00,U.S. House,8,REP,Write-in,0,0,2,0,2
+Lackawanna,Jefferson Township W-00 P-00,General Assembly,118,REP,Andrew Holter,275,108,17,8,408
+Lackawanna,Jefferson Township W-00 P-00,General Assembly,118,REP,Write-in,1,0,0,0,1
+Lackawanna,Jermyn W-01 P-00,Registered Voters,,,,,,,,326
+Lackawanna,Jermyn W-01 P-00,Registered Voters,,DEM,,,,,,191
+Lackawanna,Jermyn W-01 P-00,Registered Voters,,REP,,,,,,135
+Lackawanna,Jermyn W-01 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Jermyn W-01 P-00,Ballots Cast,,,,77,44,16,0,137
+Lackawanna,Jermyn W-01 P-00,Ballots Cast,,DEM,,36,34,10,0,80
+Lackawanna,Jermyn W-01 P-00,Ballots Cast,,REP,,41,10,6,0,57
+Lackawanna,Jermyn W-01 P-00,President,,DEM,Bernie Sanders,9,5,2,0,16
+Lackawanna,Jermyn W-01 P-00,President,,DEM,Joseph R. Biden,22,26,8,0,56
+Lackawanna,Jermyn W-01 P-00,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Lackawanna,Jermyn W-01 P-00,President,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jermyn W-01 P-00,Attorney General,,DEM,Josh Shapiro,22,28,9,0,59
+Lackawanna,Jermyn W-01 P-00,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jermyn W-01 P-00,Auditor General,,DEM,H. Scott Conklin,3,1,0,0,4
+Lackawanna,Jermyn W-01 P-00,Auditor General,,DEM,Michael Lamb,3,2,4,0,9
+Lackawanna,Jermyn W-01 P-00,Auditor General,,DEM,Tracie Fountain,0,1,0,0,1
+Lackawanna,Jermyn W-01 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,7,14,2,0,23
+Lackawanna,Jermyn W-01 P-00,Auditor General,,DEM,Nina Ahmad,9,6,1,0,16
+Lackawanna,Jermyn W-01 P-00,Auditor General,,DEM,Christina M. Hartman,5,5,3,0,13
+Lackawanna,Jermyn W-01 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jermyn W-01 P-00,State Treasurer,,DEM,Joe Torsella,23,29,9,0,61
+Lackawanna,Jermyn W-01 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,DEM,Matt Cartwright,25,31,10,0,66
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,DEM,Write-in,5,0,0,0,5
+Lackawanna,Jermyn W-01 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,26,30,9,0,65
+Lackawanna,Jermyn W-01 P-00,General Assembly,114,DEM,Write-in,2,0,0,0,2
+Lackawanna,Jermyn W-01 P-00,President,,REP,Donald J. Trump,39,7,4,0,50
+Lackawanna,Jermyn W-01 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Jermyn W-01 P-00,President,,REP,Bill Weld,0,2,2,0,4
+Lackawanna,Jermyn W-01 P-00,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Jermyn W-01 P-00,Attorney General,,REP,Heather Heidelbaugh,30,9,3,0,42
+Lackawanna,Jermyn W-01 P-00,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Jermyn W-01 P-00,Auditor General,,REP,Timothy DeFoor,29,9,3,0,41
+Lackawanna,Jermyn W-01 P-00,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Jermyn W-01 P-00,State Treasurer,,REP,Stacy L. Garrity,28,9,3,0,40
+Lackawanna,Jermyn W-01 P-00,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,REP,Teddy Daniels,7,0,0,0,7
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,REP,Jim Bognet,4,0,0,0,4
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,REP,Earl Granville,28,10,6,0,44
+Lackawanna,Jermyn W-01 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-01 P-00,General Assembly,114,REP,James May,32,9,6,0,47
+Lackawanna,Jermyn W-01 P-00,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Jermyn W-02 P-00,Registered Voters,,,,,,,,473
+Lackawanna,Jermyn W-02 P-00,Registered Voters,,DEM,,,,,,272
+Lackawanna,Jermyn W-02 P-00,Registered Voters,,REP,,,,,,201
+Lackawanna,Jermyn W-02 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Jermyn W-02 P-00,Ballots Cast,,,,103,76,11,4,194
+Lackawanna,Jermyn W-02 P-00,Ballots Cast,,DEM,,44,57,5,3,109
+Lackawanna,Jermyn W-02 P-00,Ballots Cast,,REP,,59,19,6,1,85
+Lackawanna,Jermyn W-02 P-00,President,,DEM,Bernie Sanders,8,8,1,0,17
+Lackawanna,Jermyn W-02 P-00,President,,DEM,Joseph R. Biden,28,45,4,2,79
+Lackawanna,Jermyn W-02 P-00,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Jermyn W-02 P-00,President,,DEM,Write-in,3,3,0,0,6
+Lackawanna,Jermyn W-02 P-00,Attorney General,,DEM,Josh Shapiro,30,50,5,3,88
+Lackawanna,Jermyn W-02 P-00,Attorney General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Jermyn W-02 P-00,Auditor General,,DEM,H. Scott Conklin,0,2,0,1,3
+Lackawanna,Jermyn W-02 P-00,Auditor General,,DEM,Michael Lamb,9,4,2,0,15
+Lackawanna,Jermyn W-02 P-00,Auditor General,,DEM,Tracie Fountain,3,8,1,0,12
+Lackawanna,Jermyn W-02 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,8,14,1,0,23
+Lackawanna,Jermyn W-02 P-00,Auditor General,,DEM,Nina Ahmad,7,11,0,0,18
+Lackawanna,Jermyn W-02 P-00,Auditor General,,DEM,Christina M. Hartman,6,8,1,1,16
+Lackawanna,Jermyn W-02 P-00,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Jermyn W-02 P-00,State Treasurer,,DEM,Joe Torsella,30,48,5,3,86
+Lackawanna,Jermyn W-02 P-00,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,DEM,Matt Cartwright,36,54,5,3,98
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,DEM,Write-in,3,2,0,0,5
+Lackawanna,Jermyn W-02 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,33,53,4,3,93
+Lackawanna,Jermyn W-02 P-00,General Assembly,114,DEM,Write-in,2,0,0,0,2
+Lackawanna,Jermyn W-02 P-00,President,,REP,Donald J. Trump,53,13,5,1,72
+Lackawanna,Jermyn W-02 P-00,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Jermyn W-02 P-00,President,,REP,Bill Weld,1,3,0,0,4
+Lackawanna,Jermyn W-02 P-00,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Jermyn W-02 P-00,Attorney General,,REP,Heather Heidelbaugh,42,15,5,0,62
+Lackawanna,Jermyn W-02 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-02 P-00,Auditor General,,REP,Timothy DeFoor,40,14,5,0,59
+Lackawanna,Jermyn W-02 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-02 P-00,State Treasurer,,REP,Stacy L. Garrity,41,15,5,0,61
+Lackawanna,Jermyn W-02 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,REP,Harry Haas,3,0,1,0,4
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,REP,Teddy Daniels,11,0,2,1,14
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,REP,Jim Bognet,7,0,0,0,7
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,REP,Earl Granville,35,18,3,0,56
+Lackawanna,Jermyn W-02 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-02 P-00,General Assembly,114,REP,James May,50,14,4,0,68
+Lackawanna,Jermyn W-02 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-03 P-00,Registered Voters,,,,,,,,472
+Lackawanna,Jermyn W-03 P-00,Registered Voters,,DEM,,,,,,276
+Lackawanna,Jermyn W-03 P-00,Registered Voters,,REP,,,,,,196
+Lackawanna,Jermyn W-03 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Jermyn W-03 P-00,Ballots Cast,,,,97,110,16,6,229
+Lackawanna,Jermyn W-03 P-00,Ballots Cast,,DEM,,26,84,12,4,126
+Lackawanna,Jermyn W-03 P-00,Ballots Cast,,REP,,71,26,4,2,103
+Lackawanna,Jermyn W-03 P-00,President,,DEM,Bernie Sanders,7,15,1,0,23
+Lackawanna,Jermyn W-03 P-00,President,,DEM,Joseph R. Biden,16,63,7,4,90
+Lackawanna,Jermyn W-03 P-00,President,,DEM,Tulsi Gabbard,2,5,2,0,9
+Lackawanna,Jermyn W-03 P-00,President,,DEM,Write-in,1,0,1,0,2
+Lackawanna,Jermyn W-03 P-00,Attorney General,,DEM,Josh Shapiro,18,70,9,1,98
+Lackawanna,Jermyn W-03 P-00,Attorney General,,DEM,Write-in,0,3,1,0,4
+Lackawanna,Jermyn W-03 P-00,Auditor General,,DEM,H. Scott Conklin,2,5,0,0,7
+Lackawanna,Jermyn W-03 P-00,Auditor General,,DEM,Michael Lamb,8,5,0,0,13
+Lackawanna,Jermyn W-03 P-00,Auditor General,,DEM,Tracie Fountain,1,3,0,0,4
+Lackawanna,Jermyn W-03 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,4,26,4,2,36
+Lackawanna,Jermyn W-03 P-00,Auditor General,,DEM,Nina Ahmad,7,10,1,1,19
+Lackawanna,Jermyn W-03 P-00,Auditor General,,DEM,Christina M. Hartman,2,20,5,0,27
+Lackawanna,Jermyn W-03 P-00,Auditor General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Jermyn W-03 P-00,State Treasurer,,DEM,Joe Torsella,16,67,10,1,94
+Lackawanna,Jermyn W-03 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,DEM,Matt Cartwright,21,76,9,1,107
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,DEM,Write-in,0,3,0,1,4
+Lackawanna,Jermyn W-03 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,20,70,10,2,102
+Lackawanna,Jermyn W-03 P-00,General Assembly,114,DEM,Write-in,0,2,0,0,2
+Lackawanna,Jermyn W-03 P-00,President,,REP,Donald J. Trump,70,20,2,2,94
+Lackawanna,Jermyn W-03 P-00,President,,REP,Roque Rocky De La Fuente,0,3,0,0,3
+Lackawanna,Jermyn W-03 P-00,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Jermyn W-03 P-00,President,,REP,Write-in,0,1,2,0,3
+Lackawanna,Jermyn W-03 P-00,Attorney General,,REP,Heather Heidelbaugh,63,23,2,2,90
+Lackawanna,Jermyn W-03 P-00,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Jermyn W-03 P-00,Auditor General,,REP,Timothy DeFoor,64,22,2,2,90
+Lackawanna,Jermyn W-03 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-03 P-00,State Treasurer,,REP,Stacy L. Garrity,62,22,2,2,88
+Lackawanna,Jermyn W-03 P-00,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,REP,Teddy Daniels,12,1,0,2,15
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,REP,Jim Bognet,12,3,0,0,15
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,REP,Mike Marsicano,2,0,0,0,2
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,REP,Earl Granville,44,22,3,0,69
+Lackawanna,Jermyn W-03 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Jermyn W-03 P-00,General Assembly,114,REP,James May,64,24,3,2,93
+Lackawanna,Jermyn W-03 P-00,General Assembly,114,REP,Write-in,2,0,0,0,2
+Lackawanna,Jessup W-01 P-01,Registered Voters,,,,,,,,779
+Lackawanna,Jessup W-01 P-01,Registered Voters,,DEM,,,,,,615
+Lackawanna,Jessup W-01 P-01,Registered Voters,,REP,,,,,,164
+Lackawanna,Jessup W-01 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Jessup W-01 P-01,Ballots Cast,,,,150,188,38,0,376
+Lackawanna,Jessup W-01 P-01,Ballots Cast,,DEM,,113,177,28,0,318
+Lackawanna,Jessup W-01 P-01,Ballots Cast,,REP,,37,11,10,0,58
+Lackawanna,Jessup W-01 P-01,President,,DEM,Bernie Sanders,16,10,4,0,30
+Lackawanna,Jessup W-01 P-01,President,,DEM,Joseph R. Biden,72,151,18,0,241
+Lackawanna,Jessup W-01 P-01,President,,DEM,Tulsi Gabbard,14,4,2,0,20
+Lackawanna,Jessup W-01 P-01,President,,DEM,Write-in,5,3,1,0,9
+Lackawanna,Jessup W-01 P-01,Attorney General,,DEM,Josh Shapiro,91,146,20,0,257
+Lackawanna,Jessup W-01 P-01,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Jessup W-01 P-01,Auditor General,,DEM,H. Scott Conklin,14,13,1,0,28
+Lackawanna,Jessup W-01 P-01,Auditor General,,DEM,Michael Lamb,23,38,5,0,66
+Lackawanna,Jessup W-01 P-01,Auditor General,,DEM,Tracie Fountain,7,7,3,0,17
+Lackawanna,Jessup W-01 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,15,26,6,0,47
+Lackawanna,Jessup W-01 P-01,Auditor General,,DEM,Nina Ahmad,32,37,3,0,72
+Lackawanna,Jessup W-01 P-01,Auditor General,,DEM,Christina M. Hartman,3,28,4,0,35
+Lackawanna,Jessup W-01 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-01 P-01,State Treasurer,,DEM,Joe Torsella,84,141,18,0,243
+Lackawanna,Jessup W-01 P-01,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Jessup W-01 P-01,U.S. House,8,DEM,Matt Cartwright,88,161,26,0,275
+Lackawanna,Jessup W-01 P-01,U.S. House,8,DEM,Write-in,5,1,0,0,6
+Lackawanna,Jessup W-01 P-01,General Assembly,112,DEM,Kyle J. Mullins,103,172,25,0,300
+Lackawanna,Jessup W-01 P-01,General Assembly,112,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-01 P-01,President,,REP,Donald J. Trump,34,8,10,0,52
+Lackawanna,Jessup W-01 P-01,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Jessup W-01 P-01,President,,REP,Bill Weld,1,2,0,0,3
+Lackawanna,Jessup W-01 P-01,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-01 P-01,Attorney General,,REP,Heather Heidelbaugh,29,10,9,0,48
+Lackawanna,Jessup W-01 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-01 P-01,Auditor General,,REP,Timothy DeFoor,27,9,9,0,45
+Lackawanna,Jessup W-01 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-01 P-01,State Treasurer,,REP,Stacy L. Garrity,28,10,9,0,47
+Lackawanna,Jessup W-01 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-01 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Jessup W-01 P-01,U.S. House,8,REP,Teddy Daniels,11,1,3,0,15
+Lackawanna,Jessup W-01 P-01,U.S. House,8,REP,Jim Bognet,7,3,0,0,10
+Lackawanna,Jessup W-01 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Jessup W-01 P-01,U.S. House,8,REP,Mike Marsicano,3,2,1,0,6
+Lackawanna,Jessup W-01 P-01,U.S. House,8,REP,Earl Granville,16,5,6,0,27
+Lackawanna,Jessup W-01 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-01 P-01,General Assembly,112,REP,Write-in,10,0,0,0,10
+Lackawanna,Jessup W-02 P-01,Registered Voters,,,,,,,,913
+Lackawanna,Jessup W-02 P-01,Registered Voters,,DEM,,,,,,688
+Lackawanna,Jessup W-02 P-01,Registered Voters,,REP,,,,,,225
+Lackawanna,Jessup W-02 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Jessup W-02 P-01,Ballots Cast,,,,176,195,24,4,399
+Lackawanna,Jessup W-02 P-01,Ballots Cast,,DEM,,120,176,20,2,318
+Lackawanna,Jessup W-02 P-01,Ballots Cast,,REP,,56,19,4,2,81
+Lackawanna,Jessup W-02 P-01,President,,DEM,Bernie Sanders,19,22,1,1,43
+Lackawanna,Jessup W-02 P-01,President,,DEM,Joseph R. Biden,71,143,16,0,230
+Lackawanna,Jessup W-02 P-01,President,,DEM,Tulsi Gabbard,5,0,0,0,5
+Lackawanna,Jessup W-02 P-01,President,,DEM,Write-in,15,2,3,0,20
+Lackawanna,Jessup W-02 P-01,Attorney General,,DEM,Josh Shapiro,91,148,20,1,260
+Lackawanna,Jessup W-02 P-01,Attorney General,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Jessup W-02 P-01,Auditor General,,DEM,H. Scott Conklin,4,7,2,0,13
+Lackawanna,Jessup W-02 P-01,Auditor General,,DEM,Michael Lamb,37,35,3,1,76
+Lackawanna,Jessup W-02 P-01,Auditor General,,DEM,Tracie Fountain,4,10,2,0,16
+Lackawanna,Jessup W-02 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,10,33,4,0,47
+Lackawanna,Jessup W-02 P-01,Auditor General,,DEM,Nina Ahmad,34,41,3,0,78
+Lackawanna,Jessup W-02 P-01,Auditor General,,DEM,Christina M. Hartman,12,14,5,1,32
+Lackawanna,Jessup W-02 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-02 P-01,State Treasurer,,DEM,Joe Torsella,84,142,19,1,246
+Lackawanna,Jessup W-02 P-01,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Jessup W-02 P-01,U.S. House,8,DEM,Matt Cartwright,90,161,19,0,270
+Lackawanna,Jessup W-02 P-01,U.S. House,8,DEM,Write-in,6,0,0,1,7
+Lackawanna,Jessup W-02 P-01,General Assembly,112,DEM,Kyle J. Mullins,105,165,20,1,291
+Lackawanna,Jessup W-02 P-01,General Assembly,112,DEM,Write-in,2,0,0,0,2
+Lackawanna,Jessup W-02 P-01,President,,REP,Donald J. Trump,53,18,4,2,77
+Lackawanna,Jessup W-02 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Jessup W-02 P-01,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Jessup W-02 P-01,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-02 P-01,Attorney General,,REP,Heather Heidelbaugh,35,18,4,2,59
+Lackawanna,Jessup W-02 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-02 P-01,Auditor General,,REP,Timothy DeFoor,34,19,4,2,59
+Lackawanna,Jessup W-02 P-01,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-02 P-01,State Treasurer,,REP,Stacy L. Garrity,36,19,3,2,60
+Lackawanna,Jessup W-02 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-02 P-01,U.S. House,8,REP,Harry Haas,1,1,0,0,2
+Lackawanna,Jessup W-02 P-01,U.S. House,8,REP,Teddy Daniels,18,2,1,0,21
+Lackawanna,Jessup W-02 P-01,U.S. House,8,REP,Jim Bognet,11,5,1,2,19
+Lackawanna,Jessup W-02 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Jessup W-02 P-01,U.S. House,8,REP,Mike Marsicano,4,0,1,0,5
+Lackawanna,Jessup W-02 P-01,U.S. House,8,REP,Earl Granville,21,11,1,0,33
+Lackawanna,Jessup W-02 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-02 P-01,General Assembly,112,REP,Write-in,4,4,1,1,10
+Lackawanna,Jessup W-03 P-01,Registered Voters,,,,,,,,827
+Lackawanna,Jessup W-03 P-01,Registered Voters,,DEM,,,,,,678
+Lackawanna,Jessup W-03 P-01,Registered Voters,,REP,,,,,,149
+Lackawanna,Jessup W-03 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Jessup W-03 P-01,Ballots Cast,,,,159,221,34,9,423
+Lackawanna,Jessup W-03 P-01,Ballots Cast,,DEM,,112,205,33,7,357
+Lackawanna,Jessup W-03 P-01,Ballots Cast,,REP,,47,16,1,2,66
+Lackawanna,Jessup W-03 P-01,President,,DEM,Bernie Sanders,17,20,4,2,43
+Lackawanna,Jessup W-03 P-01,President,,DEM,Joseph R. Biden,70,177,27,5,279
+Lackawanna,Jessup W-03 P-01,President,,DEM,Tulsi Gabbard,13,4,0,0,17
+Lackawanna,Jessup W-03 P-01,President,,DEM,Write-in,5,1,0,0,6
+Lackawanna,Jessup W-03 P-01,Attorney General,,DEM,Josh Shapiro,81,181,27,7,296
+Lackawanna,Jessup W-03 P-01,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-03 P-01,Auditor General,,DEM,H. Scott Conklin,7,10,3,0,20
+Lackawanna,Jessup W-03 P-01,Auditor General,,DEM,Michael Lamb,36,37,4,2,79
+Lackawanna,Jessup W-03 P-01,Auditor General,,DEM,Tracie Fountain,1,17,0,0,18
+Lackawanna,Jessup W-03 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,12,35,7,0,54
+Lackawanna,Jessup W-03 P-01,Auditor General,,DEM,Nina Ahmad,29,47,2,4,82
+Lackawanna,Jessup W-03 P-01,Auditor General,,DEM,Christina M. Hartman,11,28,10,1,50
+Lackawanna,Jessup W-03 P-01,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Jessup W-03 P-01,State Treasurer,,DEM,Joe Torsella,74,170,27,7,278
+Lackawanna,Jessup W-03 P-01,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Jessup W-03 P-01,U.S. House,8,DEM,Matt Cartwright,90,192,29,7,318
+Lackawanna,Jessup W-03 P-01,U.S. House,8,DEM,Write-in,2,2,0,0,4
+Lackawanna,Jessup W-03 P-01,General Assembly,112,DEM,Kyle J. Mullins,94,194,30,7,325
+Lackawanna,Jessup W-03 P-01,General Assembly,112,DEM,Write-in,4,1,0,0,5
+Lackawanna,Jessup W-03 P-01,President,,REP,Donald J. Trump,43,15,1,1,60
+Lackawanna,Jessup W-03 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Jessup W-03 P-01,President,,REP,Bill Weld,1,1,0,1,3
+Lackawanna,Jessup W-03 P-01,President,,REP,Write-in,3,0,0,0,3
+Lackawanna,Jessup W-03 P-01,Attorney General,,REP,Heather Heidelbaugh,38,14,1,2,55
+Lackawanna,Jessup W-03 P-01,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-03 P-01,Auditor General,,REP,Timothy DeFoor,37,14,1,2,54
+Lackawanna,Jessup W-03 P-01,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-03 P-01,State Treasurer,,REP,Stacy L. Garrity,40,15,1,2,58
+Lackawanna,Jessup W-03 P-01,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-03 P-01,U.S. House,8,REP,Harry Haas,0,3,0,0,3
+Lackawanna,Jessup W-03 P-01,U.S. House,8,REP,Teddy Daniels,13,1,0,1,15
+Lackawanna,Jessup W-03 P-01,U.S. House,8,REP,Jim Bognet,9,1,1,0,11
+Lackawanna,Jessup W-03 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Jessup W-03 P-01,U.S. House,8,REP,Mike Marsicano,5,1,0,0,6
+Lackawanna,Jessup W-03 P-01,U.S. House,8,REP,Earl Granville,16,9,0,1,26
+Lackawanna,Jessup W-03 P-01,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-03 P-01,General Assembly,112,REP,Write-in,6,4,0,0,10
+Lackawanna,Jessup W-03 P-02,Registered Voters,,,,,,,,549
+Lackawanna,Jessup W-03 P-02,Registered Voters,,DEM,,,,,,435
+Lackawanna,Jessup W-03 P-02,Registered Voters,,REP,,,,,,114
+Lackawanna,Jessup W-03 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Jessup W-03 P-02,Ballots Cast,,,,84,144,21,8,257
+Lackawanna,Jessup W-03 P-02,Ballots Cast,,DEM,,66,135,20,6,227
+Lackawanna,Jessup W-03 P-02,Ballots Cast,,REP,,18,9,1,2,30
+Lackawanna,Jessup W-03 P-02,President,,DEM,Bernie Sanders,9,5,3,1,18
+Lackawanna,Jessup W-03 P-02,President,,DEM,Joseph R. Biden,41,122,14,4,181
+Lackawanna,Jessup W-03 P-02,President,,DEM,Tulsi Gabbard,1,3,0,0,4
+Lackawanna,Jessup W-03 P-02,President,,DEM,Write-in,9,2,1,1,13
+Lackawanna,Jessup W-03 P-02,Attorney General,,DEM,Josh Shapiro,44,120,14,4,182
+Lackawanna,Jessup W-03 P-02,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-03 P-02,Auditor General,,DEM,H. Scott Conklin,1,5,0,0,6
+Lackawanna,Jessup W-03 P-02,Auditor General,,DEM,Michael Lamb,17,35,5,0,57
+Lackawanna,Jessup W-03 P-02,Auditor General,,DEM,Tracie Fountain,0,6,2,0,8
+Lackawanna,Jessup W-03 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,5,29,4,1,39
+Lackawanna,Jessup W-03 P-02,Auditor General,,DEM,Nina Ahmad,20,23,2,3,48
+Lackawanna,Jessup W-03 P-02,Auditor General,,DEM,Christina M. Hartman,7,13,2,1,23
+Lackawanna,Jessup W-03 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Jessup W-03 P-02,State Treasurer,,DEM,Joe Torsella,39,116,13,4,172
+Lackawanna,Jessup W-03 P-02,State Treasurer,,DEM,Write-in,2,0,1,0,3
+Lackawanna,Jessup W-03 P-02,U.S. House,8,DEM,Matt Cartwright,47,128,19,4,198
+Lackawanna,Jessup W-03 P-02,U.S. House,8,DEM,Write-in,7,2,1,1,11
+Lackawanna,Jessup W-03 P-02,General Assembly,112,DEM,Kyle J. Mullins,54,125,17,4,200
+Lackawanna,Jessup W-03 P-02,General Assembly,112,DEM,Write-in,2,1,0,0,3
+Lackawanna,Jessup W-03 P-02,President,,REP,Donald J. Trump,17,7,1,2,27
+Lackawanna,Jessup W-03 P-02,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Jessup W-03 P-02,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Jessup W-03 P-02,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Jessup W-03 P-02,Attorney General,,REP,Heather Heidelbaugh,12,8,1,1,22
+Lackawanna,Jessup W-03 P-02,Attorney General,,REP,Write-in,0,0,0,1,1
+Lackawanna,Jessup W-03 P-02,Auditor General,,REP,Timothy DeFoor,10,8,1,0,19
+Lackawanna,Jessup W-03 P-02,Auditor General,,REP,Write-in,0,1,0,1,2
+Lackawanna,Jessup W-03 P-02,State Treasurer,,REP,Stacy L. Garrity,11,9,1,1,22
+Lackawanna,Jessup W-03 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-03 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Jessup W-03 P-02,U.S. House,8,REP,Teddy Daniels,6,0,0,0,6
+Lackawanna,Jessup W-03 P-02,U.S. House,8,REP,Jim Bognet,5,1,0,0,6
+Lackawanna,Jessup W-03 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Jessup W-03 P-02,U.S. House,8,REP,Mike Marsicano,2,2,0,0,4
+Lackawanna,Jessup W-03 P-02,U.S. House,8,REP,Earl Granville,4,6,1,2,13
+Lackawanna,Jessup W-03 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Jessup W-03 P-02,General Assembly,112,REP,Write-in,4,1,0,1,6
+Lackawanna,La Plume Township W-00 P-00,Registered Voters,,,,,,,,280
+Lackawanna,La Plume Township W-00 P-00,Registered Voters,,DEM,,,,,,140
+Lackawanna,La Plume Township W-00 P-00,Registered Voters,,REP,,,,,,140
+Lackawanna,La Plume Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,La Plume Township W-00 P-00,Ballots Cast,,,,65,31,9,2,107
+Lackawanna,La Plume Township W-00 P-00,Ballots Cast,,DEM,,28,19,7,0,54
+Lackawanna,La Plume Township W-00 P-00,Ballots Cast,,REP,,37,12,2,2,53
+Lackawanna,La Plume Township W-00 P-00,President,,DEM,Bernie Sanders,6,4,0,0,10
+Lackawanna,La Plume Township W-00 P-00,President,,DEM,Joseph R. Biden,15,13,6,0,34
+Lackawanna,La Plume Township W-00 P-00,President,,DEM,Tulsi Gabbard,6,2,0,0,8
+Lackawanna,La Plume Township W-00 P-00,President,,DEM,Write-in,1,0,1,0,2
+Lackawanna,La Plume Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,21,17,4,0,42
+Lackawanna,La Plume Township W-00 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,3,0,0,0,3
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,DEM,Michael Lamb,1,4,0,0,5
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,1,3,1,0,5
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,9,2,1,0,12
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,7,6,0,0,13
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,1,1,2,0,4
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,20,15,4,0,39
+Lackawanna,La Plume Township W-00 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,24,18,5,0,47
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,DEM,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,General Assembly,117,DEM,Write-in,1,1,1,0,3
+Lackawanna,La Plume Township W-00 P-00,President,,REP,Donald J. Trump,33,8,2,1,44
+Lackawanna,La Plume Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,President,,REP,Bill Weld,2,2,0,1,5
+Lackawanna,La Plume Township W-00 P-00,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,32,11,2,2,47
+Lackawanna,La Plume Township W-00 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,32,11,2,2,47
+Lackawanna,La Plume Township W-00 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,29,11,2,2,44
+Lackawanna,La Plume Township W-00 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,7,0,1,0,8
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,REP,Jim Bognet,5,3,0,0,8
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,4,2,0,0,6
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,REP,Earl Granville,16,6,1,2,25
+Lackawanna,La Plume Township W-00 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,La Plume Township W-00 P-00,General Assembly,117,REP,Karen Boback,35,11,2,2,50
+Lackawanna,La Plume Township W-00 P-00,General Assembly,117,REP,Write-in,0,0,0,0,0
+Lackawanna,Thornhurst Twp. W-00 P-00,Registered Voters,,,,,,,,594
+Lackawanna,Thornhurst Twp. W-00 P-00,Registered Voters,,DEM,,,,,,276
+Lackawanna,Thornhurst Twp. W-00 P-00,Registered Voters,,REP,,,,,,318
+Lackawanna,Thornhurst Twp. W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Thornhurst Twp. W-00 P-00,Ballots Cast,,,,148,67,32,9,256
+Lackawanna,Thornhurst Twp. W-00 P-00,Ballots Cast,,DEM,,40,51,27,7,125
+Lackawanna,Thornhurst Twp. W-00 P-00,Ballots Cast,,REP,,108,16,5,2,131
+Lackawanna,Thornhurst Twp. W-00 P-00,President,,DEM,Bernie Sanders,7,7,8,3,25
+Lackawanna,Thornhurst Twp. W-00 P-00,President,,DEM,Joseph R. Biden,27,40,19,4,90
+Lackawanna,Thornhurst Twp. W-00 P-00,President,,DEM,Tulsi Gabbard,2,2,0,0,4
+Lackawanna,Thornhurst Twp. W-00 P-00,President,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Thornhurst Twp. W-00 P-00,Attorney General,,DEM,Josh Shapiro,34,43,23,6,106
+Lackawanna,Thornhurst Twp. W-00 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,DEM,H. Scott Conklin,2,2,0,1,5
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,DEM,Michael Lamb,3,4,3,2,12
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,DEM,Tracie Fountain,2,3,1,0,6
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,14,20,13,1,48
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,DEM,Nina Ahmad,12,9,4,3,28
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,DEM,Christina M. Hartman,2,3,0,0,5
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Thornhurst Twp. W-00 P-00,State Treasurer,,DEM,Joe Torsella,28,42,22,7,99
+Lackawanna,Thornhurst Twp. W-00 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,DEM,Matt Cartwright,37,48,26,7,118
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,DEM,Write-in,1,2,0,0,3
+Lackawanna,Thornhurst Twp. W-00 P-00,General Assembly,118,DEM,Mike Carroll,34,41,23,7,105
+Lackawanna,Thornhurst Twp. W-00 P-00,General Assembly,118,DEM,Write-in,0,0,0,0,0
+Lackawanna,Thornhurst Twp. W-00 P-00,President,,REP,Donald J. Trump,102,12,5,2,121
+Lackawanna,Thornhurst Twp. W-00 P-00,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Thornhurst Twp. W-00 P-00,President,,REP,Bill Weld,4,0,0,0,4
+Lackawanna,Thornhurst Twp. W-00 P-00,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Thornhurst Twp. W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,82,14,3,2,101
+Lackawanna,Thornhurst Twp. W-00 P-00,Attorney General,,REP,Write-in,3,0,0,0,3
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,REP,Timothy DeFoor,84,14,3,2,103
+Lackawanna,Thornhurst Twp. W-00 P-00,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Thornhurst Twp. W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,79,14,3,1,97
+Lackawanna,Thornhurst Twp. W-00 P-00,State Treasurer,,REP,Write-in,2,0,0,0,2
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,REP,Harry Haas,5,0,0,0,5
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,REP,Teddy Daniels,37,2,2,0,41
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,REP,Jim Bognet,24,1,1,1,27
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,REP,Mike Cammisa,2,0,1,0,3
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,REP,Mike Marsicano,13,4,1,0,18
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,REP,Earl Granville,24,8,0,1,33
+Lackawanna,Thornhurst Twp. W-00 P-00,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Thornhurst Twp. W-00 P-00,General Assembly,118,REP,Andrew Holter,78,12,3,1,94
+Lackawanna,Thornhurst Twp. W-00 P-00,General Assembly,118,REP,Write-in,3,0,0,0,3
+Lackawanna,Madison Township W-00 P-00,Registered Voters,,,,,,,,1574
+Lackawanna,Madison Township W-00 P-00,Registered Voters,,DEM,,,,,,715
+Lackawanna,Madison Township W-00 P-00,Registered Voters,,REP,,,,,,859
+Lackawanna,Madison Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Madison Township W-00 P-00,Ballots Cast,,,,354,258,62,8,682
+Lackawanna,Madison Township W-00 P-00,Ballots Cast,,DEM,,109,170,39,4,322
+Lackawanna,Madison Township W-00 P-00,Ballots Cast,,REP,,245,88,23,4,360
+Lackawanna,Madison Township W-00 P-00,President,,DEM,Bernie Sanders,15,15,4,3,37
+Lackawanna,Madison Township W-00 P-00,President,,DEM,Joseph R. Biden,73,145,30,1,249
+Lackawanna,Madison Township W-00 P-00,President,,DEM,Tulsi Gabbard,8,5,2,0,15
+Lackawanna,Madison Township W-00 P-00,President,,DEM,Write-in,8,2,2,0,12
+Lackawanna,Madison Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,79,149,29,2,259
+Lackawanna,Madison Township W-00 P-00,Attorney General,,DEM,Write-in,5,0,1,0,6
+Lackawanna,Madison Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,11,12,3,0,26
+Lackawanna,Madison Township W-00 P-00,Auditor General,,DEM,Michael Lamb,11,17,5,1,34
+Lackawanna,Madison Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,3,11,2,0,16
+Lackawanna,Madison Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,24,49,8,0,81
+Lackawanna,Madison Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,20,19,7,0,46
+Lackawanna,Madison Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,15,30,6,3,54
+Lackawanna,Madison Township W-00 P-00,Auditor General,,DEM,Write-in,4,0,1,0,5
+Lackawanna,Madison Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,74,144,28,3,249
+Lackawanna,Madison Township W-00 P-00,State Treasurer,,DEM,Write-in,5,0,1,0,6
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,82,160,34,3,279
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,DEM,Write-in,8,1,1,0,10
+Lackawanna,Madison Township W-00 P-00,General Assembly,118,DEM,Mike Carroll,75,134,28,4,241
+Lackawanna,Madison Township W-00 P-00,General Assembly,118,DEM,Write-in,5,1,1,0,7
+Lackawanna,Madison Township W-00 P-00,President,,REP,Donald J. Trump,235,60,17,4,316
+Lackawanna,Madison Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,4,4,3,0,11
+Lackawanna,Madison Township W-00 P-00,President,,REP,Bill Weld,2,16,2,0,20
+Lackawanna,Madison Township W-00 P-00,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Madison Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,203,68,18,2,291
+Lackawanna,Madison Township W-00 P-00,Attorney General,,REP,Write-in,1,4,0,0,5
+Lackawanna,Madison Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,199,69,18,2,288
+Lackawanna,Madison Township W-00 P-00,Auditor General,,REP,Write-in,3,1,0,0,4
+Lackawanna,Madison Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,201,67,18,4,290
+Lackawanna,Madison Township W-00 P-00,State Treasurer,,REP,Write-in,1,1,0,0,2
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,REP,Harry Haas,4,3,2,0,9
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,89,9,3,0,101
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,REP,Jim Bognet,48,18,1,0,67
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,28,5,1,3,37
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,REP,Earl Granville,70,48,13,0,131
+Lackawanna,Madison Township W-00 P-00,U.S. House,8,REP,Write-in,1,1,0,1,3
+Lackawanna,Madison Township W-00 P-00,General Assembly,118,REP,Andrew Holter,202,64,18,2,286
+Lackawanna,Madison Township W-00 P-00,General Assembly,118,REP,Write-in,0,1,0,0,1
+Lackawanna,Mayfield W-01 P-00,Registered Voters,,,,,,,,341
+Lackawanna,Mayfield W-01 P-00,Registered Voters,,DEM,,,,,,220
+Lackawanna,Mayfield W-01 P-00,Registered Voters,,REP,,,,,,121
+Lackawanna,Mayfield W-01 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Mayfield W-01 P-00,Ballots Cast,,,,59,60,15,1,135
+Lackawanna,Mayfield W-01 P-00,Ballots Cast,,DEM,,31,46,11,0,88
+Lackawanna,Mayfield W-01 P-00,Ballots Cast,,REP,,28,14,4,1,47
+Lackawanna,Mayfield W-01 P-00,President,,DEM,Bernie Sanders,3,6,0,0,9
+Lackawanna,Mayfield W-01 P-00,President,,DEM,Joseph R. Biden,16,40,7,0,63
+Lackawanna,Mayfield W-01 P-00,President,,DEM,Tulsi Gabbard,4,0,1,0,5
+Lackawanna,Mayfield W-01 P-00,President,,DEM,Write-in,4,0,1,0,5
+Lackawanna,Mayfield W-01 P-00,Attorney General,,DEM,Josh Shapiro,20,43,11,0,74
+Lackawanna,Mayfield W-01 P-00,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Mayfield W-01 P-00,Auditor General,,DEM,H. Scott Conklin,3,2,1,0,6
+Lackawanna,Mayfield W-01 P-00,Auditor General,,DEM,Michael Lamb,4,6,1,0,11
+Lackawanna,Mayfield W-01 P-00,Auditor General,,DEM,Tracie Fountain,2,3,0,0,5
+Lackawanna,Mayfield W-01 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,4,14,5,0,23
+Lackawanna,Mayfield W-01 P-00,Auditor General,,DEM,Nina Ahmad,4,5,1,0,10
+Lackawanna,Mayfield W-01 P-00,Auditor General,,DEM,Christina M. Hartman,6,12,3,0,21
+Lackawanna,Mayfield W-01 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Mayfield W-01 P-00,State Treasurer,,DEM,Joe Torsella,23,44,11,0,78
+Lackawanna,Mayfield W-01 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,DEM,Matt Cartwright,23,44,9,0,76
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,DEM,Write-in,3,0,0,0,3
+Lackawanna,Mayfield W-01 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,26,45,11,0,82
+Lackawanna,Mayfield W-01 P-00,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-01 P-00,President,,REP,Donald J. Trump,27,10,3,1,41
+Lackawanna,Mayfield W-01 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Mayfield W-01 P-00,President,,REP,Bill Weld,0,1,1,0,2
+Lackawanna,Mayfield W-01 P-00,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Mayfield W-01 P-00,Attorney General,,REP,Heather Heidelbaugh,17,11,4,1,33
+Lackawanna,Mayfield W-01 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-01 P-00,Auditor General,,REP,Timothy DeFoor,18,11,4,1,34
+Lackawanna,Mayfield W-01 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-01 P-00,State Treasurer,,REP,Stacy L. Garrity,18,11,4,1,34
+Lackawanna,Mayfield W-01 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,REP,Harry Haas,1,0,1,0,2
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,REP,Teddy Daniels,2,2,0,0,4
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,REP,Jim Bognet,2,3,1,0,6
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,REP,Mike Marsicano,0,1,0,0,1
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,REP,Earl Granville,21,6,2,1,30
+Lackawanna,Mayfield W-01 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Mayfield W-01 P-00,General Assembly,114,REP,James May,19,11,4,1,35
+Lackawanna,Mayfield W-01 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-02 P-00,Registered Voters,,,,,,,,485
+Lackawanna,Mayfield W-02 P-00,Registered Voters,,DEM,,,,,,324
+Lackawanna,Mayfield W-02 P-00,Registered Voters,,REP,,,,,,161
+Lackawanna,Mayfield W-02 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Mayfield W-02 P-00,Ballots Cast,,,,110,82,13,3,208
+Lackawanna,Mayfield W-02 P-00,Ballots Cast,,DEM,,60,64,13,2,139
+Lackawanna,Mayfield W-02 P-00,Ballots Cast,,REP,,50,18,0,1,69
+Lackawanna,Mayfield W-02 P-00,President,,DEM,Bernie Sanders,9,8,0,1,18
+Lackawanna,Mayfield W-02 P-00,President,,DEM,Joseph R. Biden,34,51,12,1,98
+Lackawanna,Mayfield W-02 P-00,President,,DEM,Tulsi Gabbard,4,1,1,0,6
+Lackawanna,Mayfield W-02 P-00,President,,DEM,Write-in,7,2,0,0,9
+Lackawanna,Mayfield W-02 P-00,Attorney General,,DEM,Josh Shapiro,40,49,12,1,102
+Lackawanna,Mayfield W-02 P-00,Attorney General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Mayfield W-02 P-00,Auditor General,,DEM,H. Scott Conklin,6,1,1,1,9
+Lackawanna,Mayfield W-02 P-00,Auditor General,,DEM,Michael Lamb,11,4,0,0,15
+Lackawanna,Mayfield W-02 P-00,Auditor General,,DEM,Tracie Fountain,2,5,1,0,8
+Lackawanna,Mayfield W-02 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,10,16,7,0,33
+Lackawanna,Mayfield W-02 P-00,Auditor General,,DEM,Nina Ahmad,7,16,1,0,24
+Lackawanna,Mayfield W-02 P-00,Auditor General,,DEM,Christina M. Hartman,11,14,1,1,27
+Lackawanna,Mayfield W-02 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Mayfield W-02 P-00,State Treasurer,,DEM,Joe Torsella,40,48,10,2,100
+Lackawanna,Mayfield W-02 P-00,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,DEM,Matt Cartwright,42,54,11,2,109
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,DEM,Write-in,7,0,0,0,7
+Lackawanna,Mayfield W-02 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,47,56,12,2,117
+Lackawanna,Mayfield W-02 P-00,General Assembly,114,DEM,Write-in,3,0,0,0,3
+Lackawanna,Mayfield W-02 P-00,President,,REP,Donald J. Trump,47,13,0,1,61
+Lackawanna,Mayfield W-02 P-00,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Mayfield W-02 P-00,President,,REP,Bill Weld,1,4,0,0,5
+Lackawanna,Mayfield W-02 P-00,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-02 P-00,Attorney General,,REP,Heather Heidelbaugh,32,12,0,1,45
+Lackawanna,Mayfield W-02 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-02 P-00,Auditor General,,REP,Timothy DeFoor,31,12,0,1,44
+Lackawanna,Mayfield W-02 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-02 P-00,State Treasurer,,REP,Stacy L. Garrity,28,12,0,1,41
+Lackawanna,Mayfield W-02 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,REP,Harry Haas,0,1,0,0,1
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,REP,Teddy Daniels,4,2,0,0,6
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,REP,Jim Bognet,6,2,0,0,8
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,REP,Earl Granville,36,12,0,1,49
+Lackawanna,Mayfield W-02 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-02 P-00,General Assembly,114,REP,James May,37,12,0,1,50
+Lackawanna,Mayfield W-02 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,Registered Voters,,,,,,,,298
+Lackawanna,Mayfield W-03 P-00,Registered Voters,,DEM,,,,,,193
+Lackawanna,Mayfield W-03 P-00,Registered Voters,,REP,,,,,,105
+Lackawanna,Mayfield W-03 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Mayfield W-03 P-00,Ballots Cast,,,,72,64,9,2,147
+Lackawanna,Mayfield W-03 P-00,Ballots Cast,,DEM,,26,54,9,1,90
+Lackawanna,Mayfield W-03 P-00,Ballots Cast,,REP,,46,10,0,1,57
+Lackawanna,Mayfield W-03 P-00,President,,DEM,Bernie Sanders,5,3,0,0,8
+Lackawanna,Mayfield W-03 P-00,President,,DEM,Joseph R. Biden,15,48,8,1,72
+Lackawanna,Mayfield W-03 P-00,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Mayfield W-03 P-00,President,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Mayfield W-03 P-00,Attorney General,,DEM,Josh Shapiro,19,49,8,1,77
+Lackawanna,Mayfield W-03 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,Auditor General,,DEM,H. Scott Conklin,2,3,1,0,6
+Lackawanna,Mayfield W-03 P-00,Auditor General,,DEM,Michael Lamb,5,7,2,0,14
+Lackawanna,Mayfield W-03 P-00,Auditor General,,DEM,Tracie Fountain,2,1,0,0,3
+Lackawanna,Mayfield W-03 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,4,9,0,1,14
+Lackawanna,Mayfield W-03 P-00,Auditor General,,DEM,Nina Ahmad,4,8,2,0,14
+Lackawanna,Mayfield W-03 P-00,Auditor General,,DEM,Christina M. Hartman,3,18,3,0,24
+Lackawanna,Mayfield W-03 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,State Treasurer,,DEM,Joe Torsella,21,48,8,1,78
+Lackawanna,Mayfield W-03 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,DEM,Matt Cartwright,19,51,9,1,80
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,DEM,Write-in,4,1,0,0,5
+Lackawanna,Mayfield W-03 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,20,53,8,1,82
+Lackawanna,Mayfield W-03 P-00,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,President,,REP,Donald J. Trump,46,8,0,0,54
+Lackawanna,Mayfield W-03 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,1,1
+Lackawanna,Mayfield W-03 P-00,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Mayfield W-03 P-00,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,Attorney General,,REP,Heather Heidelbaugh,34,8,0,1,43
+Lackawanna,Mayfield W-03 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,Auditor General,,REP,Timothy DeFoor,33,8,0,1,42
+Lackawanna,Mayfield W-03 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,State Treasurer,,REP,Stacy L. Garrity,32,8,0,0,40
+Lackawanna,Mayfield W-03 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,REP,Teddy Daniels,11,1,0,0,12
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,REP,Jim Bognet,6,0,0,0,6
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,REP,Earl Granville,27,8,0,1,36
+Lackawanna,Mayfield W-03 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Mayfield W-03 P-00,General Assembly,114,REP,James May,34,6,0,0,40
+Lackawanna,Mayfield W-03 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-01 P-00,Registered Voters,,,,,,,,962
+Lackawanna,Moosic W-01 P-00,Registered Voters,,DEM,,,,,,680
+Lackawanna,Moosic W-01 P-00,Registered Voters,,REP,,,,,,282
+Lackawanna,Moosic W-01 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Moosic W-01 P-00,Ballots Cast,,,,196,162,40,5,403
+Lackawanna,Moosic W-01 P-00,Ballots Cast,,DEM,,108,138,28,3,277
+Lackawanna,Moosic W-01 P-00,Ballots Cast,,REP,,88,24,12,2,126
+Lackawanna,Moosic W-01 P-00,President,,DEM,Bernie Sanders,23,15,1,0,39
+Lackawanna,Moosic W-01 P-00,President,,DEM,Joseph R. Biden,62,119,24,3,208
+Lackawanna,Moosic W-01 P-00,President,,DEM,Tulsi Gabbard,8,3,0,0,11
+Lackawanna,Moosic W-01 P-00,President,,DEM,Write-in,6,0,1,0,7
+Lackawanna,Moosic W-01 P-00,Attorney General,,DEM,Josh Shapiro,81,115,21,3,220
+Lackawanna,Moosic W-01 P-00,Attorney General,,DEM,Write-in,2,1,1,0,4
+Lackawanna,Moosic W-01 P-00,Auditor General,,DEM,H. Scott Conklin,8,4,1,0,13
+Lackawanna,Moosic W-01 P-00,Auditor General,,DEM,Michael Lamb,20,16,0,2,38
+Lackawanna,Moosic W-01 P-00,Auditor General,,DEM,Tracie Fountain,4,15,3,1,23
+Lackawanna,Moosic W-01 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,17,42,10,0,69
+Lackawanna,Moosic W-01 P-00,Auditor General,,DEM,Nina Ahmad,19,24,2,0,45
+Lackawanna,Moosic W-01 P-00,Auditor General,,DEM,Christina M. Hartman,17,15,7,0,39
+Lackawanna,Moosic W-01 P-00,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Moosic W-01 P-00,State Treasurer,,DEM,Joe Torsella,77,110,22,3,212
+Lackawanna,Moosic W-01 P-00,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Moosic W-01 P-00,U.S. House,8,DEM,Matt Cartwright,92,133,26,3,254
+Lackawanna,Moosic W-01 P-00,U.S. House,8,DEM,Write-in,7,0,1,0,8
+Lackawanna,Moosic W-01 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,93,122,22,3,240
+Lackawanna,Moosic W-01 P-00,General Assembly,114,DEM,Write-in,3,1,0,0,4
+Lackawanna,Moosic W-01 P-00,President,,REP,Donald J. Trump,82,22,11,2,117
+Lackawanna,Moosic W-01 P-00,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Moosic W-01 P-00,President,,REP,Bill Weld,2,2,0,0,4
+Lackawanna,Moosic W-01 P-00,President,,REP,Write-in,2,0,1,0,3
+Lackawanna,Moosic W-01 P-00,Attorney General,,REP,Heather Heidelbaugh,72,18,12,0,102
+Lackawanna,Moosic W-01 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-01 P-00,Auditor General,,REP,Timothy DeFoor,70,18,12,0,100
+Lackawanna,Moosic W-01 P-00,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Moosic W-01 P-00,State Treasurer,,REP,Stacy L. Garrity,73,18,12,0,103
+Lackawanna,Moosic W-01 P-00,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Moosic W-01 P-00,U.S. House,8,REP,Harry Haas,4,1,0,0,5
+Lackawanna,Moosic W-01 P-00,U.S. House,8,REP,Teddy Daniels,28,4,0,0,32
+Lackawanna,Moosic W-01 P-00,U.S. House,8,REP,Jim Bognet,20,3,9,1,33
+Lackawanna,Moosic W-01 P-00,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Moosic W-01 P-00,U.S. House,8,REP,Mike Marsicano,14,2,0,1,17
+Lackawanna,Moosic W-01 P-00,U.S. House,8,REP,Earl Granville,19,12,3,0,34
+Lackawanna,Moosic W-01 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-01 P-00,General Assembly,114,REP,James May,78,21,11,1,111
+Lackawanna,Moosic W-01 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-02 P-00,Registered Voters,,,,,,,,1293
+Lackawanna,Moosic W-02 P-00,Registered Voters,,DEM,,,,,,804
+Lackawanna,Moosic W-02 P-00,Registered Voters,,REP,,,,,,489
+Lackawanna,Moosic W-02 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Moosic W-02 P-00,Ballots Cast,,,,210,237,70,11,528
+Lackawanna,Moosic W-02 P-00,Ballots Cast,,DEM,,108,182,56,8,354
+Lackawanna,Moosic W-02 P-00,Ballots Cast,,REP,,102,55,14,3,174
+Lackawanna,Moosic W-02 P-00,President,,DEM,Bernie Sanders,21,18,10,1,50
+Lackawanna,Moosic W-02 P-00,President,,DEM,Joseph R. Biden,68,147,44,7,266
+Lackawanna,Moosic W-02 P-00,President,,DEM,Tulsi Gabbard,6,6,0,0,12
+Lackawanna,Moosic W-02 P-00,President,,DEM,Write-in,6,6,0,0,12
+Lackawanna,Moosic W-02 P-00,Attorney General,,DEM,Josh Shapiro,79,160,48,5,292
+Lackawanna,Moosic W-02 P-00,Attorney General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Moosic W-02 P-00,Auditor General,,DEM,H. Scott Conklin,7,12,1,0,20
+Lackawanna,Moosic W-02 P-00,Auditor General,,DEM,Michael Lamb,24,23,9,2,58
+Lackawanna,Moosic W-02 P-00,Auditor General,,DEM,Tracie Fountain,6,19,4,1,30
+Lackawanna,Moosic W-02 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,17,31,15,1,64
+Lackawanna,Moosic W-02 P-00,Auditor General,,DEM,Nina Ahmad,22,30,9,2,63
+Lackawanna,Moosic W-02 P-00,Auditor General,,DEM,Christina M. Hartman,9,32,10,0,51
+Lackawanna,Moosic W-02 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Moosic W-02 P-00,State Treasurer,,DEM,Joe Torsella,77,146,45,3,271
+Lackawanna,Moosic W-02 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Moosic W-02 P-00,U.S. House,8,DEM,Matt Cartwright,90,164,49,5,308
+Lackawanna,Moosic W-02 P-00,U.S. House,8,DEM,Write-in,2,0,1,0,3
+Lackawanna,Moosic W-02 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,84,169,48,7,308
+Lackawanna,Moosic W-02 P-00,General Assembly,114,DEM,Write-in,3,0,0,0,3
+Lackawanna,Moosic W-02 P-00,President,,REP,Donald J. Trump,98,45,12,3,158
+Lackawanna,Moosic W-02 P-00,President,,REP,Roque Rocky De La Fuente,1,1,1,0,3
+Lackawanna,Moosic W-02 P-00,President,,REP,Bill Weld,1,4,0,0,5
+Lackawanna,Moosic W-02 P-00,President,,REP,Write-in,2,1,1,0,4
+Lackawanna,Moosic W-02 P-00,Attorney General,,REP,Heather Heidelbaugh,78,48,13,3,142
+Lackawanna,Moosic W-02 P-00,Attorney General,,REP,Write-in,1,2,0,0,3
+Lackawanna,Moosic W-02 P-00,Auditor General,,REP,Timothy DeFoor,76,48,11,2,137
+Lackawanna,Moosic W-02 P-00,Auditor General,,REP,Write-in,2,2,0,0,4
+Lackawanna,Moosic W-02 P-00,State Treasurer,,REP,Stacy L. Garrity,80,48,11,2,141
+Lackawanna,Moosic W-02 P-00,State Treasurer,,REP,Write-in,1,1,0,0,2
+Lackawanna,Moosic W-02 P-00,U.S. House,8,REP,Harry Haas,2,1,0,0,3
+Lackawanna,Moosic W-02 P-00,U.S. House,8,REP,Teddy Daniels,22,1,0,0,23
+Lackawanna,Moosic W-02 P-00,U.S. House,8,REP,Jim Bognet,25,16,5,1,47
+Lackawanna,Moosic W-02 P-00,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Moosic W-02 P-00,U.S. House,8,REP,Mike Marsicano,18,1,2,0,21
+Lackawanna,Moosic W-02 P-00,U.S. House,8,REP,Earl Granville,28,27,6,1,62
+Lackawanna,Moosic W-02 P-00,U.S. House,8,REP,Write-in,1,1,0,0,2
+Lackawanna,Moosic W-02 P-00,General Assembly,114,REP,James May,80,45,11,3,139
+Lackawanna,Moosic W-02 P-00,General Assembly,114,REP,Write-in,1,4,0,0,5
+Lackawanna,Moosic W-03 P-00,Registered Voters,,,,,,,,736
+Lackawanna,Moosic W-03 P-00,Registered Voters,,DEM,,,,,,505
+Lackawanna,Moosic W-03 P-00,Registered Voters,,REP,,,,,,231
+Lackawanna,Moosic W-03 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Moosic W-03 P-00,Ballots Cast,,,,111,113,23,9,256
+Lackawanna,Moosic W-03 P-00,Ballots Cast,,DEM,,66,89,16,5,176
+Lackawanna,Moosic W-03 P-00,Ballots Cast,,REP,,45,24,7,4,80
+Lackawanna,Moosic W-03 P-00,President,,DEM,Bernie Sanders,14,13,4,1,32
+Lackawanna,Moosic W-03 P-00,President,,DEM,Joseph R. Biden,36,73,10,4,123
+Lackawanna,Moosic W-03 P-00,President,,DEM,Tulsi Gabbard,5,0,0,0,5
+Lackawanna,Moosic W-03 P-00,President,,DEM,Write-in,5,1,1,0,7
+Lackawanna,Moosic W-03 P-00,Attorney General,,DEM,Josh Shapiro,48,76,13,4,141
+Lackawanna,Moosic W-03 P-00,Attorney General,,DEM,Write-in,2,3,1,0,6
+Lackawanna,Moosic W-03 P-00,Auditor General,,DEM,H. Scott Conklin,5,11,4,0,20
+Lackawanna,Moosic W-03 P-00,Auditor General,,DEM,Michael Lamb,14,8,1,2,25
+Lackawanna,Moosic W-03 P-00,Auditor General,,DEM,Tracie Fountain,1,8,0,0,9
+Lackawanna,Moosic W-03 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,14,13,5,0,32
+Lackawanna,Moosic W-03 P-00,Auditor General,,DEM,Nina Ahmad,13,17,2,2,34
+Lackawanna,Moosic W-03 P-00,Auditor General,,DEM,Christina M. Hartman,9,18,2,0,29
+Lackawanna,Moosic W-03 P-00,Auditor General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Moosic W-03 P-00,State Treasurer,,DEM,Joe Torsella,51,72,13,4,140
+Lackawanna,Moosic W-03 P-00,State Treasurer,,DEM,Write-in,0,1,1,0,2
+Lackawanna,Moosic W-03 P-00,U.S. House,8,DEM,Matt Cartwright,51,83,12,5,151
+Lackawanna,Moosic W-03 P-00,U.S. House,8,DEM,Write-in,3,1,2,0,6
+Lackawanna,Moosic W-03 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,51,80,13,5,149
+Lackawanna,Moosic W-03 P-00,General Assembly,114,DEM,Write-in,3,0,1,0,4
+Lackawanna,Moosic W-03 P-00,President,,REP,Donald J. Trump,44,23,7,4,78
+Lackawanna,Moosic W-03 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Moosic W-03 P-00,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Moosic W-03 P-00,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Moosic W-03 P-00,Attorney General,,REP,Heather Heidelbaugh,33,19,6,4,62
+Lackawanna,Moosic W-03 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-03 P-00,Auditor General,,REP,Timothy DeFoor,33,17,6,4,60
+Lackawanna,Moosic W-03 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-03 P-00,State Treasurer,,REP,Stacy L. Garrity,34,16,6,4,60
+Lackawanna,Moosic W-03 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-03 P-00,U.S. House,8,REP,Harry Haas,0,0,2,0,2
+Lackawanna,Moosic W-03 P-00,U.S. House,8,REP,Teddy Daniels,17,0,1,0,18
+Lackawanna,Moosic W-03 P-00,U.S. House,8,REP,Jim Bognet,8,9,0,1,18
+Lackawanna,Moosic W-03 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Moosic W-03 P-00,U.S. House,8,REP,Mike Marsicano,8,2,0,1,11
+Lackawanna,Moosic W-03 P-00,U.S. House,8,REP,Earl Granville,9,12,3,2,26
+Lackawanna,Moosic W-03 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-03 P-00,General Assembly,114,REP,James May,32,15,5,4,56
+Lackawanna,Moosic W-03 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-04 P-00,Registered Voters,,,,,,,,859
+Lackawanna,Moosic W-04 P-00,Registered Voters,,DEM,,,,,,635
+Lackawanna,Moosic W-04 P-00,Registered Voters,,REP,,,,,,224
+Lackawanna,Moosic W-04 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Moosic W-04 P-00,Ballots Cast,,,,159,191,44,6,400
+Lackawanna,Moosic W-04 P-00,Ballots Cast,,DEM,,101,166,42,3,312
+Lackawanna,Moosic W-04 P-00,Ballots Cast,,REP,,58,25,2,3,88
+Lackawanna,Moosic W-04 P-00,President,,DEM,Bernie Sanders,14,20,1,2,37
+Lackawanna,Moosic W-04 P-00,President,,DEM,Joseph R. Biden,67,130,38,1,236
+Lackawanna,Moosic W-04 P-00,President,,DEM,Tulsi Gabbard,5,3,1,0,9
+Lackawanna,Moosic W-04 P-00,President,,DEM,Write-in,8,7,2,0,17
+Lackawanna,Moosic W-04 P-00,Attorney General,,DEM,Josh Shapiro,73,132,36,2,243
+Lackawanna,Moosic W-04 P-00,Attorney General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Moosic W-04 P-00,Auditor General,,DEM,H. Scott Conklin,10,8,3,0,21
+Lackawanna,Moosic W-04 P-00,Auditor General,,DEM,Michael Lamb,19,15,8,0,42
+Lackawanna,Moosic W-04 P-00,Auditor General,,DEM,Tracie Fountain,4,15,5,0,24
+Lackawanna,Moosic W-04 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,21,45,17,0,83
+Lackawanna,Moosic W-04 P-00,Auditor General,,DEM,Nina Ahmad,11,15,4,2,32
+Lackawanna,Moosic W-04 P-00,Auditor General,,DEM,Christina M. Hartman,7,26,3,0,36
+Lackawanna,Moosic W-04 P-00,Auditor General,,DEM,Write-in,0,0,0,1,1
+Lackawanna,Moosic W-04 P-00,State Treasurer,,DEM,Joe Torsella,70,125,39,2,236
+Lackawanna,Moosic W-04 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-04 P-00,U.S. House,8,DEM,Matt Cartwright,81,147,41,3,272
+Lackawanna,Moosic W-04 P-00,U.S. House,8,DEM,Write-in,3,3,0,0,6
+Lackawanna,Moosic W-04 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,81,141,38,3,263
+Lackawanna,Moosic W-04 P-00,General Assembly,114,DEM,Write-in,2,0,0,0,2
+Lackawanna,Moosic W-04 P-00,President,,REP,Donald J. Trump,52,20,2,2,76
+Lackawanna,Moosic W-04 P-00,President,,REP,Roque Rocky De La Fuente,0,1,0,1,2
+Lackawanna,Moosic W-04 P-00,President,,REP,Bill Weld,1,4,0,0,5
+Lackawanna,Moosic W-04 P-00,President,,REP,Write-in,4,0,0,0,4
+Lackawanna,Moosic W-04 P-00,Attorney General,,REP,Heather Heidelbaugh,46,20,1,3,70
+Lackawanna,Moosic W-04 P-00,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Moosic W-04 P-00,Auditor General,,REP,Timothy DeFoor,46,19,1,3,69
+Lackawanna,Moosic W-04 P-00,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Moosic W-04 P-00,State Treasurer,,REP,Stacy L. Garrity,46,20,1,3,70
+Lackawanna,Moosic W-04 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-04 P-00,U.S. House,8,REP,Harry Haas,0,2,0,0,2
+Lackawanna,Moosic W-04 P-00,U.S. House,8,REP,Teddy Daniels,17,1,0,0,18
+Lackawanna,Moosic W-04 P-00,U.S. House,8,REP,Jim Bognet,14,8,0,2,24
+Lackawanna,Moosic W-04 P-00,U.S. House,8,REP,Mike Cammisa,2,1,0,0,3
+Lackawanna,Moosic W-04 P-00,U.S. House,8,REP,Mike Marsicano,4,1,1,0,6
+Lackawanna,Moosic W-04 P-00,U.S. House,8,REP,Earl Granville,21,12,1,1,35
+Lackawanna,Moosic W-04 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Moosic W-04 P-00,General Assembly,114,REP,James May,49,22,2,3,76
+Lackawanna,Moosic W-04 P-00,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Moscow W-00 P-00,Registered Voters,,,,,,,,1341
+Lackawanna,Moscow W-00 P-00,Registered Voters,,DEM,,,,,,698
+Lackawanna,Moscow W-00 P-00,Registered Voters,,REP,,,,,,643
+Lackawanna,Moscow W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Moscow W-00 P-00,Ballots Cast,,,,293,304,53,6,656
+Lackawanna,Moscow W-00 P-00,Ballots Cast,,DEM,,112,234,37,5,388
+Lackawanna,Moscow W-00 P-00,Ballots Cast,,REP,,181,70,16,1,268
+Lackawanna,Moscow W-00 P-00,President,,DEM,Bernie Sanders,25,18,7,2,52
+Lackawanna,Moscow W-00 P-00,President,,DEM,Joseph R. Biden,83,207,26,2,318
+Lackawanna,Moscow W-00 P-00,President,,DEM,Tulsi Gabbard,2,3,2,0,7
+Lackawanna,Moscow W-00 P-00,President,,DEM,Write-in,2,2,1,1,6
+Lackawanna,Moscow W-00 P-00,Attorney General,,DEM,Josh Shapiro,89,203,32,2,326
+Lackawanna,Moscow W-00 P-00,Attorney General,,DEM,Write-in,4,2,1,1,8
+Lackawanna,Moscow W-00 P-00,Auditor General,,DEM,H. Scott Conklin,4,12,0,0,16
+Lackawanna,Moscow W-00 P-00,Auditor General,,DEM,Michael Lamb,11,22,6,1,40
+Lackawanna,Moscow W-00 P-00,Auditor General,,DEM,Tracie Fountain,5,27,3,0,35
+Lackawanna,Moscow W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,37,59,14,1,111
+Lackawanna,Moscow W-00 P-00,Auditor General,,DEM,Nina Ahmad,29,36,5,1,71
+Lackawanna,Moscow W-00 P-00,Auditor General,,DEM,Christina M. Hartman,10,32,5,0,47
+Lackawanna,Moscow W-00 P-00,Auditor General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Moscow W-00 P-00,State Treasurer,,DEM,Joe Torsella,86,189,31,2,308
+Lackawanna,Moscow W-00 P-00,State Treasurer,,DEM,Write-in,3,1,0,1,5
+Lackawanna,Moscow W-00 P-00,U.S. House,8,DEM,Matt Cartwright,97,218,30,3,348
+Lackawanna,Moscow W-00 P-00,U.S. House,8,DEM,Write-in,3,1,2,1,7
+Lackawanna,Moscow W-00 P-00,General Assembly,118,DEM,Mike Carroll,94,199,30,2,325
+Lackawanna,Moscow W-00 P-00,General Assembly,118,DEM,Write-in,3,1,0,1,5
+Lackawanna,Moscow W-00 P-00,President,,REP,Donald J. Trump,168,52,10,1,231
+Lackawanna,Moscow W-00 P-00,President,,REP,Roque Rocky De La Fuente,4,1,1,0,6
+Lackawanna,Moscow W-00 P-00,President,,REP,Bill Weld,5,9,5,0,19
+Lackawanna,Moscow W-00 P-00,President,,REP,Write-in,1,4,0,0,5
+Lackawanna,Moscow W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,151,54,15,1,221
+Lackawanna,Moscow W-00 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Moscow W-00 P-00,Auditor General,,REP,Timothy DeFoor,146,55,14,1,216
+Lackawanna,Moscow W-00 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Moscow W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,142,54,15,1,212
+Lackawanna,Moscow W-00 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Moscow W-00 P-00,U.S. House,8,REP,Harry Haas,6,1,0,0,7
+Lackawanna,Moscow W-00 P-00,U.S. House,8,REP,Teddy Daniels,49,3,2,0,54
+Lackawanna,Moscow W-00 P-00,U.S. House,8,REP,Jim Bognet,34,10,3,0,47
+Lackawanna,Moscow W-00 P-00,U.S. House,8,REP,Mike Cammisa,1,1,0,0,2
+Lackawanna,Moscow W-00 P-00,U.S. House,8,REP,Mike Marsicano,7,5,1,0,13
+Lackawanna,Moscow W-00 P-00,U.S. House,8,REP,Earl Granville,76,42,8,1,127
+Lackawanna,Moscow W-00 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Moscow W-00 P-00,General Assembly,118,REP,Andrew Holter,138,49,16,1,204
+Lackawanna,Moscow W-00 P-00,General Assembly,118,REP,Write-in,2,0,0,0,2
+Lackawanna,Newton Township W-00 P-00,Registered Voters,,,,,,,,1844
+Lackawanna,Newton Township W-00 P-00,Registered Voters,,DEM,,,,,,784
+Lackawanna,Newton Township W-00 P-00,Registered Voters,,REP,,,,,,1060
+Lackawanna,Newton Township W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Newton Township W-00 P-00,Ballots Cast,,,,367,308,61,11,747
+Lackawanna,Newton Township W-00 P-00,Ballots Cast,,DEM,,89,178,41,6,314
+Lackawanna,Newton Township W-00 P-00,Ballots Cast,,REP,,278,130,20,5,433
+Lackawanna,Newton Township W-00 P-00,President,,DEM,Bernie Sanders,16,23,3,1,43
+Lackawanna,Newton Township W-00 P-00,President,,DEM,Joseph R. Biden,63,146,37,4,250
+Lackawanna,Newton Township W-00 P-00,President,,DEM,Tulsi Gabbard,5,6,1,0,12
+Lackawanna,Newton Township W-00 P-00,President,,DEM,Write-in,4,3,0,0,7
+Lackawanna,Newton Township W-00 P-00,Attorney General,,DEM,Josh Shapiro,76,157,38,4,275
+Lackawanna,Newton Township W-00 P-00,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Newton Township W-00 P-00,Auditor General,,DEM,H. Scott Conklin,10,10,0,0,20
+Lackawanna,Newton Township W-00 P-00,Auditor General,,DEM,Michael Lamb,17,32,5,1,55
+Lackawanna,Newton Township W-00 P-00,Auditor General,,DEM,Tracie Fountain,7,19,1,0,27
+Lackawanna,Newton Township W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,13,28,10,0,51
+Lackawanna,Newton Township W-00 P-00,Auditor General,,DEM,Nina Ahmad,23,26,8,2,59
+Lackawanna,Newton Township W-00 P-00,Auditor General,,DEM,Christina M. Hartman,10,31,8,1,50
+Lackawanna,Newton Township W-00 P-00,Auditor General,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Newton Township W-00 P-00,State Treasurer,,DEM,Joe Torsella,74,146,34,5,259
+Lackawanna,Newton Township W-00 P-00,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,DEM,Matt Cartwright,73,168,36,5,282
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,DEM,Write-in,3,3,1,0,7
+Lackawanna,Newton Township W-00 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,79,159,37,5,280
+Lackawanna,Newton Township W-00 P-00,General Assembly,114,DEM,Write-in,2,2,0,0,4
+Lackawanna,Newton Township W-00 P-00,President,,REP,Donald J. Trump,263,101,19,5,388
+Lackawanna,Newton Township W-00 P-00,President,,REP,Roque Rocky De La Fuente,4,1,0,0,5
+Lackawanna,Newton Township W-00 P-00,President,,REP,Bill Weld,5,14,1,0,20
+Lackawanna,Newton Township W-00 P-00,President,,REP,Write-in,3,2,0,0,5
+Lackawanna,Newton Township W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,218,115,14,4,351
+Lackawanna,Newton Township W-00 P-00,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Newton Township W-00 P-00,Auditor General,,REP,Timothy DeFoor,215,109,14,4,342
+Lackawanna,Newton Township W-00 P-00,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Newton Township W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,219,112,14,4,349
+Lackawanna,Newton Township W-00 P-00,State Treasurer,,REP,Write-in,2,0,0,0,2
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,REP,Harry Haas,7,9,1,0,17
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,REP,Teddy Daniels,81,8,0,3,92
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,REP,Jim Bognet,52,25,6,1,84
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,3,0,0,3
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,REP,Mike Marsicano,31,3,0,1,35
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,REP,Earl Granville,97,74,11,0,182
+Lackawanna,Newton Township W-00 P-00,U.S. House,8,REP,Write-in,0,2,1,0,3
+Lackawanna,Newton Township W-00 P-00,General Assembly,114,REP,James May,248,121,17,5,391
+Lackawanna,Newton Township W-00 P-00,General Assembly,114,REP,Write-in,1,1,1,0,3
+Lackawanna,North Abington Twp. W-00 P-00,Registered Voters,,,,,,,,482
+Lackawanna,North Abington Twp. W-00 P-00,Registered Voters,,DEM,,,,,,218
+Lackawanna,North Abington Twp. W-00 P-00,Registered Voters,,REP,,,,,,264
+Lackawanna,North Abington Twp. W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,North Abington Twp. W-00 P-00,Ballots Cast,,,,102,84,13,2,201
+Lackawanna,North Abington Twp. W-00 P-00,Ballots Cast,,DEM,,35,61,9,1,106
+Lackawanna,North Abington Twp. W-00 P-00,Ballots Cast,,REP,,67,23,4,1,95
+Lackawanna,North Abington Twp. W-00 P-00,President,,DEM,Bernie Sanders,10,9,2,1,22
+Lackawanna,North Abington Twp. W-00 P-00,President,,DEM,Joseph R. Biden,23,49,7,0,79
+Lackawanna,North Abington Twp. W-00 P-00,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Lackawanna,North Abington Twp. W-00 P-00,President,,DEM,Write-in,0,1,0,0,1
+Lackawanna,North Abington Twp. W-00 P-00,Attorney General,,DEM,Josh Shapiro,30,52,6,1,89
+Lackawanna,North Abington Twp. W-00 P-00,Attorney General,,DEM,Write-in,0,0,1,0,1
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,DEM,H. Scott Conklin,0,2,0,0,2
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,DEM,Michael Lamb,4,11,1,0,16
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,DEM,Tracie Fountain,1,6,0,0,7
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,1,0,6
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,DEM,Nina Ahmad,19,18,2,1,40
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,DEM,Christina M. Hartman,4,9,2,0,15
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,State Treasurer,,DEM,Joe Torsella,27,50,5,1,83
+Lackawanna,North Abington Twp. W-00 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,DEM,Matt Cartwright,32,58,8,1,99
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,DEM,Write-in,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,32,59,8,1,100
+Lackawanna,North Abington Twp. W-00 P-00,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,President,,REP,Donald J. Trump,60,20,4,1,85
+Lackawanna,North Abington Twp. W-00 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,President,,REP,Bill Weld,3,3,0,0,6
+Lackawanna,North Abington Twp. W-00 P-00,President,,REP,Write-in,2,0,0,0,2
+Lackawanna,North Abington Twp. W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,49,18,3,1,71
+Lackawanna,North Abington Twp. W-00 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,REP,Timothy DeFoor,47,18,3,1,69
+Lackawanna,North Abington Twp. W-00 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,47,17,3,1,68
+Lackawanna,North Abington Twp. W-00 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,REP,Teddy Daniels,13,1,0,0,14
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,REP,Jim Bognet,13,4,0,1,18
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,3,0,0,3
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,REP,Mike Marsicano,5,0,0,0,5
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,REP,Earl Granville,33,12,4,0,49
+Lackawanna,North Abington Twp. W-00 P-00,U.S. House,8,REP,Write-in,0,2,0,0,2
+Lackawanna,North Abington Twp. W-00 P-00,General Assembly,114,REP,James May,62,16,3,1,82
+Lackawanna,North Abington Twp. W-00 P-00,General Assembly,114,REP,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,Registered Voters,,,,,,,,683
+Lackawanna,Old Forge W-01 P-00,Registered Voters,,DEM,,,,,,384
+Lackawanna,Old Forge W-01 P-00,Registered Voters,,REP,,,,,,299
+Lackawanna,Old Forge W-01 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Old Forge W-01 P-00,Ballots Cast,,,,150,112,14,3,279
+Lackawanna,Old Forge W-01 P-00,Ballots Cast,,DEM,,57,76,12,1,146
+Lackawanna,Old Forge W-01 P-00,Ballots Cast,,REP,,93,36,2,2,133
+Lackawanna,Old Forge W-01 P-00,President,,DEM,Bernie Sanders,3,4,1,0,8
+Lackawanna,Old Forge W-01 P-00,President,,DEM,Joseph R. Biden,49,71,11,1,132
+Lackawanna,Old Forge W-01 P-00,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Lackawanna,Old Forge W-01 P-00,President,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Old Forge W-01 P-00,Attorney General,,DEM,Josh Shapiro,43,67,12,1,123
+Lackawanna,Old Forge W-01 P-00,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Old Forge W-01 P-00,Auditor General,,DEM,H. Scott Conklin,2,9,0,0,11
+Lackawanna,Old Forge W-01 P-00,Auditor General,,DEM,Michael Lamb,17,14,3,0,34
+Lackawanna,Old Forge W-01 P-00,Auditor General,,DEM,Tracie Fountain,1,8,0,0,9
+Lackawanna,Old Forge W-01 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,8,15,1,1,25
+Lackawanna,Old Forge W-01 P-00,Auditor General,,DEM,Nina Ahmad,17,9,3,0,29
+Lackawanna,Old Forge W-01 P-00,Auditor General,,DEM,Christina M. Hartman,4,11,5,0,20
+Lackawanna,Old Forge W-01 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-01 P-00,State Treasurer,,DEM,Joe Torsella,35,65,12,1,113
+Lackawanna,Old Forge W-01 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,DEM,Matt Cartwright,48,68,12,1,129
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,47,75,10,1,133
+Lackawanna,Old Forge W-01 P-00,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,President,,REP,Donald J. Trump,87,29,1,2,119
+Lackawanna,Old Forge W-01 P-00,President,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Lackawanna,Old Forge W-01 P-00,President,,REP,Bill Weld,1,2,0,0,3
+Lackawanna,Old Forge W-01 P-00,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,Attorney General,,REP,Heather Heidelbaugh,68,31,2,2,103
+Lackawanna,Old Forge W-01 P-00,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,Auditor General,,REP,Timothy DeFoor,69,32,2,1,104
+Lackawanna,Old Forge W-01 P-00,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,State Treasurer,,REP,Stacy L. Garrity,69,30,2,1,102
+Lackawanna,Old Forge W-01 P-00,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,REP,Teddy Daniels,31,4,0,0,35
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,REP,Jim Bognet,19,6,0,0,25
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,REP,Mike Marsicano,13,2,0,0,15
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,REP,Earl Granville,26,21,2,2,51
+Lackawanna,Old Forge W-01 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-01 P-00,General Assembly,114,REP,James May,76,33,2,2,113
+Lackawanna,Old Forge W-01 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-02 P-00,Registered Voters,,,,,,,,684
+Lackawanna,Old Forge W-02 P-00,Registered Voters,,DEM,,,,,,415
+Lackawanna,Old Forge W-02 P-00,Registered Voters,,REP,,,,,,269
+Lackawanna,Old Forge W-02 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Old Forge W-02 P-00,Ballots Cast,,,,150,117,8,4,279
+Lackawanna,Old Forge W-02 P-00,Ballots Cast,,DEM,,71,87,5,2,165
+Lackawanna,Old Forge W-02 P-00,Ballots Cast,,REP,,79,30,3,2,114
+Lackawanna,Old Forge W-02 P-00,President,,DEM,Bernie Sanders,10,10,0,2,22
+Lackawanna,Old Forge W-02 P-00,President,,DEM,Joseph R. Biden,45,74,4,0,123
+Lackawanna,Old Forge W-02 P-00,President,,DEM,Tulsi Gabbard,5,2,1,0,8
+Lackawanna,Old Forge W-02 P-00,President,,DEM,Write-in,4,1,0,0,5
+Lackawanna,Old Forge W-02 P-00,Attorney General,,DEM,Josh Shapiro,55,76,5,2,138
+Lackawanna,Old Forge W-02 P-00,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-02 P-00,Auditor General,,DEM,H. Scott Conklin,2,4,0,0,6
+Lackawanna,Old Forge W-02 P-00,Auditor General,,DEM,Michael Lamb,14,17,1,0,32
+Lackawanna,Old Forge W-02 P-00,Auditor General,,DEM,Tracie Fountain,6,2,0,0,8
+Lackawanna,Old Forge W-02 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,10,25,2,0,37
+Lackawanna,Old Forge W-02 P-00,Auditor General,,DEM,Nina Ahmad,16,8,1,2,27
+Lackawanna,Old Forge W-02 P-00,Auditor General,,DEM,Christina M. Hartman,8,17,1,0,26
+Lackawanna,Old Forge W-02 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-02 P-00,State Treasurer,,DEM,Joe Torsella,54,73,4,2,133
+Lackawanna,Old Forge W-02 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,DEM,Matt Cartwright,59,82,4,2,147
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,DEM,Write-in,1,3,0,0,4
+Lackawanna,Old Forge W-02 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,61,77,5,2,145
+Lackawanna,Old Forge W-02 P-00,General Assembly,114,DEM,Write-in,1,2,0,0,3
+Lackawanna,Old Forge W-02 P-00,President,,REP,Donald J. Trump,77,24,3,2,106
+Lackawanna,Old Forge W-02 P-00,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Old Forge W-02 P-00,President,,REP,Bill Weld,0,3,0,0,3
+Lackawanna,Old Forge W-02 P-00,President,,REP,Write-in,1,1,0,0,2
+Lackawanna,Old Forge W-02 P-00,Attorney General,,REP,Heather Heidelbaugh,53,24,3,1,81
+Lackawanna,Old Forge W-02 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-02 P-00,Auditor General,,REP,Timothy DeFoor,54,23,3,1,81
+Lackawanna,Old Forge W-02 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-02 P-00,State Treasurer,,REP,Stacy L. Garrity,52,26,3,1,82
+Lackawanna,Old Forge W-02 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,REP,Teddy Daniels,29,3,0,0,32
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,REP,Jim Bognet,16,10,0,1,27
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,REP,Mike Marsicano,8,3,0,1,12
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,REP,Earl Granville,20,14,3,0,37
+Lackawanna,Old Forge W-02 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-02 P-00,General Assembly,114,REP,James May,63,26,3,2,94
+Lackawanna,Old Forge W-02 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-03 P-00,Registered Voters,,,,,,,,1108
+Lackawanna,Old Forge W-03 P-00,Registered Voters,,DEM,,,,,,680
+Lackawanna,Old Forge W-03 P-00,Registered Voters,,REP,,,,,,428
+Lackawanna,Old Forge W-03 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Old Forge W-03 P-00,Ballots Cast,,,,182,206,35,11,434
+Lackawanna,Old Forge W-03 P-00,Ballots Cast,,DEM,,86,152,27,2,267
+Lackawanna,Old Forge W-03 P-00,Ballots Cast,,REP,,96,54,8,9,167
+Lackawanna,Old Forge W-03 P-00,President,,DEM,Bernie Sanders,22,18,2,0,42
+Lackawanna,Old Forge W-03 P-00,President,,DEM,Joseph R. Biden,55,126,24,2,207
+Lackawanna,Old Forge W-03 P-00,President,,DEM,Tulsi Gabbard,1,5,0,0,6
+Lackawanna,Old Forge W-03 P-00,President,,DEM,Write-in,2,0,1,0,3
+Lackawanna,Old Forge W-03 P-00,Attorney General,,DEM,Josh Shapiro,70,134,25,2,231
+Lackawanna,Old Forge W-03 P-00,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-03 P-00,Auditor General,,DEM,H. Scott Conklin,5,7,3,0,15
+Lackawanna,Old Forge W-03 P-00,Auditor General,,DEM,Michael Lamb,19,35,4,1,59
+Lackawanna,Old Forge W-03 P-00,Auditor General,,DEM,Tracie Fountain,4,8,2,0,14
+Lackawanna,Old Forge W-03 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,9,46,9,0,64
+Lackawanna,Old Forge W-03 P-00,Auditor General,,DEM,Nina Ahmad,25,16,2,1,44
+Lackawanna,Old Forge W-03 P-00,Auditor General,,DEM,Christina M. Hartman,15,20,3,0,38
+Lackawanna,Old Forge W-03 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-03 P-00,State Treasurer,,DEM,Joe Torsella,70,131,23,1,225
+Lackawanna,Old Forge W-03 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,DEM,Matt Cartwright,77,147,24,2,250
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Old Forge W-03 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,75,142,25,2,244
+Lackawanna,Old Forge W-03 P-00,General Assembly,114,DEM,Write-in,2,0,0,0,2
+Lackawanna,Old Forge W-03 P-00,President,,REP,Donald J. Trump,92,43,8,9,152
+Lackawanna,Old Forge W-03 P-00,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Old Forge W-03 P-00,President,,REP,Bill Weld,2,5,0,0,7
+Lackawanna,Old Forge W-03 P-00,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Old Forge W-03 P-00,Attorney General,,REP,Heather Heidelbaugh,64,41,8,2,115
+Lackawanna,Old Forge W-03 P-00,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-03 P-00,Auditor General,,REP,Timothy DeFoor,63,38,8,2,111
+Lackawanna,Old Forge W-03 P-00,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Old Forge W-03 P-00,State Treasurer,,REP,Stacy L. Garrity,62,39,8,2,111
+Lackawanna,Old Forge W-03 P-00,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,REP,Harry Haas,5,1,0,0,6
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,REP,Teddy Daniels,48,3,0,7,58
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,REP,Jim Bognet,16,15,3,1,35
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,REP,Mike Cammisa,0,2,0,0,2
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,REP,Mike Marsicano,7,5,1,0,13
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,REP,Earl Granville,14,23,4,1,42
+Lackawanna,Old Forge W-03 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-03 P-00,General Assembly,114,REP,James May,78,40,7,5,130
+Lackawanna,Old Forge W-03 P-00,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-04 P-00,Registered Voters,,,,,,,,753
+Lackawanna,Old Forge W-04 P-00,Registered Voters,,DEM,,,,,,467
+Lackawanna,Old Forge W-04 P-00,Registered Voters,,REP,,,,,,286
+Lackawanna,Old Forge W-04 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Old Forge W-04 P-00,Ballots Cast,,,,125,129,22,7,283
+Lackawanna,Old Forge W-04 P-00,Ballots Cast,,DEM,,66,92,21,2,181
+Lackawanna,Old Forge W-04 P-00,Ballots Cast,,REP,,59,37,1,5,102
+Lackawanna,Old Forge W-04 P-00,President,,DEM,Bernie Sanders,11,13,3,1,28
+Lackawanna,Old Forge W-04 P-00,President,,DEM,Joseph R. Biden,46,73,17,1,137
+Lackawanna,Old Forge W-04 P-00,President,,DEM,Tulsi Gabbard,4,1,0,0,5
+Lackawanna,Old Forge W-04 P-00,President,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Old Forge W-04 P-00,Attorney General,,DEM,Josh Shapiro,59,81,15,1,156
+Lackawanna,Old Forge W-04 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-04 P-00,Auditor General,,DEM,H. Scott Conklin,4,6,1,0,11
+Lackawanna,Old Forge W-04 P-00,Auditor General,,DEM,Michael Lamb,13,17,1,0,31
+Lackawanna,Old Forge W-04 P-00,Auditor General,,DEM,Tracie Fountain,9,2,2,0,13
+Lackawanna,Old Forge W-04 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,11,33,6,0,50
+Lackawanna,Old Forge W-04 P-00,Auditor General,,DEM,Nina Ahmad,18,10,7,1,36
+Lackawanna,Old Forge W-04 P-00,Auditor General,,DEM,Christina M. Hartman,3,14,0,0,17
+Lackawanna,Old Forge W-04 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-04 P-00,State Treasurer,,DEM,Joe Torsella,57,79,15,1,152
+Lackawanna,Old Forge W-04 P-00,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,DEM,Matt Cartwright,62,84,18,2,166
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,DEM,Write-in,0,2,0,0,2
+Lackawanna,Old Forge W-04 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,63,82,17,1,163
+Lackawanna,Old Forge W-04 P-00,General Assembly,114,DEM,Write-in,0,2,0,0,2
+Lackawanna,Old Forge W-04 P-00,President,,REP,Donald J. Trump,56,31,0,5,92
+Lackawanna,Old Forge W-04 P-00,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Old Forge W-04 P-00,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Old Forge W-04 P-00,President,,REP,Write-in,1,4,1,0,6
+Lackawanna,Old Forge W-04 P-00,Attorney General,,REP,Heather Heidelbaugh,42,26,1,4,73
+Lackawanna,Old Forge W-04 P-00,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-04 P-00,Auditor General,,REP,Timothy DeFoor,42,26,0,4,72
+Lackawanna,Old Forge W-04 P-00,Auditor General,,REP,Write-in,0,1,1,0,2
+Lackawanna,Old Forge W-04 P-00,State Treasurer,,REP,Stacy L. Garrity,41,28,1,4,74
+Lackawanna,Old Forge W-04 P-00,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,REP,Teddy Daniels,23,5,0,1,29
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,REP,Jim Bognet,15,5,0,2,22
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,REP,Mike Marsicano,12,4,0,1,17
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,REP,Earl Granville,6,20,1,1,28
+Lackawanna,Old Forge W-04 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-04 P-00,General Assembly,114,REP,James May,47,32,1,5,85
+Lackawanna,Old Forge W-04 P-00,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-05 P-00,Registered Voters,,,,,,,,651
+Lackawanna,Old Forge W-05 P-00,Registered Voters,,DEM,,,,,,362
+Lackawanna,Old Forge W-05 P-00,Registered Voters,,REP,,,,,,289
+Lackawanna,Old Forge W-05 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Old Forge W-05 P-00,Ballots Cast,,,,113,123,28,1,265
+Lackawanna,Old Forge W-05 P-00,Ballots Cast,,DEM,,45,91,24,1,161
+Lackawanna,Old Forge W-05 P-00,Ballots Cast,,REP,,68,32,4,0,104
+Lackawanna,Old Forge W-05 P-00,President,,DEM,Bernie Sanders,3,9,0,1,13
+Lackawanna,Old Forge W-05 P-00,President,,DEM,Joseph R. Biden,36,72,24,0,132
+Lackawanna,Old Forge W-05 P-00,President,,DEM,Tulsi Gabbard,3,5,0,0,8
+Lackawanna,Old Forge W-05 P-00,President,,DEM,Write-in,0,3,0,0,3
+Lackawanna,Old Forge W-05 P-00,Attorney General,,DEM,Josh Shapiro,38,76,21,1,136
+Lackawanna,Old Forge W-05 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-05 P-00,Auditor General,,DEM,H. Scott Conklin,4,8,1,1,14
+Lackawanna,Old Forge W-05 P-00,Auditor General,,DEM,Michael Lamb,11,12,6,0,29
+Lackawanna,Old Forge W-05 P-00,Auditor General,,DEM,Tracie Fountain,1,9,0,0,10
+Lackawanna,Old Forge W-05 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,8,20,3,0,31
+Lackawanna,Old Forge W-05 P-00,Auditor General,,DEM,Nina Ahmad,14,15,4,0,33
+Lackawanna,Old Forge W-05 P-00,Auditor General,,DEM,Christina M. Hartman,3,12,2,0,17
+Lackawanna,Old Forge W-05 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-05 P-00,State Treasurer,,DEM,Joe Torsella,35,72,21,1,129
+Lackawanna,Old Forge W-05 P-00,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,DEM,Matt Cartwright,42,79,23,1,145
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,DEM,Write-in,1,2,0,0,3
+Lackawanna,Old Forge W-05 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,39,80,23,1,143
+Lackawanna,Old Forge W-05 P-00,General Assembly,114,DEM,Write-in,2,1,0,0,3
+Lackawanna,Old Forge W-05 P-00,President,,REP,Donald J. Trump,65,24,2,0,91
+Lackawanna,Old Forge W-05 P-00,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Old Forge W-05 P-00,President,,REP,Bill Weld,0,3,1,0,4
+Lackawanna,Old Forge W-05 P-00,President,,REP,Write-in,2,3,1,0,6
+Lackawanna,Old Forge W-05 P-00,Attorney General,,REP,Heather Heidelbaugh,51,20,4,0,75
+Lackawanna,Old Forge W-05 P-00,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-05 P-00,Auditor General,,REP,Timothy DeFoor,48,20,4,0,72
+Lackawanna,Old Forge W-05 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-05 P-00,State Treasurer,,REP,Stacy L. Garrity,47,22,4,0,73
+Lackawanna,Old Forge W-05 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,REP,Harry Haas,3,0,0,0,3
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,REP,Teddy Daniels,29,1,0,0,30
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,REP,Jim Bognet,10,6,2,0,18
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,REP,Mike Marsicano,6,1,0,0,7
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,REP,Earl Granville,19,18,2,0,39
+Lackawanna,Old Forge W-05 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-05 P-00,General Assembly,114,REP,James May,51,24,4,0,79
+Lackawanna,Old Forge W-05 P-00,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Old Forge W-06 P-01,Registered Voters,,,,,,,,648
+Lackawanna,Old Forge W-06 P-01,Registered Voters,,DEM,,,,,,416
+Lackawanna,Old Forge W-06 P-01,Registered Voters,,REP,,,,,,232
+Lackawanna,Old Forge W-06 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Old Forge W-06 P-01,Ballots Cast,,,,91,109,22,6,228
+Lackawanna,Old Forge W-06 P-01,Ballots Cast,,DEM,,40,83,18,4,145
+Lackawanna,Old Forge W-06 P-01,Ballots Cast,,REP,,51,26,4,2,83
+Lackawanna,Old Forge W-06 P-01,President,,DEM,Bernie Sanders,4,10,1,1,16
+Lackawanna,Old Forge W-06 P-01,President,,DEM,Joseph R. Biden,29,70,17,3,119
+Lackawanna,Old Forge W-06 P-01,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Old Forge W-06 P-01,President,,DEM,Write-in,3,2,0,0,5
+Lackawanna,Old Forge W-06 P-01,Attorney General,,DEM,Josh Shapiro,28,64,17,3,112
+Lackawanna,Old Forge W-06 P-01,Attorney General,,DEM,Write-in,2,0,1,0,3
+Lackawanna,Old Forge W-06 P-01,Auditor General,,DEM,H. Scott Conklin,3,8,3,0,14
+Lackawanna,Old Forge W-06 P-01,Auditor General,,DEM,Michael Lamb,9,7,3,0,19
+Lackawanna,Old Forge W-06 P-01,Auditor General,,DEM,Tracie Fountain,3,2,2,0,7
+Lackawanna,Old Forge W-06 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,4,19,3,1,27
+Lackawanna,Old Forge W-06 P-01,Auditor General,,DEM,Nina Ahmad,11,15,3,2,31
+Lackawanna,Old Forge W-06 P-01,Auditor General,,DEM,Christina M. Hartman,2,15,4,0,21
+Lackawanna,Old Forge W-06 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-06 P-01,State Treasurer,,DEM,Joe Torsella,26,66,17,3,112
+Lackawanna,Old Forge W-06 P-01,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,DEM,Matt Cartwright,35,73,17,3,128
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,DEM,Write-in,1,1,0,0,2
+Lackawanna,Old Forge W-06 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,33,72,17,3,125
+Lackawanna,Old Forge W-06 P-01,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-06 P-01,President,,REP,Donald J. Trump,50,23,2,2,77
+Lackawanna,Old Forge W-06 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-01,President,,REP,Bill Weld,1,2,0,0,3
+Lackawanna,Old Forge W-06 P-01,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-01,Attorney General,,REP,Heather Heidelbaugh,40,20,1,2,63
+Lackawanna,Old Forge W-06 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-01,Auditor General,,REP,Timothy DeFoor,37,19,1,1,58
+Lackawanna,Old Forge W-06 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-01,State Treasurer,,REP,Stacy L. Garrity,38,20,2,1,61
+Lackawanna,Old Forge W-06 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,REP,Harry Haas,1,1,0,0,2
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,REP,Teddy Daniels,18,1,0,1,20
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,REP,Jim Bognet,8,4,0,1,13
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,REP,Mike Marsicano,8,0,0,0,8
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,REP,Earl Granville,12,19,3,0,34
+Lackawanna,Old Forge W-06 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-01,General Assembly,114,REP,James May,41,22,4,1,68
+Lackawanna,Old Forge W-06 P-01,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-02,Registered Voters,,,,,,,,974
+Lackawanna,Old Forge W-06 P-02,Registered Voters,,DEM,,,,,,626
+Lackawanna,Old Forge W-06 P-02,Registered Voters,,REP,,,,,,348
+Lackawanna,Old Forge W-06 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Old Forge W-06 P-02,Ballots Cast,,,,132,229,40,6,407
+Lackawanna,Old Forge W-06 P-02,Ballots Cast,,DEM,,58,188,32,4,282
+Lackawanna,Old Forge W-06 P-02,Ballots Cast,,REP,,74,41,8,2,125
+Lackawanna,Old Forge W-06 P-02,President,,DEM,Bernie Sanders,6,13,3,1,23
+Lackawanna,Old Forge W-06 P-02,President,,DEM,Joseph R. Biden,40,164,24,2,230
+Lackawanna,Old Forge W-06 P-02,President,,DEM,Tulsi Gabbard,3,3,0,0,6
+Lackawanna,Old Forge W-06 P-02,President,,DEM,Write-in,6,6,4,0,16
+Lackawanna,Old Forge W-06 P-02,Attorney General,,DEM,Josh Shapiro,40,157,28,4,229
+Lackawanna,Old Forge W-06 P-02,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-06 P-02,Auditor General,,DEM,H. Scott Conklin,1,17,3,0,21
+Lackawanna,Old Forge W-06 P-02,Auditor General,,DEM,Michael Lamb,16,19,4,1,40
+Lackawanna,Old Forge W-06 P-02,Auditor General,,DEM,Tracie Fountain,1,11,4,0,16
+Lackawanna,Old Forge W-06 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,5,44,9,1,59
+Lackawanna,Old Forge W-06 P-02,Auditor General,,DEM,Nina Ahmad,18,32,1,2,53
+Lackawanna,Old Forge W-06 P-02,Auditor General,,DEM,Christina M. Hartman,4,21,8,0,33
+Lackawanna,Old Forge W-06 P-02,Auditor General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Old Forge W-06 P-02,State Treasurer,,DEM,Joe Torsella,40,146,28,4,218
+Lackawanna,Old Forge W-06 P-02,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,DEM,Matt Cartwright,46,175,29,4,254
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,DEM,Write-in,2,1,1,0,4
+Lackawanna,Old Forge W-06 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,48,167,30,4,249
+Lackawanna,Old Forge W-06 P-02,General Assembly,114,DEM,Write-in,2,0,0,0,2
+Lackawanna,Old Forge W-06 P-02,President,,REP,Donald J. Trump,71,33,5,1,110
+Lackawanna,Old Forge W-06 P-02,President,,REP,Roque Rocky De La Fuente,0,1,0,1,2
+Lackawanna,Old Forge W-06 P-02,President,,REP,Bill Weld,0,2,1,0,3
+Lackawanna,Old Forge W-06 P-02,President,,REP,Write-in,2,1,2,0,5
+Lackawanna,Old Forge W-06 P-02,Attorney General,,REP,Heather Heidelbaugh,53,33,3,2,91
+Lackawanna,Old Forge W-06 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Old Forge W-06 P-02,Auditor General,,REP,Timothy DeFoor,54,31,3,2,90
+Lackawanna,Old Forge W-06 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-02,State Treasurer,,REP,Stacy L. Garrity,52,32,3,2,89
+Lackawanna,Old Forge W-06 P-02,State Treasurer,,REP,Write-in,0,0,1,0,1
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,REP,Harry Haas,1,3,0,0,4
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,REP,Teddy Daniels,29,3,0,0,32
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,REP,Jim Bognet,12,4,0,1,17
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,REP,Mike Marsicano,7,1,0,1,9
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,REP,Earl Granville,23,23,4,0,50
+Lackawanna,Old Forge W-06 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Old Forge W-06 P-02,General Assembly,114,REP,James May,56,33,4,2,95
+Lackawanna,Old Forge W-06 P-02,General Assembly,114,REP,Write-in,1,0,0,0,1
+Lackawanna,Olyphant W-01 P-00,Registered Voters,,,,,,,,554
+Lackawanna,Olyphant W-01 P-00,Registered Voters,,DEM,,,,,,428
+Lackawanna,Olyphant W-01 P-00,Registered Voters,,REP,,,,,,126
+Lackawanna,Olyphant W-01 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Olyphant W-01 P-00,Ballots Cast,,,,87,127,18,0,232
+Lackawanna,Olyphant W-01 P-00,Ballots Cast,,DEM,,47,119,16,0,182
+Lackawanna,Olyphant W-01 P-00,Ballots Cast,,REP,,40,8,2,0,50
+Lackawanna,Olyphant W-01 P-00,President,,DEM,Bernie Sanders,10,6,2,0,18
+Lackawanna,Olyphant W-01 P-00,President,,DEM,Joseph R. Biden,28,109,11,0,148
+Lackawanna,Olyphant W-01 P-00,President,,DEM,Tulsi Gabbard,3,1,1,0,5
+Lackawanna,Olyphant W-01 P-00,President,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Olyphant W-01 P-00,Attorney General,,DEM,Josh Shapiro,34,105,15,0,154
+Lackawanna,Olyphant W-01 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-01 P-00,Auditor General,,DEM,H. Scott Conklin,6,10,1,0,17
+Lackawanna,Olyphant W-01 P-00,Auditor General,,DEM,Michael Lamb,13,13,3,0,29
+Lackawanna,Olyphant W-01 P-00,Auditor General,,DEM,Tracie Fountain,1,8,0,0,9
+Lackawanna,Olyphant W-01 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,4,27,7,0,38
+Lackawanna,Olyphant W-01 P-00,Auditor General,,DEM,Nina Ahmad,7,24,0,0,31
+Lackawanna,Olyphant W-01 P-00,Auditor General,,DEM,Christina M. Hartman,5,18,3,0,26
+Lackawanna,Olyphant W-01 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-01 P-00,State Treasurer,,DEM,Joe Torsella,33,97,14,0,144
+Lackawanna,Olyphant W-01 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,DEM,Matt Cartwright,34,106,16,0,156
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Olyphant W-01 P-00,General Assembly,112,DEM,Kyle J. Mullins,36,113,15,0,164
+Lackawanna,Olyphant W-01 P-00,General Assembly,112,DEM,Write-in,2,0,0,0,2
+Lackawanna,Olyphant W-01 P-00,President,,REP,Donald J. Trump,37,5,2,0,44
+Lackawanna,Olyphant W-01 P-00,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Olyphant W-01 P-00,President,,REP,Bill Weld,2,2,0,0,4
+Lackawanna,Olyphant W-01 P-00,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-01 P-00,Attorney General,,REP,Heather Heidelbaugh,30,6,2,0,38
+Lackawanna,Olyphant W-01 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-01 P-00,Auditor General,,REP,Timothy DeFoor,30,6,2,0,38
+Lackawanna,Olyphant W-01 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-01 P-00,State Treasurer,,REP,Stacy L. Garrity,29,5,2,0,36
+Lackawanna,Olyphant W-01 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,REP,Harry Haas,3,0,0,0,3
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,REP,Teddy Daniels,14,0,2,0,16
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,REP,Jim Bognet,5,1,0,0,6
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,REP,Mike Cammisa,0,2,0,0,2
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,REP,Earl Granville,14,5,0,0,19
+Lackawanna,Olyphant W-01 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-01 P-00,General Assembly,112,REP,Write-in,29,2,0,0,31
+Lackawanna,Olyphant W-02 P-00,Registered Voters,,,,,,,,631
+Lackawanna,Olyphant W-02 P-00,Registered Voters,,DEM,,,,,,456
+Lackawanna,Olyphant W-02 P-00,Registered Voters,,REP,,,,,,175
+Lackawanna,Olyphant W-02 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Olyphant W-02 P-00,Ballots Cast,,,,111,90,13,0,214
+Lackawanna,Olyphant W-02 P-00,Ballots Cast,,DEM,,70,69,11,0,150
+Lackawanna,Olyphant W-02 P-00,Ballots Cast,,REP,,41,21,2,0,64
+Lackawanna,Olyphant W-02 P-00,President,,DEM,Bernie Sanders,15,4,1,0,20
+Lackawanna,Olyphant W-02 P-00,President,,DEM,Joseph R. Biden,46,59,9,0,114
+Lackawanna,Olyphant W-02 P-00,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Lackawanna,Olyphant W-02 P-00,President,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Olyphant W-02 P-00,Attorney General,,DEM,Josh Shapiro,55,58,11,0,124
+Lackawanna,Olyphant W-02 P-00,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Olyphant W-02 P-00,Auditor General,,DEM,H. Scott Conklin,2,1,1,0,4
+Lackawanna,Olyphant W-02 P-00,Auditor General,,DEM,Michael Lamb,13,11,1,0,25
+Lackawanna,Olyphant W-02 P-00,Auditor General,,DEM,Tracie Fountain,1,4,0,0,5
+Lackawanna,Olyphant W-02 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,9,14,3,0,26
+Lackawanna,Olyphant W-02 P-00,Auditor General,,DEM,Nina Ahmad,20,12,2,0,34
+Lackawanna,Olyphant W-02 P-00,Auditor General,,DEM,Christina M. Hartman,13,9,4,0,26
+Lackawanna,Olyphant W-02 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Olyphant W-02 P-00,State Treasurer,,DEM,Joe Torsella,51,58,11,0,120
+Lackawanna,Olyphant W-02 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,DEM,Matt Cartwright,56,63,10,0,129
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,DEM,Write-in,3,1,0,0,4
+Lackawanna,Olyphant W-02 P-00,General Assembly,112,DEM,Kyle J. Mullins,57,65,11,0,133
+Lackawanna,Olyphant W-02 P-00,General Assembly,112,DEM,Write-in,3,1,0,0,4
+Lackawanna,Olyphant W-02 P-00,President,,REP,Donald J. Trump,38,17,2,0,57
+Lackawanna,Olyphant W-02 P-00,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Olyphant W-02 P-00,President,,REP,Bill Weld,2,1,0,0,3
+Lackawanna,Olyphant W-02 P-00,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Olyphant W-02 P-00,Attorney General,,REP,Heather Heidelbaugh,34,20,2,0,56
+Lackawanna,Olyphant W-02 P-00,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Olyphant W-02 P-00,Auditor General,,REP,Timothy DeFoor,32,20,2,0,54
+Lackawanna,Olyphant W-02 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-02 P-00,State Treasurer,,REP,Stacy L. Garrity,33,20,2,0,55
+Lackawanna,Olyphant W-02 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,REP,Harry Haas,1,2,0,0,3
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,REP,Teddy Daniels,13,1,0,0,14
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,REP,Jim Bognet,6,2,1,0,9
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,REP,Mike Marsicano,1,1,0,0,2
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,REP,Earl Granville,18,13,1,0,32
+Lackawanna,Olyphant W-02 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-02 P-00,General Assembly,112,REP,Write-in,6,6,0,0,12
+Lackawanna,Olyphant W-03 P-01,Registered Voters,,,,,,,,373
+Lackawanna,Olyphant W-03 P-01,Registered Voters,,DEM,,,,,,289
+Lackawanna,Olyphant W-03 P-01,Registered Voters,,REP,,,,,,84
+Lackawanna,Olyphant W-03 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Olyphant W-03 P-01,Ballots Cast,,,,78,59,7,4,148
+Lackawanna,Olyphant W-03 P-01,Ballots Cast,,DEM,,52,49,5,3,109
+Lackawanna,Olyphant W-03 P-01,Ballots Cast,,REP,,26,10,2,1,39
+Lackawanna,Olyphant W-03 P-01,President,,DEM,Bernie Sanders,12,7,1,0,20
+Lackawanna,Olyphant W-03 P-01,President,,DEM,Joseph R. Biden,28,34,3,1,66
+Lackawanna,Olyphant W-03 P-01,President,,DEM,Tulsi Gabbard,6,1,0,1,8
+Lackawanna,Olyphant W-03 P-01,President,,DEM,Write-in,4,4,1,0,9
+Lackawanna,Olyphant W-03 P-01,Attorney General,,DEM,Josh Shapiro,38,38,3,2,81
+Lackawanna,Olyphant W-03 P-01,Attorney General,,DEM,Write-in,1,0,2,0,3
+Lackawanna,Olyphant W-03 P-01,Auditor General,,DEM,H. Scott Conklin,3,0,0,0,3
+Lackawanna,Olyphant W-03 P-01,Auditor General,,DEM,Michael Lamb,7,10,1,0,18
+Lackawanna,Olyphant W-03 P-01,Auditor General,,DEM,Tracie Fountain,1,1,0,0,2
+Lackawanna,Olyphant W-03 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,6,8,2,0,16
+Lackawanna,Olyphant W-03 P-01,Auditor General,,DEM,Nina Ahmad,11,18,0,1,30
+Lackawanna,Olyphant W-03 P-01,Auditor General,,DEM,Christina M. Hartman,7,4,0,0,11
+Lackawanna,Olyphant W-03 P-01,Auditor General,,DEM,Write-in,1,0,2,0,3
+Lackawanna,Olyphant W-03 P-01,State Treasurer,,DEM,Joe Torsella,32,36,3,1,72
+Lackawanna,Olyphant W-03 P-01,State Treasurer,,DEM,Write-in,2,0,2,0,4
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,DEM,Matt Cartwright,38,39,3,2,82
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,DEM,Write-in,6,1,2,0,9
+Lackawanna,Olyphant W-03 P-01,General Assembly,112,DEM,Kyle J. Mullins,38,44,3,3,88
+Lackawanna,Olyphant W-03 P-01,General Assembly,112,DEM,Write-in,6,1,0,0,7
+Lackawanna,Olyphant W-03 P-01,President,,REP,Donald J. Trump,22,6,2,1,31
+Lackawanna,Olyphant W-03 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-01,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-01,President,,REP,Write-in,3,3,0,0,6
+Lackawanna,Olyphant W-03 P-01,Attorney General,,REP,Heather Heidelbaugh,16,9,2,0,27
+Lackawanna,Olyphant W-03 P-01,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Olyphant W-03 P-01,Auditor General,,REP,Timothy DeFoor,15,8,2,0,25
+Lackawanna,Olyphant W-03 P-01,Auditor General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Olyphant W-03 P-01,State Treasurer,,REP,Stacy L. Garrity,14,8,2,0,24
+Lackawanna,Olyphant W-03 P-01,State Treasurer,,REP,Write-in,2,0,0,0,2
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,REP,Harry Haas,0,1,1,0,2
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,REP,Teddy Daniels,6,0,0,1,7
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,REP,Jim Bognet,5,1,1,0,7
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,REP,Earl Granville,13,8,0,0,21
+Lackawanna,Olyphant W-03 P-01,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Olyphant W-03 P-01,General Assembly,112,REP,Write-in,7,2,0,1,10
+Lackawanna,Olyphant W-03 P-02,Registered Voters,,,,,,,,654
+Lackawanna,Olyphant W-03 P-02,Registered Voters,,DEM,,,,,,488
+Lackawanna,Olyphant W-03 P-02,Registered Voters,,REP,,,,,,166
+Lackawanna,Olyphant W-03 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Olyphant W-03 P-02,Ballots Cast,,,,153,134,26,4,317
+Lackawanna,Olyphant W-03 P-02,Ballots Cast,,DEM,,102,122,23,4,251
+Lackawanna,Olyphant W-03 P-02,Ballots Cast,,REP,,51,12,3,0,66
+Lackawanna,Olyphant W-03 P-02,President,,DEM,Bernie Sanders,19,16,0,1,36
+Lackawanna,Olyphant W-03 P-02,President,,DEM,Joseph R. Biden,63,95,22,3,183
+Lackawanna,Olyphant W-03 P-02,President,,DEM,Tulsi Gabbard,6,10,1,0,17
+Lackawanna,Olyphant W-03 P-02,President,,DEM,Write-in,5,0,0,0,5
+Lackawanna,Olyphant W-03 P-02,Attorney General,,DEM,Josh Shapiro,64,108,20,4,196
+Lackawanna,Olyphant W-03 P-02,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Olyphant W-03 P-02,Auditor General,,DEM,H. Scott Conklin,2,7,0,0,9
+Lackawanna,Olyphant W-03 P-02,Auditor General,,DEM,Michael Lamb,31,28,8,1,68
+Lackawanna,Olyphant W-03 P-02,Auditor General,,DEM,Tracie Fountain,4,10,2,0,16
+Lackawanna,Olyphant W-03 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,15,25,3,1,44
+Lackawanna,Olyphant W-03 P-02,Auditor General,,DEM,Nina Ahmad,25,19,3,1,48
+Lackawanna,Olyphant W-03 P-02,Auditor General,,DEM,Christina M. Hartman,5,9,4,1,19
+Lackawanna,Olyphant W-03 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-02,State Treasurer,,DEM,Joe Torsella,62,99,18,4,183
+Lackawanna,Olyphant W-03 P-02,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,DEM,Matt Cartwright,78,112,20,4,214
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,DEM,Write-in,1,1,0,0,2
+Lackawanna,Olyphant W-03 P-02,General Assembly,112,DEM,Kyle J. Mullins,81,113,20,4,218
+Lackawanna,Olyphant W-03 P-02,General Assembly,112,DEM,Write-in,0,1,1,0,2
+Lackawanna,Olyphant W-03 P-02,President,,REP,Donald J. Trump,50,11,3,0,64
+Lackawanna,Olyphant W-03 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-02,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-02,President,,REP,Write-in,1,1,0,0,2
+Lackawanna,Olyphant W-03 P-02,Attorney General,,REP,Heather Heidelbaugh,34,12,2,0,48
+Lackawanna,Olyphant W-03 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-02,Auditor General,,REP,Timothy DeFoor,33,11,2,0,46
+Lackawanna,Olyphant W-03 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-02,State Treasurer,,REP,Stacy L. Garrity,32,12,2,0,46
+Lackawanna,Olyphant W-03 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,REP,Teddy Daniels,11,0,0,0,11
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,REP,Jim Bognet,11,2,0,0,13
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,REP,Mike Marsicano,1,2,0,0,3
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,REP,Earl Granville,26,8,2,0,36
+Lackawanna,Olyphant W-03 P-02,U.S. House,8,REP,Write-in,0,0,1,0,1
+Lackawanna,Olyphant W-03 P-02,General Assembly,112,REP,Write-in,4,1,0,0,5
+Lackawanna,Olyphant W-04 P-01,Registered Voters,,,,,,,,745
+Lackawanna,Olyphant W-04 P-01,Registered Voters,,DEM,,,,,,556
+Lackawanna,Olyphant W-04 P-01,Registered Voters,,REP,,,,,,189
+Lackawanna,Olyphant W-04 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Olyphant W-04 P-01,Ballots Cast,,,,161,161,15,7,344
+Lackawanna,Olyphant W-04 P-01,Ballots Cast,,DEM,,106,139,10,6,261
+Lackawanna,Olyphant W-04 P-01,Ballots Cast,,REP,,55,22,5,1,83
+Lackawanna,Olyphant W-04 P-01,President,,DEM,Bernie Sanders,23,11,0,0,34
+Lackawanna,Olyphant W-04 P-01,President,,DEM,Joseph R. Biden,55,119,10,5,189
+Lackawanna,Olyphant W-04 P-01,President,,DEM,Tulsi Gabbard,13,5,0,0,18
+Lackawanna,Olyphant W-04 P-01,President,,DEM,Write-in,5,1,0,1,7
+Lackawanna,Olyphant W-04 P-01,Attorney General,,DEM,Josh Shapiro,75,115,7,4,201
+Lackawanna,Olyphant W-04 P-01,Attorney General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Olyphant W-04 P-01,Auditor General,,DEM,H. Scott Conklin,5,9,0,0,14
+Lackawanna,Olyphant W-04 P-01,Auditor General,,DEM,Michael Lamb,26,26,3,0,55
+Lackawanna,Olyphant W-04 P-01,Auditor General,,DEM,Tracie Fountain,0,4,0,1,5
+Lackawanna,Olyphant W-04 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,11,26,2,0,39
+Lackawanna,Olyphant W-04 P-01,Auditor General,,DEM,Nina Ahmad,30,34,1,4,69
+Lackawanna,Olyphant W-04 P-01,Auditor General,,DEM,Christina M. Hartman,11,17,1,0,29
+Lackawanna,Olyphant W-04 P-01,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Olyphant W-04 P-01,State Treasurer,,DEM,Joe Torsella,69,112,4,4,189
+Lackawanna,Olyphant W-04 P-01,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,DEM,Matt Cartwright,77,125,9,5,216
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,DEM,Write-in,6,1,0,0,7
+Lackawanna,Olyphant W-04 P-01,General Assembly,112,DEM,Kyle J. Mullins,85,126,7,6,224
+Lackawanna,Olyphant W-04 P-01,General Assembly,112,DEM,Write-in,5,0,0,0,5
+Lackawanna,Olyphant W-04 P-01,President,,REP,Donald J. Trump,52,18,4,1,75
+Lackawanna,Olyphant W-04 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-01,President,,REP,Bill Weld,1,2,0,0,3
+Lackawanna,Olyphant W-04 P-01,President,,REP,Write-in,2,2,1,0,5
+Lackawanna,Olyphant W-04 P-01,Attorney General,,REP,Heather Heidelbaugh,46,18,5,1,70
+Lackawanna,Olyphant W-04 P-01,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Olyphant W-04 P-01,Auditor General,,REP,Timothy DeFoor,47,18,5,1,71
+Lackawanna,Olyphant W-04 P-01,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Olyphant W-04 P-01,State Treasurer,,REP,Stacy L. Garrity,45,18,3,1,67
+Lackawanna,Olyphant W-04 P-01,State Treasurer,,REP,Write-in,1,1,0,0,2
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,REP,Harry Haas,0,3,0,0,3
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,REP,Teddy Daniels,20,2,1,0,23
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,REP,Jim Bognet,14,2,1,0,17
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,REP,Earl Granville,13,14,3,1,31
+Lackawanna,Olyphant W-04 P-01,U.S. House,8,REP,Write-in,1,1,0,0,2
+Lackawanna,Olyphant W-04 P-01,General Assembly,112,REP,Write-in,24,8,0,1,33
+Lackawanna,Olyphant W-04 P-02,Registered Voters,,,,,,,,468
+Lackawanna,Olyphant W-04 P-02,Registered Voters,,DEM,,,,,,357
+Lackawanna,Olyphant W-04 P-02,Registered Voters,,REP,,,,,,111
+Lackawanna,Olyphant W-04 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Olyphant W-04 P-02,Ballots Cast,,,,80,81,24,0,185
+Lackawanna,Olyphant W-04 P-02,Ballots Cast,,DEM,,52,71,22,0,145
+Lackawanna,Olyphant W-04 P-02,Ballots Cast,,REP,,28,10,2,0,40
+Lackawanna,Olyphant W-04 P-02,President,,DEM,Bernie Sanders,10,7,3,0,20
+Lackawanna,Olyphant W-04 P-02,President,,DEM,Joseph R. Biden,31,58,15,0,104
+Lackawanna,Olyphant W-04 P-02,President,,DEM,Tulsi Gabbard,5,5,1,0,11
+Lackawanna,Olyphant W-04 P-02,President,,DEM,Write-in,3,0,2,0,5
+Lackawanna,Olyphant W-04 P-02,Attorney General,,DEM,Josh Shapiro,43,55,16,0,114
+Lackawanna,Olyphant W-04 P-02,Attorney General,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Olyphant W-04 P-02,Auditor General,,DEM,H. Scott Conklin,0,5,2,0,7
+Lackawanna,Olyphant W-04 P-02,Auditor General,,DEM,Michael Lamb,11,9,2,0,22
+Lackawanna,Olyphant W-04 P-02,Auditor General,,DEM,Tracie Fountain,3,1,4,0,8
+Lackawanna,Olyphant W-04 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,5,19,2,0,26
+Lackawanna,Olyphant W-04 P-02,Auditor General,,DEM,Nina Ahmad,17,18,7,0,42
+Lackawanna,Olyphant W-04 P-02,Auditor General,,DEM,Christina M. Hartman,7,6,1,0,14
+Lackawanna,Olyphant W-04 P-02,Auditor General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Olyphant W-04 P-02,State Treasurer,,DEM,Joe Torsella,39,51,16,0,106
+Lackawanna,Olyphant W-04 P-02,State Treasurer,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,DEM,Matt Cartwright,37,65,20,0,122
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,DEM,Write-in,5,1,2,0,8
+Lackawanna,Olyphant W-04 P-02,General Assembly,112,DEM,Kyle J. Mullins,42,62,19,0,123
+Lackawanna,Olyphant W-04 P-02,General Assembly,112,DEM,Write-in,4,0,0,0,4
+Lackawanna,Olyphant W-04 P-02,President,,REP,Donald J. Trump,28,8,2,0,38
+Lackawanna,Olyphant W-04 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-02,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Olyphant W-04 P-02,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Olyphant W-04 P-02,Attorney General,,REP,Heather Heidelbaugh,23,8,2,0,33
+Lackawanna,Olyphant W-04 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-02,Auditor General,,REP,Timothy DeFoor,23,8,2,0,33
+Lackawanna,Olyphant W-04 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-02,State Treasurer,,REP,Stacy L. Garrity,22,8,2,0,32
+Lackawanna,Olyphant W-04 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,REP,Teddy Daniels,8,2,0,0,10
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,REP,Jim Bognet,3,3,0,0,6
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,REP,Mike Marsicano,2,0,1,0,3
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,REP,Earl Granville,13,5,1,0,19
+Lackawanna,Olyphant W-04 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Olyphant W-04 P-02,General Assembly,112,REP,Write-in,18,0,0,0,18
+Lackawanna,Ransom Township W-00 P-01,Registered Voters,,,,,,,,443
+Lackawanna,Ransom Township W-00 P-01,Registered Voters,,DEM,,,,,,218
+Lackawanna,Ransom Township W-00 P-01,Registered Voters,,REP,,,,,,225
+Lackawanna,Ransom Township W-00 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Ransom Township W-00 P-01,Ballots Cast,,,,133,70,11,1,215
+Lackawanna,Ransom Township W-00 P-01,Ballots Cast,,DEM,,40,50,8,1,99
+Lackawanna,Ransom Township W-00 P-01,Ballots Cast,,REP,,93,20,3,0,116
+Lackawanna,Ransom Township W-00 P-01,President,,DEM,Bernie Sanders,6,4,4,0,14
+Lackawanna,Ransom Township W-00 P-01,President,,DEM,Joseph R. Biden,25,44,4,1,74
+Lackawanna,Ransom Township W-00 P-01,President,,DEM,Tulsi Gabbard,5,1,0,0,6
+Lackawanna,Ransom Township W-00 P-01,President,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Ransom Township W-00 P-01,Attorney General,,DEM,Josh Shapiro,31,48,7,1,87
+Lackawanna,Ransom Township W-00 P-01,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,DEM,H. Scott Conklin,4,5,1,0,10
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,DEM,Michael Lamb,6,4,2,0,12
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,DEM,Tracie Fountain,2,0,0,0,2
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,8,13,0,0,21
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,DEM,Nina Ahmad,7,5,2,1,15
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,DEM,Christina M. Hartman,6,15,2,0,23
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Ransom Township W-00 P-01,State Treasurer,,DEM,Joe Torsella,29,46,6,0,81
+Lackawanna,Ransom Township W-00 P-01,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,DEM,Matt Cartwright,33,48,7,1,89
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,DEM,Write-in,3,0,0,0,3
+Lackawanna,Ransom Township W-00 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,33,49,6,1,89
+Lackawanna,Ransom Township W-00 P-01,General Assembly,114,DEM,Write-in,2,1,0,0,3
+Lackawanna,Ransom Township W-00 P-01,President,,REP,Donald J. Trump,80,17,1,0,98
+Lackawanna,Ransom Township W-00 P-01,President,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Lackawanna,Ransom Township W-00 P-01,President,,REP,Bill Weld,4,1,1,0,6
+Lackawanna,Ransom Township W-00 P-01,President,,REP,Write-in,3,1,0,0,4
+Lackawanna,Ransom Township W-00 P-01,Attorney General,,REP,Heather Heidelbaugh,63,17,2,0,82
+Lackawanna,Ransom Township W-00 P-01,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,REP,Timothy DeFoor,63,17,3,0,83
+Lackawanna,Ransom Township W-00 P-01,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Ransom Township W-00 P-01,State Treasurer,,REP,Stacy L. Garrity,62,15,3,0,80
+Lackawanna,Ransom Township W-00 P-01,State Treasurer,,REP,Write-in,1,1,0,0,2
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,REP,Harry Haas,1,2,0,0,3
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,REP,Teddy Daniels,20,3,0,0,23
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,REP,Jim Bognet,16,5,0,0,21
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,REP,Mike Cammisa,0,0,1,0,1
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,REP,Mike Marsicano,8,1,1,0,10
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,REP,Earl Granville,42,8,1,0,51
+Lackawanna,Ransom Township W-00 P-01,U.S. House,8,REP,Write-in,1,1,0,0,2
+Lackawanna,Ransom Township W-00 P-01,General Assembly,114,REP,James May,79,18,2,0,99
+Lackawanna,Ransom Township W-00 P-01,General Assembly,114,REP,Write-in,3,1,0,0,4
+Lackawanna,Ransom Township W-00 P-02,Registered Voters,,,,,,,,208
+Lackawanna,Ransom Township W-00 P-02,Registered Voters,,DEM,,,,,,86
+Lackawanna,Ransom Township W-00 P-02,Registered Voters,,REP,,,,,,122
+Lackawanna,Ransom Township W-00 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Ransom Township W-00 P-02,Ballots Cast,,,,61,22,2,2,87
+Lackawanna,Ransom Township W-00 P-02,Ballots Cast,,DEM,,19,8,2,1,30
+Lackawanna,Ransom Township W-00 P-02,Ballots Cast,,REP,,42,14,0,1,57
+Lackawanna,Ransom Township W-00 P-02,President,,DEM,Bernie Sanders,5,0,0,0,5
+Lackawanna,Ransom Township W-00 P-02,President,,DEM,Joseph R. Biden,10,8,1,1,20
+Lackawanna,Ransom Township W-00 P-02,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Ransom Township W-00 P-02,President,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Ransom Township W-00 P-02,Attorney General,,DEM,Josh Shapiro,16,7,2,1,26
+Lackawanna,Ransom Township W-00 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,DEM,H. Scott Conklin,1,0,0,0,1
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,DEM,Michael Lamb,4,0,0,0,4
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,DEM,Tracie Fountain,2,0,0,1,3
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,2,0,7
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,DEM,Nina Ahmad,5,3,0,0,8
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,DEM,Christina M. Hartman,3,0,0,0,3
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-02,State Treasurer,,DEM,Joe Torsella,13,6,2,1,22
+Lackawanna,Ransom Township W-00 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,DEM,Matt Cartwright,14,8,2,1,25
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Ransom Township W-00 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,13,7,2,1,23
+Lackawanna,Ransom Township W-00 P-02,General Assembly,114,DEM,Write-in,1,0,0,0,1
+Lackawanna,Ransom Township W-00 P-02,President,,REP,Donald J. Trump,39,10,0,1,50
+Lackawanna,Ransom Township W-00 P-02,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Ransom Township W-00 P-02,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Ransom Township W-00 P-02,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Ransom Township W-00 P-02,Attorney General,,REP,Heather Heidelbaugh,31,11,0,1,43
+Lackawanna,Ransom Township W-00 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,REP,Timothy DeFoor,30,11,0,1,42
+Lackawanna,Ransom Township W-00 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-02,State Treasurer,,REP,Stacy L. Garrity,31,10,0,1,42
+Lackawanna,Ransom Township W-00 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,REP,Harry Haas,2,0,0,0,2
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,REP,Teddy Daniels,8,3,0,0,11
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,REP,Jim Bognet,10,0,0,0,10
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,REP,Earl Granville,16,8,0,1,25
+Lackawanna,Ransom Township W-00 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-02,General Assembly,114,REP,James May,40,12,0,1,53
+Lackawanna,Ransom Township W-00 P-02,General Assembly,114,REP,Write-in,1,0,0,0,1
+Lackawanna,Ransom Township W-00 P-03,Registered Voters,,,,,,,,264
+Lackawanna,Ransom Township W-00 P-03,Registered Voters,,DEM,,,,,,135
+Lackawanna,Ransom Township W-00 P-03,Registered Voters,,REP,,,,,,129
+Lackawanna,Ransom Township W-00 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Ransom Township W-00 P-03,Ballots Cast,,,,74,36,9,3,122
+Lackawanna,Ransom Township W-00 P-03,Ballots Cast,,DEM,,25,29,4,1,59
+Lackawanna,Ransom Township W-00 P-03,Ballots Cast,,REP,,49,7,5,2,63
+Lackawanna,Ransom Township W-00 P-03,President,,DEM,Bernie Sanders,5,3,0,1,9
+Lackawanna,Ransom Township W-00 P-03,President,,DEM,Joseph R. Biden,17,26,4,0,47
+Lackawanna,Ransom Township W-00 P-03,President,,DEM,Tulsi Gabbard,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,President,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,Attorney General,,DEM,Josh Shapiro,20,26,4,1,51
+Lackawanna,Ransom Township W-00 P-03,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,DEM,H. Scott Conklin,1,1,0,0,2
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,DEM,Michael Lamb,3,4,0,1,8
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,DEM,Tracie Fountain,2,4,0,0,6
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,3,0,9
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,DEM,Nina Ahmad,7,4,0,0,11
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,DEM,Christina M. Hartman,1,5,1,0,7
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,State Treasurer,,DEM,Joe Torsella,17,25,4,1,47
+Lackawanna,Ransom Township W-00 P-03,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,DEM,Matt Cartwright,21,27,4,1,53
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Ransom Township W-00 P-03,General Assembly,114,DEM,Bridget Malloy Kosierowski,17,28,4,0,49
+Lackawanna,Ransom Township W-00 P-03,General Assembly,114,DEM,Write-in,0,0,0,1,1
+Lackawanna,Ransom Township W-00 P-03,President,,REP,Donald J. Trump,43,4,4,2,53
+Lackawanna,Ransom Township W-00 P-03,President,,REP,Roque Rocky De La Fuente,0,2,0,0,2
+Lackawanna,Ransom Township W-00 P-03,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Ransom Township W-00 P-03,President,,REP,Write-in,0,0,1,0,1
+Lackawanna,Ransom Township W-00 P-03,Attorney General,,REP,Heather Heidelbaugh,39,5,5,1,50
+Lackawanna,Ransom Township W-00 P-03,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,REP,Timothy DeFoor,38,5,5,1,49
+Lackawanna,Ransom Township W-00 P-03,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,State Treasurer,,REP,Stacy L. Garrity,41,5,4,1,51
+Lackawanna,Ransom Township W-00 P-03,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,REP,Teddy Daniels,18,1,0,1,20
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,REP,Jim Bognet,14,0,0,0,14
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,REP,Mike Marsicano,4,2,0,0,6
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,REP,Earl Granville,12,3,5,1,21
+Lackawanna,Ransom Township W-00 P-03,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Ransom Township W-00 P-03,General Assembly,114,REP,James May,49,6,5,2,62
+Lackawanna,Ransom Township W-00 P-03,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Roaring Brook Twp. W-00 P-00,Registered Voters,,,,,,,,1395
+Lackawanna,Roaring Brook Twp. W-00 P-00,Registered Voters,,DEM,,,,,,727
+Lackawanna,Roaring Brook Twp. W-00 P-00,Registered Voters,,REP,,,,,,668
+Lackawanna,Roaring Brook Twp. W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Roaring Brook Twp. W-00 P-00,Ballots Cast,,,,277,300,55,7,639
+Lackawanna,Roaring Brook Twp. W-00 P-00,Ballots Cast,,DEM,,92,231,38,2,363
+Lackawanna,Roaring Brook Twp. W-00 P-00,Ballots Cast,,REP,,185,69,17,5,276
+Lackawanna,Roaring Brook Twp. W-00 P-00,President,,DEM,Bernie Sanders,17,16,3,0,36
+Lackawanna,Roaring Brook Twp. W-00 P-00,President,,DEM,Joseph R. Biden,62,201,34,2,299
+Lackawanna,Roaring Brook Twp. W-00 P-00,President,,DEM,Tulsi Gabbard,6,5,1,0,12
+Lackawanna,Roaring Brook Twp. W-00 P-00,President,,DEM,Write-in,1,4,0,0,5
+Lackawanna,Roaring Brook Twp. W-00 P-00,Attorney General,,DEM,Josh Shapiro,73,192,35,2,302
+Lackawanna,Roaring Brook Twp. W-00 P-00,Attorney General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,DEM,H. Scott Conklin,4,14,5,0,23
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,DEM,Michael Lamb,15,28,2,0,45
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,DEM,Tracie Fountain,3,21,3,0,27
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,19,68,14,0,101
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,DEM,Nina Ahmad,24,35,4,2,65
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,DEM,Christina M. Hartman,8,23,6,0,37
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Roaring Brook Twp. W-00 P-00,State Treasurer,,DEM,Joe Torsella,74,186,32,2,294
+Lackawanna,Roaring Brook Twp. W-00 P-00,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,DEM,Matt Cartwright,81,212,35,1,329
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,DEM,Write-in,2,3,0,0,5
+Lackawanna,Roaring Brook Twp. W-00 P-00,General Assembly,118,DEM,Mike Carroll,77,174,30,2,283
+Lackawanna,Roaring Brook Twp. W-00 P-00,General Assembly,118,DEM,Write-in,2,2,0,0,4
+Lackawanna,Roaring Brook Twp. W-00 P-00,President,,REP,Donald J. Trump,173,52,11,5,241
+Lackawanna,Roaring Brook Twp. W-00 P-00,President,,REP,Roque Rocky De La Fuente,3,4,0,0,7
+Lackawanna,Roaring Brook Twp. W-00 P-00,President,,REP,Bill Weld,3,6,3,0,12
+Lackawanna,Roaring Brook Twp. W-00 P-00,President,,REP,Write-in,2,0,3,0,5
+Lackawanna,Roaring Brook Twp. W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,151,54,16,5,226
+Lackawanna,Roaring Brook Twp. W-00 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,REP,Timothy DeFoor,146,52,16,5,219
+Lackawanna,Roaring Brook Twp. W-00 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Roaring Brook Twp. W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,147,52,16,5,220
+Lackawanna,Roaring Brook Twp. W-00 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,REP,Harry Haas,1,2,0,0,3
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,REP,Teddy Daniels,64,2,3,1,70
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,REP,Jim Bognet,33,24,6,1,64
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,2,0,0,2
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,REP,Mike Marsicano,12,1,1,0,14
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,REP,Earl Granville,69,37,7,3,116
+Lackawanna,Roaring Brook Twp. W-00 P-00,U.S. House,8,REP,Write-in,2,0,0,0,2
+Lackawanna,Roaring Brook Twp. W-00 P-00,General Assembly,118,REP,Andrew Holter,140,48,15,4,207
+Lackawanna,Roaring Brook Twp. W-00 P-00,General Assembly,118,REP,Write-in,2,1,0,0,3
+Lackawanna,Scott Township W-00 P-01,Registered Voters,,,,,,,,1784
+Lackawanna,Scott Township W-00 P-01,Registered Voters,,DEM,,,,,,1010
+Lackawanna,Scott Township W-00 P-01,Registered Voters,,REP,,,,,,774
+Lackawanna,Scott Township W-00 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scott Township W-00 P-01,Ballots Cast,,,,432,262,73,9,776
+Lackawanna,Scott Township W-00 P-01,Ballots Cast,,DEM,,164,193,54,2,413
+Lackawanna,Scott Township W-00 P-01,Ballots Cast,,REP,,268,69,19,7,363
+Lackawanna,Scott Township W-00 P-01,President,,DEM,Bernie Sanders,37,26,12,1,76
+Lackawanna,Scott Township W-00 P-01,President,,DEM,Joseph R. Biden,89,159,39,1,288
+Lackawanna,Scott Township W-00 P-01,President,,DEM,Tulsi Gabbard,14,4,2,0,20
+Lackawanna,Scott Township W-00 P-01,President,,DEM,Write-in,8,2,1,0,11
+Lackawanna,Scott Township W-00 P-01,Attorney General,,DEM,Josh Shapiro,120,163,46,2,331
+Lackawanna,Scott Township W-00 P-01,Attorney General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scott Township W-00 P-01,Auditor General,,DEM,H. Scott Conklin,4,15,7,0,26
+Lackawanna,Scott Township W-00 P-01,Auditor General,,DEM,Michael Lamb,26,20,6,2,54
+Lackawanna,Scott Township W-00 P-01,Auditor General,,DEM,Tracie Fountain,4,17,4,0,25
+Lackawanna,Scott Township W-00 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,29,48,14,0,91
+Lackawanna,Scott Township W-00 P-01,Auditor General,,DEM,Nina Ahmad,42,31,5,0,78
+Lackawanna,Scott Township W-00 P-01,Auditor General,,DEM,Christina M. Hartman,20,21,10,0,51
+Lackawanna,Scott Township W-00 P-01,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scott Township W-00 P-01,State Treasurer,,DEM,Joe Torsella,112,156,44,2,314
+Lackawanna,Scott Township W-00 P-01,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,DEM,Matt Cartwright,119,177,48,2,346
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,DEM,Write-in,11,5,0,0,16
+Lackawanna,Scott Township W-00 P-01,General Assembly,114,DEM,Bridget Malloy Kosierowski,130,163,46,1,340
+Lackawanna,Scott Township W-00 P-01,General Assembly,114,DEM,Write-in,3,2,1,1,7
+Lackawanna,Scott Township W-00 P-01,President,,REP,Donald J. Trump,254,57,18,7,336
+Lackawanna,Scott Township W-00 P-01,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Scott Township W-00 P-01,President,,REP,Bill Weld,5,2,1,0,8
+Lackawanna,Scott Township W-00 P-01,President,,REP,Write-in,4,7,0,0,11
+Lackawanna,Scott Township W-00 P-01,Attorney General,,REP,Heather Heidelbaugh,188,46,17,5,256
+Lackawanna,Scott Township W-00 P-01,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scott Township W-00 P-01,Auditor General,,REP,Timothy DeFoor,180,44,17,5,246
+Lackawanna,Scott Township W-00 P-01,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scott Township W-00 P-01,State Treasurer,,REP,Stacy L. Garrity,183,46,17,4,250
+Lackawanna,Scott Township W-00 P-01,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,REP,Harry Haas,7,0,0,0,7
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,REP,Teddy Daniels,41,4,0,1,46
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,REP,Jim Bognet,26,5,5,0,36
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,REP,Mike Marsicano,14,1,1,0,16
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,REP,Earl Granville,170,56,13,6,245
+Lackawanna,Scott Township W-00 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scott Township W-00 P-01,General Assembly,114,REP,James May,205,49,17,6,277
+Lackawanna,Scott Township W-00 P-01,General Assembly,114,REP,Write-in,1,1,0,0,2
+Lackawanna,Scott Township W-00 P-02,Registered Voters,,,,,,,,1553
+Lackawanna,Scott Township W-00 P-02,Registered Voters,,DEM,,,,,,877
+Lackawanna,Scott Township W-00 P-02,Registered Voters,,REP,,,,,,676
+Lackawanna,Scott Township W-00 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scott Township W-00 P-02,Ballots Cast,,,,313,329,68,9,719
+Lackawanna,Scott Township W-00 P-02,Ballots Cast,,DEM,,116,235,48,3,402
+Lackawanna,Scott Township W-00 P-02,Ballots Cast,,REP,,197,94,20,6,317
+Lackawanna,Scott Township W-00 P-02,President,,DEM,Bernie Sanders,18,16,3,1,38
+Lackawanna,Scott Township W-00 P-02,President,,DEM,Joseph R. Biden,75,209,35,2,321
+Lackawanna,Scott Township W-00 P-02,President,,DEM,Tulsi Gabbard,9,3,4,0,16
+Lackawanna,Scott Township W-00 P-02,President,,DEM,Write-in,4,4,1,0,9
+Lackawanna,Scott Township W-00 P-02,Attorney General,,DEM,Josh Shapiro,83,206,43,3,335
+Lackawanna,Scott Township W-00 P-02,Attorney General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scott Township W-00 P-02,Auditor General,,DEM,H. Scott Conklin,10,9,2,0,21
+Lackawanna,Scott Township W-00 P-02,Auditor General,,DEM,Michael Lamb,18,33,5,2,58
+Lackawanna,Scott Township W-00 P-02,Auditor General,,DEM,Tracie Fountain,5,15,5,0,25
+Lackawanna,Scott Township W-00 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,12,59,13,0,84
+Lackawanna,Scott Township W-00 P-02,Auditor General,,DEM,Nina Ahmad,36,30,4,1,71
+Lackawanna,Scott Township W-00 P-02,Auditor General,,DEM,Christina M. Hartman,15,46,9,0,70
+Lackawanna,Scott Township W-00 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scott Township W-00 P-02,State Treasurer,,DEM,Joe Torsella,83,193,39,2,317
+Lackawanna,Scott Township W-00 P-02,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,DEM,Matt Cartwright,91,221,42,3,357
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,DEM,Write-in,7,5,3,0,15
+Lackawanna,Scott Township W-00 P-02,General Assembly,114,DEM,Bridget Malloy Kosierowski,94,218,43,3,358
+Lackawanna,Scott Township W-00 P-02,General Assembly,114,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scott Township W-00 P-02,President,,REP,Donald J. Trump,187,79,15,5,286
+Lackawanna,Scott Township W-00 P-02,President,,REP,Roque Rocky De La Fuente,0,4,0,0,4
+Lackawanna,Scott Township W-00 P-02,President,,REP,Bill Weld,3,3,5,0,11
+Lackawanna,Scott Township W-00 P-02,President,,REP,Write-in,0,3,0,0,3
+Lackawanna,Scott Township W-00 P-02,Attorney General,,REP,Heather Heidelbaugh,134,66,18,3,221
+Lackawanna,Scott Township W-00 P-02,Attorney General,,REP,Write-in,4,1,0,0,5
+Lackawanna,Scott Township W-00 P-02,Auditor General,,REP,Timothy DeFoor,139,64,17,3,223
+Lackawanna,Scott Township W-00 P-02,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scott Township W-00 P-02,State Treasurer,,REP,Stacy L. Garrity,134,64,18,3,219
+Lackawanna,Scott Township W-00 P-02,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,REP,Harry Haas,4,0,0,0,4
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,REP,Teddy Daniels,28,8,0,0,36
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,REP,Jim Bognet,24,15,0,1,40
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,REP,Mike Marsicano,10,4,2,0,16
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,REP,Earl Granville,119,61,17,4,201
+Lackawanna,Scott Township W-00 P-02,U.S. House,8,REP,Write-in,0,2,0,0,2
+Lackawanna,Scott Township W-00 P-02,General Assembly,114,REP,James May,152,73,18,5,248
+Lackawanna,Scott Township W-00 P-02,General Assembly,114,REP,Write-in,0,5,0,0,5
+Lackawanna,Scranton W-01 P-01,Registered Voters,,,,,,,,993
+Lackawanna,Scranton W-01 P-01,Registered Voters,,DEM,,,,,,737
+Lackawanna,Scranton W-01 P-01,Registered Voters,,REP,,,,,,256
+Lackawanna,Scranton W-01 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-01 P-01,Ballots Cast,,,,181,157,28,10,376
+Lackawanna,Scranton W-01 P-01,Ballots Cast,,DEM,,121,137,26,7,291
+Lackawanna,Scranton W-01 P-01,Ballots Cast,,REP,,60,20,2,3,85
+Lackawanna,Scranton W-01 P-01,President,,DEM,Bernie Sanders,22,16,4,0,42
+Lackawanna,Scranton W-01 P-01,President,,DEM,Joseph R. Biden,88,117,22,7,234
+Lackawanna,Scranton W-01 P-01,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Lackawanna,Scranton W-01 P-01,President,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-01 P-01,Attorney General,,DEM,Josh Shapiro,96,111,19,6,232
+Lackawanna,Scranton W-01 P-01,Attorney General,,DEM,Write-in,5,1,0,0,6
+Lackawanna,Scranton W-01 P-01,Auditor General,,DEM,H. Scott Conklin,7,6,1,0,14
+Lackawanna,Scranton W-01 P-01,Auditor General,,DEM,Michael Lamb,23,28,3,0,54
+Lackawanna,Scranton W-01 P-01,Auditor General,,DEM,Tracie Fountain,6,15,0,1,22
+Lackawanna,Scranton W-01 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,12,17,8,1,38
+Lackawanna,Scranton W-01 P-01,Auditor General,,DEM,Nina Ahmad,47,20,2,2,71
+Lackawanna,Scranton W-01 P-01,Auditor General,,DEM,Christina M. Hartman,10,22,6,2,40
+Lackawanna,Scranton W-01 P-01,Auditor General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-01 P-01,State Treasurer,,DEM,Joe Torsella,89,104,17,6,216
+Lackawanna,Scranton W-01 P-01,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-01 P-01,U.S. House,8,DEM,Matt Cartwright,106,125,23,7,261
+Lackawanna,Scranton W-01 P-01,U.S. House,8,DEM,Write-in,4,0,0,0,4
+Lackawanna,Scranton W-01 P-01,General Assembly,113,DEM,Marty Flynn,105,111,23,7,246
+Lackawanna,Scranton W-01 P-01,General Assembly,113,DEM,Write-in,5,1,0,0,6
+Lackawanna,Scranton W-01 P-01,President,,REP,Donald J. Trump,57,18,1,3,79
+Lackawanna,Scranton W-01 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-01 P-01,President,,REP,Bill Weld,2,1,0,0,3
+Lackawanna,Scranton W-01 P-01,President,,REP,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-01 P-01,Attorney General,,REP,Heather Heidelbaugh,47,20,1,3,71
+Lackawanna,Scranton W-01 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-01,Auditor General,,REP,Timothy DeFoor,46,19,1,3,69
+Lackawanna,Scranton W-01 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-01,State Treasurer,,REP,Stacy L. Garrity,44,19,0,3,66
+Lackawanna,Scranton W-01 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-01,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Scranton W-01 P-01,U.S. House,8,REP,Teddy Daniels,16,4,0,3,23
+Lackawanna,Scranton W-01 P-01,U.S. House,8,REP,Jim Bognet,7,2,0,0,9
+Lackawanna,Scranton W-01 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-01 P-01,U.S. House,8,REP,Mike Marsicano,8,1,0,0,9
+Lackawanna,Scranton W-01 P-01,U.S. House,8,REP,Earl Granville,26,12,1,0,39
+Lackawanna,Scranton W-01 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-01,General Assembly,113,REP,William Kresge,46,19,1,3,69
+Lackawanna,Scranton W-01 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-02,Registered Voters,,,,,,,,703
+Lackawanna,Scranton W-01 P-02,Registered Voters,,DEM,,,,,,511
+Lackawanna,Scranton W-01 P-02,Registered Voters,,REP,,,,,,192
+Lackawanna,Scranton W-01 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-01 P-02,Ballots Cast,,,,132,109,13,2,256
+Lackawanna,Scranton W-01 P-02,Ballots Cast,,DEM,,89,94,10,0,193
+Lackawanna,Scranton W-01 P-02,Ballots Cast,,REP,,43,15,3,2,63
+Lackawanna,Scranton W-01 P-02,President,,DEM,Bernie Sanders,14,9,1,0,24
+Lackawanna,Scranton W-01 P-02,President,,DEM,Joseph R. Biden,57,80,8,0,145
+Lackawanna,Scranton W-01 P-02,President,,DEM,Tulsi Gabbard,3,1,0,0,4
+Lackawanna,Scranton W-01 P-02,President,,DEM,Write-in,5,1,0,0,6
+Lackawanna,Scranton W-01 P-02,Attorney General,,DEM,Josh Shapiro,63,79,9,0,151
+Lackawanna,Scranton W-01 P-02,Attorney General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-01 P-02,Auditor General,,DEM,H. Scott Conklin,5,5,1,0,11
+Lackawanna,Scranton W-01 P-02,Auditor General,,DEM,Michael Lamb,12,11,0,0,23
+Lackawanna,Scranton W-01 P-02,Auditor General,,DEM,Tracie Fountain,3,10,2,0,15
+Lackawanna,Scranton W-01 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,10,19,3,0,32
+Lackawanna,Scranton W-01 P-02,Auditor General,,DEM,Nina Ahmad,30,11,1,0,42
+Lackawanna,Scranton W-01 P-02,Auditor General,,DEM,Christina M. Hartman,12,12,1,0,25
+Lackawanna,Scranton W-01 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-02,State Treasurer,,DEM,Joe Torsella,56,68,8,0,132
+Lackawanna,Scranton W-01 P-02,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-01 P-02,U.S. House,8,DEM,Matt Cartwright,75,90,9,0,174
+Lackawanna,Scranton W-01 P-02,U.S. House,8,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-01 P-02,General Assembly,113,DEM,Marty Flynn,64,82,10,0,156
+Lackawanna,Scranton W-01 P-02,General Assembly,113,DEM,Write-in,5,1,0,0,6
+Lackawanna,Scranton W-01 P-02,President,,REP,Donald J. Trump,39,7,3,2,51
+Lackawanna,Scranton W-01 P-02,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Scranton W-01 P-02,President,,REP,Bill Weld,2,3,0,0,5
+Lackawanna,Scranton W-01 P-02,President,,REP,Write-in,0,3,0,0,3
+Lackawanna,Scranton W-01 P-02,Attorney General,,REP,Heather Heidelbaugh,32,8,2,2,44
+Lackawanna,Scranton W-01 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-01 P-02,Auditor General,,REP,Timothy DeFoor,30,8,2,2,42
+Lackawanna,Scranton W-01 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-02,State Treasurer,,REP,Stacy L. Garrity,31,8,2,2,43
+Lackawanna,Scranton W-01 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-02,U.S. House,8,REP,Harry Haas,3,0,0,0,3
+Lackawanna,Scranton W-01 P-02,U.S. House,8,REP,Teddy Daniels,9,1,0,0,10
+Lackawanna,Scranton W-01 P-02,U.S. House,8,REP,Jim Bognet,12,0,0,0,12
+Lackawanna,Scranton W-01 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-01 P-02,U.S. House,8,REP,Mike Marsicano,0,1,0,1,2
+Lackawanna,Scranton W-01 P-02,U.S. House,8,REP,Earl Granville,17,10,3,1,31
+Lackawanna,Scranton W-01 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-01 P-02,General Assembly,113,REP,William Kresge,36,12,3,2,53
+Lackawanna,Scranton W-01 P-02,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,Registered Voters,,,,,,,,718
+Lackawanna,Scranton W-02 P-01,Registered Voters,,DEM,,,,,,542
+Lackawanna,Scranton W-02 P-01,Registered Voters,,REP,,,,,,176
+Lackawanna,Scranton W-02 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-02 P-01,Ballots Cast,,,,104,129,18,3,254
+Lackawanna,Scranton W-02 P-01,Ballots Cast,,DEM,,64,119,16,2,201
+Lackawanna,Scranton W-02 P-01,Ballots Cast,,REP,,40,10,2,1,53
+Lackawanna,Scranton W-02 P-01,President,,DEM,Bernie Sanders,5,13,3,2,23
+Lackawanna,Scranton W-02 P-01,President,,DEM,Joseph R. Biden,54,99,12,0,165
+Lackawanna,Scranton W-02 P-01,President,,DEM,Tulsi Gabbard,2,3,0,0,5
+Lackawanna,Scranton W-02 P-01,President,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,Attorney General,,DEM,Josh Shapiro,44,105,13,2,164
+Lackawanna,Scranton W-02 P-01,Attorney General,,DEM,Write-in,1,0,1,0,2
+Lackawanna,Scranton W-02 P-01,Auditor General,,DEM,H. Scott Conklin,4,9,1,0,14
+Lackawanna,Scranton W-02 P-01,Auditor General,,DEM,Michael Lamb,7,20,3,0,30
+Lackawanna,Scranton W-02 P-01,Auditor General,,DEM,Tracie Fountain,1,6,2,0,9
+Lackawanna,Scranton W-02 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,7,32,2,1,42
+Lackawanna,Scranton W-02 P-01,Auditor General,,DEM,Nina Ahmad,20,18,2,1,41
+Lackawanna,Scranton W-02 P-01,Auditor General,,DEM,Christina M. Hartman,9,22,3,0,34
+Lackawanna,Scranton W-02 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,State Treasurer,,DEM,Joe Torsella,35,100,10,2,147
+Lackawanna,Scranton W-02 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,U.S. House,8,DEM,Matt Cartwright,55,112,13,2,182
+Lackawanna,Scranton W-02 P-01,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-02 P-01,General Assembly,113,DEM,Marty Flynn,51,109,12,2,174
+Lackawanna,Scranton W-02 P-01,General Assembly,113,DEM,Write-in,3,3,0,0,6
+Lackawanna,Scranton W-02 P-01,President,,REP,Donald J. Trump,39,7,2,1,49
+Lackawanna,Scranton W-02 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-02 P-01,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,President,,REP,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-02 P-01,Attorney General,,REP,Heather Heidelbaugh,29,5,2,1,37
+Lackawanna,Scranton W-02 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,Auditor General,,REP,Timothy DeFoor,32,4,2,1,39
+Lackawanna,Scranton W-02 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,State Treasurer,,REP,Stacy L. Garrity,30,6,2,1,39
+Lackawanna,Scranton W-02 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,U.S. House,8,REP,Teddy Daniels,13,0,0,0,13
+Lackawanna,Scranton W-02 P-01,U.S. House,8,REP,Jim Bognet,7,4,0,1,12
+Lackawanna,Scranton W-02 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Scranton W-02 P-01,U.S. House,8,REP,Earl Granville,17,4,2,0,23
+Lackawanna,Scranton W-02 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-01,General Assembly,113,REP,William Kresge,34,6,2,1,43
+Lackawanna,Scranton W-02 P-01,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-02 P-02,Registered Voters,,,,,,,,869
+Lackawanna,Scranton W-02 P-02,Registered Voters,,DEM,,,,,,634
+Lackawanna,Scranton W-02 P-02,Registered Voters,,REP,,,,,,235
+Lackawanna,Scranton W-02 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-02 P-02,Ballots Cast,,,,115,137,13,6,271
+Lackawanna,Scranton W-02 P-02,Ballots Cast,,DEM,,74,118,10,5,207
+Lackawanna,Scranton W-02 P-02,Ballots Cast,,REP,,41,19,3,1,64
+Lackawanna,Scranton W-02 P-02,President,,DEM,Bernie Sanders,10,11,0,2,23
+Lackawanna,Scranton W-02 P-02,President,,DEM,Joseph R. Biden,52,100,9,2,163
+Lackawanna,Scranton W-02 P-02,President,,DEM,Tulsi Gabbard,2,3,0,0,5
+Lackawanna,Scranton W-02 P-02,President,,DEM,Write-in,4,1,1,1,7
+Lackawanna,Scranton W-02 P-02,Attorney General,,DEM,Josh Shapiro,53,97,9,3,162
+Lackawanna,Scranton W-02 P-02,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-02 P-02,Auditor General,,DEM,H. Scott Conklin,5,7,0,0,12
+Lackawanna,Scranton W-02 P-02,Auditor General,,DEM,Michael Lamb,11,17,3,1,32
+Lackawanna,Scranton W-02 P-02,Auditor General,,DEM,Tracie Fountain,3,6,0,2,11
+Lackawanna,Scranton W-02 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,12,27,3,1,43
+Lackawanna,Scranton W-02 P-02,Auditor General,,DEM,Nina Ahmad,21,19,0,1,41
+Lackawanna,Scranton W-02 P-02,Auditor General,,DEM,Christina M. Hartman,7,19,3,0,29
+Lackawanna,Scranton W-02 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-02,State Treasurer,,DEM,Joe Torsella,51,96,9,3,159
+Lackawanna,Scranton W-02 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-02,U.S. House,8,DEM,Matt Cartwright,61,110,10,5,186
+Lackawanna,Scranton W-02 P-02,U.S. House,8,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-02 P-02,General Assembly,113,DEM,Marty Flynn,56,105,9,4,174
+Lackawanna,Scranton W-02 P-02,General Assembly,113,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-02 P-02,President,,REP,Donald J. Trump,38,16,2,1,57
+Lackawanna,Scranton W-02 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-02 P-02,President,,REP,Bill Weld,0,3,0,0,3
+Lackawanna,Scranton W-02 P-02,President,,REP,Write-in,2,0,1,0,3
+Lackawanna,Scranton W-02 P-02,Attorney General,,REP,Heather Heidelbaugh,30,16,2,0,48
+Lackawanna,Scranton W-02 P-02,Attorney General,,REP,Write-in,4,1,1,0,6
+Lackawanna,Scranton W-02 P-02,Auditor General,,REP,Timothy DeFoor,32,15,2,0,49
+Lackawanna,Scranton W-02 P-02,Auditor General,,REP,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-02 P-02,State Treasurer,,REP,Stacy L. Garrity,31,16,2,0,49
+Lackawanna,Scranton W-02 P-02,State Treasurer,,REP,Write-in,2,1,1,0,4
+Lackawanna,Scranton W-02 P-02,U.S. House,8,REP,Harry Haas,1,0,1,0,2
+Lackawanna,Scranton W-02 P-02,U.S. House,8,REP,Teddy Daniels,10,2,0,1,13
+Lackawanna,Scranton W-02 P-02,U.S. House,8,REP,Jim Bognet,8,3,1,0,12
+Lackawanna,Scranton W-02 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-02 P-02,U.S. House,8,REP,Mike Marsicano,3,1,0,0,4
+Lackawanna,Scranton W-02 P-02,U.S. House,8,REP,Earl Granville,18,12,0,0,30
+Lackawanna,Scranton W-02 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-02,General Assembly,113,REP,William Kresge,34,16,2,0,52
+Lackawanna,Scranton W-02 P-02,General Assembly,113,REP,Write-in,2,0,1,0,3
+Lackawanna,Scranton W-02 P-03,Registered Voters,,,,,,,,453
+Lackawanna,Scranton W-02 P-03,Registered Voters,,DEM,,,,,,318
+Lackawanna,Scranton W-02 P-03,Registered Voters,,REP,,,,,,135
+Lackawanna,Scranton W-02 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-02 P-03,Ballots Cast,,,,83,76,19,2,180
+Lackawanna,Scranton W-02 P-03,Ballots Cast,,DEM,,51,57,15,2,125
+Lackawanna,Scranton W-02 P-03,Ballots Cast,,REP,,32,19,4,0,55
+Lackawanna,Scranton W-02 P-03,President,,DEM,Bernie Sanders,9,8,2,0,19
+Lackawanna,Scranton W-02 P-03,President,,DEM,Joseph R. Biden,37,43,12,2,94
+Lackawanna,Scranton W-02 P-03,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Lackawanna,Scranton W-02 P-03,President,,DEM,Write-in,2,2,1,0,5
+Lackawanna,Scranton W-02 P-03,Attorney General,,DEM,Josh Shapiro,36,54,14,2,106
+Lackawanna,Scranton W-02 P-03,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-02 P-03,Auditor General,,DEM,H. Scott Conklin,2,2,2,0,6
+Lackawanna,Scranton W-02 P-03,Auditor General,,DEM,Michael Lamb,6,8,3,0,17
+Lackawanna,Scranton W-02 P-03,Auditor General,,DEM,Tracie Fountain,1,5,2,0,8
+Lackawanna,Scranton W-02 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,5,11,5,0,21
+Lackawanna,Scranton W-02 P-03,Auditor General,,DEM,Nina Ahmad,14,12,0,1,27
+Lackawanna,Scranton W-02 P-03,Auditor General,,DEM,Christina M. Hartman,8,11,1,0,20
+Lackawanna,Scranton W-02 P-03,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-02 P-03,State Treasurer,,DEM,Joe Torsella,34,49,13,1,97
+Lackawanna,Scranton W-02 P-03,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-02 P-03,U.S. House,8,DEM,Matt Cartwright,43,53,15,2,113
+Lackawanna,Scranton W-02 P-03,U.S. House,8,DEM,Write-in,5,0,0,0,5
+Lackawanna,Scranton W-02 P-03,General Assembly,113,DEM,Marty Flynn,41,49,15,1,106
+Lackawanna,Scranton W-02 P-03,General Assembly,113,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-02 P-03,President,,REP,Donald J. Trump,30,16,4,0,50
+Lackawanna,Scranton W-02 P-03,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-02 P-03,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Scranton W-02 P-03,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-02 P-03,Attorney General,,REP,Heather Heidelbaugh,21,14,3,0,38
+Lackawanna,Scranton W-02 P-03,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-02 P-03,Auditor General,,REP,Timothy DeFoor,22,14,3,0,39
+Lackawanna,Scranton W-02 P-03,Auditor General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-02 P-03,State Treasurer,,REP,Stacy L. Garrity,23,14,3,0,40
+Lackawanna,Scranton W-02 P-03,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-02 P-03,U.S. House,8,REP,Harry Haas,0,1,0,0,1
+Lackawanna,Scranton W-02 P-03,U.S. House,8,REP,Teddy Daniels,13,2,1,0,16
+Lackawanna,Scranton W-02 P-03,U.S. House,8,REP,Jim Bognet,1,1,0,0,2
+Lackawanna,Scranton W-02 P-03,U.S. House,8,REP,Mike Cammisa,1,1,0,0,2
+Lackawanna,Scranton W-02 P-03,U.S. House,8,REP,Mike Marsicano,5,1,0,0,6
+Lackawanna,Scranton W-02 P-03,U.S. House,8,REP,Earl Granville,10,12,3,0,25
+Lackawanna,Scranton W-02 P-03,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-02 P-03,General Assembly,113,REP,William Kresge,23,16,2,0,41
+Lackawanna,Scranton W-02 P-03,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-03 P-01,Registered Voters,,,,,,,,532
+Lackawanna,Scranton W-03 P-01,Registered Voters,,DEM,,,,,,397
+Lackawanna,Scranton W-03 P-01,Registered Voters,,REP,,,,,,135
+Lackawanna,Scranton W-03 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-03 P-01,Ballots Cast,,,,83,120,18,0,221
+Lackawanna,Scranton W-03 P-01,Ballots Cast,,DEM,,56,105,14,0,175
+Lackawanna,Scranton W-03 P-01,Ballots Cast,,REP,,27,15,4,0,46
+Lackawanna,Scranton W-03 P-01,President,,DEM,Bernie Sanders,7,11,3,0,21
+Lackawanna,Scranton W-03 P-01,President,,DEM,Joseph R. Biden,37,92,10,0,139
+Lackawanna,Scranton W-03 P-01,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Scranton W-03 P-01,President,,DEM,Write-in,5,2,0,0,7
+Lackawanna,Scranton W-03 P-01,Attorney General,,DEM,Josh Shapiro,46,90,9,0,145
+Lackawanna,Scranton W-03 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,Auditor General,,DEM,H. Scott Conklin,2,8,1,0,11
+Lackawanna,Scranton W-03 P-01,Auditor General,,DEM,Michael Lamb,7,10,1,0,18
+Lackawanna,Scranton W-03 P-01,Auditor General,,DEM,Tracie Fountain,6,11,1,0,18
+Lackawanna,Scranton W-03 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,10,24,4,0,38
+Lackawanna,Scranton W-03 P-01,Auditor General,,DEM,Nina Ahmad,16,17,1,0,34
+Lackawanna,Scranton W-03 P-01,Auditor General,,DEM,Christina M. Hartman,7,13,1,0,21
+Lackawanna,Scranton W-03 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,State Treasurer,,DEM,Joe Torsella,40,81,9,0,130
+Lackawanna,Scranton W-03 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,U.S. House,8,DEM,Matt Cartwright,45,100,13,0,158
+Lackawanna,Scranton W-03 P-01,U.S. House,8,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-03 P-01,General Assembly,113,DEM,Marty Flynn,45,92,12,0,149
+Lackawanna,Scranton W-03 P-01,General Assembly,113,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-03 P-01,President,,REP,Donald J. Trump,26,13,3,0,42
+Lackawanna,Scranton W-03 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,President,,REP,Bill Weld,1,1,1,0,3
+Lackawanna,Scranton W-03 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-03 P-01,Attorney General,,REP,Heather Heidelbaugh,19,11,3,0,33
+Lackawanna,Scranton W-03 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,Auditor General,,REP,Timothy DeFoor,19,11,3,0,33
+Lackawanna,Scranton W-03 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,State Treasurer,,REP,Stacy L. Garrity,18,12,3,0,33
+Lackawanna,Scranton W-03 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,U.S. House,8,REP,Teddy Daniels,8,0,0,0,8
+Lackawanna,Scranton W-03 P-01,U.S. House,8,REP,Jim Bognet,6,3,0,0,9
+Lackawanna,Scranton W-03 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,U.S. House,8,REP,Mike Marsicano,3,0,1,0,4
+Lackawanna,Scranton W-03 P-01,U.S. House,8,REP,Earl Granville,10,10,3,0,23
+Lackawanna,Scranton W-03 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-01,General Assembly,113,REP,William Kresge,23,12,3,0,38
+Lackawanna,Scranton W-03 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-02,Registered Voters,,,,,,,,854
+Lackawanna,Scranton W-03 P-02,Registered Voters,,DEM,,,,,,617
+Lackawanna,Scranton W-03 P-02,Registered Voters,,REP,,,,,,237
+Lackawanna,Scranton W-03 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-03 P-02,Ballots Cast,,,,111,156,70,7,344
+Lackawanna,Scranton W-03 P-02,Ballots Cast,,DEM,,65,128,56,3,252
+Lackawanna,Scranton W-03 P-02,Ballots Cast,,REP,,46,28,14,4,92
+Lackawanna,Scranton W-03 P-02,President,,DEM,Bernie Sanders,16,8,11,0,35
+Lackawanna,Scranton W-03 P-02,President,,DEM,Joseph R. Biden,39,115,43,3,200
+Lackawanna,Scranton W-03 P-02,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Lackawanna,Scranton W-03 P-02,President,,DEM,Write-in,6,3,1,0,10
+Lackawanna,Scranton W-03 P-02,Attorney General,,DEM,Josh Shapiro,49,113,47,1,210
+Lackawanna,Scranton W-03 P-02,Attorney General,,DEM,Write-in,1,0,1,0,2
+Lackawanna,Scranton W-03 P-02,Auditor General,,DEM,H. Scott Conklin,8,7,3,0,18
+Lackawanna,Scranton W-03 P-02,Auditor General,,DEM,Michael Lamb,3,29,4,0,36
+Lackawanna,Scranton W-03 P-02,Auditor General,,DEM,Tracie Fountain,2,9,4,0,15
+Lackawanna,Scranton W-03 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,7,27,11,0,45
+Lackawanna,Scranton W-03 P-02,Auditor General,,DEM,Nina Ahmad,29,19,13,0,61
+Lackawanna,Scranton W-03 P-02,Auditor General,,DEM,Christina M. Hartman,4,24,8,1,37
+Lackawanna,Scranton W-03 P-02,Auditor General,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-03 P-02,State Treasurer,,DEM,Joe Torsella,51,109,47,1,208
+Lackawanna,Scranton W-03 P-02,State Treasurer,,DEM,Write-in,0,2,1,0,3
+Lackawanna,Scranton W-03 P-02,U.S. House,8,DEM,Matt Cartwright,53,119,53,2,227
+Lackawanna,Scranton W-03 P-02,U.S. House,8,DEM,Write-in,4,3,0,0,7
+Lackawanna,Scranton W-03 P-02,General Assembly,113,DEM,Marty Flynn,51,118,50,3,222
+Lackawanna,Scranton W-03 P-02,General Assembly,113,DEM,Write-in,2,2,1,0,5
+Lackawanna,Scranton W-03 P-02,President,,REP,Donald J. Trump,43,21,12,4,80
+Lackawanna,Scranton W-03 P-02,President,,REP,Roque Rocky De La Fuente,1,3,0,0,4
+Lackawanna,Scranton W-03 P-02,President,,REP,Bill Weld,2,4,0,0,6
+Lackawanna,Scranton W-03 P-02,President,,REP,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-03 P-02,Attorney General,,REP,Heather Heidelbaugh,32,21,8,1,62
+Lackawanna,Scranton W-03 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-02,Auditor General,,REP,Timothy DeFoor,31,22,9,1,63
+Lackawanna,Scranton W-03 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-02,State Treasurer,,REP,Stacy L. Garrity,31,21,8,1,61
+Lackawanna,Scranton W-03 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-02,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Scranton W-03 P-02,U.S. House,8,REP,Teddy Daniels,13,3,0,0,16
+Lackawanna,Scranton W-03 P-02,U.S. House,8,REP,Jim Bognet,10,6,2,1,19
+Lackawanna,Scranton W-03 P-02,U.S. House,8,REP,Mike Cammisa,0,3,0,0,3
+Lackawanna,Scranton W-03 P-02,U.S. House,8,REP,Mike Marsicano,3,0,1,0,4
+Lackawanna,Scranton W-03 P-02,U.S. House,8,REP,Earl Granville,17,15,4,3,39
+Lackawanna,Scranton W-03 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-03 P-02,General Assembly,113,REP,William Kresge,36,23,8,1,68
+Lackawanna,Scranton W-03 P-02,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-04 P-01,Registered Voters,,,,,,,,754
+Lackawanna,Scranton W-04 P-01,Registered Voters,,DEM,,,,,,559
+Lackawanna,Scranton W-04 P-01,Registered Voters,,REP,,,,,,195
+Lackawanna,Scranton W-04 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-04 P-01,Ballots Cast,,,,122,109,15,4,250
+Lackawanna,Scranton W-04 P-01,Ballots Cast,,DEM,,71,93,13,4,181
+Lackawanna,Scranton W-04 P-01,Ballots Cast,,REP,,51,16,2,0,69
+Lackawanna,Scranton W-04 P-01,President,,DEM,Bernie Sanders,19,13,1,1,34
+Lackawanna,Scranton W-04 P-01,President,,DEM,Joseph R. Biden,41,76,12,3,132
+Lackawanna,Scranton W-04 P-01,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Lackawanna,Scranton W-04 P-01,President,,DEM,Write-in,5,4,0,0,9
+Lackawanna,Scranton W-04 P-01,Attorney General,,DEM,Josh Shapiro,49,74,12,3,138
+Lackawanna,Scranton W-04 P-01,Attorney General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-04 P-01,Auditor General,,DEM,H. Scott Conklin,5,0,1,2,8
+Lackawanna,Scranton W-04 P-01,Auditor General,,DEM,Michael Lamb,6,17,4,0,27
+Lackawanna,Scranton W-04 P-01,Auditor General,,DEM,Tracie Fountain,6,8,0,0,14
+Lackawanna,Scranton W-04 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,3,16,0,0,19
+Lackawanna,Scranton W-04 P-01,Auditor General,,DEM,Nina Ahmad,30,15,2,1,48
+Lackawanna,Scranton W-04 P-01,Auditor General,,DEM,Christina M. Hartman,8,13,4,0,25
+Lackawanna,Scranton W-04 P-01,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-04 P-01,State Treasurer,,DEM,Joe Torsella,49,68,12,3,132
+Lackawanna,Scranton W-04 P-01,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-04 P-01,U.S. House,8,DEM,Matt Cartwright,59,87,12,4,162
+Lackawanna,Scranton W-04 P-01,U.S. House,8,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-04 P-01,General Assembly,113,DEM,Marty Flynn,57,84,13,4,158
+Lackawanna,Scranton W-04 P-01,General Assembly,113,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-04 P-01,President,,REP,Donald J. Trump,48,13,1,0,62
+Lackawanna,Scranton W-04 P-01,President,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Lackawanna,Scranton W-04 P-01,President,,REP,Bill Weld,0,3,0,0,3
+Lackawanna,Scranton W-04 P-01,President,,REP,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-04 P-01,Attorney General,,REP,Heather Heidelbaugh,37,14,1,0,52
+Lackawanna,Scranton W-04 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-01,Auditor General,,REP,Timothy DeFoor,35,14,1,0,50
+Lackawanna,Scranton W-04 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-01,State Treasurer,,REP,Stacy L. Garrity,37,14,1,0,52
+Lackawanna,Scranton W-04 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-01,U.S. House,8,REP,Harry Haas,2,0,0,0,2
+Lackawanna,Scranton W-04 P-01,U.S. House,8,REP,Teddy Daniels,5,0,1,0,6
+Lackawanna,Scranton W-04 P-01,U.S. House,8,REP,Jim Bognet,14,3,0,0,17
+Lackawanna,Scranton W-04 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-04 P-01,U.S. House,8,REP,Mike Marsicano,7,0,0,0,7
+Lackawanna,Scranton W-04 P-01,U.S. House,8,REP,Earl Granville,22,12,1,0,35
+Lackawanna,Scranton W-04 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-01,General Assembly,113,REP,William Kresge,47,14,1,0,62
+Lackawanna,Scranton W-04 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-02,Registered Voters,,,,,,,,993
+Lackawanna,Scranton W-04 P-02,Registered Voters,,DEM,,,,,,706
+Lackawanna,Scranton W-04 P-02,Registered Voters,,REP,,,,,,287
+Lackawanna,Scranton W-04 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-04 P-02,Ballots Cast,,,,156,158,32,4,350
+Lackawanna,Scranton W-04 P-02,Ballots Cast,,DEM,,92,134,29,3,258
+Lackawanna,Scranton W-04 P-02,Ballots Cast,,REP,,64,24,3,1,92
+Lackawanna,Scranton W-04 P-02,President,,DEM,Bernie Sanders,17,16,2,0,35
+Lackawanna,Scranton W-04 P-02,President,,DEM,Joseph R. Biden,59,112,26,2,199
+Lackawanna,Scranton W-04 P-02,President,,DEM,Tulsi Gabbard,3,1,1,0,5
+Lackawanna,Scranton W-04 P-02,President,,DEM,Write-in,5,4,0,1,10
+Lackawanna,Scranton W-04 P-02,Attorney General,,DEM,Josh Shapiro,56,119,25,2,202
+Lackawanna,Scranton W-04 P-02,Attorney General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-04 P-02,Auditor General,,DEM,H. Scott Conklin,9,5,2,1,17
+Lackawanna,Scranton W-04 P-02,Auditor General,,DEM,Michael Lamb,6,17,1,0,24
+Lackawanna,Scranton W-04 P-02,Auditor General,,DEM,Tracie Fountain,3,11,0,0,14
+Lackawanna,Scranton W-04 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,21,34,6,0,61
+Lackawanna,Scranton W-04 P-02,Auditor General,,DEM,Nina Ahmad,19,19,7,1,46
+Lackawanna,Scranton W-04 P-02,Auditor General,,DEM,Christina M. Hartman,10,21,8,0,39
+Lackawanna,Scranton W-04 P-02,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-04 P-02,State Treasurer,,DEM,Joe Torsella,49,112,25,2,188
+Lackawanna,Scranton W-04 P-02,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-04 P-02,U.S. House,8,DEM,Matt Cartwright,74,123,28,3,228
+Lackawanna,Scranton W-04 P-02,U.S. House,8,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-04 P-02,General Assembly,113,DEM,Marty Flynn,67,120,27,2,216
+Lackawanna,Scranton W-04 P-02,General Assembly,113,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-04 P-02,President,,REP,Donald J. Trump,61,17,3,1,82
+Lackawanna,Scranton W-04 P-02,President,,REP,Roque Rocky De La Fuente,0,2,0,0,2
+Lackawanna,Scranton W-04 P-02,President,,REP,Bill Weld,1,5,0,0,6
+Lackawanna,Scranton W-04 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-02,Attorney General,,REP,Heather Heidelbaugh,47,16,3,1,67
+Lackawanna,Scranton W-04 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-02,Auditor General,,REP,Timothy DeFoor,45,16,3,1,65
+Lackawanna,Scranton W-04 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-02,State Treasurer,,REP,Stacy L. Garrity,46,17,3,1,67
+Lackawanna,Scranton W-04 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-02,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Scranton W-04 P-02,U.S. House,8,REP,Teddy Daniels,22,4,0,0,26
+Lackawanna,Scranton W-04 P-02,U.S. House,8,REP,Jim Bognet,10,3,0,1,14
+Lackawanna,Scranton W-04 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-04 P-02,U.S. House,8,REP,Mike Marsicano,7,1,0,0,8
+Lackawanna,Scranton W-04 P-02,U.S. House,8,REP,Earl Granville,21,9,3,0,33
+Lackawanna,Scranton W-04 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-04 P-02,General Assembly,113,REP,William Kresge,55,20,3,1,79
+Lackawanna,Scranton W-04 P-02,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-05 P-01,Registered Voters,,,,,,,,854
+Lackawanna,Scranton W-05 P-01,Registered Voters,,DEM,,,,,,667
+Lackawanna,Scranton W-05 P-01,Registered Voters,,REP,,,,,,187
+Lackawanna,Scranton W-05 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-05 P-01,Ballots Cast,,,,127,111,9,6,253
+Lackawanna,Scranton W-05 P-01,Ballots Cast,,DEM,,83,102,9,1,195
+Lackawanna,Scranton W-05 P-01,Ballots Cast,,REP,,44,9,0,5,58
+Lackawanna,Scranton W-05 P-01,President,,DEM,Bernie Sanders,17,7,2,0,26
+Lackawanna,Scranton W-05 P-01,President,,DEM,Joseph R. Biden,55,92,7,1,155
+Lackawanna,Scranton W-05 P-01,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Lackawanna,Scranton W-05 P-01,President,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-05 P-01,Attorney General,,DEM,Josh Shapiro,62,91,8,1,162
+Lackawanna,Scranton W-05 P-01,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-05 P-01,Auditor General,,DEM,H. Scott Conklin,3,8,0,0,11
+Lackawanna,Scranton W-05 P-01,Auditor General,,DEM,Michael Lamb,15,19,1,0,35
+Lackawanna,Scranton W-05 P-01,Auditor General,,DEM,Tracie Fountain,6,6,1,0,13
+Lackawanna,Scranton W-05 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,10,18,4,0,32
+Lackawanna,Scranton W-05 P-01,Auditor General,,DEM,Nina Ahmad,17,21,2,1,41
+Lackawanna,Scranton W-05 P-01,Auditor General,,DEM,Christina M. Hartman,11,22,0,0,33
+Lackawanna,Scranton W-05 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-01,State Treasurer,,DEM,Joe Torsella,60,90,8,1,159
+Lackawanna,Scranton W-05 P-01,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-05 P-01,U.S. House,8,DEM,Matt Cartwright,70,98,8,1,177
+Lackawanna,Scranton W-05 P-01,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-05 P-01,General Assembly,113,DEM,Marty Flynn,72,94,9,1,176
+Lackawanna,Scranton W-05 P-01,General Assembly,113,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-05 P-01,President,,REP,Donald J. Trump,41,7,0,5,53
+Lackawanna,Scranton W-05 P-01,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Scranton W-05 P-01,President,,REP,Bill Weld,2,1,0,0,3
+Lackawanna,Scranton W-05 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-05 P-01,Attorney General,,REP,Heather Heidelbaugh,32,6,0,2,40
+Lackawanna,Scranton W-05 P-01,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-05 P-01,Auditor General,,REP,Timothy DeFoor,31,6,0,3,40
+Lackawanna,Scranton W-05 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-01,State Treasurer,,REP,Stacy L. Garrity,31,6,0,2,39
+Lackawanna,Scranton W-05 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-01,U.S. House,8,REP,Harry Haas,1,1,0,1,3
+Lackawanna,Scranton W-05 P-01,U.S. House,8,REP,Teddy Daniels,6,1,0,2,9
+Lackawanna,Scranton W-05 P-01,U.S. House,8,REP,Jim Bognet,5,1,0,1,7
+Lackawanna,Scranton W-05 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scranton W-05 P-01,U.S. House,8,REP,Mike Marsicano,6,3,0,0,9
+Lackawanna,Scranton W-05 P-01,U.S. House,8,REP,Earl Granville,21,3,0,0,24
+Lackawanna,Scranton W-05 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-01,General Assembly,113,REP,William Kresge,35,5,0,3,43
+Lackawanna,Scranton W-05 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-02,Registered Voters,,,,,,,,849
+Lackawanna,Scranton W-05 P-02,Registered Voters,,DEM,,,,,,661
+Lackawanna,Scranton W-05 P-02,Registered Voters,,REP,,,,,,188
+Lackawanna,Scranton W-05 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-05 P-02,Ballots Cast,,,,131,119,24,1,275
+Lackawanna,Scranton W-05 P-02,Ballots Cast,,DEM,,94,108,23,0,225
+Lackawanna,Scranton W-05 P-02,Ballots Cast,,REP,,37,11,1,1,50
+Lackawanna,Scranton W-05 P-02,President,,DEM,Bernie Sanders,16,12,0,0,28
+Lackawanna,Scranton W-05 P-02,President,,DEM,Joseph R. Biden,62,91,21,0,174
+Lackawanna,Scranton W-05 P-02,President,,DEM,Tulsi Gabbard,7,2,1,0,10
+Lackawanna,Scranton W-05 P-02,President,,DEM,Write-in,7,0,0,0,7
+Lackawanna,Scranton W-05 P-02,Attorney General,,DEM,Josh Shapiro,70,91,22,0,183
+Lackawanna,Scranton W-05 P-02,Attorney General,,DEM,Write-in,5,2,0,0,7
+Lackawanna,Scranton W-05 P-02,Auditor General,,DEM,H. Scott Conklin,5,11,1,0,17
+Lackawanna,Scranton W-05 P-02,Auditor General,,DEM,Michael Lamb,16,15,4,0,35
+Lackawanna,Scranton W-05 P-02,Auditor General,,DEM,Tracie Fountain,6,5,4,0,15
+Lackawanna,Scranton W-05 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,12,20,3,0,35
+Lackawanna,Scranton W-05 P-02,Auditor General,,DEM,Nina Ahmad,22,21,2,0,45
+Lackawanna,Scranton W-05 P-02,Auditor General,,DEM,Christina M. Hartman,12,19,7,0,38
+Lackawanna,Scranton W-05 P-02,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-05 P-02,State Treasurer,,DEM,Joe Torsella,66,92,21,0,179
+Lackawanna,Scranton W-05 P-02,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-05 P-02,U.S. House,8,DEM,Matt Cartwright,70,104,22,0,196
+Lackawanna,Scranton W-05 P-02,U.S. House,8,DEM,Write-in,6,0,0,0,6
+Lackawanna,Scranton W-05 P-02,General Assembly,113,DEM,Marty Flynn,78,100,20,0,198
+Lackawanna,Scranton W-05 P-02,General Assembly,113,DEM,Write-in,5,1,1,0,7
+Lackawanna,Scranton W-05 P-02,President,,REP,Donald J. Trump,32,11,0,1,44
+Lackawanna,Scranton W-05 P-02,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Scranton W-05 P-02,President,,REP,Bill Weld,3,0,1,0,4
+Lackawanna,Scranton W-05 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-02,Attorney General,,REP,Heather Heidelbaugh,27,10,1,1,39
+Lackawanna,Scranton W-05 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-02,Auditor General,,REP,Timothy DeFoor,25,10,1,1,37
+Lackawanna,Scranton W-05 P-02,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-05 P-02,State Treasurer,,REP,Stacy L. Garrity,27,10,1,1,39
+Lackawanna,Scranton W-05 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-02,U.S. House,8,REP,Harry Haas,0,1,0,0,1
+Lackawanna,Scranton W-05 P-02,U.S. House,8,REP,Teddy Daniels,15,1,0,0,16
+Lackawanna,Scranton W-05 P-02,U.S. House,8,REP,Jim Bognet,9,3,0,1,13
+Lackawanna,Scranton W-05 P-02,U.S. House,8,REP,Mike Cammisa,0,0,1,0,1
+Lackawanna,Scranton W-05 P-02,U.S. House,8,REP,Mike Marsicano,4,1,0,0,5
+Lackawanna,Scranton W-05 P-02,U.S. House,8,REP,Earl Granville,6,4,0,0,10
+Lackawanna,Scranton W-05 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-05 P-02,General Assembly,113,REP,William Kresge,33,10,1,1,45
+Lackawanna,Scranton W-05 P-02,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-06 P-01,Registered Voters,,,,,,,,589
+Lackawanna,Scranton W-06 P-01,Registered Voters,,DEM,,,,,,440
+Lackawanna,Scranton W-06 P-01,Registered Voters,,REP,,,,,,149
+Lackawanna,Scranton W-06 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-06 P-01,Ballots Cast,,,,68,90,21,3,182
+Lackawanna,Scranton W-06 P-01,Ballots Cast,,DEM,,38,78,18,1,135
+Lackawanna,Scranton W-06 P-01,Ballots Cast,,REP,,30,12,3,2,47
+Lackawanna,Scranton W-06 P-01,President,,DEM,Bernie Sanders,7,9,3,1,20
+Lackawanna,Scranton W-06 P-01,President,,DEM,Joseph R. Biden,26,65,14,0,105
+Lackawanna,Scranton W-06 P-01,President,,DEM,Tulsi Gabbard,3,4,0,0,7
+Lackawanna,Scranton W-06 P-01,President,,DEM,Write-in,1,0,1,0,2
+Lackawanna,Scranton W-06 P-01,Attorney General,,DEM,Josh Shapiro,27,67,16,0,110
+Lackawanna,Scranton W-06 P-01,Attorney General,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-06 P-01,Auditor General,,DEM,H. Scott Conklin,2,2,1,0,5
+Lackawanna,Scranton W-06 P-01,Auditor General,,DEM,Michael Lamb,6,20,0,0,26
+Lackawanna,Scranton W-06 P-01,Auditor General,,DEM,Tracie Fountain,0,3,2,0,5
+Lackawanna,Scranton W-06 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,3,16,5,0,24
+Lackawanna,Scranton W-06 P-01,Auditor General,,DEM,Nina Ahmad,15,9,2,0,26
+Lackawanna,Scranton W-06 P-01,Auditor General,,DEM,Christina M. Hartman,3,16,4,0,23
+Lackawanna,Scranton W-06 P-01,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-06 P-01,State Treasurer,,DEM,Joe Torsella,26,65,13,0,104
+Lackawanna,Scranton W-06 P-01,State Treasurer,,DEM,Write-in,2,0,1,0,3
+Lackawanna,Scranton W-06 P-01,U.S. House,8,DEM,Matt Cartwright,32,69,17,0,118
+Lackawanna,Scranton W-06 P-01,U.S. House,8,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-06 P-01,General Assembly,113,DEM,Marty Flynn,31,68,17,0,116
+Lackawanna,Scranton W-06 P-01,General Assembly,113,DEM,Write-in,2,3,1,0,6
+Lackawanna,Scranton W-06 P-01,President,,REP,Donald J. Trump,30,9,2,2,43
+Lackawanna,Scranton W-06 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-06 P-01,President,,REP,Bill Weld,0,1,1,0,2
+Lackawanna,Scranton W-06 P-01,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-06 P-01,Attorney General,,REP,Heather Heidelbaugh,18,8,1,1,28
+Lackawanna,Scranton W-06 P-01,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-06 P-01,Auditor General,,REP,Timothy DeFoor,18,7,1,1,27
+Lackawanna,Scranton W-06 P-01,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-06 P-01,State Treasurer,,REP,Stacy L. Garrity,17,8,1,1,27
+Lackawanna,Scranton W-06 P-01,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-06 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-06 P-01,U.S. House,8,REP,Teddy Daniels,8,0,0,1,9
+Lackawanna,Scranton W-06 P-01,U.S. House,8,REP,Jim Bognet,8,2,1,0,11
+Lackawanna,Scranton W-06 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-06 P-01,U.S. House,8,REP,Mike Marsicano,5,0,0,1,6
+Lackawanna,Scranton W-06 P-01,U.S. House,8,REP,Earl Granville,9,9,2,0,20
+Lackawanna,Scranton W-06 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-06 P-01,General Assembly,113,REP,William Kresge,21,10,1,0,32
+Lackawanna,Scranton W-06 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-07 P-01,Registered Voters,,,,,,,,717
+Lackawanna,Scranton W-07 P-01,Registered Voters,,DEM,,,,,,553
+Lackawanna,Scranton W-07 P-01,Registered Voters,,REP,,,,,,164
+Lackawanna,Scranton W-07 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-07 P-01,Ballots Cast,,,,68,83,16,0,167
+Lackawanna,Scranton W-07 P-01,Ballots Cast,,DEM,,44,77,12,0,133
+Lackawanna,Scranton W-07 P-01,Ballots Cast,,REP,,24,6,4,0,34
+Lackawanna,Scranton W-07 P-01,President,,DEM,Bernie Sanders,9,6,4,0,19
+Lackawanna,Scranton W-07 P-01,President,,DEM,Joseph R. Biden,29,68,8,0,105
+Lackawanna,Scranton W-07 P-01,President,,DEM,Tulsi Gabbard,3,1,0,0,4
+Lackawanna,Scranton W-07 P-01,President,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-07 P-01,Attorney General,,DEM,Josh Shapiro,29,66,8,0,103
+Lackawanna,Scranton W-07 P-01,Attorney General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-07 P-01,Auditor General,,DEM,H. Scott Conklin,0,3,0,0,3
+Lackawanna,Scranton W-07 P-01,Auditor General,,DEM,Michael Lamb,6,6,2,0,14
+Lackawanna,Scranton W-07 P-01,Auditor General,,DEM,Tracie Fountain,2,6,1,0,9
+Lackawanna,Scranton W-07 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,5,29,0,0,34
+Lackawanna,Scranton W-07 P-01,Auditor General,,DEM,Nina Ahmad,22,12,3,0,37
+Lackawanna,Scranton W-07 P-01,Auditor General,,DEM,Christina M. Hartman,3,15,2,0,20
+Lackawanna,Scranton W-07 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-07 P-01,State Treasurer,,DEM,Joe Torsella,29,64,8,0,101
+Lackawanna,Scranton W-07 P-01,State Treasurer,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-07 P-01,U.S. House,8,DEM,Matt Cartwright,39,75,9,0,123
+Lackawanna,Scranton W-07 P-01,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-07 P-01,General Assembly,113,DEM,Marty Flynn,35,72,11,0,118
+Lackawanna,Scranton W-07 P-01,General Assembly,113,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-07 P-01,President,,REP,Donald J. Trump,20,4,2,0,26
+Lackawanna,Scranton W-07 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-07 P-01,President,,REP,Bill Weld,2,0,1,0,3
+Lackawanna,Scranton W-07 P-01,President,,REP,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-07 P-01,Attorney General,,REP,Heather Heidelbaugh,14,5,4,0,23
+Lackawanna,Scranton W-07 P-01,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-07 P-01,Auditor General,,REP,Timothy DeFoor,14,5,4,0,23
+Lackawanna,Scranton W-07 P-01,Auditor General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-07 P-01,State Treasurer,,REP,Stacy L. Garrity,15,5,4,0,24
+Lackawanna,Scranton W-07 P-01,State Treasurer,,REP,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-07 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-07 P-01,U.S. House,8,REP,Teddy Daniels,2,0,0,0,2
+Lackawanna,Scranton W-07 P-01,U.S. House,8,REP,Jim Bognet,4,4,0,0,8
+Lackawanna,Scranton W-07 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-07 P-01,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Scranton W-07 P-01,U.S. House,8,REP,Earl Granville,12,1,4,0,17
+Lackawanna,Scranton W-07 P-01,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-07 P-01,General Assembly,113,REP,William Kresge,16,6,4,0,26
+Lackawanna,Scranton W-07 P-01,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-09 P-01,Registered Voters,,,,,,,,1034
+Lackawanna,Scranton W-09 P-01,Registered Voters,,DEM,,,,,,842
+Lackawanna,Scranton W-09 P-01,Registered Voters,,REP,,,,,,192
+Lackawanna,Scranton W-09 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-09 P-01,Ballots Cast,,,,102,119,33,6,260
+Lackawanna,Scranton W-09 P-01,Ballots Cast,,DEM,,85,99,25,3,212
+Lackawanna,Scranton W-09 P-01,Ballots Cast,,REP,,17,20,8,3,48
+Lackawanna,Scranton W-09 P-01,President,,DEM,Bernie Sanders,29,6,4,0,39
+Lackawanna,Scranton W-09 P-01,President,,DEM,Joseph R. Biden,52,86,21,2,161
+Lackawanna,Scranton W-09 P-01,President,,DEM,Tulsi Gabbard,3,4,0,1,8
+Lackawanna,Scranton W-09 P-01,President,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-09 P-01,Attorney General,,DEM,Josh Shapiro,63,80,21,3,167
+Lackawanna,Scranton W-09 P-01,Attorney General,,DEM,Write-in,2,0,2,0,4
+Lackawanna,Scranton W-09 P-01,Auditor General,,DEM,H. Scott Conklin,10,5,5,0,20
+Lackawanna,Scranton W-09 P-01,Auditor General,,DEM,Michael Lamb,12,9,1,1,23
+Lackawanna,Scranton W-09 P-01,Auditor General,,DEM,Tracie Fountain,3,4,1,0,8
+Lackawanna,Scranton W-09 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,5,21,5,0,31
+Lackawanna,Scranton W-09 P-01,Auditor General,,DEM,Nina Ahmad,27,26,7,0,60
+Lackawanna,Scranton W-09 P-01,Auditor General,,DEM,Christina M. Hartman,10,15,4,1,30
+Lackawanna,Scranton W-09 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-09 P-01,State Treasurer,,DEM,Joe Torsella,60,74,23,3,160
+Lackawanna,Scranton W-09 P-01,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-09 P-01,U.S. House,8,DEM,Matt Cartwright,66,92,25,2,185
+Lackawanna,Scranton W-09 P-01,U.S. House,8,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-09 P-01,General Assembly,112,DEM,Kyle J. Mullins,63,83,23,2,171
+Lackawanna,Scranton W-09 P-01,General Assembly,112,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-09 P-01,President,,REP,Donald J. Trump,16,18,5,2,41
+Lackawanna,Scranton W-09 P-01,President,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Lackawanna,Scranton W-09 P-01,President,,REP,Bill Weld,0,0,2,0,2
+Lackawanna,Scranton W-09 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-09 P-01,Attorney General,,REP,Heather Heidelbaugh,11,14,6,3,34
+Lackawanna,Scranton W-09 P-01,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-09 P-01,Auditor General,,REP,Timothy DeFoor,12,14,6,3,35
+Lackawanna,Scranton W-09 P-01,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-09 P-01,State Treasurer,,REP,Stacy L. Garrity,11,17,6,3,37
+Lackawanna,Scranton W-09 P-01,State Treasurer,,REP,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-09 P-01,U.S. House,8,REP,Harry Haas,1,0,1,0,2
+Lackawanna,Scranton W-09 P-01,U.S. House,8,REP,Teddy Daniels,4,2,0,2,8
+Lackawanna,Scranton W-09 P-01,U.S. House,8,REP,Jim Bognet,0,4,0,1,5
+Lackawanna,Scranton W-09 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-09 P-01,U.S. House,8,REP,Mike Marsicano,3,0,1,0,4
+Lackawanna,Scranton W-09 P-01,U.S. House,8,REP,Earl Granville,7,12,4,0,23
+Lackawanna,Scranton W-09 P-01,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-09 P-01,General Assembly,112,REP,Write-in,1,5,0,0,6
+Lackawanna,Scranton W-09 P-02,Registered Voters,,,,,,,,712
+Lackawanna,Scranton W-09 P-02,Registered Voters,,DEM,,,,,,505
+Lackawanna,Scranton W-09 P-02,Registered Voters,,REP,,,,,,207
+Lackawanna,Scranton W-09 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-09 P-02,Ballots Cast,,,,68,98,21,1,188
+Lackawanna,Scranton W-09 P-02,Ballots Cast,,DEM,,44,80,20,1,145
+Lackawanna,Scranton W-09 P-02,Ballots Cast,,REP,,24,18,1,0,43
+Lackawanna,Scranton W-09 P-02,President,,DEM,Bernie Sanders,12,7,6,1,26
+Lackawanna,Scranton W-09 P-02,President,,DEM,Joseph R. Biden,28,68,11,0,107
+Lackawanna,Scranton W-09 P-02,President,,DEM,Tulsi Gabbard,4,1,3,0,8
+Lackawanna,Scranton W-09 P-02,President,,DEM,Write-in,0,4,0,0,4
+Lackawanna,Scranton W-09 P-02,Attorney General,,DEM,Josh Shapiro,32,72,19,1,124
+Lackawanna,Scranton W-09 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-09 P-02,Auditor General,,DEM,H. Scott Conklin,1,1,1,0,3
+Lackawanna,Scranton W-09 P-02,Auditor General,,DEM,Michael Lamb,5,8,1,1,15
+Lackawanna,Scranton W-09 P-02,Auditor General,,DEM,Tracie Fountain,4,13,3,0,20
+Lackawanna,Scranton W-09 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,5,11,4,0,20
+Lackawanna,Scranton W-09 P-02,Auditor General,,DEM,Nina Ahmad,18,26,5,0,49
+Lackawanna,Scranton W-09 P-02,Auditor General,,DEM,Christina M. Hartman,2,14,5,0,21
+Lackawanna,Scranton W-09 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-09 P-02,State Treasurer,,DEM,Joe Torsella,31,70,19,1,121
+Lackawanna,Scranton W-09 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-09 P-02,U.S. House,8,DEM,Matt Cartwright,40,77,19,1,137
+Lackawanna,Scranton W-09 P-02,U.S. House,8,DEM,Write-in,0,1,1,0,2
+Lackawanna,Scranton W-09 P-02,General Assembly,112,DEM,Kyle J. Mullins,33,73,18,1,125
+Lackawanna,Scranton W-09 P-02,General Assembly,112,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-09 P-02,President,,REP,Donald J. Trump,21,18,1,0,40
+Lackawanna,Scranton W-09 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-09 P-02,President,,REP,Bill Weld,2,0,0,0,2
+Lackawanna,Scranton W-09 P-02,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-09 P-02,Attorney General,,REP,Heather Heidelbaugh,16,14,0,0,30
+Lackawanna,Scranton W-09 P-02,Attorney General,,REP,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-09 P-02,Auditor General,,REP,Timothy DeFoor,15,13,0,0,28
+Lackawanna,Scranton W-09 P-02,Auditor General,,REP,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-09 P-02,State Treasurer,,REP,Stacy L. Garrity,17,14,0,0,31
+Lackawanna,Scranton W-09 P-02,State Treasurer,,REP,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-09 P-02,U.S. House,8,REP,Harry Haas,2,0,0,0,2
+Lackawanna,Scranton W-09 P-02,U.S. House,8,REP,Teddy Daniels,5,1,0,0,6
+Lackawanna,Scranton W-09 P-02,U.S. House,8,REP,Jim Bognet,2,2,0,0,4
+Lackawanna,Scranton W-09 P-02,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Scranton W-09 P-02,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Scranton W-09 P-02,U.S. House,8,REP,Earl Granville,10,13,1,0,24
+Lackawanna,Scranton W-09 P-02,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-09 P-02,General Assembly,112,REP,Write-in,7,4,0,0,11
+Lackawanna,Scranton W-10 P-01,Registered Voters,,,,,,,,789
+Lackawanna,Scranton W-10 P-01,Registered Voters,,DEM,,,,,,595
+Lackawanna,Scranton W-10 P-01,Registered Voters,,REP,,,,,,194
+Lackawanna,Scranton W-10 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-10 P-01,Ballots Cast,,,,102,198,32,3,335
+Lackawanna,Scranton W-10 P-01,Ballots Cast,,DEM,,71,174,30,2,277
+Lackawanna,Scranton W-10 P-01,Ballots Cast,,REP,,31,24,2,1,58
+Lackawanna,Scranton W-10 P-01,President,,DEM,Bernie Sanders,12,19,5,0,36
+Lackawanna,Scranton W-10 P-01,President,,DEM,Joseph R. Biden,45,147,25,2,219
+Lackawanna,Scranton W-10 P-01,President,,DEM,Tulsi Gabbard,10,5,0,0,15
+Lackawanna,Scranton W-10 P-01,President,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-10 P-01,Attorney General,,DEM,Josh Shapiro,51,146,25,2,224
+Lackawanna,Scranton W-10 P-01,Attorney General,,DEM,Write-in,6,3,0,0,9
+Lackawanna,Scranton W-10 P-01,Auditor General,,DEM,H. Scott Conklin,4,9,1,0,14
+Lackawanna,Scranton W-10 P-01,Auditor General,,DEM,Michael Lamb,7,12,3,1,23
+Lackawanna,Scranton W-10 P-01,Auditor General,,DEM,Tracie Fountain,5,13,1,0,19
+Lackawanna,Scranton W-10 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,10,44,2,0,56
+Lackawanna,Scranton W-10 P-01,Auditor General,,DEM,Nina Ahmad,28,43,8,0,79
+Lackawanna,Scranton W-10 P-01,Auditor General,,DEM,Christina M. Hartman,3,29,11,1,44
+Lackawanna,Scranton W-10 P-01,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-10 P-01,State Treasurer,,DEM,Joe Torsella,50,143,24,2,219
+Lackawanna,Scranton W-10 P-01,State Treasurer,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-10 P-01,U.S. House,8,DEM,Matt Cartwright,57,163,27,2,249
+Lackawanna,Scranton W-10 P-01,U.S. House,8,DEM,Write-in,4,4,0,0,8
+Lackawanna,Scranton W-10 P-01,General Assembly,112,DEM,Kyle J. Mullins,51,155,27,1,234
+Lackawanna,Scranton W-10 P-01,General Assembly,112,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-10 P-01,President,,REP,Donald J. Trump,30,15,2,1,48
+Lackawanna,Scranton W-10 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-10 P-01,President,,REP,Bill Weld,0,3,0,0,3
+Lackawanna,Scranton W-10 P-01,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-10 P-01,Attorney General,,REP,Heather Heidelbaugh,19,21,2,1,43
+Lackawanna,Scranton W-10 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-10 P-01,Auditor General,,REP,Timothy DeFoor,17,21,2,1,41
+Lackawanna,Scranton W-10 P-01,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-10 P-01,State Treasurer,,REP,Stacy L. Garrity,19,22,2,1,44
+Lackawanna,Scranton W-10 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-10 P-01,U.S. House,8,REP,Harry Haas,1,0,0,1,2
+Lackawanna,Scranton W-10 P-01,U.S. House,8,REP,Teddy Daniels,6,1,1,0,8
+Lackawanna,Scranton W-10 P-01,U.S. House,8,REP,Jim Bognet,9,2,0,0,11
+Lackawanna,Scranton W-10 P-01,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Scranton W-10 P-01,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Scranton W-10 P-01,U.S. House,8,REP,Earl Granville,8,20,1,0,29
+Lackawanna,Scranton W-10 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-10 P-01,General Assembly,112,REP,Write-in,5,5,1,0,11
+Lackawanna,Scranton W-10 P-02,Registered Voters,,,,,,,,1071
+Lackawanna,Scranton W-10 P-02,Registered Voters,,DEM,,,,,,756
+Lackawanna,Scranton W-10 P-02,Registered Voters,,REP,,,,,,315
+Lackawanna,Scranton W-10 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-10 P-02,Ballots Cast,,,,131,244,47,4,426
+Lackawanna,Scranton W-10 P-02,Ballots Cast,,DEM,,79,210,38,4,331
+Lackawanna,Scranton W-10 P-02,Ballots Cast,,REP,,52,34,9,0,95
+Lackawanna,Scranton W-10 P-02,President,,DEM,Bernie Sanders,20,27,5,1,53
+Lackawanna,Scranton W-10 P-02,President,,DEM,Joseph R. Biden,53,172,30,3,258
+Lackawanna,Scranton W-10 P-02,President,,DEM,Tulsi Gabbard,2,3,2,0,7
+Lackawanna,Scranton W-10 P-02,President,,DEM,Write-in,3,7,0,0,10
+Lackawanna,Scranton W-10 P-02,Attorney General,,DEM,Josh Shapiro,66,184,35,3,288
+Lackawanna,Scranton W-10 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-10 P-02,Auditor General,,DEM,H. Scott Conklin,3,6,0,1,10
+Lackawanna,Scranton W-10 P-02,Auditor General,,DEM,Michael Lamb,7,38,7,0,52
+Lackawanna,Scranton W-10 P-02,Auditor General,,DEM,Tracie Fountain,0,15,3,0,18
+Lackawanna,Scranton W-10 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,11,30,8,0,49
+Lackawanna,Scranton W-10 P-02,Auditor General,,DEM,Nina Ahmad,42,65,12,2,121
+Lackawanna,Scranton W-10 P-02,Auditor General,,DEM,Christina M. Hartman,6,22,5,0,33
+Lackawanna,Scranton W-10 P-02,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-10 P-02,State Treasurer,,DEM,Joe Torsella,60,173,32,2,267
+Lackawanna,Scranton W-10 P-02,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-10 P-02,U.S. House,8,DEM,Matt Cartwright,68,195,35,4,302
+Lackawanna,Scranton W-10 P-02,U.S. House,8,DEM,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-10 P-02,General Assembly,112,DEM,Kyle J. Mullins,62,180,31,3,276
+Lackawanna,Scranton W-10 P-02,General Assembly,112,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-10 P-02,President,,REP,Donald J. Trump,46,27,7,0,80
+Lackawanna,Scranton W-10 P-02,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Scranton W-10 P-02,President,,REP,Bill Weld,0,5,1,0,6
+Lackawanna,Scranton W-10 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-10 P-02,Attorney General,,REP,Heather Heidelbaugh,35,23,9,0,67
+Lackawanna,Scranton W-10 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-10 P-02,Auditor General,,REP,Timothy DeFoor,36,24,9,0,69
+Lackawanna,Scranton W-10 P-02,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-10 P-02,State Treasurer,,REP,Stacy L. Garrity,35,25,8,0,68
+Lackawanna,Scranton W-10 P-02,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-10 P-02,U.S. House,8,REP,Harry Haas,5,0,0,0,5
+Lackawanna,Scranton W-10 P-02,U.S. House,8,REP,Teddy Daniels,8,2,1,0,11
+Lackawanna,Scranton W-10 P-02,U.S. House,8,REP,Jim Bognet,12,8,0,0,20
+Lackawanna,Scranton W-10 P-02,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Scranton W-10 P-02,U.S. House,8,REP,Mike Marsicano,2,1,1,0,4
+Lackawanna,Scranton W-10 P-02,U.S. House,8,REP,Earl Granville,23,18,7,0,48
+Lackawanna,Scranton W-10 P-02,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-10 P-02,General Assembly,112,REP,Write-in,8,4,1,0,13
+Lackawanna,Scranton W-10 P-03,Registered Voters,,,,,,,,943
+Lackawanna,Scranton W-10 P-03,Registered Voters,,DEM,,,,,,656
+Lackawanna,Scranton W-10 P-03,Registered Voters,,REP,,,,,,287
+Lackawanna,Scranton W-10 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-10 P-03,Ballots Cast,,,,155,185,33,4,377
+Lackawanna,Scranton W-10 P-03,Ballots Cast,,DEM,,87,159,29,4,279
+Lackawanna,Scranton W-10 P-03,Ballots Cast,,REP,,68,26,4,0,98
+Lackawanna,Scranton W-10 P-03,President,,DEM,Bernie Sanders,24,16,3,1,44
+Lackawanna,Scranton W-10 P-03,President,,DEM,Joseph R. Biden,52,135,24,2,213
+Lackawanna,Scranton W-10 P-03,President,,DEM,Tulsi Gabbard,4,1,1,1,7
+Lackawanna,Scranton W-10 P-03,President,,DEM,Write-in,3,4,1,0,8
+Lackawanna,Scranton W-10 P-03,Attorney General,,DEM,Josh Shapiro,65,133,24,2,224
+Lackawanna,Scranton W-10 P-03,Attorney General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-10 P-03,Auditor General,,DEM,H. Scott Conklin,7,6,0,0,13
+Lackawanna,Scranton W-10 P-03,Auditor General,,DEM,Michael Lamb,10,15,4,0,29
+Lackawanna,Scranton W-10 P-03,Auditor General,,DEM,Tracie Fountain,3,4,0,0,7
+Lackawanna,Scranton W-10 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,15,42,9,0,66
+Lackawanna,Scranton W-10 P-03,Auditor General,,DEM,Nina Ahmad,32,32,8,3,75
+Lackawanna,Scranton W-10 P-03,Auditor General,,DEM,Christina M. Hartman,5,28,2,0,35
+Lackawanna,Scranton W-10 P-03,Auditor General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-10 P-03,State Treasurer,,DEM,Joe Torsella,59,123,25,2,209
+Lackawanna,Scranton W-10 P-03,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-10 P-03,U.S. House,8,DEM,Matt Cartwright,72,141,27,3,243
+Lackawanna,Scranton W-10 P-03,U.S. House,8,DEM,Write-in,2,3,0,0,5
+Lackawanna,Scranton W-10 P-03,General Assembly,112,DEM,Kyle J. Mullins,66,135,25,3,229
+Lackawanna,Scranton W-10 P-03,General Assembly,112,DEM,Write-in,3,2,0,0,5
+Lackawanna,Scranton W-10 P-03,President,,REP,Donald J. Trump,65,16,4,0,85
+Lackawanna,Scranton W-10 P-03,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-10 P-03,President,,REP,Bill Weld,2,1,0,0,3
+Lackawanna,Scranton W-10 P-03,President,,REP,Write-in,1,4,0,0,5
+Lackawanna,Scranton W-10 P-03,Attorney General,,REP,Heather Heidelbaugh,56,17,2,0,75
+Lackawanna,Scranton W-10 P-03,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-10 P-03,Auditor General,,REP,Timothy DeFoor,56,16,2,0,74
+Lackawanna,Scranton W-10 P-03,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-10 P-03,State Treasurer,,REP,Stacy L. Garrity,56,16,2,0,74
+Lackawanna,Scranton W-10 P-03,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-10 P-03,U.S. House,8,REP,Harry Haas,3,1,1,0,5
+Lackawanna,Scranton W-10 P-03,U.S. House,8,REP,Teddy Daniels,23,0,0,0,23
+Lackawanna,Scranton W-10 P-03,U.S. House,8,REP,Jim Bognet,13,1,0,0,14
+Lackawanna,Scranton W-10 P-03,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Scranton W-10 P-03,U.S. House,8,REP,Mike Marsicano,7,4,1,0,12
+Lackawanna,Scranton W-10 P-03,U.S. House,8,REP,Earl Granville,21,15,2,0,38
+Lackawanna,Scranton W-10 P-03,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-10 P-03,General Assembly,112,REP,Write-in,13,5,1,0,19
+Lackawanna,Scranton W-11 P-01,Registered Voters,,,,,,,,689
+Lackawanna,Scranton W-11 P-01,Registered Voters,,DEM,,,,,,514
+Lackawanna,Scranton W-11 P-01,Registered Voters,,REP,,,,,,175
+Lackawanna,Scranton W-11 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-11 P-01,Ballots Cast,,,,84,105,14,1,204
+Lackawanna,Scranton W-11 P-01,Ballots Cast,,DEM,,52,94,7,1,154
+Lackawanna,Scranton W-11 P-01,Ballots Cast,,REP,,32,11,7,0,50
+Lackawanna,Scranton W-11 P-01,President,,DEM,Bernie Sanders,8,5,0,0,13
+Lackawanna,Scranton W-11 P-01,President,,DEM,Joseph R. Biden,39,87,7,1,134
+Lackawanna,Scranton W-11 P-01,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Lackawanna,Scranton W-11 P-01,President,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-11 P-01,Attorney General,,DEM,Josh Shapiro,38,79,5,1,123
+Lackawanna,Scranton W-11 P-01,Attorney General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-11 P-01,Auditor General,,DEM,H. Scott Conklin,4,9,0,0,13
+Lackawanna,Scranton W-11 P-01,Auditor General,,DEM,Michael Lamb,1,10,1,0,12
+Lackawanna,Scranton W-11 P-01,Auditor General,,DEM,Tracie Fountain,2,8,0,0,10
+Lackawanna,Scranton W-11 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,4,31,2,0,37
+Lackawanna,Scranton W-11 P-01,Auditor General,,DEM,Nina Ahmad,29,11,1,1,42
+Lackawanna,Scranton W-11 P-01,Auditor General,,DEM,Christina M. Hartman,3,11,1,0,15
+Lackawanna,Scranton W-11 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-11 P-01,State Treasurer,,DEM,Joe Torsella,35,74,5,1,115
+Lackawanna,Scranton W-11 P-01,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-11 P-01,U.S. House,8,DEM,Matt Cartwright,48,85,5,1,139
+Lackawanna,Scranton W-11 P-01,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-11 P-01,General Assembly,112,DEM,Kyle J. Mullins,39,79,5,1,124
+Lackawanna,Scranton W-11 P-01,General Assembly,112,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-11 P-01,President,,REP,Donald J. Trump,27,8,6,0,41
+Lackawanna,Scranton W-11 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-11 P-01,President,,REP,Bill Weld,2,3,0,0,5
+Lackawanna,Scranton W-11 P-01,President,,REP,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-11 P-01,Attorney General,,REP,Heather Heidelbaugh,27,10,6,0,43
+Lackawanna,Scranton W-11 P-01,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-11 P-01,Auditor General,,REP,Timothy DeFoor,27,10,6,0,43
+Lackawanna,Scranton W-11 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-11 P-01,State Treasurer,,REP,Stacy L. Garrity,26,10,6,0,42
+Lackawanna,Scranton W-11 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-11 P-01,U.S. House,8,REP,Harry Haas,1,1,1,0,3
+Lackawanna,Scranton W-11 P-01,U.S. House,8,REP,Teddy Daniels,4,0,0,0,4
+Lackawanna,Scranton W-11 P-01,U.S. House,8,REP,Jim Bognet,8,4,0,0,12
+Lackawanna,Scranton W-11 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scranton W-11 P-01,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Scranton W-11 P-01,U.S. House,8,REP,Earl Granville,12,5,6,0,23
+Lackawanna,Scranton W-11 P-01,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-11 P-01,General Assembly,112,REP,Write-in,5,1,0,0,6
+Lackawanna,Scranton W-12 P-01,Registered Voters,,,,,,,,539
+Lackawanna,Scranton W-12 P-01,Registered Voters,,DEM,,,,,,417
+Lackawanna,Scranton W-12 P-01,Registered Voters,,REP,,,,,,122
+Lackawanna,Scranton W-12 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-12 P-01,Ballots Cast,,,,96,99,15,4,214
+Lackawanna,Scranton W-12 P-01,Ballots Cast,,DEM,,65,95,14,3,177
+Lackawanna,Scranton W-12 P-01,Ballots Cast,,REP,,31,4,1,1,37
+Lackawanna,Scranton W-12 P-01,President,,DEM,Bernie Sanders,13,11,4,1,29
+Lackawanna,Scranton W-12 P-01,President,,DEM,Joseph R. Biden,47,78,9,2,136
+Lackawanna,Scranton W-12 P-01,President,,DEM,Tulsi Gabbard,4,4,1,0,9
+Lackawanna,Scranton W-12 P-01,President,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-12 P-01,Attorney General,,DEM,Josh Shapiro,54,77,13,2,146
+Lackawanna,Scranton W-12 P-01,Attorney General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-12 P-01,Auditor General,,DEM,H. Scott Conklin,8,5,1,0,14
+Lackawanna,Scranton W-12 P-01,Auditor General,,DEM,Michael Lamb,13,7,0,0,20
+Lackawanna,Scranton W-12 P-01,Auditor General,,DEM,Tracie Fountain,1,8,1,0,10
+Lackawanna,Scranton W-12 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,11,33,1,2,47
+Lackawanna,Scranton W-12 P-01,Auditor General,,DEM,Nina Ahmad,17,13,4,0,34
+Lackawanna,Scranton W-12 P-01,Auditor General,,DEM,Christina M. Hartman,9,12,0,0,21
+Lackawanna,Scranton W-12 P-01,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-12 P-01,State Treasurer,,DEM,Joe Torsella,51,71,12,2,136
+Lackawanna,Scranton W-12 P-01,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-12 P-01,U.S. House,8,DEM,Matt Cartwright,59,83,13,2,157
+Lackawanna,Scranton W-12 P-01,U.S. House,8,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-12 P-01,General Assembly,112,DEM,Kyle J. Mullins,55,75,13,2,145
+Lackawanna,Scranton W-12 P-01,General Assembly,112,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-12 P-01,President,,REP,Donald J. Trump,31,2,1,1,35
+Lackawanna,Scranton W-12 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-12 P-01,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Scranton W-12 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-12 P-01,Attorney General,,REP,Heather Heidelbaugh,24,2,1,0,27
+Lackawanna,Scranton W-12 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-01,Auditor General,,REP,Timothy DeFoor,23,2,1,0,26
+Lackawanna,Scranton W-12 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-01,State Treasurer,,REP,Stacy L. Garrity,23,2,1,0,26
+Lackawanna,Scranton W-12 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-01,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Scranton W-12 P-01,U.S. House,8,REP,Teddy Daniels,6,0,0,0,6
+Lackawanna,Scranton W-12 P-01,U.S. House,8,REP,Jim Bognet,6,0,0,0,6
+Lackawanna,Scranton W-12 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-12 P-01,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Scranton W-12 P-01,U.S. House,8,REP,Earl Granville,12,3,1,1,17
+Lackawanna,Scranton W-12 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-01,General Assembly,112,REP,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-12 P-02,Registered Voters,,,,,,,,458
+Lackawanna,Scranton W-12 P-02,Registered Voters,,DEM,,,,,,356
+Lackawanna,Scranton W-12 P-02,Registered Voters,,REP,,,,,,102
+Lackawanna,Scranton W-12 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-12 P-02,Ballots Cast,,,,57,78,13,3,151
+Lackawanna,Scranton W-12 P-02,Ballots Cast,,DEM,,49,65,12,0,126
+Lackawanna,Scranton W-12 P-02,Ballots Cast,,REP,,8,13,1,3,25
+Lackawanna,Scranton W-12 P-02,President,,DEM,Bernie Sanders,13,17,1,0,31
+Lackawanna,Scranton W-12 P-02,President,,DEM,Joseph R. Biden,34,46,11,0,91
+Lackawanna,Scranton W-12 P-02,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Lackawanna,Scranton W-12 P-02,President,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-12 P-02,Attorney General,,DEM,Josh Shapiro,35,59,10,0,104
+Lackawanna,Scranton W-12 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,Auditor General,,DEM,H. Scott Conklin,3,1,0,0,4
+Lackawanna,Scranton W-12 P-02,Auditor General,,DEM,Michael Lamb,3,8,2,0,13
+Lackawanna,Scranton W-12 P-02,Auditor General,,DEM,Tracie Fountain,1,6,2,0,9
+Lackawanna,Scranton W-12 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,11,18,2,0,31
+Lackawanna,Scranton W-12 P-02,Auditor General,,DEM,Nina Ahmad,22,13,3,0,38
+Lackawanna,Scranton W-12 P-02,Auditor General,,DEM,Christina M. Hartman,3,8,1,0,12
+Lackawanna,Scranton W-12 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,State Treasurer,,DEM,Joe Torsella,33,53,10,0,96
+Lackawanna,Scranton W-12 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,U.S. House,8,DEM,Matt Cartwright,35,57,11,0,103
+Lackawanna,Scranton W-12 P-02,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-12 P-02,General Assembly,112,DEM,Kyle J. Mullins,35,59,10,0,104
+Lackawanna,Scranton W-12 P-02,General Assembly,112,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-12 P-02,President,,REP,Donald J. Trump,8,11,1,3,23
+Lackawanna,Scranton W-12 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Scranton W-12 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,Attorney General,,REP,Heather Heidelbaugh,6,12,1,3,22
+Lackawanna,Scranton W-12 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,Auditor General,,REP,Timothy DeFoor,6,12,1,3,22
+Lackawanna,Scranton W-12 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,State Treasurer,,REP,Stacy L. Garrity,5,12,1,3,21
+Lackawanna,Scranton W-12 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,U.S. House,8,REP,Teddy Daniels,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,U.S. House,8,REP,Jim Bognet,4,0,0,1,5
+Lackawanna,Scranton W-12 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,U.S. House,8,REP,Mike Marsicano,1,1,0,0,2
+Lackawanna,Scranton W-12 P-02,U.S. House,8,REP,Earl Granville,2,10,1,2,15
+Lackawanna,Scranton W-12 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-12 P-02,General Assembly,112,REP,Write-in,1,4,0,2,7
+Lackawanna,Scranton W-12 P-03,Registered Voters,,,,,,,,681
+Lackawanna,Scranton W-12 P-03,Registered Voters,,DEM,,,,,,490
+Lackawanna,Scranton W-12 P-03,Registered Voters,,REP,,,,,,191
+Lackawanna,Scranton W-12 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-12 P-03,Ballots Cast,,,,115,178,39,7,339
+Lackawanna,Scranton W-12 P-03,Ballots Cast,,DEM,,75,151,28,4,258
+Lackawanna,Scranton W-12 P-03,Ballots Cast,,REP,,40,27,11,3,81
+Lackawanna,Scranton W-12 P-03,President,,DEM,Bernie Sanders,11,15,2,0,28
+Lackawanna,Scranton W-12 P-03,President,,DEM,Joseph R. Biden,53,128,26,1,208
+Lackawanna,Scranton W-12 P-03,President,,DEM,Tulsi Gabbard,8,3,0,0,11
+Lackawanna,Scranton W-12 P-03,President,,DEM,Write-in,3,4,0,3,10
+Lackawanna,Scranton W-12 P-03,Attorney General,,DEM,Josh Shapiro,54,134,24,4,216
+Lackawanna,Scranton W-12 P-03,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-12 P-03,Auditor General,,DEM,H. Scott Conklin,3,11,1,0,15
+Lackawanna,Scranton W-12 P-03,Auditor General,,DEM,Michael Lamb,9,23,3,0,35
+Lackawanna,Scranton W-12 P-03,Auditor General,,DEM,Tracie Fountain,5,11,4,0,20
+Lackawanna,Scranton W-12 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,8,22,7,0,37
+Lackawanna,Scranton W-12 P-03,Auditor General,,DEM,Nina Ahmad,20,34,6,1,61
+Lackawanna,Scranton W-12 P-03,Auditor General,,DEM,Christina M. Hartman,7,18,3,1,29
+Lackawanna,Scranton W-12 P-03,Auditor General,,DEM,Write-in,1,1,1,0,3
+Lackawanna,Scranton W-12 P-03,State Treasurer,,DEM,Joe Torsella,44,127,24,2,197
+Lackawanna,Scranton W-12 P-03,State Treasurer,,DEM,Write-in,1,0,1,0,2
+Lackawanna,Scranton W-12 P-03,U.S. House,8,DEM,Matt Cartwright,62,140,27,1,230
+Lackawanna,Scranton W-12 P-03,U.S. House,8,DEM,Write-in,2,3,0,3,8
+Lackawanna,Scranton W-12 P-03,General Assembly,112,DEM,Kyle J. Mullins,52,137,25,2,216
+Lackawanna,Scranton W-12 P-03,General Assembly,112,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-12 P-03,President,,REP,Donald J. Trump,38,15,4,3,60
+Lackawanna,Scranton W-12 P-03,President,,REP,Roque Rocky De La Fuente,1,2,1,0,4
+Lackawanna,Scranton W-12 P-03,President,,REP,Bill Weld,0,5,2,0,7
+Lackawanna,Scranton W-12 P-03,President,,REP,Write-in,1,4,2,0,7
+Lackawanna,Scranton W-12 P-03,Attorney General,,REP,Heather Heidelbaugh,33,24,10,3,70
+Lackawanna,Scranton W-12 P-03,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-12 P-03,Auditor General,,REP,Timothy DeFoor,30,23,9,3,65
+Lackawanna,Scranton W-12 P-03,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-12 P-03,State Treasurer,,REP,Stacy L. Garrity,30,24,10,3,67
+Lackawanna,Scranton W-12 P-03,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-12 P-03,U.S. House,8,REP,Harry Haas,0,0,0,1,1
+Lackawanna,Scranton W-12 P-03,U.S. House,8,REP,Teddy Daniels,10,2,1,1,14
+Lackawanna,Scranton W-12 P-03,U.S. House,8,REP,Jim Bognet,10,2,0,1,13
+Lackawanna,Scranton W-12 P-03,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-12 P-03,U.S. House,8,REP,Mike Marsicano,2,1,0,0,3
+Lackawanna,Scranton W-12 P-03,U.S. House,8,REP,Earl Granville,16,21,9,0,46
+Lackawanna,Scranton W-12 P-03,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-12 P-03,General Assembly,112,REP,Write-in,1,8,1,3,13
+Lackawanna,Scranton W-13 P-01,Registered Voters,,,,,,,,935
+Lackawanna,Scranton W-13 P-01,Registered Voters,,DEM,,,,,,689
+Lackawanna,Scranton W-13 P-01,Registered Voters,,REP,,,,,,246
+Lackawanna,Scranton W-13 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-13 P-01,Ballots Cast,,,,145,181,48,2,376
+Lackawanna,Scranton W-13 P-01,Ballots Cast,,DEM,,97,152,40,2,291
+Lackawanna,Scranton W-13 P-01,Ballots Cast,,REP,,48,29,8,0,85
+Lackawanna,Scranton W-13 P-01,President,,DEM,Bernie Sanders,23,11,3,0,37
+Lackawanna,Scranton W-13 P-01,President,,DEM,Joseph R. Biden,60,136,34,2,232
+Lackawanna,Scranton W-13 P-01,President,,DEM,Tulsi Gabbard,5,4,0,0,9
+Lackawanna,Scranton W-13 P-01,President,,DEM,Write-in,5,0,2,0,7
+Lackawanna,Scranton W-13 P-01,Attorney General,,DEM,Josh Shapiro,78,137,31,1,247
+Lackawanna,Scranton W-13 P-01,Attorney General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-13 P-01,Auditor General,,DEM,H. Scott Conklin,4,11,0,0,15
+Lackawanna,Scranton W-13 P-01,Auditor General,,DEM,Michael Lamb,18,18,7,0,43
+Lackawanna,Scranton W-13 P-01,Auditor General,,DEM,Tracie Fountain,5,8,1,0,14
+Lackawanna,Scranton W-13 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,12,37,8,0,57
+Lackawanna,Scranton W-13 P-01,Auditor General,,DEM,Nina Ahmad,27,23,10,2,62
+Lackawanna,Scranton W-13 P-01,Auditor General,,DEM,Christina M. Hartman,5,18,7,0,30
+Lackawanna,Scranton W-13 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-13 P-01,State Treasurer,,DEM,Joe Torsella,75,119,36,0,230
+Lackawanna,Scranton W-13 P-01,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-13 P-01,U.S. House,8,DEM,Matt Cartwright,81,143,39,1,264
+Lackawanna,Scranton W-13 P-01,U.S. House,8,DEM,Write-in,4,0,0,0,4
+Lackawanna,Scranton W-13 P-01,General Assembly,113,DEM,Marty Flynn,75,138,33,1,247
+Lackawanna,Scranton W-13 P-01,General Assembly,113,DEM,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-13 P-01,President,,REP,Donald J. Trump,42,23,7,0,72
+Lackawanna,Scranton W-13 P-01,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Lackawanna,Scranton W-13 P-01,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Scranton W-13 P-01,President,,REP,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-13 P-01,Attorney General,,REP,Heather Heidelbaugh,36,27,8,0,71
+Lackawanna,Scranton W-13 P-01,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-13 P-01,Auditor General,,REP,Timothy DeFoor,33,27,8,0,68
+Lackawanna,Scranton W-13 P-01,Auditor General,,REP,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-13 P-01,State Treasurer,,REP,Stacy L. Garrity,36,27,8,0,71
+Lackawanna,Scranton W-13 P-01,State Treasurer,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-13 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-13 P-01,U.S. House,8,REP,Teddy Daniels,10,3,0,0,13
+Lackawanna,Scranton W-13 P-01,U.S. House,8,REP,Jim Bognet,7,7,1,0,15
+Lackawanna,Scranton W-13 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scranton W-13 P-01,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Scranton W-13 P-01,U.S. House,8,REP,Earl Granville,22,18,7,0,47
+Lackawanna,Scranton W-13 P-01,U.S. House,8,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-13 P-01,General Assembly,113,REP,William Kresge,42,28,8,0,78
+Lackawanna,Scranton W-13 P-01,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-13 P-02,Registered Voters,,,,,,,,466
+Lackawanna,Scranton W-13 P-02,Registered Voters,,DEM,,,,,,352
+Lackawanna,Scranton W-13 P-02,Registered Voters,,REP,,,,,,114
+Lackawanna,Scranton W-13 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-13 P-02,Ballots Cast,,,,67,111,23,1,202
+Lackawanna,Scranton W-13 P-02,Ballots Cast,,DEM,,45,96,22,1,164
+Lackawanna,Scranton W-13 P-02,Ballots Cast,,REP,,22,15,1,0,38
+Lackawanna,Scranton W-13 P-02,President,,DEM,Bernie Sanders,9,10,2,1,22
+Lackawanna,Scranton W-13 P-02,President,,DEM,Joseph R. Biden,30,83,19,0,132
+Lackawanna,Scranton W-13 P-02,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Lackawanna,Scranton W-13 P-02,President,,DEM,Write-in,2,1,1,0,4
+Lackawanna,Scranton W-13 P-02,Attorney General,,DEM,Josh Shapiro,35,79,21,1,136
+Lackawanna,Scranton W-13 P-02,Attorney General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-13 P-02,Auditor General,,DEM,H. Scott Conklin,0,6,0,0,6
+Lackawanna,Scranton W-13 P-02,Auditor General,,DEM,Michael Lamb,4,12,1,0,17
+Lackawanna,Scranton W-13 P-02,Auditor General,,DEM,Tracie Fountain,4,7,3,0,14
+Lackawanna,Scranton W-13 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,7,25,4,1,37
+Lackawanna,Scranton W-13 P-02,Auditor General,,DEM,Nina Ahmad,15,14,8,0,37
+Lackawanna,Scranton W-13 P-02,Auditor General,,DEM,Christina M. Hartman,5,7,4,0,16
+Lackawanna,Scranton W-13 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-13 P-02,State Treasurer,,DEM,Joe Torsella,32,77,20,1,130
+Lackawanna,Scranton W-13 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-13 P-02,U.S. House,8,DEM,Matt Cartwright,38,88,22,1,149
+Lackawanna,Scranton W-13 P-02,U.S. House,8,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-13 P-02,General Assembly,113,DEM,Marty Flynn,36,80,20,0,136
+Lackawanna,Scranton W-13 P-02,General Assembly,113,DEM,Write-in,2,3,2,0,7
+Lackawanna,Scranton W-13 P-02,President,,REP,Donald J. Trump,21,8,1,0,30
+Lackawanna,Scranton W-13 P-02,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Scranton W-13 P-02,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Scranton W-13 P-02,President,,REP,Write-in,0,4,0,0,4
+Lackawanna,Scranton W-13 P-02,Attorney General,,REP,Heather Heidelbaugh,17,13,1,0,31
+Lackawanna,Scranton W-13 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-13 P-02,Auditor General,,REP,Timothy DeFoor,17,13,1,0,31
+Lackawanna,Scranton W-13 P-02,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-13 P-02,State Treasurer,,REP,Stacy L. Garrity,17,13,1,0,31
+Lackawanna,Scranton W-13 P-02,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-13 P-02,U.S. House,8,REP,Harry Haas,0,1,0,0,1
+Lackawanna,Scranton W-13 P-02,U.S. House,8,REP,Teddy Daniels,1,0,0,0,1
+Lackawanna,Scranton W-13 P-02,U.S. House,8,REP,Jim Bognet,5,2,1,0,8
+Lackawanna,Scranton W-13 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-13 P-02,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Scranton W-13 P-02,U.S. House,8,REP,Earl Granville,13,11,0,0,24
+Lackawanna,Scranton W-13 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-13 P-02,General Assembly,113,REP,William Kresge,19,14,1,0,34
+Lackawanna,Scranton W-13 P-02,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,Registered Voters,,,,,,,,496
+Lackawanna,Scranton W-14 P-01,Registered Voters,,DEM,,,,,,371
+Lackawanna,Scranton W-14 P-01,Registered Voters,,REP,,,,,,125
+Lackawanna,Scranton W-14 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-14 P-01,Ballots Cast,,,,46,54,10,0,110
+Lackawanna,Scranton W-14 P-01,Ballots Cast,,DEM,,31,51,9,0,91
+Lackawanna,Scranton W-14 P-01,Ballots Cast,,REP,,15,3,1,0,19
+Lackawanna,Scranton W-14 P-01,President,,DEM,Bernie Sanders,5,9,4,0,18
+Lackawanna,Scranton W-14 P-01,President,,DEM,Joseph R. Biden,22,41,5,0,68
+Lackawanna,Scranton W-14 P-01,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Scranton W-14 P-01,President,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-14 P-01,Attorney General,,DEM,Josh Shapiro,26,46,9,0,81
+Lackawanna,Scranton W-14 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,Auditor General,,DEM,H. Scott Conklin,2,3,0,0,5
+Lackawanna,Scranton W-14 P-01,Auditor General,,DEM,Michael Lamb,5,6,1,0,12
+Lackawanna,Scranton W-14 P-01,Auditor General,,DEM,Tracie Fountain,1,6,2,0,9
+Lackawanna,Scranton W-14 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,5,8,4,0,17
+Lackawanna,Scranton W-14 P-01,Auditor General,,DEM,Nina Ahmad,8,12,1,0,21
+Lackawanna,Scranton W-14 P-01,Auditor General,,DEM,Christina M. Hartman,5,8,0,0,13
+Lackawanna,Scranton W-14 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,State Treasurer,,DEM,Joe Torsella,23,44,9,0,76
+Lackawanna,Scranton W-14 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,U.S. House,8,DEM,Matt Cartwright,28,49,9,0,86
+Lackawanna,Scranton W-14 P-01,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-14 P-01,General Assembly,113,DEM,Marty Flynn,28,44,9,0,81
+Lackawanna,Scranton W-14 P-01,General Assembly,113,DEM,Write-in,1,4,0,0,5
+Lackawanna,Scranton W-14 P-01,President,,REP,Donald J. Trump,13,2,0,0,15
+Lackawanna,Scranton W-14 P-01,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Scranton W-14 P-01,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Scranton W-14 P-01,President,,REP,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-14 P-01,Attorney General,,REP,Heather Heidelbaugh,9,1,1,0,11
+Lackawanna,Scranton W-14 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,Auditor General,,REP,Timothy DeFoor,8,1,1,0,10
+Lackawanna,Scranton W-14 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,State Treasurer,,REP,Stacy L. Garrity,8,1,1,0,10
+Lackawanna,Scranton W-14 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Scranton W-14 P-01,U.S. House,8,REP,Teddy Daniels,6,0,0,0,6
+Lackawanna,Scranton W-14 P-01,U.S. House,8,REP,Jim Bognet,2,0,0,0,2
+Lackawanna,Scranton W-14 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,U.S. House,8,REP,Mike Marsicano,1,0,0,0,1
+Lackawanna,Scranton W-14 P-01,U.S. House,8,REP,Earl Granville,3,2,1,0,6
+Lackawanna,Scranton W-14 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-14 P-01,General Assembly,113,REP,William Kresge,9,1,1,0,11
+Lackawanna,Scranton W-14 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-15 P-01,Registered Voters,,,,,,,,714
+Lackawanna,Scranton W-15 P-01,Registered Voters,,DEM,,,,,,510
+Lackawanna,Scranton W-15 P-01,Registered Voters,,REP,,,,,,204
+Lackawanna,Scranton W-15 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-15 P-01,Ballots Cast,,,,96,143,24,1,264
+Lackawanna,Scranton W-15 P-01,Ballots Cast,,DEM,,67,114,19,0,200
+Lackawanna,Scranton W-15 P-01,Ballots Cast,,REP,,29,29,5,1,64
+Lackawanna,Scranton W-15 P-01,President,,DEM,Bernie Sanders,7,16,1,0,24
+Lackawanna,Scranton W-15 P-01,President,,DEM,Joseph R. Biden,53,95,15,0,163
+Lackawanna,Scranton W-15 P-01,President,,DEM,Tulsi Gabbard,0,1,2,0,3
+Lackawanna,Scranton W-15 P-01,President,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-15 P-01,Attorney General,,DEM,Josh Shapiro,51,95,16,0,162
+Lackawanna,Scranton W-15 P-01,Attorney General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-15 P-01,Auditor General,,DEM,H. Scott Conklin,1,10,0,0,11
+Lackawanna,Scranton W-15 P-01,Auditor General,,DEM,Michael Lamb,10,16,4,0,30
+Lackawanna,Scranton W-15 P-01,Auditor General,,DEM,Tracie Fountain,2,10,1,0,13
+Lackawanna,Scranton W-15 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,17,25,4,0,46
+Lackawanna,Scranton W-15 P-01,Auditor General,,DEM,Nina Ahmad,10,16,3,0,29
+Lackawanna,Scranton W-15 P-01,Auditor General,,DEM,Christina M. Hartman,10,13,4,0,27
+Lackawanna,Scranton W-15 P-01,Auditor General,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-15 P-01,State Treasurer,,DEM,Joe Torsella,45,91,15,0,151
+Lackawanna,Scranton W-15 P-01,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-15 P-01,U.S. House,8,DEM,Matt Cartwright,60,107,17,0,184
+Lackawanna,Scranton W-15 P-01,U.S. House,8,DEM,Write-in,0,3,0,0,3
+Lackawanna,Scranton W-15 P-01,General Assembly,113,DEM,Marty Flynn,57,102,17,0,176
+Lackawanna,Scranton W-15 P-01,General Assembly,113,DEM,Write-in,2,3,1,0,6
+Lackawanna,Scranton W-15 P-01,President,,REP,Donald J. Trump,27,27,2,1,57
+Lackawanna,Scranton W-15 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-15 P-01,President,,REP,Bill Weld,1,1,2,0,4
+Lackawanna,Scranton W-15 P-01,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-15 P-01,Attorney General,,REP,Heather Heidelbaugh,22,25,1,1,49
+Lackawanna,Scranton W-15 P-01,Attorney General,,REP,Write-in,0,0,2,0,2
+Lackawanna,Scranton W-15 P-01,Auditor General,,REP,Timothy DeFoor,23,25,2,1,51
+Lackawanna,Scranton W-15 P-01,Auditor General,,REP,Write-in,0,0,2,0,2
+Lackawanna,Scranton W-15 P-01,State Treasurer,,REP,Stacy L. Garrity,21,26,3,1,51
+Lackawanna,Scranton W-15 P-01,State Treasurer,,REP,Write-in,0,0,2,0,2
+Lackawanna,Scranton W-15 P-01,U.S. House,8,REP,Harry Haas,1,1,0,0,2
+Lackawanna,Scranton W-15 P-01,U.S. House,8,REP,Teddy Daniels,8,2,0,1,11
+Lackawanna,Scranton W-15 P-01,U.S. House,8,REP,Jim Bognet,6,6,1,0,13
+Lackawanna,Scranton W-15 P-01,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Scranton W-15 P-01,U.S. House,8,REP,Mike Marsicano,5,0,0,0,5
+Lackawanna,Scranton W-15 P-01,U.S. House,8,REP,Earl Granville,9,18,2,0,29
+Lackawanna,Scranton W-15 P-01,U.S. House,8,REP,Write-in,0,0,2,0,2
+Lackawanna,Scranton W-15 P-01,General Assembly,113,REP,William Kresge,26,27,3,1,57
+Lackawanna,Scranton W-15 P-01,General Assembly,113,REP,Write-in,0,0,2,0,2
+Lackawanna,Scranton W-15 P-02,Registered Voters,,,,,,,,791
+Lackawanna,Scranton W-15 P-02,Registered Voters,,DEM,,,,,,603
+Lackawanna,Scranton W-15 P-02,Registered Voters,,REP,,,,,,188
+Lackawanna,Scranton W-15 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-15 P-02,Ballots Cast,,,,102,137,26,1,266
+Lackawanna,Scranton W-15 P-02,Ballots Cast,,DEM,,65,121,25,0,211
+Lackawanna,Scranton W-15 P-02,Ballots Cast,,REP,,37,16,1,1,55
+Lackawanna,Scranton W-15 P-02,President,,DEM,Bernie Sanders,9,9,2,0,20
+Lackawanna,Scranton W-15 P-02,President,,DEM,Joseph R. Biden,44,109,23,0,176
+Lackawanna,Scranton W-15 P-02,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Lackawanna,Scranton W-15 P-02,President,,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-15 P-02,Attorney General,,DEM,Josh Shapiro,44,103,21,0,168
+Lackawanna,Scranton W-15 P-02,Attorney General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-15 P-02,Auditor General,,DEM,H. Scott Conklin,2,12,0,0,14
+Lackawanna,Scranton W-15 P-02,Auditor General,,DEM,Michael Lamb,8,20,4,0,32
+Lackawanna,Scranton W-15 P-02,Auditor General,,DEM,Tracie Fountain,1,3,0,0,4
+Lackawanna,Scranton W-15 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,8,29,6,0,43
+Lackawanna,Scranton W-15 P-02,Auditor General,,DEM,Nina Ahmad,16,16,3,0,35
+Lackawanna,Scranton W-15 P-02,Auditor General,,DEM,Christina M. Hartman,12,13,2,0,27
+Lackawanna,Scranton W-15 P-02,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-15 P-02,State Treasurer,,DEM,Joe Torsella,42,99,18,0,159
+Lackawanna,Scranton W-15 P-02,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-15 P-02,U.S. House,8,DEM,Matt Cartwright,55,111,22,0,188
+Lackawanna,Scranton W-15 P-02,U.S. House,8,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-15 P-02,General Assembly,113,DEM,Marty Flynn,57,107,24,0,188
+Lackawanna,Scranton W-15 P-02,General Assembly,113,DEM,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-15 P-02,President,,REP,Donald J. Trump,34,13,1,1,49
+Lackawanna,Scranton W-15 P-02,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-15 P-02,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Scranton W-15 P-02,President,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-15 P-02,Attorney General,,REP,Heather Heidelbaugh,22,13,1,0,36
+Lackawanna,Scranton W-15 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-15 P-02,Auditor General,,REP,Timothy DeFoor,23,13,1,0,37
+Lackawanna,Scranton W-15 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-15 P-02,State Treasurer,,REP,Stacy L. Garrity,24,13,1,0,38
+Lackawanna,Scranton W-15 P-02,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-15 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-15 P-02,U.S. House,8,REP,Teddy Daniels,8,3,1,0,12
+Lackawanna,Scranton W-15 P-02,U.S. House,8,REP,Jim Bognet,8,7,0,1,16
+Lackawanna,Scranton W-15 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-15 P-02,U.S. House,8,REP,Mike Marsicano,7,1,0,0,8
+Lackawanna,Scranton W-15 P-02,U.S. House,8,REP,Earl Granville,13,5,0,0,18
+Lackawanna,Scranton W-15 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-15 P-02,General Assembly,113,REP,William Kresge,28,12,1,0,41
+Lackawanna,Scranton W-15 P-02,General Assembly,113,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-16 P-01,Registered Voters,,,,,,,,857
+Lackawanna,Scranton W-16 P-01,Registered Voters,,DEM,,,,,,616
+Lackawanna,Scranton W-16 P-01,Registered Voters,,REP,,,,,,241
+Lackawanna,Scranton W-16 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-16 P-01,Ballots Cast,,,,58,102,84,3,247
+Lackawanna,Scranton W-16 P-01,Ballots Cast,,DEM,,43,92,56,2,193
+Lackawanna,Scranton W-16 P-01,Ballots Cast,,REP,,15,10,28,1,54
+Lackawanna,Scranton W-16 P-01,President,,DEM,Bernie Sanders,10,15,5,0,30
+Lackawanna,Scranton W-16 P-01,President,,DEM,Joseph R. Biden,30,74,46,2,152
+Lackawanna,Scranton W-16 P-01,President,,DEM,Tulsi Gabbard,0,1,2,0,3
+Lackawanna,Scranton W-16 P-01,President,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-16 P-01,Attorney General,,DEM,Josh Shapiro,25,79,45,2,151
+Lackawanna,Scranton W-16 P-01,Attorney General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-16 P-01,Auditor General,,DEM,H. Scott Conklin,3,10,6,0,19
+Lackawanna,Scranton W-16 P-01,Auditor General,,DEM,Michael Lamb,2,12,7,0,21
+Lackawanna,Scranton W-16 P-01,Auditor General,,DEM,Tracie Fountain,1,2,1,0,4
+Lackawanna,Scranton W-16 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,4,14,10,0,28
+Lackawanna,Scranton W-16 P-01,Auditor General,,DEM,Nina Ahmad,20,26,14,2,62
+Lackawanna,Scranton W-16 P-01,Auditor General,,DEM,Christina M. Hartman,3,14,8,0,25
+Lackawanna,Scranton W-16 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-16 P-01,State Treasurer,,DEM,Joe Torsella,28,80,40,2,150
+Lackawanna,Scranton W-16 P-01,State Treasurer,,DEM,Write-in,0,1,1,0,2
+Lackawanna,Scranton W-16 P-01,U.S. House,8,DEM,Matt Cartwright,35,86,48,2,171
+Lackawanna,Scranton W-16 P-01,U.S. House,8,DEM,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-16 P-01,General Assembly,113,DEM,Marty Flynn,31,82,52,2,167
+Lackawanna,Scranton W-16 P-01,General Assembly,113,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-16 P-01,President,,REP,Donald J. Trump,13,7,23,1,44
+Lackawanna,Scranton W-16 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-16 P-01,President,,REP,Bill Weld,1,1,1,0,3
+Lackawanna,Scranton W-16 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-16 P-01,Attorney General,,REP,Heather Heidelbaugh,12,7,18,1,38
+Lackawanna,Scranton W-16 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-16 P-01,Auditor General,,REP,Timothy DeFoor,10,8,17,1,36
+Lackawanna,Scranton W-16 P-01,Auditor General,,REP,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-16 P-01,State Treasurer,,REP,Stacy L. Garrity,11,8,19,1,39
+Lackawanna,Scranton W-16 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-16 P-01,U.S. House,8,REP,Harry Haas,0,0,1,0,1
+Lackawanna,Scranton W-16 P-01,U.S. House,8,REP,Teddy Daniels,3,0,0,1,4
+Lackawanna,Scranton W-16 P-01,U.S. House,8,REP,Jim Bognet,5,4,2,0,11
+Lackawanna,Scranton W-16 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-16 P-01,U.S. House,8,REP,Mike Marsicano,2,0,3,0,5
+Lackawanna,Scranton W-16 P-01,U.S. House,8,REP,Earl Granville,3,6,13,0,22
+Lackawanna,Scranton W-16 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-16 P-01,General Assembly,113,REP,William Kresge,10,9,19,1,39
+Lackawanna,Scranton W-16 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-01,Registered Voters,,,,,,,,997
+Lackawanna,Scranton W-17 P-01,Registered Voters,,DEM,,,,,,771
+Lackawanna,Scranton W-17 P-01,Registered Voters,,REP,,,,,,226
+Lackawanna,Scranton W-17 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-17 P-01,Ballots Cast,,,,132,153,39,3,327
+Lackawanna,Scranton W-17 P-01,Ballots Cast,,DEM,,88,128,36,3,255
+Lackawanna,Scranton W-17 P-01,Ballots Cast,,REP,,44,25,3,0,72
+Lackawanna,Scranton W-17 P-01,President,,DEM,Bernie Sanders,26,17,10,1,54
+Lackawanna,Scranton W-17 P-01,President,,DEM,Joseph R. Biden,60,104,24,2,190
+Lackawanna,Scranton W-17 P-01,President,,DEM,Tulsi Gabbard,0,4,2,0,6
+Lackawanna,Scranton W-17 P-01,President,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-17 P-01,Attorney General,,DEM,Josh Shapiro,61,108,31,2,202
+Lackawanna,Scranton W-17 P-01,Attorney General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-17 P-01,Auditor General,,DEM,H. Scott Conklin,2,3,3,0,8
+Lackawanna,Scranton W-17 P-01,Auditor General,,DEM,Michael Lamb,14,14,2,1,31
+Lackawanna,Scranton W-17 P-01,Auditor General,,DEM,Tracie Fountain,4,13,2,0,19
+Lackawanna,Scranton W-17 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,11,21,8,0,40
+Lackawanna,Scranton W-17 P-01,Auditor General,,DEM,Nina Ahmad,36,28,12,2,78
+Lackawanna,Scranton W-17 P-01,Auditor General,,DEM,Christina M. Hartman,6,26,5,0,37
+Lackawanna,Scranton W-17 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-01,State Treasurer,,DEM,Joe Torsella,60,101,31,2,194
+Lackawanna,Scranton W-17 P-01,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-17 P-01,U.S. House,8,DEM,Matt Cartwright,66,128,35,3,232
+Lackawanna,Scranton W-17 P-01,U.S. House,8,DEM,Write-in,5,0,0,0,5
+Lackawanna,Scranton W-17 P-01,General Assembly,112,DEM,Kyle J. Mullins,63,109,29,3,204
+Lackawanna,Scranton W-17 P-01,General Assembly,112,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-17 P-01,President,,REP,Donald J. Trump,38,16,3,0,57
+Lackawanna,Scranton W-17 P-01,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Scranton W-17 P-01,President,,REP,Bill Weld,2,4,0,0,6
+Lackawanna,Scranton W-17 P-01,President,,REP,Write-in,1,4,0,0,5
+Lackawanna,Scranton W-17 P-01,Attorney General,,REP,Heather Heidelbaugh,36,21,3,0,60
+Lackawanna,Scranton W-17 P-01,Attorney General,,REP,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-17 P-01,Auditor General,,REP,Timothy DeFoor,36,20,3,0,59
+Lackawanna,Scranton W-17 P-01,Auditor General,,REP,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-17 P-01,State Treasurer,,REP,Stacy L. Garrity,32,20,3,0,55
+Lackawanna,Scranton W-17 P-01,State Treasurer,,REP,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-17 P-01,U.S. House,8,REP,Harry Haas,2,2,1,0,5
+Lackawanna,Scranton W-17 P-01,U.S. House,8,REP,Teddy Daniels,8,0,0,0,8
+Lackawanna,Scranton W-17 P-01,U.S. House,8,REP,Jim Bognet,13,1,0,0,14
+Lackawanna,Scranton W-17 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-17 P-01,U.S. House,8,REP,Mike Marsicano,6,1,0,0,7
+Lackawanna,Scranton W-17 P-01,U.S. House,8,REP,Earl Granville,12,17,2,0,31
+Lackawanna,Scranton W-17 P-01,U.S. House,8,REP,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-17 P-01,General Assembly,112,REP,Write-in,8,8,0,0,16
+Lackawanna,Scranton W-17 P-02,Registered Voters,,,,,,,,1003
+Lackawanna,Scranton W-17 P-02,Registered Voters,,DEM,,,,,,607
+Lackawanna,Scranton W-17 P-02,Registered Voters,,REP,,,,,,396
+Lackawanna,Scranton W-17 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-17 P-02,Ballots Cast,,,,29,97,21,0,147
+Lackawanna,Scranton W-17 P-02,Ballots Cast,,DEM,,17,81,19,0,117
+Lackawanna,Scranton W-17 P-02,Ballots Cast,,REP,,12,16,2,0,30
+Lackawanna,Scranton W-17 P-02,President,,DEM,Bernie Sanders,8,9,7,0,24
+Lackawanna,Scranton W-17 P-02,President,,DEM,Joseph R. Biden,8,70,11,0,89
+Lackawanna,Scranton W-17 P-02,President,,DEM,Tulsi Gabbard,0,2,1,0,3
+Lackawanna,Scranton W-17 P-02,President,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,Attorney General,,DEM,Josh Shapiro,15,71,18,0,104
+Lackawanna,Scranton W-17 P-02,Attorney General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-17 P-02,Auditor General,,DEM,H. Scott Conklin,1,5,1,0,7
+Lackawanna,Scranton W-17 P-02,Auditor General,,DEM,Michael Lamb,0,10,0,0,10
+Lackawanna,Scranton W-17 P-02,Auditor General,,DEM,Tracie Fountain,1,5,2,0,8
+Lackawanna,Scranton W-17 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,2,17,4,0,23
+Lackawanna,Scranton W-17 P-02,Auditor General,,DEM,Nina Ahmad,8,23,5,0,36
+Lackawanna,Scranton W-17 P-02,Auditor General,,DEM,Christina M. Hartman,2,10,2,0,14
+Lackawanna,Scranton W-17 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,State Treasurer,,DEM,Joe Torsella,13,69,17,0,99
+Lackawanna,Scranton W-17 P-02,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,U.S. House,8,DEM,Matt Cartwright,16,78,16,0,110
+Lackawanna,Scranton W-17 P-02,U.S. House,8,DEM,Write-in,0,1,1,0,2
+Lackawanna,Scranton W-17 P-02,General Assembly,112,DEM,Kyle J. Mullins,13,72,15,0,100
+Lackawanna,Scranton W-17 P-02,General Assembly,112,DEM,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-17 P-02,President,,REP,Donald J. Trump,12,15,1,0,28
+Lackawanna,Scranton W-17 P-02,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Scranton W-17 P-02,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,Attorney General,,REP,Heather Heidelbaugh,11,14,2,0,27
+Lackawanna,Scranton W-17 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,Auditor General,,REP,Timothy DeFoor,11,13,2,0,26
+Lackawanna,Scranton W-17 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,State Treasurer,,REP,Stacy L. Garrity,11,12,2,0,25
+Lackawanna,Scranton W-17 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,U.S. House,8,REP,Harry Haas,0,1,1,0,2
+Lackawanna,Scranton W-17 P-02,U.S. House,8,REP,Teddy Daniels,2,1,0,0,3
+Lackawanna,Scranton W-17 P-02,U.S. House,8,REP,Jim Bognet,2,2,0,0,4
+Lackawanna,Scranton W-17 P-02,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scranton W-17 P-02,U.S. House,8,REP,Mike Marsicano,2,1,0,0,3
+Lackawanna,Scranton W-17 P-02,U.S. House,8,REP,Earl Granville,5,10,1,0,16
+Lackawanna,Scranton W-17 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-17 P-02,General Assembly,112,REP,Write-in,1,2,1,0,4
+Lackawanna,Scranton W-19 P-01,Registered Voters,,,,,,,,846
+Lackawanna,Scranton W-19 P-01,Registered Voters,,DEM,,,,,,628
+Lackawanna,Scranton W-19 P-01,Registered Voters,,REP,,,,,,218
+Lackawanna,Scranton W-19 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-19 P-01,Ballots Cast,,,,110,101,22,2,235
+Lackawanna,Scranton W-19 P-01,Ballots Cast,,DEM,,80,79,18,2,179
+Lackawanna,Scranton W-19 P-01,Ballots Cast,,REP,,30,22,4,0,56
+Lackawanna,Scranton W-19 P-01,President,,DEM,Bernie Sanders,17,5,1,2,25
+Lackawanna,Scranton W-19 P-01,President,,DEM,Joseph R. Biden,55,68,16,0,139
+Lackawanna,Scranton W-19 P-01,President,,DEM,Tulsi Gabbard,3,3,0,0,6
+Lackawanna,Scranton W-19 P-01,President,,DEM,Write-in,4,2,0,0,6
+Lackawanna,Scranton W-19 P-01,Attorney General,,DEM,Josh Shapiro,71,65,16,2,154
+Lackawanna,Scranton W-19 P-01,Attorney General,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-19 P-01,Auditor General,,DEM,H. Scott Conklin,7,7,0,0,14
+Lackawanna,Scranton W-19 P-01,Auditor General,,DEM,Michael Lamb,12,7,2,1,22
+Lackawanna,Scranton W-19 P-01,Auditor General,,DEM,Tracie Fountain,1,7,4,0,12
+Lackawanna,Scranton W-19 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,10,17,7,0,34
+Lackawanna,Scranton W-19 P-01,Auditor General,,DEM,Nina Ahmad,27,17,2,1,47
+Lackawanna,Scranton W-19 P-01,Auditor General,,DEM,Christina M. Hartman,14,12,2,0,28
+Lackawanna,Scranton W-19 P-01,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-19 P-01,State Treasurer,,DEM,Joe Torsella,67,62,16,2,147
+Lackawanna,Scranton W-19 P-01,State Treasurer,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-19 P-01,U.S. House,8,DEM,Matt Cartwright,76,70,14,2,162
+Lackawanna,Scranton W-19 P-01,U.S. House,8,DEM,Write-in,3,2,2,0,7
+Lackawanna,Scranton W-19 P-01,General Assembly,112,DEM,Kyle J. Mullins,72,68,16,2,158
+Lackawanna,Scranton W-19 P-01,General Assembly,112,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-19 P-01,President,,REP,Donald J. Trump,28,19,3,0,50
+Lackawanna,Scranton W-19 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-19 P-01,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Scranton W-19 P-01,President,,REP,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-19 P-01,Attorney General,,REP,Heather Heidelbaugh,20,16,3,0,39
+Lackawanna,Scranton W-19 P-01,Attorney General,,REP,Write-in,1,0,1,0,2
+Lackawanna,Scranton W-19 P-01,Auditor General,,REP,Timothy DeFoor,21,15,3,0,39
+Lackawanna,Scranton W-19 P-01,Auditor General,,REP,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-19 P-01,State Treasurer,,REP,Stacy L. Garrity,20,15,3,0,38
+Lackawanna,Scranton W-19 P-01,State Treasurer,,REP,Write-in,1,0,1,0,2
+Lackawanna,Scranton W-19 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-19 P-01,U.S. House,8,REP,Teddy Daniels,5,3,0,0,8
+Lackawanna,Scranton W-19 P-01,U.S. House,8,REP,Jim Bognet,5,7,1,0,13
+Lackawanna,Scranton W-19 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-19 P-01,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Scranton W-19 P-01,U.S. House,8,REP,Earl Granville,17,11,2,0,30
+Lackawanna,Scranton W-19 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-01,General Assembly,112,REP,Write-in,2,4,1,0,7
+Lackawanna,Scranton W-19 P-02,Registered Voters,,,,,,,,657
+Lackawanna,Scranton W-19 P-02,Registered Voters,,DEM,,,,,,481
+Lackawanna,Scranton W-19 P-02,Registered Voters,,REP,,,,,,176
+Lackawanna,Scranton W-19 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-19 P-02,Ballots Cast,,,,124,117,23,7,271
+Lackawanna,Scranton W-19 P-02,Ballots Cast,,DEM,,77,97,18,4,196
+Lackawanna,Scranton W-19 P-02,Ballots Cast,,REP,,47,20,5,3,75
+Lackawanna,Scranton W-19 P-02,President,,DEM,Bernie Sanders,15,14,5,2,36
+Lackawanna,Scranton W-19 P-02,President,,DEM,Joseph R. Biden,47,81,12,2,142
+Lackawanna,Scranton W-19 P-02,President,,DEM,Tulsi Gabbard,6,2,1,0,9
+Lackawanna,Scranton W-19 P-02,President,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-19 P-02,Attorney General,,DEM,Josh Shapiro,54,90,18,4,166
+Lackawanna,Scranton W-19 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-02,Auditor General,,DEM,H. Scott Conklin,6,4,1,0,11
+Lackawanna,Scranton W-19 P-02,Auditor General,,DEM,Michael Lamb,10,17,2,0,29
+Lackawanna,Scranton W-19 P-02,Auditor General,,DEM,Tracie Fountain,2,9,2,0,13
+Lackawanna,Scranton W-19 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,11,22,4,3,40
+Lackawanna,Scranton W-19 P-02,Auditor General,,DEM,Nina Ahmad,23,20,4,1,48
+Lackawanna,Scranton W-19 P-02,Auditor General,,DEM,Christina M. Hartman,9,7,4,0,20
+Lackawanna,Scranton W-19 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-19 P-02,State Treasurer,,DEM,Joe Torsella,56,82,17,4,159
+Lackawanna,Scranton W-19 P-02,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-19 P-02,U.S. House,8,DEM,Matt Cartwright,61,92,18,4,175
+Lackawanna,Scranton W-19 P-02,U.S. House,8,DEM,Write-in,5,0,0,0,5
+Lackawanna,Scranton W-19 P-02,General Assembly,112,DEM,Kyle J. Mullins,55,86,16,4,161
+Lackawanna,Scranton W-19 P-02,General Assembly,112,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-02,President,,REP,Donald J. Trump,42,13,5,3,63
+Lackawanna,Scranton W-19 P-02,President,,REP,Roque Rocky De La Fuente,0,3,0,0,3
+Lackawanna,Scranton W-19 P-02,President,,REP,Bill Weld,3,3,0,0,6
+Lackawanna,Scranton W-19 P-02,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-19 P-02,Attorney General,,REP,Heather Heidelbaugh,41,19,4,3,67
+Lackawanna,Scranton W-19 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-02,Auditor General,,REP,Timothy DeFoor,39,19,4,3,65
+Lackawanna,Scranton W-19 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-02,State Treasurer,,REP,Stacy L. Garrity,41,19,4,3,67
+Lackawanna,Scranton W-19 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-02,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Scranton W-19 P-02,U.S. House,8,REP,Teddy Daniels,14,1,2,0,17
+Lackawanna,Scranton W-19 P-02,U.S. House,8,REP,Jim Bognet,11,7,1,1,20
+Lackawanna,Scranton W-19 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-19 P-02,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Scranton W-19 P-02,U.S. House,8,REP,Earl Granville,17,11,1,2,31
+Lackawanna,Scranton W-19 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-02,General Assembly,112,REP,Write-in,8,6,2,1,17
+Lackawanna,Scranton W-19 P-03,Registered Voters,,,,,,,,778
+Lackawanna,Scranton W-19 P-03,Registered Voters,,DEM,,,,,,554
+Lackawanna,Scranton W-19 P-03,Registered Voters,,REP,,,,,,224
+Lackawanna,Scranton W-19 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-19 P-03,Ballots Cast,,,,133,220,27,7,387
+Lackawanna,Scranton W-19 P-03,Ballots Cast,,DEM,,87,177,19,6,289
+Lackawanna,Scranton W-19 P-03,Ballots Cast,,REP,,46,43,8,1,98
+Lackawanna,Scranton W-19 P-03,President,,DEM,Bernie Sanders,14,15,0,0,29
+Lackawanna,Scranton W-19 P-03,President,,DEM,Joseph R. Biden,62,157,19,6,244
+Lackawanna,Scranton W-19 P-03,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Lackawanna,Scranton W-19 P-03,President,,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-19 P-03,Attorney General,,DEM,Josh Shapiro,59,143,13,6,221
+Lackawanna,Scranton W-19 P-03,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-19 P-03,Auditor General,,DEM,H. Scott Conklin,6,8,1,1,16
+Lackawanna,Scranton W-19 P-03,Auditor General,,DEM,Michael Lamb,10,17,0,2,29
+Lackawanna,Scranton W-19 P-03,Auditor General,,DEM,Tracie Fountain,2,3,0,0,5
+Lackawanna,Scranton W-19 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,12,37,1,1,51
+Lackawanna,Scranton W-19 P-03,Auditor General,,DEM,Nina Ahmad,29,35,5,1,70
+Lackawanna,Scranton W-19 P-03,Auditor General,,DEM,Christina M. Hartman,11,24,6,1,42
+Lackawanna,Scranton W-19 P-03,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-19 P-03,State Treasurer,,DEM,Joe Torsella,57,129,14,6,206
+Lackawanna,Scranton W-19 P-03,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-19 P-03,U.S. House,8,DEM,Matt Cartwright,77,164,16,4,261
+Lackawanna,Scranton W-19 P-03,U.S. House,8,DEM,Write-in,0,0,0,2,2
+Lackawanna,Scranton W-19 P-03,General Assembly,113,DEM,Marty Flynn,62,145,16,5,228
+Lackawanna,Scranton W-19 P-03,General Assembly,113,DEM,Write-in,5,4,2,0,11
+Lackawanna,Scranton W-19 P-03,President,,REP,Donald J. Trump,40,30,6,1,77
+Lackawanna,Scranton W-19 P-03,President,,REP,Roque Rocky De La Fuente,0,2,0,0,2
+Lackawanna,Scranton W-19 P-03,President,,REP,Bill Weld,3,7,1,0,11
+Lackawanna,Scranton W-19 P-03,President,,REP,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-19 P-03,Attorney General,,REP,Heather Heidelbaugh,27,37,6,1,71
+Lackawanna,Scranton W-19 P-03,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-03,Auditor General,,REP,Timothy DeFoor,26,36,6,1,69
+Lackawanna,Scranton W-19 P-03,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-19 P-03,State Treasurer,,REP,Stacy L. Garrity,26,38,6,1,71
+Lackawanna,Scranton W-19 P-03,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-19 P-03,U.S. House,8,REP,Harry Haas,2,1,0,0,3
+Lackawanna,Scranton W-19 P-03,U.S. House,8,REP,Teddy Daniels,14,3,1,0,18
+Lackawanna,Scranton W-19 P-03,U.S. House,8,REP,Jim Bognet,13,5,0,1,19
+Lackawanna,Scranton W-19 P-03,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Scranton W-19 P-03,U.S. House,8,REP,Mike Marsicano,2,5,2,0,9
+Lackawanna,Scranton W-19 P-03,U.S. House,8,REP,Earl Granville,10,22,5,0,37
+Lackawanna,Scranton W-19 P-03,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-19 P-03,General Assembly,113,REP,William Kresge,28,38,6,1,73
+Lackawanna,Scranton W-19 P-03,General Assembly,113,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-19 P-04,Registered Voters,,,,,,,,795
+Lackawanna,Scranton W-19 P-04,Registered Voters,,DEM,,,,,,531
+Lackawanna,Scranton W-19 P-04,Registered Voters,,REP,,,,,,264
+Lackawanna,Scranton W-19 P-04,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-19 P-04,Ballots Cast,,,,97,167,22,1,287
+Lackawanna,Scranton W-19 P-04,Ballots Cast,,DEM,,61,137,19,1,218
+Lackawanna,Scranton W-19 P-04,Ballots Cast,,REP,,36,30,3,0,69
+Lackawanna,Scranton W-19 P-04,President,,DEM,Bernie Sanders,12,18,3,0,33
+Lackawanna,Scranton W-19 P-04,President,,DEM,Joseph R. Biden,43,108,14,1,166
+Lackawanna,Scranton W-19 P-04,President,,DEM,Tulsi Gabbard,4,7,1,0,12
+Lackawanna,Scranton W-19 P-04,President,,DEM,Write-in,1,3,1,0,5
+Lackawanna,Scranton W-19 P-04,Attorney General,,DEM,Josh Shapiro,51,110,17,1,179
+Lackawanna,Scranton W-19 P-04,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-04,Auditor General,,DEM,H. Scott Conklin,1,6,1,0,8
+Lackawanna,Scranton W-19 P-04,Auditor General,,DEM,Michael Lamb,9,20,0,0,29
+Lackawanna,Scranton W-19 P-04,Auditor General,,DEM,Tracie Fountain,4,7,3,1,15
+Lackawanna,Scranton W-19 P-04,Auditor General,,DEM,Rose Rosie Marie Davis,12,36,5,0,53
+Lackawanna,Scranton W-19 P-04,Auditor General,,DEM,Nina Ahmad,15,17,3,0,35
+Lackawanna,Scranton W-19 P-04,Auditor General,,DEM,Christina M. Hartman,10,27,2,0,39
+Lackawanna,Scranton W-19 P-04,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-04,State Treasurer,,DEM,Joe Torsella,47,100,13,1,161
+Lackawanna,Scranton W-19 P-04,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-19 P-04,U.S. House,8,DEM,Matt Cartwright,52,122,18,0,192
+Lackawanna,Scranton W-19 P-04,U.S. House,8,DEM,Write-in,3,2,1,0,6
+Lackawanna,Scranton W-19 P-04,General Assembly,113,DEM,Marty Flynn,49,113,16,1,179
+Lackawanna,Scranton W-19 P-04,General Assembly,113,DEM,Write-in,1,1,2,0,4
+Lackawanna,Scranton W-19 P-04,President,,REP,Donald J. Trump,33,22,2,0,57
+Lackawanna,Scranton W-19 P-04,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-19 P-04,President,,REP,Bill Weld,1,4,0,0,5
+Lackawanna,Scranton W-19 P-04,President,,REP,Write-in,1,0,1,0,2
+Lackawanna,Scranton W-19 P-04,Attorney General,,REP,Heather Heidelbaugh,18,23,2,0,43
+Lackawanna,Scranton W-19 P-04,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-04,Auditor General,,REP,Timothy DeFoor,19,21,2,0,42
+Lackawanna,Scranton W-19 P-04,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-04,State Treasurer,,REP,Stacy L. Garrity,18,22,2,0,42
+Lackawanna,Scranton W-19 P-04,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-04,U.S. House,8,REP,Harry Haas,0,2,0,0,2
+Lackawanna,Scranton W-19 P-04,U.S. House,8,REP,Teddy Daniels,11,1,0,0,12
+Lackawanna,Scranton W-19 P-04,U.S. House,8,REP,Jim Bognet,5,7,1,0,13
+Lackawanna,Scranton W-19 P-04,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-19 P-04,U.S. House,8,REP,Mike Marsicano,2,2,1,0,5
+Lackawanna,Scranton W-19 P-04,U.S. House,8,REP,Earl Granville,14,16,0,0,30
+Lackawanna,Scranton W-19 P-04,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-19 P-04,General Assembly,113,REP,William Kresge,22,24,2,0,48
+Lackawanna,Scranton W-19 P-04,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-20 P-01,Registered Voters,,,,,,,,905
+Lackawanna,Scranton W-20 P-01,Registered Voters,,DEM,,,,,,673
+Lackawanna,Scranton W-20 P-01,Registered Voters,,REP,,,,,,232
+Lackawanna,Scranton W-20 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-20 P-01,Ballots Cast,,,,125,139,27,2,293
+Lackawanna,Scranton W-20 P-01,Ballots Cast,,DEM,,79,118,19,1,217
+Lackawanna,Scranton W-20 P-01,Ballots Cast,,REP,,46,21,8,1,76
+Lackawanna,Scranton W-20 P-01,President,,DEM,Bernie Sanders,18,22,2,0,42
+Lackawanna,Scranton W-20 P-01,President,,DEM,Joseph R. Biden,48,91,17,1,157
+Lackawanna,Scranton W-20 P-01,President,,DEM,Tulsi Gabbard,4,5,0,0,9
+Lackawanna,Scranton W-20 P-01,President,,DEM,Write-in,4,0,0,0,4
+Lackawanna,Scranton W-20 P-01,Attorney General,,DEM,Josh Shapiro,54,105,16,1,176
+Lackawanna,Scranton W-20 P-01,Attorney General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Scranton W-20 P-01,Auditor General,,DEM,H. Scott Conklin,3,2,2,0,7
+Lackawanna,Scranton W-20 P-01,Auditor General,,DEM,Michael Lamb,5,16,1,0,22
+Lackawanna,Scranton W-20 P-01,Auditor General,,DEM,Tracie Fountain,6,9,1,0,16
+Lackawanna,Scranton W-20 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,11,34,4,0,49
+Lackawanna,Scranton W-20 P-01,Auditor General,,DEM,Nina Ahmad,29,29,7,1,66
+Lackawanna,Scranton W-20 P-01,Auditor General,,DEM,Christina M. Hartman,12,11,1,0,24
+Lackawanna,Scranton W-20 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-01,State Treasurer,,DEM,Joe Torsella,54,98,17,1,170
+Lackawanna,Scranton W-20 P-01,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-20 P-01,U.S. House,8,DEM,Matt Cartwright,62,115,17,1,195
+Lackawanna,Scranton W-20 P-01,U.S. House,8,DEM,Write-in,5,0,0,0,5
+Lackawanna,Scranton W-20 P-01,General Assembly,113,DEM,Marty Flynn,64,109,16,1,190
+Lackawanna,Scranton W-20 P-01,General Assembly,113,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-20 P-01,President,,REP,Donald J. Trump,38,17,8,1,64
+Lackawanna,Scranton W-20 P-01,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Scranton W-20 P-01,President,,REP,Bill Weld,5,2,0,0,7
+Lackawanna,Scranton W-20 P-01,President,,REP,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-20 P-01,Attorney General,,REP,Heather Heidelbaugh,35,18,8,0,61
+Lackawanna,Scranton W-20 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-01,Auditor General,,REP,Timothy DeFoor,31,17,8,1,57
+Lackawanna,Scranton W-20 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-01,State Treasurer,,REP,Stacy L. Garrity,32,20,8,1,61
+Lackawanna,Scranton W-20 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-01,U.S. House,8,REP,Harry Haas,2,0,0,0,2
+Lackawanna,Scranton W-20 P-01,U.S. House,8,REP,Teddy Daniels,12,4,0,0,16
+Lackawanna,Scranton W-20 P-01,U.S. House,8,REP,Jim Bognet,5,2,2,0,9
+Lackawanna,Scranton W-20 P-01,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scranton W-20 P-01,U.S. House,8,REP,Mike Marsicano,6,1,3,0,10
+Lackawanna,Scranton W-20 P-01,U.S. House,8,REP,Earl Granville,14,14,3,1,32
+Lackawanna,Scranton W-20 P-01,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-20 P-01,General Assembly,113,REP,William Kresge,36,20,8,0,64
+Lackawanna,Scranton W-20 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-02,Registered Voters,,,,,,,,600
+Lackawanna,Scranton W-20 P-02,Registered Voters,,DEM,,,,,,464
+Lackawanna,Scranton W-20 P-02,Registered Voters,,REP,,,,,,136
+Lackawanna,Scranton W-20 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-20 P-02,Ballots Cast,,,,84,89,11,3,187
+Lackawanna,Scranton W-20 P-02,Ballots Cast,,DEM,,49,81,8,1,139
+Lackawanna,Scranton W-20 P-02,Ballots Cast,,REP,,35,8,3,2,48
+Lackawanna,Scranton W-20 P-02,President,,DEM,Bernie Sanders,9,14,0,1,24
+Lackawanna,Scranton W-20 P-02,President,,DEM,Joseph R. Biden,34,62,6,0,102
+Lackawanna,Scranton W-20 P-02,President,,DEM,Tulsi Gabbard,2,2,2,0,6
+Lackawanna,Scranton W-20 P-02,President,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-20 P-02,Attorney General,,DEM,Josh Shapiro,37,68,7,1,113
+Lackawanna,Scranton W-20 P-02,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-20 P-02,Auditor General,,DEM,H. Scott Conklin,1,8,0,0,9
+Lackawanna,Scranton W-20 P-02,Auditor General,,DEM,Michael Lamb,9,3,2,0,14
+Lackawanna,Scranton W-20 P-02,Auditor General,,DEM,Tracie Fountain,2,6,0,0,8
+Lackawanna,Scranton W-20 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,2,21,2,0,25
+Lackawanna,Scranton W-20 P-02,Auditor General,,DEM,Nina Ahmad,22,13,1,1,37
+Lackawanna,Scranton W-20 P-02,Auditor General,,DEM,Christina M. Hartman,1,9,2,0,12
+Lackawanna,Scranton W-20 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-02,State Treasurer,,DEM,Joe Torsella,36,68,6,1,111
+Lackawanna,Scranton W-20 P-02,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-20 P-02,U.S. House,8,DEM,Matt Cartwright,40,78,6,0,124
+Lackawanna,Scranton W-20 P-02,U.S. House,8,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-20 P-02,General Assembly,113,DEM,Marty Flynn,38,71,5,1,115
+Lackawanna,Scranton W-20 P-02,General Assembly,113,DEM,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-20 P-02,President,,REP,Donald J. Trump,31,5,3,2,41
+Lackawanna,Scranton W-20 P-02,President,,REP,Roque Rocky De La Fuente,2,1,0,0,3
+Lackawanna,Scranton W-20 P-02,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Scranton W-20 P-02,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-20 P-02,Attorney General,,REP,Heather Heidelbaugh,25,7,3,2,37
+Lackawanna,Scranton W-20 P-02,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-20 P-02,Auditor General,,REP,Timothy DeFoor,25,8,3,2,38
+Lackawanna,Scranton W-20 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-02,State Treasurer,,REP,Stacy L. Garrity,23,7,3,2,35
+Lackawanna,Scranton W-20 P-02,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-20 P-02,U.S. House,8,REP,Harry Haas,2,3,0,0,5
+Lackawanna,Scranton W-20 P-02,U.S. House,8,REP,Teddy Daniels,10,0,2,2,14
+Lackawanna,Scranton W-20 P-02,U.S. House,8,REP,Jim Bognet,4,1,1,0,6
+Lackawanna,Scranton W-20 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-20 P-02,U.S. House,8,REP,Mike Marsicano,6,1,0,0,7
+Lackawanna,Scranton W-20 P-02,U.S. House,8,REP,Earl Granville,11,3,0,0,14
+Lackawanna,Scranton W-20 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-02,General Assembly,113,REP,William Kresge,26,8,3,2,39
+Lackawanna,Scranton W-20 P-02,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-03,Registered Voters,,,,,,,,1053
+Lackawanna,Scranton W-20 P-03,Registered Voters,,DEM,,,,,,863
+Lackawanna,Scranton W-20 P-03,Registered Voters,,REP,,,,,,190
+Lackawanna,Scranton W-20 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-20 P-03,Ballots Cast,,,,113,213,47,0,373
+Lackawanna,Scranton W-20 P-03,Ballots Cast,,DEM,,77,192,41,0,310
+Lackawanna,Scranton W-20 P-03,Ballots Cast,,REP,,36,21,6,0,63
+Lackawanna,Scranton W-20 P-03,President,,DEM,Bernie Sanders,12,20,2,0,34
+Lackawanna,Scranton W-20 P-03,President,,DEM,Joseph R. Biden,58,163,39,0,260
+Lackawanna,Scranton W-20 P-03,President,,DEM,Tulsi Gabbard,4,3,0,0,7
+Lackawanna,Scranton W-20 P-03,President,,DEM,Write-in,1,4,0,0,5
+Lackawanna,Scranton W-20 P-03,Attorney General,,DEM,Josh Shapiro,63,162,36,0,261
+Lackawanna,Scranton W-20 P-03,Attorney General,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-20 P-03,Auditor General,,DEM,H. Scott Conklin,1,10,1,0,12
+Lackawanna,Scranton W-20 P-03,Auditor General,,DEM,Michael Lamb,18,28,6,0,52
+Lackawanna,Scranton W-20 P-03,Auditor General,,DEM,Tracie Fountain,2,15,1,0,18
+Lackawanna,Scranton W-20 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,11,35,8,0,54
+Lackawanna,Scranton W-20 P-03,Auditor General,,DEM,Nina Ahmad,25,38,9,0,72
+Lackawanna,Scranton W-20 P-03,Auditor General,,DEM,Christina M. Hartman,8,33,6,0,47
+Lackawanna,Scranton W-20 P-03,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-20 P-03,State Treasurer,,DEM,Joe Torsella,50,151,33,0,234
+Lackawanna,Scranton W-20 P-03,State Treasurer,,DEM,Write-in,3,3,0,0,6
+Lackawanna,Scranton W-20 P-03,U.S. House,8,DEM,Matt Cartwright,65,182,39,0,286
+Lackawanna,Scranton W-20 P-03,U.S. House,8,DEM,Write-in,3,2,0,0,5
+Lackawanna,Scranton W-20 P-03,General Assembly,113,DEM,Marty Flynn,53,174,39,0,266
+Lackawanna,Scranton W-20 P-03,General Assembly,113,DEM,Write-in,7,3,0,0,10
+Lackawanna,Scranton W-20 P-03,President,,REP,Donald J. Trump,35,15,5,0,55
+Lackawanna,Scranton W-20 P-03,President,,REP,Roque Rocky De La Fuente,1,4,1,0,6
+Lackawanna,Scranton W-20 P-03,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Scranton W-20 P-03,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-03,Attorney General,,REP,Heather Heidelbaugh,24,14,6,0,44
+Lackawanna,Scranton W-20 P-03,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-03,Auditor General,,REP,Timothy DeFoor,24,13,4,0,41
+Lackawanna,Scranton W-20 P-03,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-03,State Treasurer,,REP,Stacy L. Garrity,23,13,5,0,41
+Lackawanna,Scranton W-20 P-03,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-03,U.S. House,8,REP,Harry Haas,0,2,1,0,3
+Lackawanna,Scranton W-20 P-03,U.S. House,8,REP,Teddy Daniels,6,0,0,0,6
+Lackawanna,Scranton W-20 P-03,U.S. House,8,REP,Jim Bognet,3,3,1,0,7
+Lackawanna,Scranton W-20 P-03,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scranton W-20 P-03,U.S. House,8,REP,Mike Marsicano,10,2,0,0,12
+Lackawanna,Scranton W-20 P-03,U.S. House,8,REP,Earl Granville,15,14,4,0,33
+Lackawanna,Scranton W-20 P-03,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-20 P-03,General Assembly,113,REP,William Kresge,28,15,6,0,49
+Lackawanna,Scranton W-20 P-03,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-01,Registered Voters,,,,,,,,620
+Lackawanna,Scranton W-21 P-01,Registered Voters,,DEM,,,,,,463
+Lackawanna,Scranton W-21 P-01,Registered Voters,,REP,,,,,,157
+Lackawanna,Scranton W-21 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-21 P-01,Ballots Cast,,,,73,46,21,0,140
+Lackawanna,Scranton W-21 P-01,Ballots Cast,,DEM,,48,38,17,0,103
+Lackawanna,Scranton W-21 P-01,Ballots Cast,,REP,,25,8,4,0,37
+Lackawanna,Scranton W-21 P-01,President,,DEM,Bernie Sanders,7,6,2,0,15
+Lackawanna,Scranton W-21 P-01,President,,DEM,Joseph R. Biden,34,32,13,0,79
+Lackawanna,Scranton W-21 P-01,President,,DEM,Tulsi Gabbard,2,0,1,0,3
+Lackawanna,Scranton W-21 P-01,President,,DEM,Write-in,2,0,1,0,3
+Lackawanna,Scranton W-21 P-01,Attorney General,,DEM,Josh Shapiro,35,35,15,0,85
+Lackawanna,Scranton W-21 P-01,Attorney General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-21 P-01,Auditor General,,DEM,H. Scott Conklin,0,1,0,0,1
+Lackawanna,Scranton W-21 P-01,Auditor General,,DEM,Michael Lamb,5,0,1,0,6
+Lackawanna,Scranton W-21 P-01,Auditor General,,DEM,Tracie Fountain,2,1,0,0,3
+Lackawanna,Scranton W-21 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,3,13,8,0,24
+Lackawanna,Scranton W-21 P-01,Auditor General,,DEM,Nina Ahmad,19,9,3,0,31
+Lackawanna,Scranton W-21 P-01,Auditor General,,DEM,Christina M. Hartman,9,7,2,0,18
+Lackawanna,Scranton W-21 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-21 P-01,State Treasurer,,DEM,Joe Torsella,33,33,13,0,79
+Lackawanna,Scranton W-21 P-01,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-21 P-01,U.S. House,8,DEM,Matt Cartwright,38,37,15,0,90
+Lackawanna,Scranton W-21 P-01,U.S. House,8,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-21 P-01,General Assembly,113,DEM,Marty Flynn,36,36,14,0,86
+Lackawanna,Scranton W-21 P-01,General Assembly,113,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-21 P-01,President,,REP,Donald J. Trump,23,3,2,0,28
+Lackawanna,Scranton W-21 P-01,President,,REP,Roque Rocky De La Fuente,0,2,1,0,3
+Lackawanna,Scranton W-21 P-01,President,,REP,Bill Weld,0,0,1,0,1
+Lackawanna,Scranton W-21 P-01,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-21 P-01,Attorney General,,REP,Heather Heidelbaugh,18,8,3,0,29
+Lackawanna,Scranton W-21 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-01,Auditor General,,REP,Timothy DeFoor,18,8,3,0,29
+Lackawanna,Scranton W-21 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-01,State Treasurer,,REP,Stacy L. Garrity,18,7,3,0,28
+Lackawanna,Scranton W-21 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-01,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Scranton W-21 P-01,U.S. House,8,REP,Teddy Daniels,4,3,1,0,8
+Lackawanna,Scranton W-21 P-01,U.S. House,8,REP,Jim Bognet,8,1,0,0,9
+Lackawanna,Scranton W-21 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-21 P-01,U.S. House,8,REP,Mike Marsicano,1,1,0,0,2
+Lackawanna,Scranton W-21 P-01,U.S. House,8,REP,Earl Granville,8,3,3,0,14
+Lackawanna,Scranton W-21 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-01,General Assembly,113,REP,William Kresge,20,7,3,0,30
+Lackawanna,Scranton W-21 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-02,Registered Voters,,,,,,,,1033
+Lackawanna,Scranton W-21 P-02,Registered Voters,,DEM,,,,,,775
+Lackawanna,Scranton W-21 P-02,Registered Voters,,REP,,,,,,258
+Lackawanna,Scranton W-21 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-21 P-02,Ballots Cast,,,,166,229,41,5,441
+Lackawanna,Scranton W-21 P-02,Ballots Cast,,DEM,,110,195,36,4,345
+Lackawanna,Scranton W-21 P-02,Ballots Cast,,REP,,56,34,5,1,96
+Lackawanna,Scranton W-21 P-02,President,,DEM,Bernie Sanders,19,34,4,1,58
+Lackawanna,Scranton W-21 P-02,President,,DEM,Joseph R. Biden,69,153,32,3,257
+Lackawanna,Scranton W-21 P-02,President,,DEM,Tulsi Gabbard,7,1,0,0,8
+Lackawanna,Scranton W-21 P-02,President,,DEM,Write-in,7,4,0,0,11
+Lackawanna,Scranton W-21 P-02,Attorney General,,DEM,Josh Shapiro,76,161,29,3,269
+Lackawanna,Scranton W-21 P-02,Attorney General,,DEM,Write-in,2,3,0,0,5
+Lackawanna,Scranton W-21 P-02,Auditor General,,DEM,H. Scott Conklin,9,10,1,0,20
+Lackawanna,Scranton W-21 P-02,Auditor General,,DEM,Michael Lamb,19,36,2,2,59
+Lackawanna,Scranton W-21 P-02,Auditor General,,DEM,Tracie Fountain,3,12,3,0,18
+Lackawanna,Scranton W-21 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,12,36,7,0,55
+Lackawanna,Scranton W-21 P-02,Auditor General,,DEM,Nina Ahmad,33,51,10,1,95
+Lackawanna,Scranton W-21 P-02,Auditor General,,DEM,Christina M. Hartman,10,25,6,0,41
+Lackawanna,Scranton W-21 P-02,Auditor General,,DEM,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-21 P-02,State Treasurer,,DEM,Joe Torsella,74,165,29,3,271
+Lackawanna,Scranton W-21 P-02,State Treasurer,,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-21 P-02,U.S. House,8,DEM,Matt Cartwright,94,185,34,4,317
+Lackawanna,Scranton W-21 P-02,U.S. House,8,DEM,Write-in,5,1,0,0,6
+Lackawanna,Scranton W-21 P-02,General Assembly,113,DEM,Marty Flynn,94,164,34,3,295
+Lackawanna,Scranton W-21 P-02,General Assembly,113,DEM,Write-in,8,8,1,0,17
+Lackawanna,Scranton W-21 P-02,President,,REP,Donald J. Trump,51,27,5,1,84
+Lackawanna,Scranton W-21 P-02,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Scranton W-21 P-02,President,,REP,Bill Weld,1,3,0,0,4
+Lackawanna,Scranton W-21 P-02,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-21 P-02,Attorney General,,REP,Heather Heidelbaugh,40,28,5,1,74
+Lackawanna,Scranton W-21 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-02,Auditor General,,REP,Timothy DeFoor,38,26,5,1,70
+Lackawanna,Scranton W-21 P-02,Auditor General,,REP,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-21 P-02,State Treasurer,,REP,Stacy L. Garrity,40,27,5,1,73
+Lackawanna,Scranton W-21 P-02,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-21 P-02,U.S. House,8,REP,Harry Haas,3,1,0,0,4
+Lackawanna,Scranton W-21 P-02,U.S. House,8,REP,Teddy Daniels,10,2,0,0,12
+Lackawanna,Scranton W-21 P-02,U.S. House,8,REP,Jim Bognet,11,9,1,0,21
+Lackawanna,Scranton W-21 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-21 P-02,U.S. House,8,REP,Mike Marsicano,6,1,0,0,7
+Lackawanna,Scranton W-21 P-02,U.S. House,8,REP,Earl Granville,26,18,4,1,49
+Lackawanna,Scranton W-21 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-02,General Assembly,113,REP,William Kresge,48,27,5,1,81
+Lackawanna,Scranton W-21 P-02,General Assembly,113,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-21 P-03,Registered Voters,,,,,,,,1221
+Lackawanna,Scranton W-21 P-03,Registered Voters,,DEM,,,,,,875
+Lackawanna,Scranton W-21 P-03,Registered Voters,,REP,,,,,,346
+Lackawanna,Scranton W-21 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-21 P-03,Ballots Cast,,,,242,284,37,1,564
+Lackawanna,Scranton W-21 P-03,Ballots Cast,,DEM,,155,247,32,0,434
+Lackawanna,Scranton W-21 P-03,Ballots Cast,,REP,,87,37,5,1,130
+Lackawanna,Scranton W-21 P-03,President,,DEM,Bernie Sanders,18,23,1,0,42
+Lackawanna,Scranton W-21 P-03,President,,DEM,Joseph R. Biden,105,208,30,0,343
+Lackawanna,Scranton W-21 P-03,President,,DEM,Tulsi Gabbard,11,8,0,0,19
+Lackawanna,Scranton W-21 P-03,President,,DEM,Write-in,9,1,1,0,11
+Lackawanna,Scranton W-21 P-03,Attorney General,,DEM,Josh Shapiro,109,210,27,0,346
+Lackawanna,Scranton W-21 P-03,Attorney General,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-21 P-03,Auditor General,,DEM,H. Scott Conklin,5,19,1,0,25
+Lackawanna,Scranton W-21 P-03,Auditor General,,DEM,Michael Lamb,22,24,1,0,47
+Lackawanna,Scranton W-21 P-03,Auditor General,,DEM,Tracie Fountain,7,15,4,0,26
+Lackawanna,Scranton W-21 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,14,50,7,0,71
+Lackawanna,Scranton W-21 P-03,Auditor General,,DEM,Nina Ahmad,45,49,2,0,96
+Lackawanna,Scranton W-21 P-03,Auditor General,,DEM,Christina M. Hartman,17,42,7,0,66
+Lackawanna,Scranton W-21 P-03,Auditor General,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-21 P-03,State Treasurer,,DEM,Joe Torsella,99,200,26,0,325
+Lackawanna,Scranton W-21 P-03,State Treasurer,,DEM,Write-in,3,2,0,0,5
+Lackawanna,Scranton W-21 P-03,U.S. House,8,DEM,Matt Cartwright,118,226,32,0,376
+Lackawanna,Scranton W-21 P-03,U.S. House,8,DEM,Write-in,7,4,0,0,11
+Lackawanna,Scranton W-21 P-03,General Assembly,113,DEM,Marty Flynn,120,216,27,0,363
+Lackawanna,Scranton W-21 P-03,General Assembly,113,DEM,Write-in,11,3,0,0,14
+Lackawanna,Scranton W-21 P-03,President,,REP,Donald J. Trump,84,27,5,1,117
+Lackawanna,Scranton W-21 P-03,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-21 P-03,President,,REP,Bill Weld,0,5,0,0,5
+Lackawanna,Scranton W-21 P-03,President,,REP,Write-in,2,1,0,0,3
+Lackawanna,Scranton W-21 P-03,Attorney General,,REP,Heather Heidelbaugh,62,32,3,1,98
+Lackawanna,Scranton W-21 P-03,Attorney General,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-21 P-03,Auditor General,,REP,Timothy DeFoor,63,32,3,1,99
+Lackawanna,Scranton W-21 P-03,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-03,State Treasurer,,REP,Stacy L. Garrity,57,33,3,1,94
+Lackawanna,Scranton W-21 P-03,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-21 P-03,U.S. House,8,REP,Harry Haas,0,2,0,0,2
+Lackawanna,Scranton W-21 P-03,U.S. House,8,REP,Teddy Daniels,39,2,0,0,41
+Lackawanna,Scranton W-21 P-03,U.S. House,8,REP,Jim Bognet,11,9,1,0,21
+Lackawanna,Scranton W-21 P-03,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Scranton W-21 P-03,U.S. House,8,REP,Mike Marsicano,3,2,0,0,5
+Lackawanna,Scranton W-21 P-03,U.S. House,8,REP,Earl Granville,29,18,4,1,52
+Lackawanna,Scranton W-21 P-03,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-21 P-03,General Assembly,113,REP,William Kresge,63,32,3,1,99
+Lackawanna,Scranton W-21 P-03,General Assembly,113,REP,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-21 P-04,Registered Voters,,,,,,,,1613
+Lackawanna,Scranton W-21 P-04,Registered Voters,,DEM,,,,,,1140
+Lackawanna,Scranton W-21 P-04,Registered Voters,,REP,,,,,,473
+Lackawanna,Scranton W-21 P-04,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-21 P-04,Ballots Cast,,,,287,377,63,8,735
+Lackawanna,Scranton W-21 P-04,Ballots Cast,,DEM,,180,299,54,5,538
+Lackawanna,Scranton W-21 P-04,Ballots Cast,,REP,,107,78,9,3,197
+Lackawanna,Scranton W-21 P-04,President,,DEM,Bernie Sanders,26,22,6,3,57
+Lackawanna,Scranton W-21 P-04,President,,DEM,Joseph R. Biden,125,260,43,2,430
+Lackawanna,Scranton W-21 P-04,President,,DEM,Tulsi Gabbard,13,3,4,0,20
+Lackawanna,Scranton W-21 P-04,President,,DEM,Write-in,11,6,1,0,18
+Lackawanna,Scranton W-21 P-04,Attorney General,,DEM,Josh Shapiro,121,236,48,4,409
+Lackawanna,Scranton W-21 P-04,Attorney General,,DEM,Write-in,4,3,0,0,7
+Lackawanna,Scranton W-21 P-04,Auditor General,,DEM,H. Scott Conklin,9,6,1,0,16
+Lackawanna,Scranton W-21 P-04,Auditor General,,DEM,Michael Lamb,26,37,4,1,68
+Lackawanna,Scranton W-21 P-04,Auditor General,,DEM,Tracie Fountain,6,15,3,0,24
+Lackawanna,Scranton W-21 P-04,Auditor General,,DEM,Rose Rosie Marie Davis,25,61,19,2,107
+Lackawanna,Scranton W-21 P-04,Auditor General,,DEM,Nina Ahmad,52,53,8,1,114
+Lackawanna,Scranton W-21 P-04,Auditor General,,DEM,Christina M. Hartman,9,49,7,0,65
+Lackawanna,Scranton W-21 P-04,Auditor General,,DEM,Write-in,4,3,0,0,7
+Lackawanna,Scranton W-21 P-04,State Treasurer,,DEM,Joe Torsella,104,227,45,3,379
+Lackawanna,Scranton W-21 P-04,State Treasurer,,DEM,Write-in,5,2,0,0,7
+Lackawanna,Scranton W-21 P-04,U.S. House,8,DEM,Matt Cartwright,145,276,48,4,473
+Lackawanna,Scranton W-21 P-04,U.S. House,8,DEM,Write-in,10,5,1,0,16
+Lackawanna,Scranton W-21 P-04,General Assembly,113,DEM,Marty Flynn,132,258,52,3,445
+Lackawanna,Scranton W-21 P-04,General Assembly,113,DEM,Write-in,8,4,0,0,12
+Lackawanna,Scranton W-21 P-04,President,,REP,Donald J. Trump,102,67,6,3,178
+Lackawanna,Scranton W-21 P-04,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Lackawanna,Scranton W-21 P-04,President,,REP,Bill Weld,1,2,0,0,3
+Lackawanna,Scranton W-21 P-04,President,,REP,Write-in,1,4,2,0,7
+Lackawanna,Scranton W-21 P-04,Attorney General,,REP,Heather Heidelbaugh,77,68,7,2,154
+Lackawanna,Scranton W-21 P-04,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-21 P-04,Auditor General,,REP,Timothy DeFoor,74,64,6,2,146
+Lackawanna,Scranton W-21 P-04,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-21 P-04,State Treasurer,,REP,Stacy L. Garrity,78,66,7,2,153
+Lackawanna,Scranton W-21 P-04,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-21 P-04,U.S. House,8,REP,Harry Haas,2,1,1,0,4
+Lackawanna,Scranton W-21 P-04,U.S. House,8,REP,Teddy Daniels,32,7,0,1,40
+Lackawanna,Scranton W-21 P-04,U.S. House,8,REP,Jim Bognet,24,13,1,1,39
+Lackawanna,Scranton W-21 P-04,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-21 P-04,U.S. House,8,REP,Mike Marsicano,10,9,0,0,19
+Lackawanna,Scranton W-21 P-04,U.S. House,8,REP,Earl Granville,35,43,6,1,85
+Lackawanna,Scranton W-21 P-04,U.S. House,8,REP,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-21 P-04,General Assembly,113,REP,William Kresge,81,66,7,2,156
+Lackawanna,Scranton W-21 P-04,General Assembly,113,REP,Write-in,3,0,1,0,4
+Lackawanna,Scranton W-22 P-01,Registered Voters,,,,,,,,521
+Lackawanna,Scranton W-22 P-01,Registered Voters,,DEM,,,,,,396
+Lackawanna,Scranton W-22 P-01,Registered Voters,,REP,,,,,,125
+Lackawanna,Scranton W-22 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-22 P-01,Ballots Cast,,,,79,134,9,0,222
+Lackawanna,Scranton W-22 P-01,Ballots Cast,,DEM,,42,119,8,0,169
+Lackawanna,Scranton W-22 P-01,Ballots Cast,,REP,,37,15,1,0,53
+Lackawanna,Scranton W-22 P-01,President,,DEM,Bernie Sanders,12,3,0,0,15
+Lackawanna,Scranton W-22 P-01,President,,DEM,Joseph R. Biden,24,110,8,0,142
+Lackawanna,Scranton W-22 P-01,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Lackawanna,Scranton W-22 P-01,President,,DEM,Write-in,1,3,0,0,4
+Lackawanna,Scranton W-22 P-01,Attorney General,,DEM,Josh Shapiro,32,100,8,0,140
+Lackawanna,Scranton W-22 P-01,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-01,Auditor General,,DEM,H. Scott Conklin,7,11,0,0,18
+Lackawanna,Scranton W-22 P-01,Auditor General,,DEM,Michael Lamb,5,13,0,0,18
+Lackawanna,Scranton W-22 P-01,Auditor General,,DEM,Tracie Fountain,2,11,0,0,13
+Lackawanna,Scranton W-22 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,10,32,2,0,44
+Lackawanna,Scranton W-22 P-01,Auditor General,,DEM,Nina Ahmad,7,13,1,0,21
+Lackawanna,Scranton W-22 P-01,Auditor General,,DEM,Christina M. Hartman,7,16,2,0,25
+Lackawanna,Scranton W-22 P-01,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-01,State Treasurer,,DEM,Joe Torsella,35,99,7,0,141
+Lackawanna,Scranton W-22 P-01,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-01,U.S. House,8,DEM,Matt Cartwright,32,114,8,0,154
+Lackawanna,Scranton W-22 P-01,U.S. House,8,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-01,General Assembly,113,DEM,Marty Flynn,37,105,8,0,150
+Lackawanna,Scranton W-22 P-01,General Assembly,113,DEM,Write-in,0,5,0,0,5
+Lackawanna,Scranton W-22 P-01,President,,REP,Donald J. Trump,34,11,1,0,46
+Lackawanna,Scranton W-22 P-01,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,Scranton W-22 P-01,President,,REP,Bill Weld,1,0,0,0,1
+Lackawanna,Scranton W-22 P-01,President,,REP,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-22 P-01,Attorney General,,REP,Heather Heidelbaugh,26,8,0,0,34
+Lackawanna,Scranton W-22 P-01,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-22 P-01,Auditor General,,REP,Timothy DeFoor,27,5,0,0,32
+Lackawanna,Scranton W-22 P-01,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-22 P-01,State Treasurer,,REP,Stacy L. Garrity,26,8,1,0,35
+Lackawanna,Scranton W-22 P-01,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-22 P-01,U.S. House,8,REP,Harry Haas,0,2,0,0,2
+Lackawanna,Scranton W-22 P-01,U.S. House,8,REP,Teddy Daniels,8,0,0,0,8
+Lackawanna,Scranton W-22 P-01,U.S. House,8,REP,Jim Bognet,3,0,0,0,3
+Lackawanna,Scranton W-22 P-01,U.S. House,8,REP,Mike Cammisa,1,0,1,0,2
+Lackawanna,Scranton W-22 P-01,U.S. House,8,REP,Mike Marsicano,4,2,0,0,6
+Lackawanna,Scranton W-22 P-01,U.S. House,8,REP,Earl Granville,19,7,0,0,26
+Lackawanna,Scranton W-22 P-01,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-22 P-01,General Assembly,113,REP,William Kresge,30,9,1,0,40
+Lackawanna,Scranton W-22 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-02,Registered Voters,,,,,,,,771
+Lackawanna,Scranton W-22 P-02,Registered Voters,,DEM,,,,,,581
+Lackawanna,Scranton W-22 P-02,Registered Voters,,REP,,,,,,190
+Lackawanna,Scranton W-22 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-22 P-02,Ballots Cast,,,,117,189,30,5,341
+Lackawanna,Scranton W-22 P-02,Ballots Cast,,DEM,,77,173,26,4,280
+Lackawanna,Scranton W-22 P-02,Ballots Cast,,REP,,40,16,4,1,61
+Lackawanna,Scranton W-22 P-02,President,,DEM,Bernie Sanders,17,12,3,1,33
+Lackawanna,Scranton W-22 P-02,President,,DEM,Joseph R. Biden,45,151,23,2,221
+Lackawanna,Scranton W-22 P-02,President,,DEM,Tulsi Gabbard,6,2,0,1,9
+Lackawanna,Scranton W-22 P-02,President,,DEM,Write-in,8,1,0,0,9
+Lackawanna,Scranton W-22 P-02,Attorney General,,DEM,Josh Shapiro,56,148,17,2,223
+Lackawanna,Scranton W-22 P-02,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-22 P-02,Auditor General,,DEM,H. Scott Conklin,2,13,2,0,17
+Lackawanna,Scranton W-22 P-02,Auditor General,,DEM,Michael Lamb,10,22,5,0,37
+Lackawanna,Scranton W-22 P-02,Auditor General,,DEM,Tracie Fountain,2,15,0,2,19
+Lackawanna,Scranton W-22 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,14,28,4,0,46
+Lackawanna,Scranton W-22 P-02,Auditor General,,DEM,Nina Ahmad,19,22,5,1,47
+Lackawanna,Scranton W-22 P-02,Auditor General,,DEM,Christina M. Hartman,9,20,2,0,31
+Lackawanna,Scranton W-22 P-02,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-22 P-02,State Treasurer,,DEM,Joe Torsella,52,122,18,2,194
+Lackawanna,Scranton W-22 P-02,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-22 P-02,U.S. House,8,DEM,Matt Cartwright,64,163,22,2,251
+Lackawanna,Scranton W-22 P-02,U.S. House,8,DEM,Write-in,2,4,0,0,6
+Lackawanna,Scranton W-22 P-02,General Assembly,113,DEM,Marty Flynn,65,148,17,2,232
+Lackawanna,Scranton W-22 P-02,General Assembly,113,DEM,Write-in,3,4,1,0,8
+Lackawanna,Scranton W-22 P-02,President,,REP,Donald J. Trump,38,13,4,1,56
+Lackawanna,Scranton W-22 P-02,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Scranton W-22 P-02,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Scranton W-22 P-02,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-22 P-02,Attorney General,,REP,Heather Heidelbaugh,31,15,4,0,50
+Lackawanna,Scranton W-22 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-02,Auditor General,,REP,Timothy DeFoor,29,15,4,0,48
+Lackawanna,Scranton W-22 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-02,State Treasurer,,REP,Stacy L. Garrity,31,14,4,0,49
+Lackawanna,Scranton W-22 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-02,U.S. House,8,REP,Harry Haas,0,1,0,0,1
+Lackawanna,Scranton W-22 P-02,U.S. House,8,REP,Teddy Daniels,11,1,0,0,12
+Lackawanna,Scranton W-22 P-02,U.S. House,8,REP,Jim Bognet,9,5,2,0,16
+Lackawanna,Scranton W-22 P-02,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,Scranton W-22 P-02,U.S. House,8,REP,Mike Marsicano,6,1,0,0,7
+Lackawanna,Scranton W-22 P-02,U.S. House,8,REP,Earl Granville,9,7,2,0,18
+Lackawanna,Scranton W-22 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-22 P-02,General Assembly,113,REP,William Kresge,34,16,4,0,54
+Lackawanna,Scranton W-22 P-02,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-01,Registered Voters,,,,,,,,832
+Lackawanna,Scranton W-23 P-01,Registered Voters,,DEM,,,,,,630
+Lackawanna,Scranton W-23 P-01,Registered Voters,,REP,,,,,,202
+Lackawanna,Scranton W-23 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-23 P-01,Ballots Cast,,,,151,207,42,4,404
+Lackawanna,Scranton W-23 P-01,Ballots Cast,,DEM,,104,189,41,2,336
+Lackawanna,Scranton W-23 P-01,Ballots Cast,,REP,,47,18,1,2,68
+Lackawanna,Scranton W-23 P-01,President,,DEM,Bernie Sanders,14,24,9,0,47
+Lackawanna,Scranton W-23 P-01,President,,DEM,Joseph R. Biden,82,157,30,2,271
+Lackawanna,Scranton W-23 P-01,President,,DEM,Tulsi Gabbard,2,3,0,0,5
+Lackawanna,Scranton W-23 P-01,President,,DEM,Write-in,3,2,1,0,6
+Lackawanna,Scranton W-23 P-01,Attorney General,,DEM,Josh Shapiro,80,162,34,1,277
+Lackawanna,Scranton W-23 P-01,Attorney General,,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-23 P-01,Auditor General,,DEM,H. Scott Conklin,3,13,4,0,20
+Lackawanna,Scranton W-23 P-01,Auditor General,,DEM,Michael Lamb,21,24,6,0,51
+Lackawanna,Scranton W-23 P-01,Auditor General,,DEM,Tracie Fountain,1,18,1,0,20
+Lackawanna,Scranton W-23 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,21,37,9,0,67
+Lackawanna,Scranton W-23 P-01,Auditor General,,DEM,Nina Ahmad,32,30,6,1,69
+Lackawanna,Scranton W-23 P-01,Auditor General,,DEM,Christina M. Hartman,8,29,8,0,45
+Lackawanna,Scranton W-23 P-01,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-23 P-01,State Treasurer,,DEM,Joe Torsella,75,155,33,2,265
+Lackawanna,Scranton W-23 P-01,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-23 P-01,U.S. House,8,DEM,Matt Cartwright,94,181,36,2,313
+Lackawanna,Scranton W-23 P-01,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-23 P-01,General Assembly,113,DEM,Marty Flynn,86,164,34,2,286
+Lackawanna,Scranton W-23 P-01,General Assembly,113,DEM,Write-in,5,2,2,0,9
+Lackawanna,Scranton W-23 P-01,President,,REP,Donald J. Trump,42,14,1,2,59
+Lackawanna,Scranton W-23 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-23 P-01,President,,REP,Bill Weld,2,2,0,0,4
+Lackawanna,Scranton W-23 P-01,President,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-23 P-01,Attorney General,,REP,Heather Heidelbaugh,35,13,1,2,51
+Lackawanna,Scranton W-23 P-01,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-01,Auditor General,,REP,Timothy DeFoor,36,13,1,2,52
+Lackawanna,Scranton W-23 P-01,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-01,State Treasurer,,REP,Stacy L. Garrity,35,13,1,2,51
+Lackawanna,Scranton W-23 P-01,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-01,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-23 P-01,U.S. House,8,REP,Teddy Daniels,10,1,0,1,12
+Lackawanna,Scranton W-23 P-01,U.S. House,8,REP,Jim Bognet,7,4,0,0,11
+Lackawanna,Scranton W-23 P-01,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-23 P-01,U.S. House,8,REP,Mike Marsicano,5,0,0,0,5
+Lackawanna,Scranton W-23 P-01,U.S. House,8,REP,Earl Granville,25,11,1,1,38
+Lackawanna,Scranton W-23 P-01,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-01,General Assembly,113,REP,William Kresge,38,15,1,2,56
+Lackawanna,Scranton W-23 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-02,Registered Voters,,,,,,,,816
+Lackawanna,Scranton W-23 P-02,Registered Voters,,DEM,,,,,,617
+Lackawanna,Scranton W-23 P-02,Registered Voters,,REP,,,,,,199
+Lackawanna,Scranton W-23 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-23 P-02,Ballots Cast,,,,160,135,15,8,318
+Lackawanna,Scranton W-23 P-02,Ballots Cast,,DEM,,110,126,12,5,253
+Lackawanna,Scranton W-23 P-02,Ballots Cast,,REP,,50,9,3,3,65
+Lackawanna,Scranton W-23 P-02,President,,DEM,Bernie Sanders,16,10,4,0,30
+Lackawanna,Scranton W-23 P-02,President,,DEM,Joseph R. Biden,79,108,6,5,198
+Lackawanna,Scranton W-23 P-02,President,,DEM,Tulsi Gabbard,6,2,0,0,8
+Lackawanna,Scranton W-23 P-02,President,,DEM,Write-in,4,0,0,0,4
+Lackawanna,Scranton W-23 P-02,Attorney General,,DEM,Josh Shapiro,78,95,10,5,188
+Lackawanna,Scranton W-23 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-02,Auditor General,,DEM,H. Scott Conklin,8,6,0,0,14
+Lackawanna,Scranton W-23 P-02,Auditor General,,DEM,Michael Lamb,20,18,3,1,42
+Lackawanna,Scranton W-23 P-02,Auditor General,,DEM,Tracie Fountain,2,14,1,0,17
+Lackawanna,Scranton W-23 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,14,24,1,0,39
+Lackawanna,Scranton W-23 P-02,Auditor General,,DEM,Nina Ahmad,20,27,4,3,54
+Lackawanna,Scranton W-23 P-02,Auditor General,,DEM,Christina M. Hartman,11,9,1,1,22
+Lackawanna,Scranton W-23 P-02,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-23 P-02,State Treasurer,,DEM,Joe Torsella,76,90,10,4,180
+Lackawanna,Scranton W-23 P-02,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Scranton W-23 P-02,U.S. House,8,DEM,Matt Cartwright,96,109,10,5,220
+Lackawanna,Scranton W-23 P-02,U.S. House,8,DEM,Write-in,4,1,0,0,5
+Lackawanna,Scranton W-23 P-02,General Assembly,113,DEM,Marty Flynn,92,96,9,5,202
+Lackawanna,Scranton W-23 P-02,General Assembly,113,DEM,Write-in,6,6,0,0,12
+Lackawanna,Scranton W-23 P-02,President,,REP,Donald J. Trump,49,4,3,3,59
+Lackawanna,Scranton W-23 P-02,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-23 P-02,President,,REP,Bill Weld,1,2,0,0,3
+Lackawanna,Scranton W-23 P-02,President,,REP,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-23 P-02,Attorney General,,REP,Heather Heidelbaugh,35,4,3,2,44
+Lackawanna,Scranton W-23 P-02,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-23 P-02,Auditor General,,REP,Timothy DeFoor,32,4,3,2,41
+Lackawanna,Scranton W-23 P-02,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-23 P-02,State Treasurer,,REP,Stacy L. Garrity,34,4,3,2,43
+Lackawanna,Scranton W-23 P-02,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-23 P-02,U.S. House,8,REP,Harry Haas,4,0,0,0,4
+Lackawanna,Scranton W-23 P-02,U.S. House,8,REP,Teddy Daniels,19,1,0,0,20
+Lackawanna,Scranton W-23 P-02,U.S. House,8,REP,Jim Bognet,8,0,1,1,10
+Lackawanna,Scranton W-23 P-02,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Scranton W-23 P-02,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Scranton W-23 P-02,U.S. House,8,REP,Earl Granville,15,5,2,2,24
+Lackawanna,Scranton W-23 P-02,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-23 P-02,General Assembly,113,REP,William Kresge,40,5,2,2,49
+Lackawanna,Scranton W-23 P-02,General Assembly,113,REP,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-23 P-03,Registered Voters,,,,,,,,850
+Lackawanna,Scranton W-23 P-03,Registered Voters,,DEM,,,,,,640
+Lackawanna,Scranton W-23 P-03,Registered Voters,,REP,,,,,,210
+Lackawanna,Scranton W-23 P-03,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-23 P-03,Ballots Cast,,,,133,242,41,5,421
+Lackawanna,Scranton W-23 P-03,Ballots Cast,,DEM,,88,225,36,4,353
+Lackawanna,Scranton W-23 P-03,Ballots Cast,,REP,,45,17,5,1,68
+Lackawanna,Scranton W-23 P-03,President,,DEM,Bernie Sanders,11,23,4,1,39
+Lackawanna,Scranton W-23 P-03,President,,DEM,Joseph R. Biden,68,191,32,3,294
+Lackawanna,Scranton W-23 P-03,President,,DEM,Tulsi Gabbard,3,4,0,0,7
+Lackawanna,Scranton W-23 P-03,President,,DEM,Write-in,3,1,0,0,4
+Lackawanna,Scranton W-23 P-03,Attorney General,,DEM,Josh Shapiro,62,185,27,4,278
+Lackawanna,Scranton W-23 P-03,Attorney General,,DEM,Write-in,4,2,0,0,6
+Lackawanna,Scranton W-23 P-03,Auditor General,,DEM,H. Scott Conklin,4,7,0,0,11
+Lackawanna,Scranton W-23 P-03,Auditor General,,DEM,Michael Lamb,21,53,7,1,82
+Lackawanna,Scranton W-23 P-03,Auditor General,,DEM,Tracie Fountain,2,17,5,0,24
+Lackawanna,Scranton W-23 P-03,Auditor General,,DEM,Rose Rosie Marie Davis,6,34,3,1,44
+Lackawanna,Scranton W-23 P-03,Auditor General,,DEM,Nina Ahmad,33,43,7,1,84
+Lackawanna,Scranton W-23 P-03,Auditor General,,DEM,Christina M. Hartman,4,24,4,0,32
+Lackawanna,Scranton W-23 P-03,Auditor General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-23 P-03,State Treasurer,,DEM,Joe Torsella,67,180,27,3,277
+Lackawanna,Scranton W-23 P-03,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Scranton W-23 P-03,U.S. House,8,DEM,Matt Cartwright,77,205,33,4,319
+Lackawanna,Scranton W-23 P-03,U.S. House,8,DEM,Write-in,3,4,0,0,7
+Lackawanna,Scranton W-23 P-03,General Assembly,113,DEM,Marty Flynn,69,174,27,4,274
+Lackawanna,Scranton W-23 P-03,General Assembly,113,DEM,Write-in,6,7,1,0,14
+Lackawanna,Scranton W-23 P-03,President,,REP,Donald J. Trump,43,11,4,1,59
+Lackawanna,Scranton W-23 P-03,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-23 P-03,President,,REP,Bill Weld,1,0,1,0,2
+Lackawanna,Scranton W-23 P-03,President,,REP,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-23 P-03,Attorney General,,REP,Heather Heidelbaugh,37,16,5,1,59
+Lackawanna,Scranton W-23 P-03,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-03,Auditor General,,REP,Timothy DeFoor,38,15,4,1,58
+Lackawanna,Scranton W-23 P-03,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-03,State Treasurer,,REP,Stacy L. Garrity,36,16,4,1,57
+Lackawanna,Scranton W-23 P-03,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-03,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Scranton W-23 P-03,U.S. House,8,REP,Teddy Daniels,5,0,0,0,5
+Lackawanna,Scranton W-23 P-03,U.S. House,8,REP,Jim Bognet,13,6,0,0,19
+Lackawanna,Scranton W-23 P-03,U.S. House,8,REP,Mike Cammisa,2,0,0,0,2
+Lackawanna,Scranton W-23 P-03,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Scranton W-23 P-03,U.S. House,8,REP,Earl Granville,16,11,4,1,32
+Lackawanna,Scranton W-23 P-03,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-23 P-03,General Assembly,113,REP,William Kresge,39,16,5,1,61
+Lackawanna,Scranton W-23 P-03,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-24 P-01,Registered Voters,,,,,,,,875
+Lackawanna,Scranton W-24 P-01,Registered Voters,,DEM,,,,,,685
+Lackawanna,Scranton W-24 P-01,Registered Voters,,REP,,,,,,190
+Lackawanna,Scranton W-24 P-01,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-24 P-01,Ballots Cast,,,,131,196,37,4,368
+Lackawanna,Scranton W-24 P-01,Ballots Cast,,DEM,,102,166,25,3,296
+Lackawanna,Scranton W-24 P-01,Ballots Cast,,REP,,29,30,12,1,72
+Lackawanna,Scranton W-24 P-01,President,,DEM,Bernie Sanders,11,16,1,1,29
+Lackawanna,Scranton W-24 P-01,President,,DEM,Joseph R. Biden,80,138,21,1,240
+Lackawanna,Scranton W-24 P-01,President,,DEM,Tulsi Gabbard,3,5,1,0,9
+Lackawanna,Scranton W-24 P-01,President,,DEM,Write-in,4,5,2,0,11
+Lackawanna,Scranton W-24 P-01,Attorney General,,DEM,Josh Shapiro,75,132,20,1,228
+Lackawanna,Scranton W-24 P-01,Attorney General,,DEM,Write-in,2,2,0,0,4
+Lackawanna,Scranton W-24 P-01,Auditor General,,DEM,H. Scott Conklin,9,9,2,0,20
+Lackawanna,Scranton W-24 P-01,Auditor General,,DEM,Michael Lamb,12,35,6,0,53
+Lackawanna,Scranton W-24 P-01,Auditor General,,DEM,Tracie Fountain,2,5,2,0,9
+Lackawanna,Scranton W-24 P-01,Auditor General,,DEM,Rose Rosie Marie Davis,12,28,6,1,47
+Lackawanna,Scranton W-24 P-01,Auditor General,,DEM,Nina Ahmad,38,32,2,0,72
+Lackawanna,Scranton W-24 P-01,Auditor General,,DEM,Christina M. Hartman,9,28,1,1,39
+Lackawanna,Scranton W-24 P-01,Auditor General,,DEM,Write-in,0,2,0,0,2
+Lackawanna,Scranton W-24 P-01,State Treasurer,,DEM,Joe Torsella,68,131,17,1,217
+Lackawanna,Scranton W-24 P-01,State Treasurer,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-24 P-01,U.S. House,8,DEM,Matt Cartwright,86,150,22,2,260
+Lackawanna,Scranton W-24 P-01,U.S. House,8,DEM,Write-in,3,2,0,0,5
+Lackawanna,Scranton W-24 P-01,General Assembly,113,DEM,Marty Flynn,80,148,20,2,250
+Lackawanna,Scranton W-24 P-01,General Assembly,113,DEM,Write-in,4,3,1,0,8
+Lackawanna,Scranton W-24 P-01,President,,REP,Donald J. Trump,28,20,9,1,58
+Lackawanna,Scranton W-24 P-01,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Scranton W-24 P-01,President,,REP,Bill Weld,0,4,1,0,5
+Lackawanna,Scranton W-24 P-01,President,,REP,Write-in,1,5,1,0,7
+Lackawanna,Scranton W-24 P-01,Attorney General,,REP,Heather Heidelbaugh,22,20,7,0,49
+Lackawanna,Scranton W-24 P-01,Attorney General,,REP,Write-in,1,1,1,0,3
+Lackawanna,Scranton W-24 P-01,Auditor General,,REP,Timothy DeFoor,20,22,7,0,49
+Lackawanna,Scranton W-24 P-01,Auditor General,,REP,Write-in,1,0,1,0,2
+Lackawanna,Scranton W-24 P-01,State Treasurer,,REP,Stacy L. Garrity,17,20,8,0,45
+Lackawanna,Scranton W-24 P-01,State Treasurer,,REP,Write-in,2,0,0,0,2
+Lackawanna,Scranton W-24 P-01,U.S. House,8,REP,Harry Haas,0,1,1,0,2
+Lackawanna,Scranton W-24 P-01,U.S. House,8,REP,Teddy Daniels,7,2,0,0,9
+Lackawanna,Scranton W-24 P-01,U.S. House,8,REP,Jim Bognet,7,4,1,0,12
+Lackawanna,Scranton W-24 P-01,U.S. House,8,REP,Mike Cammisa,0,0,1,0,1
+Lackawanna,Scranton W-24 P-01,U.S. House,8,REP,Mike Marsicano,3,3,0,0,6
+Lackawanna,Scranton W-24 P-01,U.S. House,8,REP,Earl Granville,11,16,7,0,34
+Lackawanna,Scranton W-24 P-01,U.S. House,8,REP,Write-in,1,2,0,0,3
+Lackawanna,Scranton W-24 P-01,General Assembly,113,REP,William Kresge,26,26,8,1,61
+Lackawanna,Scranton W-24 P-01,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-24 P-02,Registered Voters,,,,,,,,455
+Lackawanna,Scranton W-24 P-02,Registered Voters,,DEM,,,,,,355
+Lackawanna,Scranton W-24 P-02,Registered Voters,,REP,,,,,,100
+Lackawanna,Scranton W-24 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,Scranton W-24 P-02,Ballots Cast,,,,81,122,24,1,228
+Lackawanna,Scranton W-24 P-02,Ballots Cast,,DEM,,59,109,21,1,190
+Lackawanna,Scranton W-24 P-02,Ballots Cast,,REP,,22,13,3,0,38
+Lackawanna,Scranton W-24 P-02,President,,DEM,Bernie Sanders,8,12,3,0,23
+Lackawanna,Scranton W-24 P-02,President,,DEM,Joseph R. Biden,48,90,15,0,153
+Lackawanna,Scranton W-24 P-02,President,,DEM,Tulsi Gabbard,0,5,3,0,8
+Lackawanna,Scranton W-24 P-02,President,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-24 P-02,Attorney General,,DEM,Josh Shapiro,53,87,17,0,157
+Lackawanna,Scranton W-24 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-24 P-02,Auditor General,,DEM,H. Scott Conklin,4,8,1,0,13
+Lackawanna,Scranton W-24 P-02,Auditor General,,DEM,Michael Lamb,11,15,7,0,33
+Lackawanna,Scranton W-24 P-02,Auditor General,,DEM,Tracie Fountain,1,8,0,0,9
+Lackawanna,Scranton W-24 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,11,20,4,0,35
+Lackawanna,Scranton W-24 P-02,Auditor General,,DEM,Nina Ahmad,19,16,4,0,39
+Lackawanna,Scranton W-24 P-02,Auditor General,,DEM,Christina M. Hartman,6,19,3,0,28
+Lackawanna,Scranton W-24 P-02,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-24 P-02,State Treasurer,,DEM,Joe Torsella,50,79,18,0,147
+Lackawanna,Scranton W-24 P-02,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Scranton W-24 P-02,U.S. House,8,DEM,Matt Cartwright,51,101,19,1,172
+Lackawanna,Scranton W-24 P-02,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Scranton W-24 P-02,General Assembly,113,DEM,Marty Flynn,51,91,19,0,161
+Lackawanna,Scranton W-24 P-02,General Assembly,113,DEM,Write-in,3,7,0,0,10
+Lackawanna,Scranton W-24 P-02,President,,REP,Donald J. Trump,18,10,2,0,30
+Lackawanna,Scranton W-24 P-02,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Lackawanna,Scranton W-24 P-02,President,,REP,Bill Weld,1,3,0,0,4
+Lackawanna,Scranton W-24 P-02,President,,REP,Write-in,2,0,1,0,3
+Lackawanna,Scranton W-24 P-02,Attorney General,,REP,Heather Heidelbaugh,15,9,2,0,26
+Lackawanna,Scranton W-24 P-02,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-24 P-02,Auditor General,,REP,Timothy DeFoor,16,9,2,0,27
+Lackawanna,Scranton W-24 P-02,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-24 P-02,State Treasurer,,REP,Stacy L. Garrity,15,9,2,0,26
+Lackawanna,Scranton W-24 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-24 P-02,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Scranton W-24 P-02,U.S. House,8,REP,Teddy Daniels,4,2,0,0,6
+Lackawanna,Scranton W-24 P-02,U.S. House,8,REP,Jim Bognet,4,2,1,0,7
+Lackawanna,Scranton W-24 P-02,U.S. House,8,REP,Mike Cammisa,0,2,0,0,2
+Lackawanna,Scranton W-24 P-02,U.S. House,8,REP,Mike Marsicano,5,2,0,0,7
+Lackawanna,Scranton W-24 P-02,U.S. House,8,REP,Earl Granville,8,4,1,0,13
+Lackawanna,Scranton W-24 P-02,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Scranton W-24 P-02,General Assembly,113,REP,William Kresge,19,9,3,0,31
+Lackawanna,Scranton W-24 P-02,General Assembly,113,REP,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-02,Registered Voters,,,,,,,,1203
+Lackawanna,South Abington Twp. W-00 P-02,Registered Voters,,DEM,,,,,,623
+Lackawanna,South Abington Twp. W-00 P-02,Registered Voters,,REP,,,,,,580
+Lackawanna,South Abington Twp. W-00 P-02,Registered Voters,,NPA,,,,,,0
+Lackawanna,South Abington Twp. W-00 P-02,Ballots Cast,,,,181,287,54,6,528
+Lackawanna,South Abington Twp. W-00 P-02,Ballots Cast,,DEM,,53,209,44,3,309
+Lackawanna,South Abington Twp. W-00 P-02,Ballots Cast,,REP,,128,78,10,3,219
+Lackawanna,South Abington Twp. W-00 P-02,President,,DEM,Bernie Sanders,7,23,2,0,32
+Lackawanna,South Abington Twp. W-00 P-02,President,,DEM,Joseph R. Biden,41,180,41,2,264
+Lackawanna,South Abington Twp. W-00 P-02,President,,DEM,Tulsi Gabbard,2,3,0,0,5
+Lackawanna,South Abington Twp. W-00 P-02,President,,DEM,Write-in,1,3,1,1,6
+Lackawanna,South Abington Twp. W-00 P-02,Attorney General,,DEM,Josh Shapiro,39,182,39,3,263
+Lackawanna,South Abington Twp. W-00 P-02,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,DEM,H. Scott Conklin,2,11,2,0,15
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,DEM,Michael Lamb,9,25,6,0,40
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,DEM,Tracie Fountain,4,21,3,0,28
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,DEM,Rose Rosie Marie Davis,6,31,8,1,46
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,DEM,Nina Ahmad,16,40,11,1,68
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,DEM,Christina M. Hartman,7,40,5,0,52
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,DEM,Write-in,0,0,0,1,1
+Lackawanna,South Abington Twp. W-00 P-02,State Treasurer,,DEM,Joe Torsella,37,170,36,2,245
+Lackawanna,South Abington Twp. W-00 P-02,State Treasurer,,DEM,Write-in,0,0,1,1,2
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,DEM,Matt Cartwright,48,198,41,3,290
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,DEM,Write-in,0,3,0,0,3
+Lackawanna,South Abington Twp. W-00 P-02,General Assembly,113,DEM,Marty Flynn,43,180,41,1,265
+Lackawanna,South Abington Twp. W-00 P-02,General Assembly,113,DEM,Write-in,0,4,0,2,6
+Lackawanna,South Abington Twp. W-00 P-02,President,,REP,Donald J. Trump,120,59,6,2,187
+Lackawanna,South Abington Twp. W-00 P-02,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Lackawanna,South Abington Twp. W-00 P-02,President,,REP,Bill Weld,2,10,2,1,15
+Lackawanna,South Abington Twp. W-00 P-02,President,,REP,Write-in,2,4,0,0,6
+Lackawanna,South Abington Twp. W-00 P-02,Attorney General,,REP,Heather Heidelbaugh,97,64,10,2,173
+Lackawanna,South Abington Twp. W-00 P-02,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,REP,Timothy DeFoor,96,61,10,2,169
+Lackawanna,South Abington Twp. W-00 P-02,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-02,State Treasurer,,REP,Stacy L. Garrity,102,65,10,2,179
+Lackawanna,South Abington Twp. W-00 P-02,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,REP,Harry Haas,3,4,0,0,7
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,REP,Teddy Daniels,34,1,0,0,35
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,REP,Jim Bognet,28,21,1,2,52
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,REP,Mike Cammisa,0,1,1,0,2
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,REP,Mike Marsicano,7,2,0,0,9
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,REP,Earl Granville,53,42,7,1,103
+Lackawanna,South Abington Twp. W-00 P-02,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,South Abington Twp. W-00 P-02,General Assembly,113,REP,William Kresge,107,64,9,2,182
+Lackawanna,South Abington Twp. W-00 P-02,General Assembly,113,REP,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-1-1,Registered Voters,,,,,,,,1136
+Lackawanna,South Abington Twp. W-00 P-1-1,Registered Voters,,DEM,,,,,,589
+Lackawanna,South Abington Twp. W-00 P-1-1,Registered Voters,,REP,,,,,,547
+Lackawanna,South Abington Twp. W-00 P-1-1,Registered Voters,,NPA,,,,,,0
+Lackawanna,South Abington Twp. W-00 P-1-1,Ballots Cast,,,,170,249,57,9,485
+Lackawanna,South Abington Twp. W-00 P-1-1,Ballots Cast,,DEM,,60,178,46,5,289
+Lackawanna,South Abington Twp. W-00 P-1-1,Ballots Cast,,REP,,110,71,11,4,196
+Lackawanna,South Abington Twp. W-00 P-1-1,President,,DEM,Bernie Sanders,9,21,5,1,36
+Lackawanna,South Abington Twp. W-00 P-1-1,President,,DEM,Joseph R. Biden,45,146,36,4,231
+Lackawanna,South Abington Twp. W-00 P-1-1,President,,DEM,Tulsi Gabbard,5,6,4,0,15
+Lackawanna,South Abington Twp. W-00 P-1-1,President,,DEM,Write-in,1,5,1,0,7
+Lackawanna,South Abington Twp. W-00 P-1-1,Attorney General,,DEM,Josh Shapiro,51,153,42,3,249
+Lackawanna,South Abington Twp. W-00 P-1-1,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,DEM,H. Scott Conklin,1,5,3,1,10
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,DEM,Michael Lamb,7,24,6,0,37
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,DEM,Tracie Fountain,3,14,4,0,21
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,DEM,Rose Rosie Marie Davis,4,34,11,0,49
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,DEM,Nina Ahmad,25,30,8,1,64
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,DEM,Christina M. Hartman,2,27,2,0,31
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-1-1,State Treasurer,,DEM,Joe Torsella,46,136,34,3,219
+Lackawanna,South Abington Twp. W-00 P-1-1,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,DEM,Matt Cartwright,53,167,40,4,264
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,DEM,Write-in,1,0,1,0,2
+Lackawanna,South Abington Twp. W-00 P-1-1,General Assembly,113,DEM,Marty Flynn,50,148,35,4,237
+Lackawanna,South Abington Twp. W-00 P-1-1,General Assembly,113,DEM,Write-in,2,6,0,0,8
+Lackawanna,South Abington Twp. W-00 P-1-1,President,,REP,Donald J. Trump,100,53,6,4,163
+Lackawanna,South Abington Twp. W-00 P-1-1,President,,REP,Roque Rocky De La Fuente,2,2,1,0,5
+Lackawanna,South Abington Twp. W-00 P-1-1,President,,REP,Bill Weld,2,8,3,0,13
+Lackawanna,South Abington Twp. W-00 P-1-1,President,,REP,Write-in,3,6,0,0,9
+Lackawanna,South Abington Twp. W-00 P-1-1,Attorney General,,REP,Heather Heidelbaugh,93,54,11,3,161
+Lackawanna,South Abington Twp. W-00 P-1-1,Attorney General,,REP,Write-in,0,2,0,0,2
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,REP,Timothy DeFoor,94,54,10,2,160
+Lackawanna,South Abington Twp. W-00 P-1-1,Auditor General,,REP,Write-in,0,2,0,0,2
+Lackawanna,South Abington Twp. W-00 P-1-1,State Treasurer,,REP,Stacy L. Garrity,92,52,11,3,158
+Lackawanna,South Abington Twp. W-00 P-1-1,State Treasurer,,REP,Write-in,0,3,0,0,3
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,REP,Harry Haas,4,2,0,0,6
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,REP,Teddy Daniels,23,1,0,0,24
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,REP,Jim Bognet,18,4,2,1,25
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,REP,Mike Cammisa,1,1,1,0,3
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,REP,Mike Marsicano,8,9,0,0,17
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,REP,Earl Granville,54,48,7,3,112
+Lackawanna,South Abington Twp. W-00 P-1-1,U.S. House,8,REP,Write-in,0,4,1,0,5
+Lackawanna,South Abington Twp. W-00 P-1-1,General Assembly,113,REP,William Kresge,93,55,11,3,162
+Lackawanna,South Abington Twp. W-00 P-1-1,General Assembly,113,REP,Write-in,0,2,0,0,2
+Lackawanna,South Abington Twp. W-00 P-1-2,Registered Voters,,,,,,,,1518
+Lackawanna,South Abington Twp. W-00 P-1-2,Registered Voters,,DEM,,,,,,830
+Lackawanna,South Abington Twp. W-00 P-1-2,Registered Voters,,REP,,,,,,688
+Lackawanna,South Abington Twp. W-00 P-1-2,Registered Voters,,NPA,,,,,,0
+Lackawanna,South Abington Twp. W-00 P-1-2,Ballots Cast,,,,264,365,60,7,696
+Lackawanna,South Abington Twp. W-00 P-1-2,Ballots Cast,,DEM,,107,269,43,2,421
+Lackawanna,South Abington Twp. W-00 P-1-2,Ballots Cast,,REP,,157,96,17,5,275
+Lackawanna,South Abington Twp. W-00 P-1-2,President,,DEM,Bernie Sanders,20,23,2,1,46
+Lackawanna,South Abington Twp. W-00 P-1-2,President,,DEM,Joseph R. Biden,80,235,38,1,354
+Lackawanna,South Abington Twp. W-00 P-1-2,President,,DEM,Tulsi Gabbard,2,5,1,0,8
+Lackawanna,South Abington Twp. W-00 P-1-2,President,,DEM,Write-in,4,4,2,0,10
+Lackawanna,South Abington Twp. W-00 P-1-2,Attorney General,,DEM,Josh Shapiro,97,239,41,1,378
+Lackawanna,South Abington Twp. W-00 P-1-2,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,DEM,H. Scott Conklin,4,19,5,0,28
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,DEM,Michael Lamb,12,34,4,0,50
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,DEM,Tracie Fountain,6,23,5,0,34
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,DEM,Rose Rosie Marie Davis,13,39,5,2,59
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,DEM,Nina Ahmad,49,63,13,0,125
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,DEM,Christina M. Hartman,13,40,6,0,59
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-1-2,State Treasurer,,DEM,Joe Torsella,95,225,37,1,358
+Lackawanna,South Abington Twp. W-00 P-1-2,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,DEM,Matt Cartwright,96,259,40,1,396
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,South Abington Twp. W-00 P-1-2,General Assembly,113,DEM,Marty Flynn,91,229,41,1,362
+Lackawanna,South Abington Twp. W-00 P-1-2,General Assembly,113,DEM,Write-in,4,4,0,0,8
+Lackawanna,South Abington Twp. W-00 P-1-2,President,,REP,Donald J. Trump,150,72,11,4,237
+Lackawanna,South Abington Twp. W-00 P-1-2,President,,REP,Roque Rocky De La Fuente,2,2,2,1,7
+Lackawanna,South Abington Twp. W-00 P-1-2,President,,REP,Bill Weld,2,7,1,0,10
+Lackawanna,South Abington Twp. W-00 P-1-2,President,,REP,Write-in,2,10,2,0,14
+Lackawanna,South Abington Twp. W-00 P-1-2,Attorney General,,REP,Heather Heidelbaugh,123,78,14,4,219
+Lackawanna,South Abington Twp. W-00 P-1-2,Attorney General,,REP,Write-in,1,2,0,0,3
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,REP,Timothy DeFoor,121,80,11,4,216
+Lackawanna,South Abington Twp. W-00 P-1-2,Auditor General,,REP,Write-in,1,0,2,0,3
+Lackawanna,South Abington Twp. W-00 P-1-2,State Treasurer,,REP,Stacy L. Garrity,124,81,12,4,221
+Lackawanna,South Abington Twp. W-00 P-1-2,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,REP,Harry Haas,8,1,2,1,12
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,REP,Teddy Daniels,37,6,1,0,44
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,REP,Jim Bognet,43,19,2,1,65
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,REP,Mike Cammisa,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,REP,Mike Marsicano,11,10,1,0,22
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,REP,Earl Granville,52,51,11,3,117
+Lackawanna,South Abington Twp. W-00 P-1-2,U.S. House,8,REP,Write-in,1,2,0,0,3
+Lackawanna,South Abington Twp. W-00 P-1-2,General Assembly,113,REP,William Kresge,131,81,13,4,229
+Lackawanna,South Abington Twp. W-00 P-1-2,General Assembly,113,REP,Write-in,0,2,1,0,3
+Lackawanna,South Abington Twp. W-00 P-3-1,Registered Voters,,,,,,,,1055
+Lackawanna,South Abington Twp. W-00 P-3-1,Registered Voters,,DEM,,,,,,556
+Lackawanna,South Abington Twp. W-00 P-3-1,Registered Voters,,REP,,,,,,499
+Lackawanna,South Abington Twp. W-00 P-3-1,Registered Voters,,NPA,,,,,,0
+Lackawanna,South Abington Twp. W-00 P-3-1,Ballots Cast,,,,183,210,53,6,452
+Lackawanna,South Abington Twp. W-00 P-3-1,Ballots Cast,,DEM,,77,152,36,6,271
+Lackawanna,South Abington Twp. W-00 P-3-1,Ballots Cast,,REP,,106,58,17,0,181
+Lackawanna,South Abington Twp. W-00 P-3-1,President,,DEM,Bernie Sanders,12,16,3,1,32
+Lackawanna,South Abington Twp. W-00 P-3-1,President,,DEM,Joseph R. Biden,62,134,29,4,229
+Lackawanna,South Abington Twp. W-00 P-3-1,President,,DEM,Tulsi Gabbard,2,0,3,1,6
+Lackawanna,South Abington Twp. W-00 P-3-1,President,,DEM,Write-in,0,1,1,0,2
+Lackawanna,South Abington Twp. W-00 P-3-1,Attorney General,,DEM,Josh Shapiro,63,131,31,3,228
+Lackawanna,South Abington Twp. W-00 P-3-1,Attorney General,,DEM,Write-in,1,2,0,0,3
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,DEM,H. Scott Conklin,7,11,2,0,20
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,DEM,Michael Lamb,10,18,4,0,32
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,DEM,Tracie Fountain,5,15,1,1,22
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,DEM,Rose Rosie Marie Davis,12,23,8,1,44
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,DEM,Nina Ahmad,19,31,11,1,62
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,DEM,Christina M. Hartman,9,13,5,2,29
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-3-1,State Treasurer,,DEM,Joe Torsella,61,125,30,3,219
+Lackawanna,South Abington Twp. W-00 P-3-1,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,DEM,Matt Cartwright,72,139,34,5,250
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,South Abington Twp. W-00 P-3-1,General Assembly,113,DEM,Marty Flynn,67,132,34,4,237
+Lackawanna,South Abington Twp. W-00 P-3-1,General Assembly,113,DEM,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-3-1,President,,REP,Donald J. Trump,98,41,15,0,154
+Lackawanna,South Abington Twp. W-00 P-3-1,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Lackawanna,South Abington Twp. W-00 P-3-1,President,,REP,Bill Weld,3,8,2,0,13
+Lackawanna,South Abington Twp. W-00 P-3-1,President,,REP,Write-in,1,4,0,0,5
+Lackawanna,South Abington Twp. W-00 P-3-1,Attorney General,,REP,Heather Heidelbaugh,82,47,15,0,144
+Lackawanna,South Abington Twp. W-00 P-3-1,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,REP,Timothy DeFoor,81,46,15,0,142
+Lackawanna,South Abington Twp. W-00 P-3-1,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,South Abington Twp. W-00 P-3-1,State Treasurer,,REP,Stacy L. Garrity,80,46,15,0,141
+Lackawanna,South Abington Twp. W-00 P-3-1,State Treasurer,,REP,Write-in,1,1,0,0,2
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,REP,Harry Haas,3,6,0,0,9
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,REP,Teddy Daniels,18,4,2,0,24
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,REP,Jim Bognet,28,9,3,0,40
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,REP,Mike Cammisa,2,2,0,0,4
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,REP,Mike Marsicano,4,4,3,0,11
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,REP,Earl Granville,47,25,9,0,81
+Lackawanna,South Abington Twp. W-00 P-3-1,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-3-1,General Assembly,113,REP,William Kresge,79,44,16,0,139
+Lackawanna,South Abington Twp. W-00 P-3-1,General Assembly,113,REP,Write-in,2,3,0,0,5
+Lackawanna,South Abington Twp. W-00 P-3-2,Registered Voters,,,,,,,,1077
+Lackawanna,South Abington Twp. W-00 P-3-2,Registered Voters,,DEM,,,,,,600
+Lackawanna,South Abington Twp. W-00 P-3-2,Registered Voters,,REP,,,,,,477
+Lackawanna,South Abington Twp. W-00 P-3-2,Registered Voters,,NPA,,,,,,0
+Lackawanna,South Abington Twp. W-00 P-3-2,Ballots Cast,,,,196,253,58,4,511
+Lackawanna,South Abington Twp. W-00 P-3-2,Ballots Cast,,DEM,,84,186,47,2,319
+Lackawanna,South Abington Twp. W-00 P-3-2,Ballots Cast,,REP,,112,67,11,2,192
+Lackawanna,South Abington Twp. W-00 P-3-2,President,,DEM,Bernie Sanders,16,16,7,0,39
+Lackawanna,South Abington Twp. W-00 P-3-2,President,,DEM,Joseph R. Biden,56,165,38,2,261
+Lackawanna,South Abington Twp. W-00 P-3-2,President,,DEM,Tulsi Gabbard,6,2,1,0,9
+Lackawanna,South Abington Twp. W-00 P-3-2,President,,DEM,Write-in,4,1,0,0,5
+Lackawanna,South Abington Twp. W-00 P-3-2,Attorney General,,DEM,Josh Shapiro,68,168,38,2,276
+Lackawanna,South Abington Twp. W-00 P-3-2,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,DEM,H. Scott Conklin,6,9,4,0,19
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,DEM,Michael Lamb,13,17,2,0,32
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,DEM,Tracie Fountain,7,30,6,0,43
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,DEM,Rose Rosie Marie Davis,9,44,6,1,60
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,DEM,Nina Ahmad,24,32,12,0,68
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,DEM,Christina M. Hartman,15,28,7,1,51
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,South Abington Twp. W-00 P-3-2,State Treasurer,,DEM,Joe Torsella,58,155,36,2,251
+Lackawanna,South Abington Twp. W-00 P-3-2,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,DEM,Matt Cartwright,63,178,44,2,287
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,DEM,Write-in,9,0,0,0,9
+Lackawanna,South Abington Twp. W-00 P-3-2,General Assembly,113,DEM,Marty Flynn,60,159,40,2,261
+Lackawanna,South Abington Twp. W-00 P-3-2,General Assembly,113,DEM,Write-in,9,4,2,0,15
+Lackawanna,South Abington Twp. W-00 P-3-2,President,,REP,Donald J. Trump,93,47,8,1,149
+Lackawanna,South Abington Twp. W-00 P-3-2,President,,REP,Roque Rocky De La Fuente,2,3,0,0,5
+Lackawanna,South Abington Twp. W-00 P-3-2,President,,REP,Bill Weld,7,11,2,1,21
+Lackawanna,South Abington Twp. W-00 P-3-2,President,,REP,Write-in,4,2,0,0,6
+Lackawanna,South Abington Twp. W-00 P-3-2,Attorney General,,REP,Heather Heidelbaugh,90,50,8,2,150
+Lackawanna,South Abington Twp. W-00 P-3-2,Attorney General,,REP,Write-in,1,1,1,0,3
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,REP,Timothy DeFoor,90,49,8,2,149
+Lackawanna,South Abington Twp. W-00 P-3-2,Auditor General,,REP,Write-in,1,1,1,0,3
+Lackawanna,South Abington Twp. W-00 P-3-2,State Treasurer,,REP,Stacy L. Garrity,89,50,9,2,150
+Lackawanna,South Abington Twp. W-00 P-3-2,State Treasurer,,REP,Write-in,1,1,1,0,3
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,REP,Harry Haas,0,3,0,0,3
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,REP,Teddy Daniels,19,0,1,1,21
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,REP,Jim Bognet,27,9,2,0,38
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,REP,Mike Cammisa,0,0,1,0,1
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,REP,Mike Marsicano,5,6,0,0,11
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,REP,Earl Granville,52,42,4,1,99
+Lackawanna,South Abington Twp. W-00 P-3-2,U.S. House,8,REP,Write-in,1,0,1,0,2
+Lackawanna,South Abington Twp. W-00 P-3-2,General Assembly,113,REP,William Kresge,98,54,10,2,164
+Lackawanna,South Abington Twp. W-00 P-3-2,General Assembly,113,REP,Write-in,2,1,1,0,4
+Lackawanna,Springbrook Twp. W-00 P-00,Registered Voters,,,,,,,,1794
+Lackawanna,Springbrook Twp. W-00 P-00,Registered Voters,,DEM,,,,,,852
+Lackawanna,Springbrook Twp. W-00 P-00,Registered Voters,,REP,,,,,,942
+Lackawanna,Springbrook Twp. W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Springbrook Twp. W-00 P-00,Ballots Cast,,,,406,330,69,5,810
+Lackawanna,Springbrook Twp. W-00 P-00,Ballots Cast,,DEM,,110,221,55,3,389
+Lackawanna,Springbrook Twp. W-00 P-00,Ballots Cast,,REP,,296,109,14,2,421
+Lackawanna,Springbrook Twp. W-00 P-00,President,,DEM,Bernie Sanders,18,28,8,1,55
+Lackawanna,Springbrook Twp. W-00 P-00,President,,DEM,Joseph R. Biden,73,181,46,2,302
+Lackawanna,Springbrook Twp. W-00 P-00,President,,DEM,Tulsi Gabbard,10,4,1,0,15
+Lackawanna,Springbrook Twp. W-00 P-00,President,,DEM,Write-in,5,6,0,0,11
+Lackawanna,Springbrook Twp. W-00 P-00,Attorney General,,DEM,Josh Shapiro,81,202,51,3,337
+Lackawanna,Springbrook Twp. W-00 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,DEM,H. Scott Conklin,7,18,5,0,30
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,DEM,Michael Lamb,16,24,6,0,46
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,DEM,Tracie Fountain,4,14,1,0,19
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,25,73,18,2,118
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,DEM,Nina Ahmad,19,24,9,1,53
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,DEM,Christina M. Hartman,13,37,6,0,56
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Springbrook Twp. W-00 P-00,State Treasurer,,DEM,Joe Torsella,76,195,45,3,319
+Lackawanna,Springbrook Twp. W-00 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,DEM,Matt Cartwright,89,209,51,3,352
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,DEM,Write-in,5,2,1,0,8
+Lackawanna,Springbrook Twp. W-00 P-00,General Assembly,118,DEM,Mike Carroll,82,192,47,3,324
+Lackawanna,Springbrook Twp. W-00 P-00,General Assembly,118,DEM,Write-in,1,0,0,0,1
+Lackawanna,Springbrook Twp. W-00 P-00,President,,REP,Donald J. Trump,278,95,14,2,389
+Lackawanna,Springbrook Twp. W-00 P-00,President,,REP,Roque Rocky De La Fuente,3,2,0,0,5
+Lackawanna,Springbrook Twp. W-00 P-00,President,,REP,Bill Weld,5,10,0,0,15
+Lackawanna,Springbrook Twp. W-00 P-00,President,,REP,Write-in,5,0,0,0,5
+Lackawanna,Springbrook Twp. W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,223,88,10,2,323
+Lackawanna,Springbrook Twp. W-00 P-00,Attorney General,,REP,Write-in,2,1,1,0,4
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,REP,Timothy DeFoor,215,86,10,2,313
+Lackawanna,Springbrook Twp. W-00 P-00,Auditor General,,REP,Write-in,1,1,1,0,3
+Lackawanna,Springbrook Twp. W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,214,87,10,2,313
+Lackawanna,Springbrook Twp. W-00 P-00,State Treasurer,,REP,Write-in,1,0,1,0,2
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,REP,Harry Haas,4,2,0,0,6
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,REP,Teddy Daniels,95,10,2,1,108
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,REP,Jim Bognet,62,20,4,0,86
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,REP,Mike Cammisa,2,3,0,0,5
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,REP,Mike Marsicano,14,8,0,0,22
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,REP,Earl Granville,108,60,8,1,177
+Lackawanna,Springbrook Twp. W-00 P-00,U.S. House,8,REP,Write-in,1,1,0,0,2
+Lackawanna,Springbrook Twp. W-00 P-00,General Assembly,118,REP,Andrew Holter,207,85,9,1,302
+Lackawanna,Springbrook Twp. W-00 P-00,General Assembly,118,REP,Write-in,2,1,1,0,4
+Lackawanna,Taylor W-01 P-00,Registered Voters,,,,,,,,395
+Lackawanna,Taylor W-01 P-00,Registered Voters,,DEM,,,,,,266
+Lackawanna,Taylor W-01 P-00,Registered Voters,,REP,,,,,,129
+Lackawanna,Taylor W-01 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Taylor W-01 P-00,Ballots Cast,,,,73,67,11,2,153
+Lackawanna,Taylor W-01 P-00,Ballots Cast,,DEM,,42,54,7,2,105
+Lackawanna,Taylor W-01 P-00,Ballots Cast,,REP,,31,13,4,0,48
+Lackawanna,Taylor W-01 P-00,President,,DEM,Bernie Sanders,7,2,0,0,9
+Lackawanna,Taylor W-01 P-00,President,,DEM,Joseph R. Biden,31,49,5,1,86
+Lackawanna,Taylor W-01 P-00,President,,DEM,Tulsi Gabbard,0,1,2,0,3
+Lackawanna,Taylor W-01 P-00,President,,DEM,Write-in,1,1,0,1,3
+Lackawanna,Taylor W-01 P-00,Attorney General,,DEM,Josh Shapiro,36,50,7,1,94
+Lackawanna,Taylor W-01 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-01 P-00,Auditor General,,DEM,H. Scott Conklin,2,4,0,0,6
+Lackawanna,Taylor W-01 P-00,Auditor General,,DEM,Michael Lamb,11,16,0,0,27
+Lackawanna,Taylor W-01 P-00,Auditor General,,DEM,Tracie Fountain,1,2,0,0,3
+Lackawanna,Taylor W-01 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,10,13,6,1,30
+Lackawanna,Taylor W-01 P-00,Auditor General,,DEM,Nina Ahmad,7,6,1,0,14
+Lackawanna,Taylor W-01 P-00,Auditor General,,DEM,Christina M. Hartman,5,7,0,0,12
+Lackawanna,Taylor W-01 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-01 P-00,State Treasurer,,DEM,Joe Torsella,31,45,7,0,83
+Lackawanna,Taylor W-01 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Taylor W-01 P-00,U.S. House,8,DEM,Matt Cartwright,34,47,7,0,88
+Lackawanna,Taylor W-01 P-00,U.S. House,8,DEM,Write-in,0,1,0,0,1
+Lackawanna,Taylor W-01 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,32,52,6,1,91
+Lackawanna,Taylor W-01 P-00,General Assembly,114,DEM,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-01 P-00,President,,REP,Donald J. Trump,29,9,4,0,42
+Lackawanna,Taylor W-01 P-00,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Taylor W-01 P-00,President,,REP,Bill Weld,0,2,0,0,2
+Lackawanna,Taylor W-01 P-00,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Taylor W-01 P-00,Attorney General,,REP,Heather Heidelbaugh,24,11,3,0,38
+Lackawanna,Taylor W-01 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-01 P-00,Auditor General,,REP,Timothy DeFoor,26,11,3,0,40
+Lackawanna,Taylor W-01 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-01 P-00,State Treasurer,,REP,Stacy L. Garrity,24,11,3,0,38
+Lackawanna,Taylor W-01 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-01 P-00,U.S. House,8,REP,Harry Haas,1,1,0,0,2
+Lackawanna,Taylor W-01 P-00,U.S. House,8,REP,Teddy Daniels,14,1,1,0,16
+Lackawanna,Taylor W-01 P-00,U.S. House,8,REP,Jim Bognet,6,8,0,0,14
+Lackawanna,Taylor W-01 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Taylor W-01 P-00,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Taylor W-01 P-00,U.S. House,8,REP,Earl Granville,6,3,2,0,11
+Lackawanna,Taylor W-01 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-01 P-00,General Assembly,114,REP,James May,25,12,4,0,41
+Lackawanna,Taylor W-01 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-02 P-00,Registered Voters,,,,,,,,604
+Lackawanna,Taylor W-02 P-00,Registered Voters,,DEM,,,,,,448
+Lackawanna,Taylor W-02 P-00,Registered Voters,,REP,,,,,,156
+Lackawanna,Taylor W-02 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Taylor W-02 P-00,Ballots Cast,,,,120,65,20,3,208
+Lackawanna,Taylor W-02 P-00,Ballots Cast,,DEM,,76,52,16,0,144
+Lackawanna,Taylor W-02 P-00,Ballots Cast,,REP,,44,13,4,3,64
+Lackawanna,Taylor W-02 P-00,President,,DEM,Bernie Sanders,20,11,3,0,34
+Lackawanna,Taylor W-02 P-00,President,,DEM,Joseph R. Biden,43,38,9,0,90
+Lackawanna,Taylor W-02 P-00,President,,DEM,Tulsi Gabbard,7,1,2,0,10
+Lackawanna,Taylor W-02 P-00,President,,DEM,Write-in,3,1,1,0,5
+Lackawanna,Taylor W-02 P-00,Attorney General,,DEM,Josh Shapiro,59,48,15,0,122
+Lackawanna,Taylor W-02 P-00,Attorney General,,DEM,Write-in,3,0,0,0,3
+Lackawanna,Taylor W-02 P-00,Auditor General,,DEM,H. Scott Conklin,10,3,0,0,13
+Lackawanna,Taylor W-02 P-00,Auditor General,,DEM,Michael Lamb,12,5,6,0,23
+Lackawanna,Taylor W-02 P-00,Auditor General,,DEM,Tracie Fountain,1,4,0,0,5
+Lackawanna,Taylor W-02 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,12,12,3,0,27
+Lackawanna,Taylor W-02 P-00,Auditor General,,DEM,Nina Ahmad,19,7,4,0,30
+Lackawanna,Taylor W-02 P-00,Auditor General,,DEM,Christina M. Hartman,12,11,2,0,25
+Lackawanna,Taylor W-02 P-00,Auditor General,,DEM,Write-in,1,0,1,0,2
+Lackawanna,Taylor W-02 P-00,State Treasurer,,DEM,Joe Torsella,52,46,14,0,112
+Lackawanna,Taylor W-02 P-00,State Treasurer,,DEM,Write-in,3,0,1,0,4
+Lackawanna,Taylor W-02 P-00,U.S. House,8,DEM,Matt Cartwright,64,46,11,0,121
+Lackawanna,Taylor W-02 P-00,U.S. House,8,DEM,Write-in,4,0,1,0,5
+Lackawanna,Taylor W-02 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,57,46,14,0,117
+Lackawanna,Taylor W-02 P-00,General Assembly,114,DEM,Write-in,2,0,1,0,3
+Lackawanna,Taylor W-02 P-00,President,,REP,Donald J. Trump,43,12,4,3,62
+Lackawanna,Taylor W-02 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Taylor W-02 P-00,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Taylor W-02 P-00,President,,REP,Write-in,1,0,0,0,1
+Lackawanna,Taylor W-02 P-00,Attorney General,,REP,Heather Heidelbaugh,32,13,4,2,51
+Lackawanna,Taylor W-02 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-02 P-00,Auditor General,,REP,Timothy DeFoor,31,13,4,1,49
+Lackawanna,Taylor W-02 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-02 P-00,State Treasurer,,REP,Stacy L. Garrity,32,13,4,2,51
+Lackawanna,Taylor W-02 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-02 P-00,U.S. House,8,REP,Harry Haas,0,7,1,0,8
+Lackawanna,Taylor W-02 P-00,U.S. House,8,REP,Teddy Daniels,19,2,0,1,22
+Lackawanna,Taylor W-02 P-00,U.S. House,8,REP,Jim Bognet,9,2,0,1,12
+Lackawanna,Taylor W-02 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Taylor W-02 P-00,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Taylor W-02 P-00,U.S. House,8,REP,Earl Granville,10,2,3,0,15
+Lackawanna,Taylor W-02 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-02 P-00,General Assembly,114,REP,James May,37,13,4,3,57
+Lackawanna,Taylor W-02 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-03 P-00,Registered Voters,,,,,,,,817
+Lackawanna,Taylor W-03 P-00,Registered Voters,,DEM,,,,,,512
+Lackawanna,Taylor W-03 P-00,Registered Voters,,REP,,,,,,305
+Lackawanna,Taylor W-03 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Taylor W-03 P-00,Ballots Cast,,,,181,126,24,6,337
+Lackawanna,Taylor W-03 P-00,Ballots Cast,,DEM,,87,96,19,2,204
+Lackawanna,Taylor W-03 P-00,Ballots Cast,,REP,,94,30,5,4,133
+Lackawanna,Taylor W-03 P-00,President,,DEM,Bernie Sanders,17,12,3,0,32
+Lackawanna,Taylor W-03 P-00,President,,DEM,Joseph R. Biden,50,82,15,2,149
+Lackawanna,Taylor W-03 P-00,President,,DEM,Tulsi Gabbard,6,0,0,0,6
+Lackawanna,Taylor W-03 P-00,President,,DEM,Write-in,7,0,0,0,7
+Lackawanna,Taylor W-03 P-00,Attorney General,,DEM,Josh Shapiro,71,89,15,2,177
+Lackawanna,Taylor W-03 P-00,Attorney General,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Taylor W-03 P-00,Auditor General,,DEM,H. Scott Conklin,5,3,0,0,8
+Lackawanna,Taylor W-03 P-00,Auditor General,,DEM,Michael Lamb,20,21,4,0,45
+Lackawanna,Taylor W-03 P-00,Auditor General,,DEM,Tracie Fountain,4,2,2,0,8
+Lackawanna,Taylor W-03 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,16,22,4,0,42
+Lackawanna,Taylor W-03 P-00,Auditor General,,DEM,Nina Ahmad,19,15,1,1,36
+Lackawanna,Taylor W-03 P-00,Auditor General,,DEM,Christina M. Hartman,4,12,5,1,22
+Lackawanna,Taylor W-03 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Taylor W-03 P-00,State Treasurer,,DEM,Joe Torsella,64,85,14,2,165
+Lackawanna,Taylor W-03 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Taylor W-03 P-00,U.S. House,8,DEM,Matt Cartwright,76,92,18,2,188
+Lackawanna,Taylor W-03 P-00,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Taylor W-03 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,73,90,16,2,181
+Lackawanna,Taylor W-03 P-00,General Assembly,114,DEM,Write-in,2,0,1,0,3
+Lackawanna,Taylor W-03 P-00,President,,REP,Donald J. Trump,85,21,5,4,115
+Lackawanna,Taylor W-03 P-00,President,,REP,Roque Rocky De La Fuente,3,0,0,0,3
+Lackawanna,Taylor W-03 P-00,President,,REP,Bill Weld,2,4,0,0,6
+Lackawanna,Taylor W-03 P-00,President,,REP,Write-in,0,3,0,0,3
+Lackawanna,Taylor W-03 P-00,Attorney General,,REP,Heather Heidelbaugh,69,22,3,2,96
+Lackawanna,Taylor W-03 P-00,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Taylor W-03 P-00,Auditor General,,REP,Timothy DeFoor,69,23,3,4,99
+Lackawanna,Taylor W-03 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-03 P-00,State Treasurer,,REP,Stacy L. Garrity,69,22,3,4,98
+Lackawanna,Taylor W-03 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-03 P-00,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,Taylor W-03 P-00,U.S. House,8,REP,Teddy Daniels,33,0,1,2,36
+Lackawanna,Taylor W-03 P-00,U.S. House,8,REP,Jim Bognet,14,5,0,0,19
+Lackawanna,Taylor W-03 P-00,U.S. House,8,REP,Mike Cammisa,2,0,0,0,2
+Lackawanna,Taylor W-03 P-00,U.S. House,8,REP,Mike Marsicano,6,1,1,0,8
+Lackawanna,Taylor W-03 P-00,U.S. House,8,REP,Earl Granville,33,20,3,2,58
+Lackawanna,Taylor W-03 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Taylor W-03 P-00,General Assembly,114,REP,James May,76,24,5,2,107
+Lackawanna,Taylor W-03 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-04 P-00,Registered Voters,,,,,,,,935
+Lackawanna,Taylor W-04 P-00,Registered Voters,,DEM,,,,,,623
+Lackawanna,Taylor W-04 P-00,Registered Voters,,REP,,,,,,312
+Lackawanna,Taylor W-04 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Taylor W-04 P-00,Ballots Cast,,,,187,136,34,4,361
+Lackawanna,Taylor W-04 P-00,Ballots Cast,,DEM,,105,103,27,1,236
+Lackawanna,Taylor W-04 P-00,Ballots Cast,,REP,,82,33,7,3,125
+Lackawanna,Taylor W-04 P-00,President,,DEM,Bernie Sanders,10,8,7,0,25
+Lackawanna,Taylor W-04 P-00,President,,DEM,Joseph R. Biden,74,90,16,1,181
+Lackawanna,Taylor W-04 P-00,President,,DEM,Tulsi Gabbard,11,1,0,0,12
+Lackawanna,Taylor W-04 P-00,President,,DEM,Write-in,7,0,0,0,7
+Lackawanna,Taylor W-04 P-00,Attorney General,,DEM,Josh Shapiro,89,95,21,1,206
+Lackawanna,Taylor W-04 P-00,Attorney General,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Taylor W-04 P-00,Auditor General,,DEM,H. Scott Conklin,6,7,1,0,14
+Lackawanna,Taylor W-04 P-00,Auditor General,,DEM,Michael Lamb,37,21,6,0,64
+Lackawanna,Taylor W-04 P-00,Auditor General,,DEM,Tracie Fountain,3,12,0,0,15
+Lackawanna,Taylor W-04 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,16,22,11,0,49
+Lackawanna,Taylor W-04 P-00,Auditor General,,DEM,Nina Ahmad,19,10,3,0,32
+Lackawanna,Taylor W-04 P-00,Auditor General,,DEM,Christina M. Hartman,10,16,4,0,30
+Lackawanna,Taylor W-04 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-04 P-00,State Treasurer,,DEM,Joe Torsella,87,90,21,1,199
+Lackawanna,Taylor W-04 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Taylor W-04 P-00,U.S. House,8,DEM,Matt Cartwright,91,100,23,1,215
+Lackawanna,Taylor W-04 P-00,U.S. House,8,DEM,Write-in,3,0,1,0,4
+Lackawanna,Taylor W-04 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,87,100,22,1,210
+Lackawanna,Taylor W-04 P-00,General Assembly,114,DEM,Write-in,3,0,1,0,4
+Lackawanna,Taylor W-04 P-00,President,,REP,Donald J. Trump,78,25,6,3,112
+Lackawanna,Taylor W-04 P-00,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Lackawanna,Taylor W-04 P-00,President,,REP,Bill Weld,4,2,1,0,7
+Lackawanna,Taylor W-04 P-00,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Taylor W-04 P-00,Attorney General,,REP,Heather Heidelbaugh,69,26,5,1,101
+Lackawanna,Taylor W-04 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-04 P-00,Auditor General,,REP,Timothy DeFoor,67,27,5,1,100
+Lackawanna,Taylor W-04 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-04 P-00,State Treasurer,,REP,Stacy L. Garrity,69,27,3,1,100
+Lackawanna,Taylor W-04 P-00,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Taylor W-04 P-00,U.S. House,8,REP,Harry Haas,1,2,0,0,3
+Lackawanna,Taylor W-04 P-00,U.S. House,8,REP,Teddy Daniels,26,5,0,0,31
+Lackawanna,Taylor W-04 P-00,U.S. House,8,REP,Jim Bognet,23,9,4,0,36
+Lackawanna,Taylor W-04 P-00,U.S. House,8,REP,Mike Cammisa,1,2,0,0,3
+Lackawanna,Taylor W-04 P-00,U.S. House,8,REP,Mike Marsicano,7,1,0,3,11
+Lackawanna,Taylor W-04 P-00,U.S. House,8,REP,Earl Granville,24,13,3,0,40
+Lackawanna,Taylor W-04 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-04 P-00,General Assembly,114,REP,James May,69,29,6,3,107
+Lackawanna,Taylor W-04 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-05 P-00,Registered Voters,,,,,,,,941
+Lackawanna,Taylor W-05 P-00,Registered Voters,,DEM,,,,,,644
+Lackawanna,Taylor W-05 P-00,Registered Voters,,REP,,,,,,297
+Lackawanna,Taylor W-05 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Taylor W-05 P-00,Ballots Cast,,,,183,185,36,6,410
+Lackawanna,Taylor W-05 P-00,Ballots Cast,,DEM,,98,156,30,4,288
+Lackawanna,Taylor W-05 P-00,Ballots Cast,,REP,,85,29,6,2,122
+Lackawanna,Taylor W-05 P-00,President,,DEM,Bernie Sanders,12,11,4,0,27
+Lackawanna,Taylor W-05 P-00,President,,DEM,Joseph R. Biden,71,138,24,2,235
+Lackawanna,Taylor W-05 P-00,President,,DEM,Tulsi Gabbard,4,5,0,2,11
+Lackawanna,Taylor W-05 P-00,President,,DEM,Write-in,5,0,1,0,6
+Lackawanna,Taylor W-05 P-00,Attorney General,,DEM,Josh Shapiro,80,142,26,1,249
+Lackawanna,Taylor W-05 P-00,Attorney General,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Taylor W-05 P-00,Auditor General,,DEM,H. Scott Conklin,6,6,1,0,13
+Lackawanna,Taylor W-05 P-00,Auditor General,,DEM,Michael Lamb,33,40,6,4,83
+Lackawanna,Taylor W-05 P-00,Auditor General,,DEM,Tracie Fountain,3,9,0,0,12
+Lackawanna,Taylor W-05 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,9,39,6,0,54
+Lackawanna,Taylor W-05 P-00,Auditor General,,DEM,Nina Ahmad,20,19,6,0,45
+Lackawanna,Taylor W-05 P-00,Auditor General,,DEM,Christina M. Hartman,11,22,8,0,41
+Lackawanna,Taylor W-05 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Taylor W-05 P-00,State Treasurer,,DEM,Joe Torsella,75,133,25,3,236
+Lackawanna,Taylor W-05 P-00,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Lackawanna,Taylor W-05 P-00,U.S. House,8,DEM,Matt Cartwright,84,150,28,2,264
+Lackawanna,Taylor W-05 P-00,U.S. House,8,DEM,Write-in,4,0,0,1,5
+Lackawanna,Taylor W-05 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,80,143,27,2,252
+Lackawanna,Taylor W-05 P-00,General Assembly,114,DEM,Write-in,2,3,1,0,6
+Lackawanna,Taylor W-05 P-00,President,,REP,Donald J. Trump,75,21,5,1,102
+Lackawanna,Taylor W-05 P-00,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Lackawanna,Taylor W-05 P-00,President,,REP,Bill Weld,1,3,1,0,5
+Lackawanna,Taylor W-05 P-00,President,,REP,Write-in,5,4,0,1,10
+Lackawanna,Taylor W-05 P-00,Attorney General,,REP,Heather Heidelbaugh,58,23,6,1,88
+Lackawanna,Taylor W-05 P-00,Attorney General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Taylor W-05 P-00,Auditor General,,REP,Timothy DeFoor,58,23,6,1,88
+Lackawanna,Taylor W-05 P-00,Auditor General,,REP,Write-in,1,1,0,0,2
+Lackawanna,Taylor W-05 P-00,State Treasurer,,REP,Stacy L. Garrity,59,24,6,1,90
+Lackawanna,Taylor W-05 P-00,State Treasurer,,REP,Write-in,1,1,0,0,2
+Lackawanna,Taylor W-05 P-00,U.S. House,8,REP,Harry Haas,1,1,1,0,3
+Lackawanna,Taylor W-05 P-00,U.S. House,8,REP,Teddy Daniels,30,2,0,1,33
+Lackawanna,Taylor W-05 P-00,U.S. House,8,REP,Jim Bognet,10,5,3,0,18
+Lackawanna,Taylor W-05 P-00,U.S. House,8,REP,Mike Cammisa,0,1,0,0,1
+Lackawanna,Taylor W-05 P-00,U.S. House,8,REP,Mike Marsicano,4,2,0,0,6
+Lackawanna,Taylor W-05 P-00,U.S. House,8,REP,Earl Granville,35,15,2,1,53
+Lackawanna,Taylor W-05 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Taylor W-05 P-00,General Assembly,114,REP,James May,65,25,6,1,97
+Lackawanna,Taylor W-05 P-00,General Assembly,114,REP,Write-in,0,1,0,0,1
+Lackawanna,Throop W-01 P-00,Registered Voters,,,,,,,,886
+Lackawanna,Throop W-01 P-00,Registered Voters,,DEM,,,,,,635
+Lackawanna,Throop W-01 P-00,Registered Voters,,REP,,,,,,251
+Lackawanna,Throop W-01 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Throop W-01 P-00,Ballots Cast,,,,178,174,28,1,381
+Lackawanna,Throop W-01 P-00,Ballots Cast,,DEM,,104,150,20,0,274
+Lackawanna,Throop W-01 P-00,Ballots Cast,,REP,,74,24,8,1,107
+Lackawanna,Throop W-01 P-00,President,,DEM,Bernie Sanders,9,12,2,0,23
+Lackawanna,Throop W-01 P-00,President,,DEM,Joseph R. Biden,72,125,16,0,213
+Lackawanna,Throop W-01 P-00,President,,DEM,Tulsi Gabbard,13,5,1,0,19
+Lackawanna,Throop W-01 P-00,President,,DEM,Write-in,6,4,0,0,10
+Lackawanna,Throop W-01 P-00,Attorney General,,DEM,Josh Shapiro,77,127,20,0,224
+Lackawanna,Throop W-01 P-00,Attorney General,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Throop W-01 P-00,Auditor General,,DEM,H. Scott Conklin,5,0,0,0,5
+Lackawanna,Throop W-01 P-00,Auditor General,,DEM,Michael Lamb,26,28,3,0,57
+Lackawanna,Throop W-01 P-00,Auditor General,,DEM,Tracie Fountain,5,11,0,0,16
+Lackawanna,Throop W-01 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,18,39,11,0,68
+Lackawanna,Throop W-01 P-00,Auditor General,,DEM,Nina Ahmad,23,19,4,0,46
+Lackawanna,Throop W-01 P-00,Auditor General,,DEM,Christina M. Hartman,8,21,1,0,30
+Lackawanna,Throop W-01 P-00,Auditor General,,DEM,Write-in,0,1,0,0,1
+Lackawanna,Throop W-01 P-00,State Treasurer,,DEM,Joe Torsella,77,115,18,0,210
+Lackawanna,Throop W-01 P-00,State Treasurer,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Throop W-01 P-00,U.S. House,8,DEM,Matt Cartwright,88,134,19,0,241
+Lackawanna,Throop W-01 P-00,U.S. House,8,DEM,Write-in,2,3,0,0,5
+Lackawanna,Throop W-01 P-00,General Assembly,112,DEM,Kyle J. Mullins,90,139,20,0,249
+Lackawanna,Throop W-01 P-00,General Assembly,112,DEM,Write-in,1,0,0,0,1
+Lackawanna,Throop W-01 P-00,President,,REP,Donald J. Trump,66,18,5,1,90
+Lackawanna,Throop W-01 P-00,President,,REP,Roque Rocky De La Fuente,1,1,1,0,3
+Lackawanna,Throop W-01 P-00,President,,REP,Bill Weld,4,1,0,0,5
+Lackawanna,Throop W-01 P-00,President,,REP,Write-in,1,2,2,0,5
+Lackawanna,Throop W-01 P-00,Attorney General,,REP,Heather Heidelbaugh,55,17,6,1,79
+Lackawanna,Throop W-01 P-00,Attorney General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Throop W-01 P-00,Auditor General,,REP,Timothy DeFoor,53,15,6,1,75
+Lackawanna,Throop W-01 P-00,Auditor General,,REP,Write-in,1,0,0,0,1
+Lackawanna,Throop W-01 P-00,State Treasurer,,REP,Stacy L. Garrity,54,15,6,1,76
+Lackawanna,Throop W-01 P-00,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Throop W-01 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Throop W-01 P-00,U.S. House,8,REP,Teddy Daniels,22,2,3,0,27
+Lackawanna,Throop W-01 P-00,U.S. House,8,REP,Jim Bognet,12,3,0,0,15
+Lackawanna,Throop W-01 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Throop W-01 P-00,U.S. House,8,REP,Mike Marsicano,3,0,0,0,3
+Lackawanna,Throop W-01 P-00,U.S. House,8,REP,Earl Granville,29,16,4,1,50
+Lackawanna,Throop W-01 P-00,U.S. House,8,REP,Write-in,3,0,0,0,3
+Lackawanna,Throop W-01 P-00,General Assembly,112,REP,Write-in,24,4,4,0,32
+Lackawanna,Throop W-02 P-00,Registered Voters,,,,,,,,655
+Lackawanna,Throop W-02 P-00,Registered Voters,,DEM,,,,,,484
+Lackawanna,Throop W-02 P-00,Registered Voters,,REP,,,,,,171
+Lackawanna,Throop W-02 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Throop W-02 P-00,Ballots Cast,,,,122,133,22,2,279
+Lackawanna,Throop W-02 P-00,Ballots Cast,,DEM,,80,117,20,2,219
+Lackawanna,Throop W-02 P-00,Ballots Cast,,REP,,42,16,2,0,60
+Lackawanna,Throop W-02 P-00,President,,DEM,Bernie Sanders,12,6,2,0,20
+Lackawanna,Throop W-02 P-00,President,,DEM,Joseph R. Biden,48,101,16,2,167
+Lackawanna,Throop W-02 P-00,President,,DEM,Tulsi Gabbard,5,9,0,0,14
+Lackawanna,Throop W-02 P-00,President,,DEM,Write-in,7,1,2,0,10
+Lackawanna,Throop W-02 P-00,Attorney General,,DEM,Josh Shapiro,56,107,16,2,181
+Lackawanna,Throop W-02 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Throop W-02 P-00,Auditor General,,DEM,H. Scott Conklin,3,3,4,0,10
+Lackawanna,Throop W-02 P-00,Auditor General,,DEM,Michael Lamb,20,14,5,1,40
+Lackawanna,Throop W-02 P-00,Auditor General,,DEM,Tracie Fountain,5,8,0,0,13
+Lackawanna,Throop W-02 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,10,36,3,1,50
+Lackawanna,Throop W-02 P-00,Auditor General,,DEM,Nina Ahmad,19,23,4,0,46
+Lackawanna,Throop W-02 P-00,Auditor General,,DEM,Christina M. Hartman,9,19,2,0,30
+Lackawanna,Throop W-02 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Throop W-02 P-00,State Treasurer,,DEM,Joe Torsella,51,103,17,2,173
+Lackawanna,Throop W-02 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Throop W-02 P-00,U.S. House,8,DEM,Matt Cartwright,63,108,18,2,191
+Lackawanna,Throop W-02 P-00,U.S. House,8,DEM,Write-in,2,3,2,0,7
+Lackawanna,Throop W-02 P-00,General Assembly,112,DEM,Kyle J. Mullins,65,112,20,2,199
+Lackawanna,Throop W-02 P-00,General Assembly,112,DEM,Write-in,0,0,0,0,0
+Lackawanna,Throop W-02 P-00,President,,REP,Donald J. Trump,40,11,2,0,53
+Lackawanna,Throop W-02 P-00,President,,REP,Roque Rocky De La Fuente,0,2,0,0,2
+Lackawanna,Throop W-02 P-00,President,,REP,Bill Weld,1,1,0,0,2
+Lackawanna,Throop W-02 P-00,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,Throop W-02 P-00,Attorney General,,REP,Heather Heidelbaugh,34,15,0,0,49
+Lackawanna,Throop W-02 P-00,Attorney General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Throop W-02 P-00,Auditor General,,REP,Timothy DeFoor,34,14,0,0,48
+Lackawanna,Throop W-02 P-00,Auditor General,,REP,Write-in,0,1,0,0,1
+Lackawanna,Throop W-02 P-00,State Treasurer,,REP,Stacy L. Garrity,34,15,0,0,49
+Lackawanna,Throop W-02 P-00,State Treasurer,,REP,Write-in,0,1,0,0,1
+Lackawanna,Throop W-02 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Throop W-02 P-00,U.S. House,8,REP,Teddy Daniels,6,0,0,0,6
+Lackawanna,Throop W-02 P-00,U.S. House,8,REP,Jim Bognet,6,1,0,0,7
+Lackawanna,Throop W-02 P-00,U.S. House,8,REP,Mike Cammisa,1,1,0,0,2
+Lackawanna,Throop W-02 P-00,U.S. House,8,REP,Mike Marsicano,8,0,0,0,8
+Lackawanna,Throop W-02 P-00,U.S. House,8,REP,Earl Granville,18,13,1,0,32
+Lackawanna,Throop W-02 P-00,U.S. House,8,REP,Write-in,0,1,0,0,1
+Lackawanna,Throop W-02 P-00,General Assembly,112,REP,Write-in,6,2,0,0,8
+Lackawanna,Throop W-03 P-00,Registered Voters,,,,,,,,481
+Lackawanna,Throop W-03 P-00,Registered Voters,,DEM,,,,,,357
+Lackawanna,Throop W-03 P-00,Registered Voters,,REP,,,,,,124
+Lackawanna,Throop W-03 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Throop W-03 P-00,Ballots Cast,,,,97,84,12,7,200
+Lackawanna,Throop W-03 P-00,Ballots Cast,,DEM,,61,78,11,1,151
+Lackawanna,Throop W-03 P-00,Ballots Cast,,REP,,36,6,1,6,49
+Lackawanna,Throop W-03 P-00,President,,DEM,Bernie Sanders,11,4,2,0,17
+Lackawanna,Throop W-03 P-00,President,,DEM,Joseph R. Biden,34,66,9,1,110
+Lackawanna,Throop W-03 P-00,President,,DEM,Tulsi Gabbard,4,3,0,0,7
+Lackawanna,Throop W-03 P-00,President,,DEM,Write-in,3,3,0,0,6
+Lackawanna,Throop W-03 P-00,Attorney General,,DEM,Josh Shapiro,45,62,8,1,116
+Lackawanna,Throop W-03 P-00,Attorney General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Throop W-03 P-00,Auditor General,,DEM,H. Scott Conklin,2,10,0,0,12
+Lackawanna,Throop W-03 P-00,Auditor General,,DEM,Michael Lamb,13,6,0,0,19
+Lackawanna,Throop W-03 P-00,Auditor General,,DEM,Tracie Fountain,1,4,1,0,6
+Lackawanna,Throop W-03 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,9,32,4,1,46
+Lackawanna,Throop W-03 P-00,Auditor General,,DEM,Nina Ahmad,16,6,3,0,25
+Lackawanna,Throop W-03 P-00,Auditor General,,DEM,Christina M. Hartman,8,7,0,0,15
+Lackawanna,Throop W-03 P-00,Auditor General,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Throop W-03 P-00,State Treasurer,,DEM,Joe Torsella,38,64,7,1,110
+Lackawanna,Throop W-03 P-00,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Lackawanna,Throop W-03 P-00,U.S. House,8,DEM,Matt Cartwright,41,72,7,1,121
+Lackawanna,Throop W-03 P-00,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,Throop W-03 P-00,General Assembly,112,DEM,Kyle J. Mullins,48,72,9,1,130
+Lackawanna,Throop W-03 P-00,General Assembly,112,DEM,Write-in,3,0,0,0,3
+Lackawanna,Throop W-03 P-00,President,,REP,Donald J. Trump,36,6,1,6,49
+Lackawanna,Throop W-03 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Throop W-03 P-00,President,,REP,Bill Weld,0,0,0,0,0
+Lackawanna,Throop W-03 P-00,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-03 P-00,Attorney General,,REP,Heather Heidelbaugh,22,5,1,4,32
+Lackawanna,Throop W-03 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-03 P-00,Auditor General,,REP,Timothy DeFoor,25,5,1,4,35
+Lackawanna,Throop W-03 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-03 P-00,State Treasurer,,REP,Stacy L. Garrity,23,5,1,4,33
+Lackawanna,Throop W-03 P-00,State Treasurer,,REP,Write-in,1,0,0,0,1
+Lackawanna,Throop W-03 P-00,U.S. House,8,REP,Harry Haas,0,0,0,1,1
+Lackawanna,Throop W-03 P-00,U.S. House,8,REP,Teddy Daniels,10,0,0,0,10
+Lackawanna,Throop W-03 P-00,U.S. House,8,REP,Jim Bognet,7,1,0,2,10
+Lackawanna,Throop W-03 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Throop W-03 P-00,U.S. House,8,REP,Mike Marsicano,4,0,0,0,4
+Lackawanna,Throop W-03 P-00,U.S. House,8,REP,Earl Granville,14,4,1,2,21
+Lackawanna,Throop W-03 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-03 P-00,General Assembly,112,REP,Write-in,3,1,0,0,4
+Lackawanna,Throop W-04 P-00,Registered Voters,,,,,,,,565
+Lackawanna,Throop W-04 P-00,Registered Voters,,DEM,,,,,,436
+Lackawanna,Throop W-04 P-00,Registered Voters,,REP,,,,,,129
+Lackawanna,Throop W-04 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Throop W-04 P-00,Ballots Cast,,,,114,116,19,6,255
+Lackawanna,Throop W-04 P-00,Ballots Cast,,DEM,,76,101,15,5,197
+Lackawanna,Throop W-04 P-00,Ballots Cast,,REP,,38,15,4,1,58
+Lackawanna,Throop W-04 P-00,President,,DEM,Bernie Sanders,10,7,0,0,17
+Lackawanna,Throop W-04 P-00,President,,DEM,Joseph R. Biden,56,91,15,4,166
+Lackawanna,Throop W-04 P-00,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Lackawanna,Throop W-04 P-00,President,,DEM,Write-in,5,2,0,0,7
+Lackawanna,Throop W-04 P-00,Attorney General,,DEM,Josh Shapiro,61,85,14,5,165
+Lackawanna,Throop W-04 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,Auditor General,,DEM,H. Scott Conklin,3,9,0,0,12
+Lackawanna,Throop W-04 P-00,Auditor General,,DEM,Michael Lamb,17,13,1,2,33
+Lackawanna,Throop W-04 P-00,Auditor General,,DEM,Tracie Fountain,1,2,3,1,7
+Lackawanna,Throop W-04 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,6,22,7,1,36
+Lackawanna,Throop W-04 P-00,Auditor General,,DEM,Nina Ahmad,30,20,3,0,53
+Lackawanna,Throop W-04 P-00,Auditor General,,DEM,Christina M. Hartman,4,13,1,0,18
+Lackawanna,Throop W-04 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,State Treasurer,,DEM,Joe Torsella,57,80,13,4,154
+Lackawanna,Throop W-04 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,U.S. House,8,DEM,Matt Cartwright,65,98,14,5,182
+Lackawanna,Throop W-04 P-00,U.S. House,8,DEM,Write-in,2,0,0,0,2
+Lackawanna,Throop W-04 P-00,General Assembly,112,DEM,Kyle J. Mullins,65,91,15,5,176
+Lackawanna,Throop W-04 P-00,General Assembly,112,DEM,Write-in,1,0,0,0,1
+Lackawanna,Throop W-04 P-00,President,,REP,Donald J. Trump,38,14,4,1,57
+Lackawanna,Throop W-04 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,President,,REP,Bill Weld,0,1,0,0,1
+Lackawanna,Throop W-04 P-00,President,,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,Attorney General,,REP,Heather Heidelbaugh,29,12,2,0,43
+Lackawanna,Throop W-04 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,Auditor General,,REP,Timothy DeFoor,30,13,3,0,46
+Lackawanna,Throop W-04 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,State Treasurer,,REP,Stacy L. Garrity,28,12,2,0,42
+Lackawanna,Throop W-04 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,U.S. House,8,REP,Teddy Daniels,12,2,0,0,14
+Lackawanna,Throop W-04 P-00,U.S. House,8,REP,Jim Bognet,10,1,1,0,12
+Lackawanna,Throop W-04 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,U.S. House,8,REP,Mike Marsicano,1,1,0,0,2
+Lackawanna,Throop W-04 P-00,U.S. House,8,REP,Earl Granville,14,11,3,1,29
+Lackawanna,Throop W-04 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Throop W-04 P-00,General Assembly,112,REP,Write-in,9,1,3,0,13
+Lackawanna,Vandling W-00 P-00,Registered Voters,,,,,,,,420
+Lackawanna,Vandling W-00 P-00,Registered Voters,,DEM,,,,,,243
+Lackawanna,Vandling W-00 P-00,Registered Voters,,REP,,,,,,177
+Lackawanna,Vandling W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,Vandling W-00 P-00,Ballots Cast,,,,126,82,19,2,229
+Lackawanna,Vandling W-00 P-00,Ballots Cast,,DEM,,58,64,13,1,136
+Lackawanna,Vandling W-00 P-00,Ballots Cast,,REP,,68,18,6,1,93
+Lackawanna,Vandling W-00 P-00,President,,DEM,Bernie Sanders,10,6,2,0,18
+Lackawanna,Vandling W-00 P-00,President,,DEM,Joseph R. Biden,40,52,8,1,101
+Lackawanna,Vandling W-00 P-00,President,,DEM,Tulsi Gabbard,4,3,1,0,8
+Lackawanna,Vandling W-00 P-00,President,,DEM,Write-in,1,2,0,0,3
+Lackawanna,Vandling W-00 P-00,Attorney General,,DEM,Josh Shapiro,48,60,13,1,122
+Lackawanna,Vandling W-00 P-00,Attorney General,,DEM,Write-in,1,1,0,0,2
+Lackawanna,Vandling W-00 P-00,Auditor General,,DEM,H. Scott Conklin,5,7,0,1,13
+Lackawanna,Vandling W-00 P-00,Auditor General,,DEM,Michael Lamb,12,7,1,0,20
+Lackawanna,Vandling W-00 P-00,Auditor General,,DEM,Tracie Fountain,1,6,3,0,10
+Lackawanna,Vandling W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,7,11,2,0,20
+Lackawanna,Vandling W-00 P-00,Auditor General,,DEM,Nina Ahmad,19,23,4,0,46
+Lackawanna,Vandling W-00 P-00,Auditor General,,DEM,Christina M. Hartman,4,8,2,0,14
+Lackawanna,Vandling W-00 P-00,Auditor General,,DEM,Write-in,1,0,1,0,2
+Lackawanna,Vandling W-00 P-00,State Treasurer,,DEM,Joe Torsella,44,60,12,1,117
+Lackawanna,Vandling W-00 P-00,State Treasurer,,DEM,Write-in,1,0,1,0,2
+Lackawanna,Vandling W-00 P-00,U.S. House,8,DEM,Matt Cartwright,50,62,12,1,125
+Lackawanna,Vandling W-00 P-00,U.S. House,8,DEM,Write-in,4,0,1,0,5
+Lackawanna,Vandling W-00 P-00,General Assembly,114,DEM,Bridget Malloy Kosierowski,44,62,13,1,120
+Lackawanna,Vandling W-00 P-00,General Assembly,114,DEM,Write-in,1,1,0,0,2
+Lackawanna,Vandling W-00 P-00,President,,REP,Donald J. Trump,65,13,5,0,83
+Lackawanna,Vandling W-00 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,Vandling W-00 P-00,President,,REP,Bill Weld,1,2,1,0,4
+Lackawanna,Vandling W-00 P-00,President,,REP,Write-in,1,1,0,0,2
+Lackawanna,Vandling W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,52,15,5,0,72
+Lackawanna,Vandling W-00 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Vandling W-00 P-00,Auditor General,,REP,Timothy DeFoor,52,14,6,0,72
+Lackawanna,Vandling W-00 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,Vandling W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,52,15,6,0,73
+Lackawanna,Vandling W-00 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,Vandling W-00 P-00,U.S. House,8,REP,Harry Haas,0,0,0,0,0
+Lackawanna,Vandling W-00 P-00,U.S. House,8,REP,Teddy Daniels,2,2,1,0,5
+Lackawanna,Vandling W-00 P-00,U.S. House,8,REP,Jim Bognet,8,1,0,0,9
+Lackawanna,Vandling W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,Vandling W-00 P-00,U.S. House,8,REP,Mike Marsicano,2,0,0,0,2
+Lackawanna,Vandling W-00 P-00,U.S. House,8,REP,Earl Granville,55,15,4,1,75
+Lackawanna,Vandling W-00 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,Vandling W-00 P-00,General Assembly,114,REP,James May,55,17,6,0,78
+Lackawanna,Vandling W-00 P-00,General Assembly,114,REP,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,Registered Voters,,,,,,,,202
+Lackawanna,West Abington Twp. W-00 P-00,Registered Voters,,DEM,,,,,,81
+Lackawanna,West Abington Twp. W-00 P-00,Registered Voters,,REP,,,,,,121
+Lackawanna,West Abington Twp. W-00 P-00,Registered Voters,,NPA,,,,,,0
+Lackawanna,West Abington Twp. W-00 P-00,Ballots Cast,,,,44,40,8,0,92
+Lackawanna,West Abington Twp. W-00 P-00,Ballots Cast,,DEM,,14,26,5,0,45
+Lackawanna,West Abington Twp. W-00 P-00,Ballots Cast,,REP,,30,14,3,0,47
+Lackawanna,West Abington Twp. W-00 P-00,President,,DEM,Bernie Sanders,1,0,0,0,1
+Lackawanna,West Abington Twp. W-00 P-00,President,,DEM,Joseph R. Biden,10,25,5,0,40
+Lackawanna,West Abington Twp. W-00 P-00,President,,DEM,Tulsi Gabbard,0,1,0,0,1
+Lackawanna,West Abington Twp. W-00 P-00,President,,DEM,Write-in,2,0,0,0,2
+Lackawanna,West Abington Twp. W-00 P-00,Attorney General,,DEM,Josh Shapiro,12,23,5,0,40
+Lackawanna,West Abington Twp. W-00 P-00,Attorney General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,DEM,H. Scott Conklin,0,1,0,0,1
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,DEM,Michael Lamb,1,4,2,0,7
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,DEM,Tracie Fountain,0,1,0,0,1
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,DEM,Rose Rosie Marie Davis,1,11,0,0,12
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,DEM,Nina Ahmad,7,3,2,0,12
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,DEM,Christina M. Hartman,3,4,1,0,8
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,DEM,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,State Treasurer,,DEM,Joe Torsella,12,23,5,0,40
+Lackawanna,West Abington Twp. W-00 P-00,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,DEM,Matt Cartwright,13,25,5,0,43
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,DEM,Write-in,1,0,0,0,1
+Lackawanna,West Abington Twp. W-00 P-00,General Assembly,117,DEM,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,President,,REP,Donald J. Trump,29,6,1,0,36
+Lackawanna,West Abington Twp. W-00 P-00,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,President,,REP,Bill Weld,1,4,1,0,6
+Lackawanna,West Abington Twp. W-00 P-00,President,,REP,Write-in,0,1,0,0,1
+Lackawanna,West Abington Twp. W-00 P-00,Attorney General,,REP,Heather Heidelbaugh,25,13,2,0,40
+Lackawanna,West Abington Twp. W-00 P-00,Attorney General,,REP,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,REP,Timothy DeFoor,24,13,2,0,39
+Lackawanna,West Abington Twp. W-00 P-00,Auditor General,,REP,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,State Treasurer,,REP,Stacy L. Garrity,26,13,2,0,41
+Lackawanna,West Abington Twp. W-00 P-00,State Treasurer,,REP,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,REP,Harry Haas,1,0,0,0,1
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,REP,Teddy Daniels,13,0,0,0,13
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,REP,Jim Bognet,6,3,0,0,9
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,REP,Mike Cammisa,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,REP,Mike Marsicano,2,0,0,0,2
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,REP,Earl Granville,6,10,3,0,19
+Lackawanna,West Abington Twp. W-00 P-00,U.S. House,8,REP,Write-in,0,0,0,0,0
+Lackawanna,West Abington Twp. W-00 P-00,General Assembly,117,REP,Karen Boback,26,14,2,0,42
+Lackawanna,West Abington Twp. W-00 P-00,General Assembly,117,REP,Write-in,0,0,0,0,0

--- a/2020/20200602__pa__primary__mercer__precinct.csv
+++ b/2020/20200602__pa__primary__mercer__precinct.csv
@@ -1,0 +1,3812 @@
+county,precinct,office,district,party,candidate,election_day,mail_in,votes
+Mercer,Clark,Registered Voters,,,,,,376
+Mercer,Clark,Registered Voters,,DEM,,,,191
+Mercer,Clark,Registered Voters,,REP,,,,185
+Mercer,Clark,Registered Voters,,NPA,,,,0
+Mercer,Clark,Ballots Cast,,,,91,47,138
+Mercer,Clark,Ballots Cast,,DEM,,43,30,73
+Mercer,Clark,Ballots Cast,,REP,,48,17,65
+Mercer,Clark,Ballots Cast,,NPA,,0,0,0
+Mercer,Clark,President,,DEM,Bernie Sanders,8,0,8
+Mercer,Clark,President,,DEM,Joseph R. Biden,28,29,57
+Mercer,Clark,President,,DEM,Tulsi Gabbard,2,0,2
+Mercer,Clark,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Clark,President,,DEM,Write-In,2,0,2
+Mercer,Clark,Attorney General,,DEM,Josh Shapiro,36,25,61
+Mercer,Clark,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Clark,Auditor General,,DEM,H. Scott Conklin,0,0,0
+Mercer,Clark,Auditor General,,DEM,Michael Lamb,25,24,49
+Mercer,Clark,Auditor General,,DEM,Tracie Fountain,2,1,3
+Mercer,Clark,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2
+Mercer,Clark,Auditor General,,DEM,Nina Ahmad,3,0,3
+Mercer,Clark,Auditor General,,DEM,Christina M. Hartman,3,3,6
+Mercer,Clark,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Clark,State Treasurer,,DEM,Joe Torsella,33,23,56
+Mercer,Clark,State Treasurer,,DEM,Write-In,1,1,2
+Mercer,Clark,U.S. House,16,DEM,Kristy Gnibus,36,22,58
+Mercer,Clark,U.S. House,16,DEM,Write-In,1,1,2
+Mercer,Clark,General Assembly,7,DEM,Mark Longietti,42,28,70
+Mercer,Clark,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Clark,President,,REP,Donald J. Trump,48,14,62
+Mercer,Clark,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Clark,President,,REP,Bill Weld,0,1,1
+Mercer,Clark,President,,REP,Write-In,0,1,1
+Mercer,Clark,Attorney General,,REP,Heather Heidelbaugh,41,14,55
+Mercer,Clark,Attorney General,,REP,Write-In,0,1,1
+Mercer,Clark,Auditor General,,REP,Timothy Defoor,43,14,57
+Mercer,Clark,Auditor General,,REP,Write-In,0,1,1
+Mercer,Clark,State Treasurer,,REP,Stacy L. Garrity,41,14,55
+Mercer,Clark,State Treasurer,,REP,Write-In,0,1,1
+Mercer,Clark,U.S. House,16,REP,Mike Kelly,43,13,56
+Mercer,Clark,U.S. House,16,REP,Write-In,1,2,3
+Mercer,Clark,General Assembly,7,REP,Write-In,4,3,7
+Mercer,Clark,General Assembly,7,REP,Mark Longietti,1,3,4
+Mercer,Coolspring,Registered Voters,,,,,,1262
+Mercer,Coolspring,Registered Voters,,DEM,,,,408
+Mercer,Coolspring,Registered Voters,,REP,,,,854
+Mercer,Coolspring,Registered Voters,,NPA,,,,0
+Mercer,Coolspring,Ballots Cast,,,,252,210,462
+Mercer,Coolspring,Ballots Cast,,DEM,,45,98,143
+Mercer,Coolspring,Ballots Cast,,REP,,207,112,319
+Mercer,Coolspring,Ballots Cast,,NPA,,0,0,0
+Mercer,Coolspring,President,,DEM,Bernie Sanders,8,7,15
+Mercer,Coolspring,President,,DEM,Joseph R. Biden,23,78,101
+Mercer,Coolspring,President,,DEM,Tulsi Gabbard,4,1,5
+Mercer,Coolspring,President,,DEM,Elizabeth Warren,2,4,6
+Mercer,Coolspring,President,,DEM,Write-In,5,6,11
+Mercer,Coolspring,Attorney General,,DEM,Josh Shapiro,40,90,130
+Mercer,Coolspring,Attorney General,,DEM,Write-In,1,1,2
+Mercer,Coolspring,Auditor General,,DEM,H. Scott Conklin,8,7,15
+Mercer,Coolspring,Auditor General,,DEM,Michael Lamb,22,58,80
+Mercer,Coolspring,Auditor General,,DEM,Tracie Fountain,1,4,5
+Mercer,Coolspring,Auditor General,,DEM,Rose Rosie Marie Davis,4,4,8
+Mercer,Coolspring,Auditor General,,DEM,Nina Ahmad,5,9,14
+Mercer,Coolspring,Auditor General,,DEM,Christina M. Hartman,4,10,14
+Mercer,Coolspring,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Coolspring,State Treasurer,,DEM,Joe Torsella,41,87,128
+Mercer,Coolspring,State Treasurer,,DEM,Write-In,0,1,1
+Mercer,Coolspring,U.S. House,16,DEM,Kristy Gnibus,42,86,128
+Mercer,Coolspring,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Coolspring,General Assembly,8,DEM,Phil Heasley,40,85,125
+Mercer,Coolspring,General Assembly,8,DEM,Write-In,1,1,2
+Mercer,Coolspring,President,,REP,Donald J. Trump,195,92,287
+Mercer,Coolspring,President,,REP,Roque Rocky De La Fuente,2,4,6
+Mercer,Coolspring,President,,REP,Bill Weld,7,8,15
+Mercer,Coolspring,President,,REP,Write-In,2,3,5
+Mercer,Coolspring,Attorney General,,REP,Heather Heidelbaugh,188,93,281
+Mercer,Coolspring,Attorney General,,REP,Write-In,0,0,0
+Mercer,Coolspring,Auditor General,,REP,Timothy Defoor,180,89,269
+Mercer,Coolspring,Auditor General,,REP,Write-In,0,0,0
+Mercer,Coolspring,State Treasurer,,REP,Stacy L. Garrity,184,88,272
+Mercer,Coolspring,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Coolspring,U.S. House,16,REP,Mike Kelly,197,96,293
+Mercer,Coolspring,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Coolspring,General Assembly,8,REP,Scott Jaillet,40,30,70
+Mercer,Coolspring,General Assembly,8,REP,Tim Bonner,163,74,237
+Mercer,Coolspring,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Deer Creek,Registered Voters,,,,,,262
+Mercer,Deer Creek,Registered Voters,,DEM,,,,86
+Mercer,Deer Creek,Registered Voters,,REP,,,,176
+Mercer,Deer Creek,Registered Voters,,NPA,,,,0
+Mercer,Deer Creek,Ballots Cast,,,,98,18,116
+Mercer,Deer Creek,Ballots Cast,,DEM,,19,15,34
+Mercer,Deer Creek,Ballots Cast,,REP,,79,3,82
+Mercer,Deer Creek,Ballots Cast,,NPA,,0,0,0
+Mercer,Deer Creek,President,,DEM,Bernie Sanders,1,1,2
+Mercer,Deer Creek,President,,DEM,Joseph R. Biden,13,13,26
+Mercer,Deer Creek,President,,DEM,Tulsi Gabbard,4,0,4
+Mercer,Deer Creek,President,,DEM,Elizabeth Warren,0,1,1
+Mercer,Deer Creek,President,,DEM,Write-In,0,0,0
+Mercer,Deer Creek,Attorney General,,DEM,Josh Shapiro,17,14,31
+Mercer,Deer Creek,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Deer Creek,Auditor General,,DEM,H. Scott Conklin,1,0,1
+Mercer,Deer Creek,Auditor General,,DEM,Michael Lamb,11,8,19
+Mercer,Deer Creek,Auditor General,,DEM,Tracie Fountain,2,3,5
+Mercer,Deer Creek,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,3
+Mercer,Deer Creek,Auditor General,,DEM,Nina Ahmad,1,1,2
+Mercer,Deer Creek,Auditor General,,DEM,Christina M. Hartman,3,1,4
+Mercer,Deer Creek,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Deer Creek,State Treasurer,,DEM,Joe Torsella,16,14,30
+Mercer,Deer Creek,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Deer Creek,U.S. House,16,DEM,Kristy Gnibus,17,14,31
+Mercer,Deer Creek,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Deer Creek,General Assembly,8,DEM,Phil Heasley,18,14,32
+Mercer,Deer Creek,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Deer Creek,President,,REP,Donald J. Trump,76,3,79
+Mercer,Deer Creek,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Deer Creek,President,,REP,Bill Weld,1,0,1
+Mercer,Deer Creek,President,,REP,Write-In,1,0,1
+Mercer,Deer Creek,Attorney General,,REP,Heather Heidelbaugh,68,2,70
+Mercer,Deer Creek,Attorney General,,REP,Write-In,0,0,0
+Mercer,Deer Creek,Auditor General,,REP,Timothy Defoor,67,2,69
+Mercer,Deer Creek,Auditor General,,REP,Write-In,0,0,0
+Mercer,Deer Creek,State Treasurer,,REP,Stacy L. Garrity,67,2,69
+Mercer,Deer Creek,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Deer Creek,U.S. House,16,REP,Mike Kelly,77,2,79
+Mercer,Deer Creek,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Deer Creek,General Assembly,8,REP,Scott Jaillet,9,1,10
+Mercer,Deer Creek,General Assembly,8,REP,Tim Bonner,65,2,67
+Mercer,Deer Creek,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Delaware,Registered Voters,,,,,,1210
+Mercer,Delaware,Registered Voters,,DEM,,,,504
+Mercer,Delaware,Registered Voters,,REP,,,,706
+Mercer,Delaware,Registered Voters,,NPA,,,,0
+Mercer,Delaware,Ballots Cast,,,,238,203,441
+Mercer,Delaware,Ballots Cast,,DEM,,75,111,186
+Mercer,Delaware,Ballots Cast,,REP,,163,92,255
+Mercer,Delaware,Ballots Cast,,NPA,,0,0,0
+Mercer,Delaware,President,,DEM,Bernie Sanders,12,14,26
+Mercer,Delaware,President,,DEM,Joseph R. Biden,50,90,140
+Mercer,Delaware,President,,DEM,Tulsi Gabbard,3,1,4
+Mercer,Delaware,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Delaware,President,,DEM,Write-In,8,3,11
+Mercer,Delaware,Attorney General,,DEM,Josh Shapiro,56,101,157
+Mercer,Delaware,Attorney General,,DEM,Write-In,3,0,3
+Mercer,Delaware,Auditor General,,DEM,H. Scott Conklin,9,17,26
+Mercer,Delaware,Auditor General,,DEM,Michael Lamb,43,56,99
+Mercer,Delaware,Auditor General,,DEM,Tracie Fountain,0,5,5
+Mercer,Delaware,Auditor General,,DEM,Rose Rosie Marie Davis,1,5,6
+Mercer,Delaware,Auditor General,,DEM,Nina Ahmad,2,3,5
+Mercer,Delaware,Auditor General,,DEM,Christina M. Hartman,8,10,18
+Mercer,Delaware,Auditor General,,DEM,Write-In,3,0,3
+Mercer,Delaware,State Treasurer,,DEM,Joe Torsella,55,96,151
+Mercer,Delaware,State Treasurer,,DEM,Write-In,4,1,5
+Mercer,Delaware,U.S. House,16,DEM,Kristy Gnibus,63,96,159
+Mercer,Delaware,U.S. House,16,DEM,Write-In,3,0,3
+Mercer,Delaware,General Assembly,17,DEM,Write-In,10,6,16
+Mercer,Delaware,General Assembly,17,DEM,Jeff O'Melian,0,3,3
+Mercer,Delaware,President,,REP,Donald J. Trump,162,75,237
+Mercer,Delaware,President,,REP,Roque Rocky De La Fuente,0,2,2
+Mercer,Delaware,President,,REP,Bill Weld,0,6,6
+Mercer,Delaware,President,,REP,Write-In,1,2,3
+Mercer,Delaware,Attorney General,,REP,Heather Heidelbaugh,146,82,228
+Mercer,Delaware,Attorney General,,REP,Write-In,0,0,0
+Mercer,Delaware,Auditor General,,REP,Timothy Defoor,142,78,220
+Mercer,Delaware,Auditor General,,REP,Write-In,1,0,1
+Mercer,Delaware,State Treasurer,,REP,Stacy L. Garrity,146,81,227
+Mercer,Delaware,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Delaware,U.S. House,16,REP,Mike Kelly,150,83,233
+Mercer,Delaware,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Delaware,General Assembly,17,REP,Parke Wentling,156,88,244
+Mercer,Delaware,General Assembly,17,REP,Write-In,0,0,0
+Mercer,East Lackawannock,Registered Voters,,,,,,956
+Mercer,East Lackawannock,Registered Voters,,DEM,,,,302
+Mercer,East Lackawannock,Registered Voters,,REP,,,,654
+Mercer,East Lackawannock,Registered Voters,,NPA,,,,0
+Mercer,East Lackawannock,Ballots Cast,,,,213,121,334
+Mercer,East Lackawannock,Ballots Cast,,DEM,,46,49,95
+Mercer,East Lackawannock,Ballots Cast,,REP,,167,72,239
+Mercer,East Lackawannock,Ballots Cast,,NPA,,0,0,0
+Mercer,East Lackawannock,President,,DEM,Bernie Sanders,5,3,8
+Mercer,East Lackawannock,President,,DEM,Joseph R. Biden,30,41,71
+Mercer,East Lackawannock,President,,DEM,Tulsi Gabbard,4,1,5
+Mercer,East Lackawannock,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,East Lackawannock,President,,DEM,Write-In,2,1,3
+Mercer,East Lackawannock,Attorney General,,DEM,Josh Shapiro,39,42,81
+Mercer,East Lackawannock,Attorney General,,DEM,Write-In,0,0,0
+Mercer,East Lackawannock,Auditor General,,DEM,H. Scott Conklin,4,3,7
+Mercer,East Lackawannock,Auditor General,,DEM,Michael Lamb,25,30,55
+Mercer,East Lackawannock,Auditor General,,DEM,Tracie Fountain,1,2,3
+Mercer,East Lackawannock,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,4
+Mercer,East Lackawannock,Auditor General,,DEM,Nina Ahmad,2,2,4
+Mercer,East Lackawannock,Auditor General,,DEM,Christina M. Hartman,1,5,6
+Mercer,East Lackawannock,Auditor General,,DEM,Write-In,0,0,0
+Mercer,East Lackawannock,State Treasurer,,DEM,Joe Torsella,36,40,76
+Mercer,East Lackawannock,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,East Lackawannock,U.S. House,16,DEM,Kristy Gnibus,34,39,73
+Mercer,East Lackawannock,U.S. House,16,DEM,Write-In,0,3,3
+Mercer,East Lackawannock,General Assembly,17,DEM,Write-In,1,5,6
+Mercer,East Lackawannock,General Assembly,17,DEM,Jeff O'Melian,0,1,1
+Mercer,East Lackawannock,President,,REP,Donald J. Trump,160,57,217
+Mercer,East Lackawannock,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,East Lackawannock,President,,REP,Bill Weld,2,8,10
+Mercer,East Lackawannock,President,,REP,Write-In,2,2,4
+Mercer,East Lackawannock,Attorney General,,REP,Heather Heidelbaugh,148,65,213
+Mercer,East Lackawannock,Attorney General,,REP,Write-In,0,0,0
+Mercer,East Lackawannock,Auditor General,,REP,Timothy Defoor,143,64,207
+Mercer,East Lackawannock,Auditor General,,REP,Write-In,0,0,0
+Mercer,East Lackawannock,State Treasurer,,REP,Stacy L. Garrity,147,66,213
+Mercer,East Lackawannock,State Treasurer,,REP,Write-In,0,0,0
+Mercer,East Lackawannock,U.S. House,16,REP,Mike Kelly,157,66,223
+Mercer,East Lackawannock,U.S. House,16,REP,Write-In,0,2,2
+Mercer,East Lackawannock,General Assembly,17,REP,Parke Wentling,158,70,228
+Mercer,East Lackawannock,General Assembly,17,REP,Write-In,0,0,0
+Mercer,Fairview,Registered Voters,,,,,,392
+Mercer,Fairview,Registered Voters,,DEM,,,,107
+Mercer,Fairview,Registered Voters,,REP,,,,285
+Mercer,Fairview,Registered Voters,,NPA,,,,0
+Mercer,Fairview,Ballots Cast,,,,129,28,157
+Mercer,Fairview,Ballots Cast,,DEM,,19,20,39
+Mercer,Fairview,Ballots Cast,,REP,,110,8,118
+Mercer,Fairview,Ballots Cast,,NPA,,0,0,0
+Mercer,Fairview,President,,DEM,Bernie Sanders,2,1,3
+Mercer,Fairview,President,,DEM,Joseph R. Biden,10,18,28
+Mercer,Fairview,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Fairview,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Fairview,President,,DEM,Write-In,2,0,2
+Mercer,Fairview,Attorney General,,DEM,Josh Shapiro,13,19,32
+Mercer,Fairview,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Fairview,Auditor General,,DEM,H. Scott Conklin,4,1,5
+Mercer,Fairview,Auditor General,,DEM,Michael Lamb,8,15,23
+Mercer,Fairview,Auditor General,,DEM,Tracie Fountain,1,0,1
+Mercer,Fairview,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,3
+Mercer,Fairview,Auditor General,,DEM,Nina Ahmad,1,1,2
+Mercer,Fairview,Auditor General,,DEM,Christina M. Hartman,0,2,2
+Mercer,Fairview,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Fairview,State Treasurer,,DEM,Joe Torsella,13,19,32
+Mercer,Fairview,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Fairview,U.S. House,16,DEM,Kristy Gnibus,15,19,34
+Mercer,Fairview,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Fairview,General Assembly,8,DEM,Phil Heasley,16,19,35
+Mercer,Fairview,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Fairview,President,,REP,Donald J. Trump,101,7,108
+Mercer,Fairview,President,,REP,Roque Rocky De La Fuente,5,0,5
+Mercer,Fairview,President,,REP,Bill Weld,1,0,1
+Mercer,Fairview,President,,REP,Write-In,0,0,0
+Mercer,Fairview,Attorney General,,REP,Heather Heidelbaugh,90,8,98
+Mercer,Fairview,Attorney General,,REP,Write-In,0,0,0
+Mercer,Fairview,Auditor General,,REP,Timothy Defoor,84,8,92
+Mercer,Fairview,Auditor General,,REP,Write-In,0,0,0
+Mercer,Fairview,State Treasurer,,REP,Stacy L. Garrity,89,8,97
+Mercer,Fairview,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Fairview,U.S. House,16,REP,Mike Kelly,98,8,106
+Mercer,Fairview,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Fairview,General Assembly,8,REP,Scott Jaillet,21,2,23
+Mercer,Fairview,General Assembly,8,REP,Tim Bonner,87,6,93
+Mercer,Fairview,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Farrell 1-1,Registered Voters,,,,,,405
+Mercer,Farrell 1-1,Registered Voters,,DEM,,,,370
+Mercer,Farrell 1-1,Registered Voters,,REP,,,,35
+Mercer,Farrell 1-1,Registered Voters,,NPA,,,,0
+Mercer,Farrell 1-1,Ballots Cast,,,,57,25,82
+Mercer,Farrell 1-1,Ballots Cast,,DEM,,53,24,77
+Mercer,Farrell 1-1,Ballots Cast,,REP,,4,1,5
+Mercer,Farrell 1-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Farrell 1-1,President,,DEM,Bernie Sanders,11,2,13
+Mercer,Farrell 1-1,President,,DEM,Joseph R. Biden,40,22,62
+Mercer,Farrell 1-1,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Farrell 1-1,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Farrell 1-1,President,,DEM,Write-In,0,0,0
+Mercer,Farrell 1-1,Attorney General,,DEM,Josh Shapiro,40,15,55
+Mercer,Farrell 1-1,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Farrell 1-1,Auditor General,,DEM,H. Scott Conklin,2,0,2
+Mercer,Farrell 1-1,Auditor General,,DEM,Michael Lamb,18,7,25
+Mercer,Farrell 1-1,Auditor General,,DEM,Tracie Fountain,6,2,8
+Mercer,Farrell 1-1,Auditor General,,DEM,Rose Rosie Marie Davis,7,0,7
+Mercer,Farrell 1-1,Auditor General,,DEM,Nina Ahmad,7,4,11
+Mercer,Farrell 1-1,Auditor General,,DEM,Christina M. Hartman,5,1,6
+Mercer,Farrell 1-1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Farrell 1-1,State Treasurer,,DEM,Joe Torsella,41,16,57
+Mercer,Farrell 1-1,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Farrell 1-1,U.S. House,16,DEM,Kristy Gnibus,41,15,56
+Mercer,Farrell 1-1,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Farrell 1-1,General Assembly,7,DEM,Mark Longietti,52,24,76
+Mercer,Farrell 1-1,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Farrell 1-1,President,,REP,Donald J. Trump,3,1,4
+Mercer,Farrell 1-1,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Farrell 1-1,President,,REP,Bill Weld,0,0,0
+Mercer,Farrell 1-1,President,,REP,Write-In,1,0,1
+Mercer,Farrell 1-1,Attorney General,,REP,Heather Heidelbaugh,3,1,4
+Mercer,Farrell 1-1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Farrell 1-1,Auditor General,,REP,Timothy Defoor,4,1,5
+Mercer,Farrell 1-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Farrell 1-1,State Treasurer,,REP,Stacy L. Garrity,3,1,4
+Mercer,Farrell 1-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Farrell 1-1,U.S. House,16,REP,Mike Kelly,3,1,4
+Mercer,Farrell 1-1,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Farrell 1-1,General Assembly,7,REP,Write-In,0,0,0
+Mercer,Farrell 1-1,General Assembly,7,REP,Mark Longietti,0,0,0
+Mercer,Farrell 1-3,Registered Voters,,,,,,436
+Mercer,Farrell 1-3,Registered Voters,,DEM,,,,372
+Mercer,Farrell 1-3,Registered Voters,,REP,,,,64
+Mercer,Farrell 1-3,Registered Voters,,NPA,,,,0
+Mercer,Farrell 1-3,Ballots Cast,,,,74,25,99
+Mercer,Farrell 1-3,Ballots Cast,,DEM,,64,22,86
+Mercer,Farrell 1-3,Ballots Cast,,REP,,10,3,13
+Mercer,Farrell 1-3,Ballots Cast,,NPA,,0,0,0
+Mercer,Farrell 1-3,President,,DEM,Bernie Sanders,6,3,9
+Mercer,Farrell 1-3,President,,DEM,Joseph R. Biden,57,17,74
+Mercer,Farrell 1-3,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Farrell 1-3,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Farrell 1-3,President,,DEM,Write-In,0,0,0
+Mercer,Farrell 1-3,Attorney General,,DEM,Josh Shapiro,42,17,59
+Mercer,Farrell 1-3,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Farrell 1-3,Auditor General,,DEM,H. Scott Conklin,1,1,2
+Mercer,Farrell 1-3,Auditor General,,DEM,Michael Lamb,22,10,32
+Mercer,Farrell 1-3,Auditor General,,DEM,Tracie Fountain,5,1,6
+Mercer,Farrell 1-3,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,4
+Mercer,Farrell 1-3,Auditor General,,DEM,Nina Ahmad,8,1,9
+Mercer,Farrell 1-3,Auditor General,,DEM,Christina M. Hartman,3,1,4
+Mercer,Farrell 1-3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Farrell 1-3,State Treasurer,,DEM,Joe Torsella,42,15,57
+Mercer,Farrell 1-3,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Farrell 1-3,U.S. House,16,DEM,Kristy Gnibus,39,13,52
+Mercer,Farrell 1-3,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Farrell 1-3,General Assembly,7,DEM,Mark Longietti,58,21,79
+Mercer,Farrell 1-3,General Assembly,7,DEM,Write-In,1,0,1
+Mercer,Farrell 1-3,President,,REP,Donald J. Trump,7,3,10
+Mercer,Farrell 1-3,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Farrell 1-3,President,,REP,Bill Weld,0,0,0
+Mercer,Farrell 1-3,President,,REP,Write-In,1,0,1
+Mercer,Farrell 1-3,Attorney General,,REP,Heather Heidelbaugh,8,3,11
+Mercer,Farrell 1-3,Attorney General,,REP,Write-In,0,0,0
+Mercer,Farrell 1-3,Auditor General,,REP,Timothy Defoor,7,3,10
+Mercer,Farrell 1-3,Auditor General,,REP,Write-In,0,0,0
+Mercer,Farrell 1-3,State Treasurer,,REP,Stacy L. Garrity,8,3,11
+Mercer,Farrell 1-3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Farrell 1-3,U.S. House,16,REP,Mike Kelly,9,3,12
+Mercer,Farrell 1-3,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Farrell 1-3,General Assembly,7,REP,Write-In,1,0,1
+Mercer,Farrell 1-3,General Assembly,7,REP,Mark Longietti,1,0,1
+Mercer,Farrell 2-1,Registered Voters,,,,,,645
+Mercer,Farrell 2-1,Registered Voters,,DEM,,,,593
+Mercer,Farrell 2-1,Registered Voters,,REP,,,,52
+Mercer,Farrell 2-1,Registered Voters,,NPA,,,,0
+Mercer,Farrell 2-1,Ballots Cast,,,,139,54,193
+Mercer,Farrell 2-1,Ballots Cast,,DEM,,134,50,184
+Mercer,Farrell 2-1,Ballots Cast,,REP,,5,4,9
+Mercer,Farrell 2-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Farrell 2-1,President,,DEM,Bernie Sanders,18,2,20
+Mercer,Farrell 2-1,President,,DEM,Joseph R. Biden,114,45,159
+Mercer,Farrell 2-1,President,,DEM,Tulsi Gabbard,0,1,1
+Mercer,Farrell 2-1,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Farrell 2-1,President,,DEM,Write-In,0,2,2
+Mercer,Farrell 2-1,Attorney General,,DEM,Josh Shapiro,84,36,120
+Mercer,Farrell 2-1,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Farrell 2-1,Auditor General,,DEM,H. Scott Conklin,4,2,6
+Mercer,Farrell 2-1,Auditor General,,DEM,Michael Lamb,37,22,59
+Mercer,Farrell 2-1,Auditor General,,DEM,Tracie Fountain,8,5,13
+Mercer,Farrell 2-1,Auditor General,,DEM,Rose Rosie Marie Davis,9,0,9
+Mercer,Farrell 2-1,Auditor General,,DEM,Nina Ahmad,23,9,32
+Mercer,Farrell 2-1,Auditor General,,DEM,Christina M. Hartman,7,1,8
+Mercer,Farrell 2-1,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Farrell 2-1,State Treasurer,,DEM,Joe Torsella,82,35,117
+Mercer,Farrell 2-1,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Farrell 2-1,U.S. House,16,DEM,Kristy Gnibus,80,35,115
+Mercer,Farrell 2-1,U.S. House,16,DEM,Write-In,1,1,2
+Mercer,Farrell 2-1,General Assembly,7,DEM,Mark Longietti,124,49,173
+Mercer,Farrell 2-1,General Assembly,7,DEM,Write-In,1,0,1
+Mercer,Farrell 2-1,President,,REP,Donald J. Trump,4,4,8
+Mercer,Farrell 2-1,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Farrell 2-1,President,,REP,Bill Weld,0,0,0
+Mercer,Farrell 2-1,President,,REP,Write-In,1,0,1
+Mercer,Farrell 2-1,Attorney General,,REP,Heather Heidelbaugh,5,4,9
+Mercer,Farrell 2-1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Farrell 2-1,Auditor General,,REP,Timothy Defoor,4,3,7
+Mercer,Farrell 2-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Farrell 2-1,State Treasurer,,REP,Stacy L. Garrity,5,4,9
+Mercer,Farrell 2-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Farrell 2-1,U.S. House,16,REP,Mike Kelly,5,4,9
+Mercer,Farrell 2-1,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Farrell 2-1,General Assembly,7,REP,Write-In,1,0,1
+Mercer,Farrell 2-1,General Assembly,7,REP,Mark Longietti,0,0,0
+Mercer,Farrell 2-3,Registered Voters,,,,,,580
+Mercer,Farrell 2-3,Registered Voters,,DEM,,,,492
+Mercer,Farrell 2-3,Registered Voters,,REP,,,,88
+Mercer,Farrell 2-3,Registered Voters,,NPA,,,,0
+Mercer,Farrell 2-3,Ballots Cast,,,,116,81,197
+Mercer,Farrell 2-3,Ballots Cast,,DEM,,96,72,168
+Mercer,Farrell 2-3,Ballots Cast,,REP,,20,9,29
+Mercer,Farrell 2-3,Ballots Cast,,NPA,,0,0,0
+Mercer,Farrell 2-3,President,,DEM,Bernie Sanders,13,6,19
+Mercer,Farrell 2-3,President,,DEM,Joseph R. Biden,81,60,141
+Mercer,Farrell 2-3,President,,DEM,Tulsi Gabbard,0,4,4
+Mercer,Farrell 2-3,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Farrell 2-3,President,,DEM,Write-In,0,1,1
+Mercer,Farrell 2-3,Attorney General,,DEM,Josh Shapiro,75,60,135
+Mercer,Farrell 2-3,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Farrell 2-3,Auditor General,,DEM,H. Scott Conklin,0,5,5
+Mercer,Farrell 2-3,Auditor General,,DEM,Michael Lamb,35,39,74
+Mercer,Farrell 2-3,Auditor General,,DEM,Tracie Fountain,5,3,8
+Mercer,Farrell 2-3,Auditor General,,DEM,Rose Rosie Marie Davis,5,3,8
+Mercer,Farrell 2-3,Auditor General,,DEM,Nina Ahmad,23,4,27
+Mercer,Farrell 2-3,Auditor General,,DEM,Christina M. Hartman,7,5,12
+Mercer,Farrell 2-3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Farrell 2-3,State Treasurer,,DEM,Joe Torsella,69,55,124
+Mercer,Farrell 2-3,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Farrell 2-3,U.S. House,16,DEM,Kristy Gnibus,72,58,130
+Mercer,Farrell 2-3,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Farrell 2-3,General Assembly,7,DEM,Mark Longietti,93,70,163
+Mercer,Farrell 2-3,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Farrell 2-3,President,,REP,Donald J. Trump,18,8,26
+Mercer,Farrell 2-3,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Farrell 2-3,President,,REP,Bill Weld,1,0,1
+Mercer,Farrell 2-3,President,,REP,Write-In,1,1,2
+Mercer,Farrell 2-3,Attorney General,,REP,Heather Heidelbaugh,14,7,21
+Mercer,Farrell 2-3,Attorney General,,REP,Write-In,0,0,0
+Mercer,Farrell 2-3,Auditor General,,REP,Timothy Defoor,12,7,19
+Mercer,Farrell 2-3,Auditor General,,REP,Write-In,0,0,0
+Mercer,Farrell 2-3,State Treasurer,,REP,Stacy L. Garrity,13,7,20
+Mercer,Farrell 2-3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Farrell 2-3,U.S. House,16,REP,Mike Kelly,15,9,24
+Mercer,Farrell 2-3,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Farrell 2-3,General Assembly,7,REP,Write-In,4,0,4
+Mercer,Farrell 2-3,General Assembly,7,REP,Mark Longietti,4,0,4
+Mercer,Farrell 2-4,Registered Voters,,,,,,587
+Mercer,Farrell 2-4,Registered Voters,,DEM,,,,469
+Mercer,Farrell 2-4,Registered Voters,,REP,,,,118
+Mercer,Farrell 2-4,Registered Voters,,NPA,,,,0
+Mercer,Farrell 2-4,Ballots Cast,,,,114,131,245
+Mercer,Farrell 2-4,Ballots Cast,,DEM,,100,118,218
+Mercer,Farrell 2-4,Ballots Cast,,REP,,14,13,27
+Mercer,Farrell 2-4,Ballots Cast,,NPA,,0,0,0
+Mercer,Farrell 2-4,President,,DEM,Bernie Sanders,6,9,15
+Mercer,Farrell 2-4,President,,DEM,Joseph R. Biden,83,98,181
+Mercer,Farrell 2-4,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Farrell 2-4,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Farrell 2-4,President,,DEM,Write-In,3,0,3
+Mercer,Farrell 2-4,Attorney General,,DEM,Josh Shapiro,73,93,166
+Mercer,Farrell 2-4,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Farrell 2-4,Auditor General,,DEM,H. Scott Conklin,4,3,7
+Mercer,Farrell 2-4,Auditor General,,DEM,Michael Lamb,38,78,116
+Mercer,Farrell 2-4,Auditor General,,DEM,Tracie Fountain,6,6,12
+Mercer,Farrell 2-4,Auditor General,,DEM,Rose Rosie Marie Davis,10,0,10
+Mercer,Farrell 2-4,Auditor General,,DEM,Nina Ahmad,11,6,17
+Mercer,Farrell 2-4,Auditor General,,DEM,Christina M. Hartman,4,2,6
+Mercer,Farrell 2-4,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Farrell 2-4,State Treasurer,,DEM,Joe Torsella,68,86,154
+Mercer,Farrell 2-4,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Farrell 2-4,U.S. House,16,DEM,Kristy Gnibus,66,84,150
+Mercer,Farrell 2-4,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Farrell 2-4,General Assembly,7,DEM,Mark Longietti,93,116,209
+Mercer,Farrell 2-4,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Farrell 2-4,President,,REP,Donald J. Trump,11,9,20
+Mercer,Farrell 2-4,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Farrell 2-4,President,,REP,Bill Weld,2,0,2
+Mercer,Farrell 2-4,President,,REP,Write-In,1,2,3
+Mercer,Farrell 2-4,Attorney General,,REP,Heather Heidelbaugh,10,12,22
+Mercer,Farrell 2-4,Attorney General,,REP,Write-In,0,0,0
+Mercer,Farrell 2-4,Auditor General,,REP,Timothy Defoor,10,12,22
+Mercer,Farrell 2-4,Auditor General,,REP,Write-In,0,0,0
+Mercer,Farrell 2-4,State Treasurer,,REP,Stacy L. Garrity,10,11,21
+Mercer,Farrell 2-4,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Farrell 2-4,U.S. House,16,REP,Mike Kelly,14,11,25
+Mercer,Farrell 2-4,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Farrell 2-4,General Assembly,7,REP,Write-In,2,0,2
+Mercer,Farrell 2-4,General Assembly,7,REP,Mark Longietti,2,0,2
+Mercer,Findley,Registered Voters,,,,,,769
+Mercer,Findley,Registered Voters,,DEM,,,,252
+Mercer,Findley,Registered Voters,,REP,,,,517
+Mercer,Findley,Registered Voters,,NPA,,,,0
+Mercer,Findley,Ballots Cast,,,,174,105,279
+Mercer,Findley,Ballots Cast,,DEM,,26,49,75
+Mercer,Findley,Ballots Cast,,REP,,148,56,204
+Mercer,Findley,Ballots Cast,,NPA,,0,0,0
+Mercer,Findley,President,,DEM,Bernie Sanders,6,3,9
+Mercer,Findley,President,,DEM,Joseph R. Biden,13,42,55
+Mercer,Findley,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Findley,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Findley,President,,DEM,Write-In,4,2,6
+Mercer,Findley,Attorney General,,DEM,Josh Shapiro,23,42,65
+Mercer,Findley,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Findley,Auditor General,,DEM,H. Scott Conklin,2,4,6
+Mercer,Findley,Auditor General,,DEM,Michael Lamb,16,30,46
+Mercer,Findley,Auditor General,,DEM,Tracie Fountain,1,2,3
+Mercer,Findley,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2
+Mercer,Findley,Auditor General,,DEM,Nina Ahmad,1,2,3
+Mercer,Findley,Auditor General,,DEM,Christina M. Hartman,3,3,6
+Mercer,Findley,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Findley,State Treasurer,,DEM,Joe Torsella,22,37,59
+Mercer,Findley,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Findley,U.S. House,16,DEM,Kristy Gnibus,21,38,59
+Mercer,Findley,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Findley,General Assembly,8,DEM,Phil Heasley,22,38,60
+Mercer,Findley,General Assembly,8,DEM,Write-In,1,0,1
+Mercer,Findley,President,,REP,Donald J. Trump,143,47,190
+Mercer,Findley,President,,REP,Roque Rocky De La Fuente,1,1,2
+Mercer,Findley,President,,REP,Bill Weld,3,2,5
+Mercer,Findley,President,,REP,Write-In,0,2,2
+Mercer,Findley,Attorney General,,REP,Heather Heidelbaugh,125,48,173
+Mercer,Findley,Attorney General,,REP,Write-In,2,0,2
+Mercer,Findley,Auditor General,,REP,Timothy Defoor,120,47,167
+Mercer,Findley,Auditor General,,REP,Write-In,1,0,1
+Mercer,Findley,State Treasurer,,REP,Stacy L. Garrity,125,45,170
+Mercer,Findley,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Findley,U.S. House,16,REP,Mike Kelly,143,48,191
+Mercer,Findley,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Findley,General Assembly,8,REP,Scott Jaillet,15,7,22
+Mercer,Findley,General Assembly,8,REP,Tim Bonner,130,47,177
+Mercer,Findley,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Fredonia,Registered Voters,,,,,,256
+Mercer,Fredonia,Registered Voters,,DEM,,,,96
+Mercer,Fredonia,Registered Voters,,REP,,,,160
+Mercer,Fredonia,Registered Voters,,NPA,,,,0
+Mercer,Fredonia,Ballots Cast,,,,66,18,84
+Mercer,Fredonia,Ballots Cast,,DEM,,17,9,26
+Mercer,Fredonia,Ballots Cast,,REP,,49,9,58
+Mercer,Fredonia,Ballots Cast,,NPA,,0,0,0
+Mercer,Fredonia,President,,DEM,Bernie Sanders,7,0,7
+Mercer,Fredonia,President,,DEM,Joseph R. Biden,9,8,17
+Mercer,Fredonia,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Fredonia,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Fredonia,President,,DEM,Write-In,1,0,1
+Mercer,Fredonia,Attorney General,,DEM,Josh Shapiro,15,9,24
+Mercer,Fredonia,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Fredonia,Auditor General,,DEM,H. Scott Conklin,2,0,2
+Mercer,Fredonia,Auditor General,,DEM,Michael Lamb,7,6,13
+Mercer,Fredonia,Auditor General,,DEM,Tracie Fountain,0,0,0
+Mercer,Fredonia,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Fredonia,Auditor General,,DEM,Nina Ahmad,0,0,0
+Mercer,Fredonia,Auditor General,,DEM,Christina M. Hartman,3,2,5
+Mercer,Fredonia,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Fredonia,State Treasurer,,DEM,Joe Torsella,13,9,22
+Mercer,Fredonia,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Fredonia,U.S. House,16,DEM,Kristy Gnibus,13,9,22
+Mercer,Fredonia,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Fredonia,General Assembly,8,DEM,Phil Heasley,13,9,22
+Mercer,Fredonia,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Fredonia,President,,REP,Donald J. Trump,46,9,55
+Mercer,Fredonia,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Fredonia,President,,REP,Bill Weld,1,0,1
+Mercer,Fredonia,President,,REP,Write-In,0,0,0
+Mercer,Fredonia,Attorney General,,REP,Heather Heidelbaugh,43,7,50
+Mercer,Fredonia,Attorney General,,REP,Write-In,1,0,1
+Mercer,Fredonia,Auditor General,,REP,Timothy Defoor,40,7,47
+Mercer,Fredonia,Auditor General,,REP,Write-In,1,0,1
+Mercer,Fredonia,State Treasurer,,REP,Stacy L. Garrity,42,7,49
+Mercer,Fredonia,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Fredonia,U.S. House,16,REP,Mike Kelly,46,9,55
+Mercer,Fredonia,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Fredonia,General Assembly,8,REP,Scott Jaillet,11,3,14
+Mercer,Fredonia,General Assembly,8,REP,Tim Bonner,36,6,42
+Mercer,Fredonia,General Assembly,8,REP,Write-In,0,0,0
+Mercer,French Creek,Registered Voters,,,,,,388
+Mercer,French Creek,Registered Voters,,DEM,,,,145
+Mercer,French Creek,Registered Voters,,REP,,,,243
+Mercer,French Creek,Registered Voters,,NPA,,,,0
+Mercer,French Creek,Ballots Cast,,,,103,27,130
+Mercer,French Creek,Ballots Cast,,DEM,,24,20,44
+Mercer,French Creek,Ballots Cast,,REP,,79,7,86
+Mercer,French Creek,Ballots Cast,,NPA,,0,0,0
+Mercer,French Creek,President,,DEM,Bernie Sanders,3,5,8
+Mercer,French Creek,President,,DEM,Joseph R. Biden,18,14,32
+Mercer,French Creek,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,French Creek,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,French Creek,President,,DEM,Write-In,0,1,1
+Mercer,French Creek,Attorney General,,DEM,Josh Shapiro,19,19,38
+Mercer,French Creek,Attorney General,,DEM,Write-In,0,0,0
+Mercer,French Creek,Auditor General,,DEM,H. Scott Conklin,4,0,4
+Mercer,French Creek,Auditor General,,DEM,Michael Lamb,11,10,21
+Mercer,French Creek,Auditor General,,DEM,Tracie Fountain,1,3,4
+Mercer,French Creek,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2
+Mercer,French Creek,Auditor General,,DEM,Nina Ahmad,1,3,4
+Mercer,French Creek,Auditor General,,DEM,Christina M. Hartman,2,3,5
+Mercer,French Creek,Auditor General,,DEM,Write-In,0,0,0
+Mercer,French Creek,State Treasurer,,DEM,Joe Torsella,19,18,37
+Mercer,French Creek,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,French Creek,U.S. House,16,DEM,Kristy Gnibus,21,19,40
+Mercer,French Creek,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,French Creek,General Assembly,8,DEM,Phil Heasley,21,18,39
+Mercer,French Creek,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,French Creek,President,,REP,Donald J. Trump,75,6,81
+Mercer,French Creek,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,French Creek,President,,REP,Bill Weld,0,0,0
+Mercer,French Creek,President,,REP,Write-In,1,1,2
+Mercer,French Creek,Attorney General,,REP,Heather Heidelbaugh,68,7,75
+Mercer,French Creek,Attorney General,,REP,Write-In,0,0,0
+Mercer,French Creek,Auditor General,,REP,Timothy Defoor,64,7,71
+Mercer,French Creek,Auditor General,,REP,Write-In,0,0,0
+Mercer,French Creek,State Treasurer,,REP,Stacy L. Garrity,69,7,76
+Mercer,French Creek,State Treasurer,,REP,Write-In,0,0,0
+Mercer,French Creek,U.S. House,16,REP,Mike Kelly,75,7,82
+Mercer,French Creek,U.S. House,16,REP,Write-In,0,0,0
+Mercer,French Creek,General Assembly,8,REP,Scott Jaillet,12,0,12
+Mercer,French Creek,General Assembly,8,REP,Tim Bonner,65,6,71
+Mercer,French Creek,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Greene,Registered Voters,,,,,,553
+Mercer,Greene,Registered Voters,,DEM,,,,216
+Mercer,Greene,Registered Voters,,REP,,,,337
+Mercer,Greene,Registered Voters,,NPA,,,,0
+Mercer,Greene,Ballots Cast,,,,103,85,188
+Mercer,Greene,Ballots Cast,,DEM,,23,45,68
+Mercer,Greene,Ballots Cast,,REP,,80,40,120
+Mercer,Greene,Ballots Cast,,NPA,,0,0,0
+Mercer,Greene,President,,DEM,Bernie Sanders,8,6,14
+Mercer,Greene,President,,DEM,Joseph R. Biden,13,39,52
+Mercer,Greene,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Greene,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Greene,President,,DEM,Write-In,1,0,1
+Mercer,Greene,Attorney General,,DEM,Josh Shapiro,17,42,59
+Mercer,Greene,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Greene,Auditor General,,DEM,H. Scott Conklin,7,3,10
+Mercer,Greene,Auditor General,,DEM,Michael Lamb,6,27,33
+Mercer,Greene,Auditor General,,DEM,Tracie Fountain,2,1,3
+Mercer,Greene,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,4
+Mercer,Greene,Auditor General,,DEM,Nina Ahmad,0,2,2
+Mercer,Greene,Auditor General,,DEM,Christina M. Hartman,2,5,7
+Mercer,Greene,Auditor General,,DEM,Write-In,2,0,2
+Mercer,Greene,State Treasurer,,DEM,Joe Torsella,16,40,56
+Mercer,Greene,State Treasurer,,DEM,Write-In,2,0,2
+Mercer,Greene,U.S. House,16,DEM,Kristy Gnibus,18,41,59
+Mercer,Greene,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,Greene,General Assembly,17,DEM,Write-In,3,5,8
+Mercer,Greene,General Assembly,17,DEM,Jeff O'Melian,0,2,2
+Mercer,Greene,President,,REP,Donald J. Trump,74,32,106
+Mercer,Greene,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Greene,President,,REP,Bill Weld,2,5,7
+Mercer,Greene,President,,REP,Write-In,1,2,3
+Mercer,Greene,Attorney General,,REP,Heather Heidelbaugh,69,36,105
+Mercer,Greene,Attorney General,,REP,Write-In,0,0,0
+Mercer,Greene,Auditor General,,REP,Timothy Defoor,69,35,104
+Mercer,Greene,Auditor General,,REP,Write-In,0,0,0
+Mercer,Greene,State Treasurer,,REP,Stacy L. Garrity,67,35,102
+Mercer,Greene,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Greene,U.S. House,16,REP,Mike Kelly,77,35,112
+Mercer,Greene,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Greene,General Assembly,17,REP,Parke Wentling,80,38,118
+Mercer,Greene,General Assembly,17,REP,Write-In,0,0,0
+Mercer,Greenville 1,Registered Voters,,,,,,472
+Mercer,Greenville 1,Registered Voters,,DEM,,,,253
+Mercer,Greenville 1,Registered Voters,,REP,,,,219
+Mercer,Greenville 1,Registered Voters,,NPA,,,,0
+Mercer,Greenville 1,Ballots Cast,,,,84,41,125
+Mercer,Greenville 1,Ballots Cast,,DEM,,28,33,61
+Mercer,Greenville 1,Ballots Cast,,REP,,56,8,64
+Mercer,Greenville 1,Ballots Cast,,NPA,,0,0,0
+Mercer,Greenville 1,President,,DEM,Bernie Sanders,6,8,14
+Mercer,Greenville 1,President,,DEM,Joseph R. Biden,18,21,39
+Mercer,Greenville 1,President,,DEM,Tulsi Gabbard,0,1,1
+Mercer,Greenville 1,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Greenville 1,President,,DEM,Write-In,1,1,2
+Mercer,Greenville 1,Attorney General,,DEM,Josh Shapiro,24,31,55
+Mercer,Greenville 1,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Greenville 1,Auditor General,,DEM,H. Scott Conklin,0,0,0
+Mercer,Greenville 1,Auditor General,,DEM,Michael Lamb,9,17,26
+Mercer,Greenville 1,Auditor General,,DEM,Tracie Fountain,0,4,4
+Mercer,Greenville 1,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,4
+Mercer,Greenville 1,Auditor General,,DEM,Nina Ahmad,3,4,7
+Mercer,Greenville 1,Auditor General,,DEM,Christina M. Hartman,8,4,12
+Mercer,Greenville 1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Greenville 1,State Treasurer,,DEM,Joe Torsella,23,31,54
+Mercer,Greenville 1,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Greenville 1,U.S. House,16,DEM,Kristy Gnibus,23,31,54
+Mercer,Greenville 1,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Greenville 1,General Assembly,7,DEM,Mark Longietti,26,33,59
+Mercer,Greenville 1,General Assembly,7,DEM,Write-In,1,0,1
+Mercer,Greenville 1,President,,REP,Donald J. Trump,55,8,63
+Mercer,Greenville 1,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Greenville 1,President,,REP,Bill Weld,1,0,1
+Mercer,Greenville 1,President,,REP,Write-In,0,0,0
+Mercer,Greenville 1,Attorney General,,REP,Heather Heidelbaugh,50,6,56
+Mercer,Greenville 1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Greenville 1,Auditor General,,REP,Timothy Defoor,49,5,54
+Mercer,Greenville 1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Greenville 1,State Treasurer,,REP,Stacy L. Garrity,50,6,56
+Mercer,Greenville 1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Greenville 1,U.S. House,16,REP,Mike Kelly,50,6,56
+Mercer,Greenville 1,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Greenville 1,General Assembly,7,REP,Write-In,8,2,10
+Mercer,Greenville 1,General Assembly,7,REP,Mark Longietti,6,2,8
+Mercer,Greenville 2,Registered Voters,,,,,,579
+Mercer,Greenville 2,Registered Voters,,DEM,,,,315
+Mercer,Greenville 2,Registered Voters,,REP,,,,264
+Mercer,Greenville 2,Registered Voters,,NPA,,,,0
+Mercer,Greenville 2,Ballots Cast,,,,86,56,142
+Mercer,Greenville 2,Ballots Cast,,DEM,,38,35,73
+Mercer,Greenville 2,Ballots Cast,,REP,,48,21,69
+Mercer,Greenville 2,Ballots Cast,,NPA,,0,0,0
+Mercer,Greenville 2,President,,DEM,Bernie Sanders,8,2,10
+Mercer,Greenville 2,President,,DEM,Joseph R. Biden,26,32,58
+Mercer,Greenville 2,President,,DEM,Tulsi Gabbard,2,0,2
+Mercer,Greenville 2,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,Greenville 2,President,,DEM,Write-In,0,0,0
+Mercer,Greenville 2,Attorney General,,DEM,Josh Shapiro,27,31,58
+Mercer,Greenville 2,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Greenville 2,Auditor General,,DEM,H. Scott Conklin,3,0,3
+Mercer,Greenville 2,Auditor General,,DEM,Michael Lamb,15,21,36
+Mercer,Greenville 2,Auditor General,,DEM,Tracie Fountain,1,2,3
+Mercer,Greenville 2,Auditor General,,DEM,Rose Rosie Marie Davis,4,2,6
+Mercer,Greenville 2,Auditor General,,DEM,Nina Ahmad,2,4,6
+Mercer,Greenville 2,Auditor General,,DEM,Christina M. Hartman,6,3,9
+Mercer,Greenville 2,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Greenville 2,State Treasurer,,DEM,Joe Torsella,27,30,57
+Mercer,Greenville 2,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Greenville 2,U.S. House,16,DEM,Kristy Gnibus,27,31,58
+Mercer,Greenville 2,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Greenville 2,General Assembly,7,DEM,Mark Longietti,35,34,69
+Mercer,Greenville 2,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Greenville 2,President,,REP,Donald J. Trump,44,16,60
+Mercer,Greenville 2,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Greenville 2,President,,REP,Bill Weld,0,2,2
+Mercer,Greenville 2,President,,REP,Write-In,0,2,2
+Mercer,Greenville 2,Attorney General,,REP,Heather Heidelbaugh,45,18,63
+Mercer,Greenville 2,Attorney General,,REP,Write-In,0,2,2
+Mercer,Greenville 2,Auditor General,,REP,Timothy Defoor,41,17,58
+Mercer,Greenville 2,Auditor General,,REP,Write-In,0,2,2
+Mercer,Greenville 2,State Treasurer,,REP,Stacy L. Garrity,44,18,62
+Mercer,Greenville 2,State Treasurer,,REP,Write-In,0,2,2
+Mercer,Greenville 2,U.S. House,16,REP,Mike Kelly,44,20,64
+Mercer,Greenville 2,U.S. House,16,REP,Write-In,2,0,2
+Mercer,Greenville 2,General Assembly,7,REP,Write-In,9,8,17
+Mercer,Greenville 2,General Assembly,7,REP,Mark Longietti,5,8,13
+Mercer,Greenville 3,Registered Voters,,,,,,740
+Mercer,Greenville 3,Registered Voters,,DEM,,,,324
+Mercer,Greenville 3,Registered Voters,,REP,,,,416
+Mercer,Greenville 3,Registered Voters,,NPA,,,,0
+Mercer,Greenville 3,Ballots Cast,,,,182,101,283
+Mercer,Greenville 3,Ballots Cast,,DEM,,71,59,130
+Mercer,Greenville 3,Ballots Cast,,REP,,111,42,153
+Mercer,Greenville 3,Ballots Cast,,NPA,,0,0,0
+Mercer,Greenville 3,President,,DEM,Bernie Sanders,15,14,29
+Mercer,Greenville 3,President,,DEM,Joseph R. Biden,41,44,85
+Mercer,Greenville 3,President,,DEM,Tulsi Gabbard,3,0,3
+Mercer,Greenville 3,President,,DEM,Elizabeth Warren,3,0,3
+Mercer,Greenville 3,President,,DEM,Write-In,5,1,6
+Mercer,Greenville 3,Attorney General,,DEM,Josh Shapiro,55,52,107
+Mercer,Greenville 3,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Greenville 3,Auditor General,,DEM,H. Scott Conklin,5,1,6
+Mercer,Greenville 3,Auditor General,,DEM,Michael Lamb,30,31,61
+Mercer,Greenville 3,Auditor General,,DEM,Tracie Fountain,1,7,8
+Mercer,Greenville 3,Auditor General,,DEM,Rose Rosie Marie Davis,5,4,9
+Mercer,Greenville 3,Auditor General,,DEM,Nina Ahmad,10,8,18
+Mercer,Greenville 3,Auditor General,,DEM,Christina M. Hartman,9,4,13
+Mercer,Greenville 3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Greenville 3,State Treasurer,,DEM,Joe Torsella,58,53,111
+Mercer,Greenville 3,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Greenville 3,U.S. House,16,DEM,Kristy Gnibus,57,52,109
+Mercer,Greenville 3,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,Greenville 3,General Assembly,7,DEM,Mark Longietti,66,57,123
+Mercer,Greenville 3,General Assembly,7,DEM,Write-In,2,2,4
+Mercer,Greenville 3,President,,REP,Donald J. Trump,108,30,138
+Mercer,Greenville 3,President,,REP,Roque Rocky De La Fuente,1,2,3
+Mercer,Greenville 3,President,,REP,Bill Weld,1,7,8
+Mercer,Greenville 3,President,,REP,Write-In,0,0,0
+Mercer,Greenville 3,Attorney General,,REP,Heather Heidelbaugh,99,39,138
+Mercer,Greenville 3,Attorney General,,REP,Write-In,1,0,1
+Mercer,Greenville 3,Auditor General,,REP,Timothy Defoor,95,36,131
+Mercer,Greenville 3,Auditor General,,REP,Write-In,1,0,1
+Mercer,Greenville 3,State Treasurer,,REP,Stacy L. Garrity,100,37,137
+Mercer,Greenville 3,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Greenville 3,U.S. House,16,REP,Mike Kelly,105,36,141
+Mercer,Greenville 3,U.S. House,16,REP,Write-In,2,0,2
+Mercer,Greenville 3,General Assembly,7,REP,Write-In,18,9,27
+Mercer,Greenville 3,General Assembly,7,REP,Mark Longietti,7,6,13
+Mercer,Greenville 4,Registered Voters,,,,,,691
+Mercer,Greenville 4,Registered Voters,,DEM,,,,324
+Mercer,Greenville 4,Registered Voters,,REP,,,,367
+Mercer,Greenville 4,Registered Voters,,NPA,,,,0
+Mercer,Greenville 4,Ballots Cast,,,,133,90,223
+Mercer,Greenville 4,Ballots Cast,,DEM,,46,57,103
+Mercer,Greenville 4,Ballots Cast,,REP,,87,33,120
+Mercer,Greenville 4,Ballots Cast,,NPA,,0,0,0
+Mercer,Greenville 4,President,,DEM,Bernie Sanders,2,4,6
+Mercer,Greenville 4,President,,DEM,Joseph R. Biden,34,52,86
+Mercer,Greenville 4,President,,DEM,Tulsi Gabbard,2,0,2
+Mercer,Greenville 4,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Greenville 4,President,,DEM,Write-In,2,0,2
+Mercer,Greenville 4,Attorney General,,DEM,Josh Shapiro,39,51,90
+Mercer,Greenville 4,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Greenville 4,Auditor General,,DEM,H. Scott Conklin,6,1,7
+Mercer,Greenville 4,Auditor General,,DEM,Michael Lamb,17,33,50
+Mercer,Greenville 4,Auditor General,,DEM,Tracie Fountain,1,5,6
+Mercer,Greenville 4,Auditor General,,DEM,Rose Rosie Marie Davis,1,6,7
+Mercer,Greenville 4,Auditor General,,DEM,Nina Ahmad,5,0,5
+Mercer,Greenville 4,Auditor General,,DEM,Christina M. Hartman,10,4,14
+Mercer,Greenville 4,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Greenville 4,State Treasurer,,DEM,Joe Torsella,38,49,87
+Mercer,Greenville 4,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Greenville 4,U.S. House,16,DEM,Kristy Gnibus,37,48,85
+Mercer,Greenville 4,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Greenville 4,General Assembly,7,DEM,Mark Longietti,43,55,98
+Mercer,Greenville 4,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Greenville 4,President,,REP,Donald J. Trump,80,28,108
+Mercer,Greenville 4,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Greenville 4,President,,REP,Bill Weld,2,2,4
+Mercer,Greenville 4,President,,REP,Write-In,3,1,4
+Mercer,Greenville 4,Attorney General,,REP,Heather Heidelbaugh,80,32,112
+Mercer,Greenville 4,Attorney General,,REP,Write-In,0,0,0
+Mercer,Greenville 4,Auditor General,,REP,Timothy Defoor,78,31,109
+Mercer,Greenville 4,Auditor General,,REP,Write-In,0,0,0
+Mercer,Greenville 4,State Treasurer,,REP,Stacy L. Garrity,78,31,109
+Mercer,Greenville 4,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Greenville 4,U.S. House,16,REP,Mike Kelly,81,30,111
+Mercer,Greenville 4,U.S. House,16,REP,Write-In,3,1,4
+Mercer,Greenville 4,General Assembly,7,REP,Write-In,20,6,26
+Mercer,Greenville 4,General Assembly,7,REP,Mark Longietti,11,4,15
+Mercer,Grove City 1,Registered Voters,,,,,,690
+Mercer,Grove City 1,Registered Voters,,DEM,,,,182
+Mercer,Grove City 1,Registered Voters,,REP,,,,508
+Mercer,Grove City 1,Registered Voters,,NPA,,,,0
+Mercer,Grove City 1,Ballots Cast,,,,144,67,211
+Mercer,Grove City 1,Ballots Cast,,DEM,,25,35,60
+Mercer,Grove City 1,Ballots Cast,,REP,,119,32,151
+Mercer,Grove City 1,Ballots Cast,,NPA,,0,0,0
+Mercer,Grove City 1,President,,DEM,Bernie Sanders,6,6,12
+Mercer,Grove City 1,President,,DEM,Joseph R. Biden,16,28,44
+Mercer,Grove City 1,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Grove City 1,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Grove City 1,President,,DEM,Write-In,0,0,0
+Mercer,Grove City 1,Attorney General,,DEM,Josh Shapiro,19,33,52
+Mercer,Grove City 1,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Grove City 1,Auditor General,,DEM,H. Scott Conklin,0,2,2
+Mercer,Grove City 1,Auditor General,,DEM,Michael Lamb,16,24,40
+Mercer,Grove City 1,Auditor General,,DEM,Tracie Fountain,0,2,2
+Mercer,Grove City 1,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Grove City 1,Auditor General,,DEM,Nina Ahmad,3,3,6
+Mercer,Grove City 1,Auditor General,,DEM,Christina M. Hartman,2,2,4
+Mercer,Grove City 1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Grove City 1,State Treasurer,,DEM,Joe Torsella,20,32,52
+Mercer,Grove City 1,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Grove City 1,U.S. House,16,DEM,Kristy Gnibus,19,33,52
+Mercer,Grove City 1,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Grove City 1,General Assembly,8,DEM,Phil Heasley,22,32,54
+Mercer,Grove City 1,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Grove City 1,President,,REP,Donald J. Trump,105,22,127
+Mercer,Grove City 1,President,,REP,Roque Rocky De La Fuente,2,1,3
+Mercer,Grove City 1,President,,REP,Bill Weld,4,3,7
+Mercer,Grove City 1,President,,REP,Write-In,3,2,5
+Mercer,Grove City 1,Attorney General,,REP,Heather Heidelbaugh,105,25,130
+Mercer,Grove City 1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Grove City 1,Auditor General,,REP,Timothy Defoor,102,26,128
+Mercer,Grove City 1,Auditor General,,REP,Write-In,1,0,1
+Mercer,Grove City 1,State Treasurer,,REP,Stacy L. Garrity,104,25,129
+Mercer,Grove City 1,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Grove City 1,U.S. House,16,REP,Mike Kelly,112,28,140
+Mercer,Grove City 1,U.S. House,16,REP,Write-In,2,0,2
+Mercer,Grove City 1,General Assembly,8,REP,Scott Jaillet,13,4,17
+Mercer,Grove City 1,General Assembly,8,REP,Tim Bonner,105,27,132
+Mercer,Grove City 1,General Assembly,8,REP,Write-In,1,0,1
+Mercer,Grove City 2,Registered Voters,,,,,,646
+Mercer,Grove City 2,Registered Voters,,DEM,,,,244
+Mercer,Grove City 2,Registered Voters,,REP,,,,402
+Mercer,Grove City 2,Registered Voters,,NPA,,,,0
+Mercer,Grove City 2,Ballots Cast,,,,150,100,250
+Mercer,Grove City 2,Ballots Cast,,DEM,,36,60,96
+Mercer,Grove City 2,Ballots Cast,,REP,,114,40,154
+Mercer,Grove City 2,Ballots Cast,,NPA,,0,0,0
+Mercer,Grove City 2,President,,DEM,Bernie Sanders,7,13,20
+Mercer,Grove City 2,President,,DEM,Joseph R. Biden,18,44,62
+Mercer,Grove City 2,President,,DEM,Tulsi Gabbard,1,3,4
+Mercer,Grove City 2,President,,DEM,Elizabeth Warren,5,0,5
+Mercer,Grove City 2,President,,DEM,Write-In,2,0,2
+Mercer,Grove City 2,Attorney General,,DEM,Josh Shapiro,29,58,87
+Mercer,Grove City 2,Attorney General,,DEM,Write-In,2,0,2
+Mercer,Grove City 2,Auditor General,,DEM,H. Scott Conklin,2,4,6
+Mercer,Grove City 2,Auditor General,,DEM,Michael Lamb,20,37,57
+Mercer,Grove City 2,Auditor General,,DEM,Tracie Fountain,0,3,3
+Mercer,Grove City 2,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,5
+Mercer,Grove City 2,Auditor General,,DEM,Nina Ahmad,4,8,12
+Mercer,Grove City 2,Auditor General,,DEM,Christina M. Hartman,3,1,4
+Mercer,Grove City 2,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Grove City 2,State Treasurer,,DEM,Joe Torsella,30,55,85
+Mercer,Grove City 2,State Treasurer,,DEM,Write-In,2,0,2
+Mercer,Grove City 2,U.S. House,16,DEM,Kristy Gnibus,31,56,87
+Mercer,Grove City 2,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,Grove City 2,General Assembly,8,DEM,Phil Heasley,31,57,88
+Mercer,Grove City 2,General Assembly,8,DEM,Write-In,2,0,2
+Mercer,Grove City 2,President,,REP,Donald J. Trump,105,34,139
+Mercer,Grove City 2,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,Grove City 2,President,,REP,Bill Weld,4,2,6
+Mercer,Grove City 2,President,,REP,Write-In,2,0,2
+Mercer,Grove City 2,Attorney General,,REP,Heather Heidelbaugh,96,35,131
+Mercer,Grove City 2,Attorney General,,REP,Write-In,1,0,1
+Mercer,Grove City 2,Auditor General,,REP,Timothy Defoor,91,35,126
+Mercer,Grove City 2,Auditor General,,REP,Write-In,1,0,1
+Mercer,Grove City 2,State Treasurer,,REP,Stacy L. Garrity,92,35,127
+Mercer,Grove City 2,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Grove City 2,U.S. House,16,REP,Mike Kelly,106,38,144
+Mercer,Grove City 2,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Grove City 2,General Assembly,8,REP,Scott Jaillet,16,6,22
+Mercer,Grove City 2,General Assembly,8,REP,Tim Bonner,93,34,127
+Mercer,Grove City 2,General Assembly,8,REP,Write-In,1,0,1
+Mercer,Grove City 3,Registered Voters,,,,,,620
+Mercer,Grove City 3,Registered Voters,,DEM,,,,244
+Mercer,Grove City 3,Registered Voters,,REP,,,,376
+Mercer,Grove City 3,Registered Voters,,NPA,,,,0
+Mercer,Grove City 3,Ballots Cast,,,,105,97,202
+Mercer,Grove City 3,Ballots Cast,,DEM,,32,55,87
+Mercer,Grove City 3,Ballots Cast,,REP,,73,42,115
+Mercer,Grove City 3,Ballots Cast,,NPA,,0,0,0
+Mercer,Grove City 3,President,,DEM,Bernie Sanders,6,11,17
+Mercer,Grove City 3,President,,DEM,Joseph R. Biden,23,40,63
+Mercer,Grove City 3,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Grove City 3,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Grove City 3,President,,DEM,Write-In,1,2,3
+Mercer,Grove City 3,Attorney General,,DEM,Josh Shapiro,28,51,79
+Mercer,Grove City 3,Attorney General,,DEM,Write-In,0,1,1
+Mercer,Grove City 3,Auditor General,,DEM,H. Scott Conklin,2,4,6
+Mercer,Grove City 3,Auditor General,,DEM,Michael Lamb,17,31,48
+Mercer,Grove City 3,Auditor General,,DEM,Tracie Fountain,0,3,3
+Mercer,Grove City 3,Auditor General,,DEM,Rose Rosie Marie Davis,6,6,12
+Mercer,Grove City 3,Auditor General,,DEM,Nina Ahmad,4,7,11
+Mercer,Grove City 3,Auditor General,,DEM,Christina M. Hartman,2,1,3
+Mercer,Grove City 3,Auditor General,,DEM,Write-In,0,1,1
+Mercer,Grove City 3,State Treasurer,,DEM,Joe Torsella,27,49,76
+Mercer,Grove City 3,State Treasurer,,DEM,Write-In,0,2,2
+Mercer,Grove City 3,U.S. House,16,DEM,Kristy Gnibus,29,53,82
+Mercer,Grove City 3,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Grove City 3,General Assembly,8,DEM,Phil Heasley,29,52,81
+Mercer,Grove City 3,General Assembly,8,DEM,Write-In,0,2,2
+Mercer,Grove City 3,President,,REP,Donald J. Trump,68,30,98
+Mercer,Grove City 3,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,Grove City 3,President,,REP,Bill Weld,0,4,4
+Mercer,Grove City 3,President,,REP,Write-In,0,3,3
+Mercer,Grove City 3,Attorney General,,REP,Heather Heidelbaugh,63,36,99
+Mercer,Grove City 3,Attorney General,,REP,Write-In,0,1,1
+Mercer,Grove City 3,Auditor General,,REP,Timothy Defoor,60,36,96
+Mercer,Grove City 3,Auditor General,,REP,Write-In,0,1,1
+Mercer,Grove City 3,State Treasurer,,REP,Stacy L. Garrity,61,36,97
+Mercer,Grove City 3,State Treasurer,,REP,Write-In,0,1,1
+Mercer,Grove City 3,U.S. House,16,REP,Mike Kelly,70,37,107
+Mercer,Grove City 3,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Grove City 3,General Assembly,8,REP,Scott Jaillet,2,10,12
+Mercer,Grove City 3,General Assembly,8,REP,Tim Bonner,71,32,103
+Mercer,Grove City 3,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Grove City 4,Registered Voters,,,,,,697
+Mercer,Grove City 4,Registered Voters,,DEM,,,,206
+Mercer,Grove City 4,Registered Voters,,REP,,,,491
+Mercer,Grove City 4,Registered Voters,,NPA,,,,0
+Mercer,Grove City 4,Ballots Cast,,,,219,103,322
+Mercer,Grove City 4,Ballots Cast,,DEM,,46,61,107
+Mercer,Grove City 4,Ballots Cast,,REP,,173,42,215
+Mercer,Grove City 4,Ballots Cast,,NPA,,0,0,0
+Mercer,Grove City 4,President,,DEM,Bernie Sanders,4,7,11
+Mercer,Grove City 4,President,,DEM,Joseph R. Biden,31,51,82
+Mercer,Grove City 4,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Grove City 4,President,,DEM,Elizabeth Warren,2,1,3
+Mercer,Grove City 4,President,,DEM,Write-In,6,1,7
+Mercer,Grove City 4,Attorney General,,DEM,Josh Shapiro,42,56,98
+Mercer,Grove City 4,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Grove City 4,Auditor General,,DEM,H. Scott Conklin,5,3,8
+Mercer,Grove City 4,Auditor General,,DEM,Michael Lamb,20,28,48
+Mercer,Grove City 4,Auditor General,,DEM,Tracie Fountain,1,5,6
+Mercer,Grove City 4,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,4
+Mercer,Grove City 4,Auditor General,,DEM,Nina Ahmad,7,13,20
+Mercer,Grove City 4,Auditor General,,DEM,Christina M. Hartman,4,6,10
+Mercer,Grove City 4,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Grove City 4,State Treasurer,,DEM,Joe Torsella,38,55,93
+Mercer,Grove City 4,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Grove City 4,U.S. House,16,DEM,Kristy Gnibus,39,54,93
+Mercer,Grove City 4,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Grove City 4,General Assembly,8,DEM,Phil Heasley,37,56,93
+Mercer,Grove City 4,General Assembly,8,DEM,Write-In,2,2,4
+Mercer,Grove City 4,President,,REP,Donald J. Trump,160,31,191
+Mercer,Grove City 4,President,,REP,Roque Rocky De La Fuente,2,1,3
+Mercer,Grove City 4,President,,REP,Bill Weld,2,2,4
+Mercer,Grove City 4,President,,REP,Write-In,5,5,10
+Mercer,Grove City 4,Attorney General,,REP,Heather Heidelbaugh,140,37,177
+Mercer,Grove City 4,Attorney General,,REP,Write-In,1,0,1
+Mercer,Grove City 4,Auditor General,,REP,Timothy Defoor,137,36,173
+Mercer,Grove City 4,Auditor General,,REP,Write-In,1,0,1
+Mercer,Grove City 4,State Treasurer,,REP,Stacy L. Garrity,140,37,177
+Mercer,Grove City 4,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Grove City 4,U.S. House,16,REP,Mike Kelly,163,34,197
+Mercer,Grove City 4,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Grove City 4,General Assembly,8,REP,Scott Jaillet,14,6,20
+Mercer,Grove City 4,General Assembly,8,REP,Tim Bonner,157,35,192
+Mercer,Grove City 4,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Grove City 5,Registered Voters,,,,,,840
+Mercer,Grove City 5,Registered Voters,,DEM,,,,329
+Mercer,Grove City 5,Registered Voters,,REP,,,,511
+Mercer,Grove City 5,Registered Voters,,NPA,,,,0
+Mercer,Grove City 5,Ballots Cast,,,,210,120,330
+Mercer,Grove City 5,Ballots Cast,,DEM,,56,76,132
+Mercer,Grove City 5,Ballots Cast,,REP,,154,44,198
+Mercer,Grove City 5,Ballots Cast,,NPA,,0,0,0
+Mercer,Grove City 5,President,,DEM,Bernie Sanders,14,15,29
+Mercer,Grove City 5,President,,DEM,Joseph R. Biden,37,56,93
+Mercer,Grove City 5,President,,DEM,Tulsi Gabbard,0,2,2
+Mercer,Grove City 5,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Grove City 5,President,,DEM,Write-In,1,3,4
+Mercer,Grove City 5,Attorney General,,DEM,Josh Shapiro,53,69,122
+Mercer,Grove City 5,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Grove City 5,Auditor General,,DEM,H. Scott Conklin,3,7,10
+Mercer,Grove City 5,Auditor General,,DEM,Michael Lamb,36,46,82
+Mercer,Grove City 5,Auditor General,,DEM,Tracie Fountain,2,2,4
+Mercer,Grove City 5,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2
+Mercer,Grove City 5,Auditor General,,DEM,Nina Ahmad,8,12,20
+Mercer,Grove City 5,Auditor General,,DEM,Christina M. Hartman,1,2,3
+Mercer,Grove City 5,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Grove City 5,State Treasurer,,DEM,Joe Torsella,53,66,119
+Mercer,Grove City 5,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Grove City 5,U.S. House,16,DEM,Kristy Gnibus,52,67,119
+Mercer,Grove City 5,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Grove City 5,General Assembly,8,DEM,Phil Heasley,52,65,117
+Mercer,Grove City 5,General Assembly,8,DEM,Write-In,1,2,3
+Mercer,Grove City 5,President,,REP,Donald J. Trump,128,35,163
+Mercer,Grove City 5,President,,REP,Roque Rocky De La Fuente,3,0,3
+Mercer,Grove City 5,President,,REP,Bill Weld,10,6,16
+Mercer,Grove City 5,President,,REP,Write-In,5,1,6
+Mercer,Grove City 5,Attorney General,,REP,Heather Heidelbaugh,133,40,173
+Mercer,Grove City 5,Attorney General,,REP,Write-In,1,0,1
+Mercer,Grove City 5,Auditor General,,REP,Timothy Defoor,131,39,170
+Mercer,Grove City 5,Auditor General,,REP,Write-In,1,1,2
+Mercer,Grove City 5,State Treasurer,,REP,Stacy L. Garrity,133,39,172
+Mercer,Grove City 5,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Grove City 5,U.S. House,16,REP,Mike Kelly,138,38,176
+Mercer,Grove City 5,U.S. House,16,REP,Write-In,1,2,3
+Mercer,Grove City 5,General Assembly,8,REP,Scott Jaillet,28,8,36
+Mercer,Grove City 5,General Assembly,8,REP,Tim Bonner,122,36,158
+Mercer,Grove City 5,General Assembly,8,REP,Write-In,2,0,2
+Mercer,Hempfield 1,Registered Voters,,,,,,460
+Mercer,Hempfield 1,Registered Voters,,DEM,,,,146
+Mercer,Hempfield 1,Registered Voters,,REP,,,,314
+Mercer,Hempfield 1,Registered Voters,,NPA,,,,0
+Mercer,Hempfield 1,Ballots Cast,,,,97,69,166
+Mercer,Hempfield 1,Ballots Cast,,DEM,,23,27,50
+Mercer,Hempfield 1,Ballots Cast,,REP,,74,42,116
+Mercer,Hempfield 1,Ballots Cast,,NPA,,0,0,0
+Mercer,Hempfield 1,President,,DEM,Bernie Sanders,2,2,4
+Mercer,Hempfield 1,President,,DEM,Joseph R. Biden,12,23,35
+Mercer,Hempfield 1,President,,DEM,Tulsi Gabbard,2,0,2
+Mercer,Hempfield 1,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Hempfield 1,President,,DEM,Write-In,6,0,6
+Mercer,Hempfield 1,Attorney General,,DEM,Josh Shapiro,18,26,44
+Mercer,Hempfield 1,Attorney General,,DEM,Write-In,4,0,4
+Mercer,Hempfield 1,Auditor General,,DEM,H. Scott Conklin,2,3,5
+Mercer,Hempfield 1,Auditor General,,DEM,Michael Lamb,10,11,21
+Mercer,Hempfield 1,Auditor General,,DEM,Tracie Fountain,0,3,3
+Mercer,Hempfield 1,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,3
+Mercer,Hempfield 1,Auditor General,,DEM,Nina Ahmad,1,2,3
+Mercer,Hempfield 1,Auditor General,,DEM,Christina M. Hartman,4,4,8
+Mercer,Hempfield 1,Auditor General,,DEM,Write-In,3,1,4
+Mercer,Hempfield 1,State Treasurer,,DEM,Joe Torsella,18,23,41
+Mercer,Hempfield 1,State Treasurer,,DEM,Write-In,3,1,4
+Mercer,Hempfield 1,U.S. House,16,DEM,Kristy Gnibus,19,23,42
+Mercer,Hempfield 1,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,Hempfield 1,General Assembly,17,DEM,Write-In,6,4,10
+Mercer,Hempfield 1,General Assembly,17,DEM,Jeff O'Melian,1,2,3
+Mercer,Hempfield 1,President,,REP,Donald J. Trump,65,35,100
+Mercer,Hempfield 1,President,,REP,Roque Rocky De La Fuente,2,1,3
+Mercer,Hempfield 1,President,,REP,Bill Weld,6,2,8
+Mercer,Hempfield 1,President,,REP,Write-In,0,0,0
+Mercer,Hempfield 1,Attorney General,,REP,Heather Heidelbaugh,65,38,103
+Mercer,Hempfield 1,Attorney General,,REP,Write-In,1,0,1
+Mercer,Hempfield 1,Auditor General,,REP,Timothy Defoor,66,37,103
+Mercer,Hempfield 1,Auditor General,,REP,Write-In,1,0,1
+Mercer,Hempfield 1,State Treasurer,,REP,Stacy L. Garrity,66,37,103
+Mercer,Hempfield 1,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Hempfield 1,U.S. House,16,REP,Mike Kelly,67,39,106
+Mercer,Hempfield 1,U.S. House,16,REP,Write-In,2,0,2
+Mercer,Hempfield 1,General Assembly,17,REP,Parke Wentling,69,40,109
+Mercer,Hempfield 1,General Assembly,17,REP,Write-In,3,1,4
+Mercer,Hempfield 2,Registered Voters,,,,,,738
+Mercer,Hempfield 2,Registered Voters,,DEM,,,,298
+Mercer,Hempfield 2,Registered Voters,,REP,,,,440
+Mercer,Hempfield 2,Registered Voters,,NPA,,,,0
+Mercer,Hempfield 2,Ballots Cast,,,,158,87,245
+Mercer,Hempfield 2,Ballots Cast,,DEM,,50,51,101
+Mercer,Hempfield 2,Ballots Cast,,REP,,108,36,144
+Mercer,Hempfield 2,Ballots Cast,,NPA,,0,0,0
+Mercer,Hempfield 2,President,,DEM,Bernie Sanders,8,4,12
+Mercer,Hempfield 2,President,,DEM,Joseph R. Biden,33,45,78
+Mercer,Hempfield 2,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,Hempfield 2,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Hempfield 2,President,,DEM,Write-In,3,1,4
+Mercer,Hempfield 2,Attorney General,,DEM,Josh Shapiro,40,45,85
+Mercer,Hempfield 2,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Hempfield 2,Auditor General,,DEM,H. Scott Conklin,3,0,3
+Mercer,Hempfield 2,Auditor General,,DEM,Michael Lamb,29,38,67
+Mercer,Hempfield 2,Auditor General,,DEM,Tracie Fountain,2,3,5
+Mercer,Hempfield 2,Auditor General,,DEM,Rose Rosie Marie Davis,5,2,7
+Mercer,Hempfield 2,Auditor General,,DEM,Nina Ahmad,1,5,6
+Mercer,Hempfield 2,Auditor General,,DEM,Christina M. Hartman,6,1,7
+Mercer,Hempfield 2,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hempfield 2,State Treasurer,,DEM,Joe Torsella,38,45,83
+Mercer,Hempfield 2,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Hempfield 2,U.S. House,16,DEM,Kristy Gnibus,38,46,84
+Mercer,Hempfield 2,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Hempfield 2,General Assembly,17,DEM,Write-In,4,3,7
+Mercer,Hempfield 2,General Assembly,17,DEM,Jeff O'Melian,0,1,1
+Mercer,Hempfield 2,President,,REP,Donald J. Trump,103,28,131
+Mercer,Hempfield 2,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Hempfield 2,President,,REP,Bill Weld,2,7,9
+Mercer,Hempfield 2,President,,REP,Write-In,0,1,1
+Mercer,Hempfield 2,Attorney General,,REP,Heather Heidelbaugh,100,30,130
+Mercer,Hempfield 2,Attorney General,,REP,Write-In,0,0,0
+Mercer,Hempfield 2,Auditor General,,REP,Timothy Defoor,99,30,129
+Mercer,Hempfield 2,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hempfield 2,State Treasurer,,REP,Stacy L. Garrity,99,30,129
+Mercer,Hempfield 2,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hempfield 2,U.S. House,16,REP,Mike Kelly,105,35,140
+Mercer,Hempfield 2,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Hempfield 2,General Assembly,17,REP,Parke Wentling,108,35,143
+Mercer,Hempfield 2,General Assembly,17,REP,Write-In,0,0,0
+Mercer,Hempfield 3,Registered Voters,,,,,,1065
+Mercer,Hempfield 3,Registered Voters,,DEM,,,,321
+Mercer,Hempfield 3,Registered Voters,,REP,,,,744
+Mercer,Hempfield 3,Registered Voters,,NPA,,,,0
+Mercer,Hempfield 3,Ballots Cast,,,,227,144,371
+Mercer,Hempfield 3,Ballots Cast,,DEM,,51,56,107
+Mercer,Hempfield 3,Ballots Cast,,REP,,176,88,264
+Mercer,Hempfield 3,Ballots Cast,,NPA,,0,0,0
+Mercer,Hempfield 3,President,,DEM,Bernie Sanders,4,2,6
+Mercer,Hempfield 3,President,,DEM,Joseph R. Biden,35,48,83
+Mercer,Hempfield 3,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Hempfield 3,President,,DEM,Elizabeth Warren,4,0,4
+Mercer,Hempfield 3,President,,DEM,Write-In,3,3,6
+Mercer,Hempfield 3,Attorney General,,DEM,Josh Shapiro,42,50,92
+Mercer,Hempfield 3,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hempfield 3,Auditor General,,DEM,H. Scott Conklin,2,7,9
+Mercer,Hempfield 3,Auditor General,,DEM,Michael Lamb,23,31,54
+Mercer,Hempfield 3,Auditor General,,DEM,Tracie Fountain,0,2,2
+Mercer,Hempfield 3,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,4
+Mercer,Hempfield 3,Auditor General,,DEM,Nina Ahmad,3,0,3
+Mercer,Hempfield 3,Auditor General,,DEM,Christina M. Hartman,11,7,18
+Mercer,Hempfield 3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hempfield 3,State Treasurer,,DEM,Joe Torsella,37,48,85
+Mercer,Hempfield 3,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hempfield 3,U.S. House,16,DEM,Kristy Gnibus,40,47,87
+Mercer,Hempfield 3,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Hempfield 3,General Assembly,17,DEM,Write-In,2,2,4
+Mercer,Hempfield 3,General Assembly,17,DEM,Jeff O'Melian,0,0,0
+Mercer,Hempfield 3,President,,REP,Donald J. Trump,167,75,242
+Mercer,Hempfield 3,President,,REP,Roque Rocky De La Fuente,0,4,4
+Mercer,Hempfield 3,President,,REP,Bill Weld,3,4,7
+Mercer,Hempfield 3,President,,REP,Write-In,0,2,2
+Mercer,Hempfield 3,Attorney General,,REP,Heather Heidelbaugh,159,75,234
+Mercer,Hempfield 3,Attorney General,,REP,Write-In,1,0,1
+Mercer,Hempfield 3,Auditor General,,REP,Timothy Defoor,156,74,230
+Mercer,Hempfield 3,Auditor General,,REP,Write-In,1,0,1
+Mercer,Hempfield 3,State Treasurer,,REP,Stacy L. Garrity,155,74,229
+Mercer,Hempfield 3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hempfield 3,U.S. House,16,REP,Mike Kelly,169,77,246
+Mercer,Hempfield 3,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Hempfield 3,General Assembly,17,REP,Parke Wentling,173,85,258
+Mercer,Hempfield 3,General Assembly,17,REP,Write-In,0,1,1
+Mercer,Hermitage NW-1,Registered Voters,,,,,,540
+Mercer,Hermitage NW-1,Registered Voters,,DEM,,,,345
+Mercer,Hermitage NW-1,Registered Voters,,REP,,,,195
+Mercer,Hermitage NW-1,Registered Voters,,NPA,,,,0
+Mercer,Hermitage NW-1,Ballots Cast,,,,108,51,159
+Mercer,Hermitage NW-1,Ballots Cast,,DEM,,57,39,96
+Mercer,Hermitage NW-1,Ballots Cast,,REP,,51,12,63
+Mercer,Hermitage NW-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage NW-1,President,,DEM,Bernie Sanders,6,3,9
+Mercer,Hermitage NW-1,President,,DEM,Joseph R. Biden,38,33,71
+Mercer,Hermitage NW-1,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Hermitage NW-1,President,,DEM,Elizabeth Warren,2,1,3
+Mercer,Hermitage NW-1,President,,DEM,Write-In,5,1,6
+Mercer,Hermitage NW-1,Attorney General,,DEM,Josh Shapiro,44,36,80
+Mercer,Hermitage NW-1,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Hermitage NW-1,Auditor General,,DEM,H. Scott Conklin,2,1,3
+Mercer,Hermitage NW-1,Auditor General,,DEM,Michael Lamb,18,29,47
+Mercer,Hermitage NW-1,Auditor General,,DEM,Tracie Fountain,4,0,4
+Mercer,Hermitage NW-1,Auditor General,,DEM,Rose Rosie Marie Davis,9,0,9
+Mercer,Hermitage NW-1,Auditor General,,DEM,Nina Ahmad,2,0,2
+Mercer,Hermitage NW-1,Auditor General,,DEM,Christina M. Hartman,8,7,15
+Mercer,Hermitage NW-1,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Hermitage NW-1,State Treasurer,,DEM,Joe Torsella,41,36,77
+Mercer,Hermitage NW-1,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Hermitage NW-1,U.S. House,16,DEM,Kristy Gnibus,41,32,73
+Mercer,Hermitage NW-1,U.S. House,16,DEM,Write-In,1,1,2
+Mercer,Hermitage NW-1,General Assembly,7,DEM,Mark Longietti,53,39,92
+Mercer,Hermitage NW-1,General Assembly,7,DEM,Write-In,1,0,1
+Mercer,Hermitage NW-1,President,,REP,Donald J. Trump,48,12,60
+Mercer,Hermitage NW-1,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,Hermitage NW-1,President,,REP,Bill Weld,0,0,0
+Mercer,Hermitage NW-1,President,,REP,Write-In,1,0,1
+Mercer,Hermitage NW-1,Attorney General,,REP,Heather Heidelbaugh,43,9,52
+Mercer,Hermitage NW-1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-1,Auditor General,,REP,Timothy Defoor,42,9,51
+Mercer,Hermitage NW-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-1,State Treasurer,,REP,Stacy L. Garrity,40,9,49
+Mercer,Hermitage NW-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-1,U.S. House,16,REP,Mike Kelly,45,10,55
+Mercer,Hermitage NW-1,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Hermitage NW-1,General Assembly,7,REP,Write-In,8,1,9
+Mercer,Hermitage NW-1,General Assembly,7,REP,Mark Longietti,7,1,8
+Mercer,Hermitage NW-2,Registered Voters,,,,,,746
+Mercer,Hermitage NW-2,Registered Voters,,DEM,,,,430
+Mercer,Hermitage NW-2,Registered Voters,,REP,,,,316
+Mercer,Hermitage NW-2,Registered Voters,,NPA,,,,0
+Mercer,Hermitage NW-2,Ballots Cast,,,,137,146,283
+Mercer,Hermitage NW-2,Ballots Cast,,DEM,,56,115,171
+Mercer,Hermitage NW-2,Ballots Cast,,REP,,81,31,112
+Mercer,Hermitage NW-2,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage NW-2,President,,DEM,Bernie Sanders,5,13,18
+Mercer,Hermitage NW-2,President,,DEM,Joseph R. Biden,38,96,134
+Mercer,Hermitage NW-2,President,,DEM,Tulsi Gabbard,2,2,4
+Mercer,Hermitage NW-2,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Hermitage NW-2,President,,DEM,Write-In,4,0,4
+Mercer,Hermitage NW-2,Attorney General,,DEM,Josh Shapiro,45,95,140
+Mercer,Hermitage NW-2,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-2,Auditor General,,DEM,H. Scott Conklin,2,7,9
+Mercer,Hermitage NW-2,Auditor General,,DEM,Michael Lamb,28,67,95
+Mercer,Hermitage NW-2,Auditor General,,DEM,Tracie Fountain,2,5,7
+Mercer,Hermitage NW-2,Auditor General,,DEM,Rose Rosie Marie Davis,1,6,7
+Mercer,Hermitage NW-2,Auditor General,,DEM,Nina Ahmad,3,7,10
+Mercer,Hermitage NW-2,Auditor General,,DEM,Christina M. Hartman,7,5,12
+Mercer,Hermitage NW-2,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-2,State Treasurer,,DEM,Joe Torsella,43,86,129
+Mercer,Hermitage NW-2,State Treasurer,,DEM,Write-In,0,2,2
+Mercer,Hermitage NW-2,U.S. House,16,DEM,Kristy Gnibus,42,90,132
+Mercer,Hermitage NW-2,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-2,General Assembly,7,DEM,Mark Longietti,55,106,161
+Mercer,Hermitage NW-2,General Assembly,7,DEM,Write-In,0,2,2
+Mercer,Hermitage NW-2,President,,REP,Donald J. Trump,71,25,96
+Mercer,Hermitage NW-2,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,Hermitage NW-2,President,,REP,Bill Weld,1,0,1
+Mercer,Hermitage NW-2,President,,REP,Write-In,2,2,4
+Mercer,Hermitage NW-2,Attorney General,,REP,Heather Heidelbaugh,68,26,94
+Mercer,Hermitage NW-2,Attorney General,,REP,Write-In,1,0,1
+Mercer,Hermitage NW-2,Auditor General,,REP,Timothy Defoor,63,24,87
+Mercer,Hermitage NW-2,Auditor General,,REP,Write-In,1,0,1
+Mercer,Hermitage NW-2,State Treasurer,,REP,Stacy L. Garrity,68,24,92
+Mercer,Hermitage NW-2,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-2,U.S. House,16,REP,Mike Kelly,77,26,103
+Mercer,Hermitage NW-2,U.S. House,16,REP,Write-In,1,3,4
+Mercer,Hermitage NW-2,General Assembly,7,REP,Write-In,22,9,31
+Mercer,Hermitage NW-2,General Assembly,7,REP,Mark Longietti,17,9,26
+Mercer,Hermitage NW-3,Registered Voters,,,,,,760
+Mercer,Hermitage NW-3,Registered Voters,,DEM,,,,445
+Mercer,Hermitage NW-3,Registered Voters,,REP,,,,315
+Mercer,Hermitage NW-3,Registered Voters,,NPA,,,,0
+Mercer,Hermitage NW-3,Ballots Cast,,,,91,107,198
+Mercer,Hermitage NW-3,Ballots Cast,,DEM,,59,68,127
+Mercer,Hermitage NW-3,Ballots Cast,,REP,,32,39,71
+Mercer,Hermitage NW-3,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage NW-3,President,,DEM,Bernie Sanders,10,6,16
+Mercer,Hermitage NW-3,President,,DEM,Joseph R. Biden,47,58,105
+Mercer,Hermitage NW-3,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Hermitage NW-3,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Hermitage NW-3,President,,DEM,Write-In,0,1,1
+Mercer,Hermitage NW-3,Attorney General,,DEM,Josh Shapiro,50,63,113
+Mercer,Hermitage NW-3,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-3,Auditor General,,DEM,H. Scott Conklin,2,4,6
+Mercer,Hermitage NW-3,Auditor General,,DEM,Michael Lamb,31,40,71
+Mercer,Hermitage NW-3,Auditor General,,DEM,Tracie Fountain,5,8,13
+Mercer,Hermitage NW-3,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,5
+Mercer,Hermitage NW-3,Auditor General,,DEM,Nina Ahmad,7,6,13
+Mercer,Hermitage NW-3,Auditor General,,DEM,Christina M. Hartman,5,2,7
+Mercer,Hermitage NW-3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-3,State Treasurer,,DEM,Joe Torsella,49,59,108
+Mercer,Hermitage NW-3,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-3,U.S. House,16,DEM,Kristy Gnibus,52,61,113
+Mercer,Hermitage NW-3,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-3,General Assembly,7,DEM,Mark Longietti,57,65,122
+Mercer,Hermitage NW-3,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-3,President,,REP,Donald J. Trump,30,34,64
+Mercer,Hermitage NW-3,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Hermitage NW-3,President,,REP,Bill Weld,1,2,3
+Mercer,Hermitage NW-3,President,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-3,Attorney General,,REP,Heather Heidelbaugh,29,35,64
+Mercer,Hermitage NW-3,Attorney General,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-3,Auditor General,,REP,Timothy Defoor,30,32,62
+Mercer,Hermitage NW-3,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-3,State Treasurer,,REP,Stacy L. Garrity,29,35,64
+Mercer,Hermitage NW-3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-3,U.S. House,16,REP,Mike Kelly,28,34,62
+Mercer,Hermitage NW-3,U.S. House,16,REP,Write-In,2,1,3
+Mercer,Hermitage NW-3,General Assembly,7,REP,Write-In,4,6,10
+Mercer,Hermitage NW-3,General Assembly,7,REP,Mark Longietti,3,4,7
+Mercer,Hermitage NW-4,Registered Voters,,,,,,1060
+Mercer,Hermitage NW-4,Registered Voters,,DEM,,,,537
+Mercer,Hermitage NW-4,Registered Voters,,REP,,,,523
+Mercer,Hermitage NW-4,Registered Voters,,NPA,,,,0
+Mercer,Hermitage NW-4,Ballots Cast,,,,143,196,339
+Mercer,Hermitage NW-4,Ballots Cast,,DEM,,71,138,209
+Mercer,Hermitage NW-4,Ballots Cast,,REP,,72,58,130
+Mercer,Hermitage NW-4,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage NW-4,President,,DEM,Bernie Sanders,10,6,16
+Mercer,Hermitage NW-4,President,,DEM,Joseph R. Biden,49,126,175
+Mercer,Hermitage NW-4,President,,DEM,Tulsi Gabbard,3,1,4
+Mercer,Hermitage NW-4,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,Hermitage NW-4,President,,DEM,Write-In,3,2,5
+Mercer,Hermitage NW-4,Attorney General,,DEM,Josh Shapiro,58,125,183
+Mercer,Hermitage NW-4,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-4,Auditor General,,DEM,H. Scott Conklin,5,4,9
+Mercer,Hermitage NW-4,Auditor General,,DEM,Michael Lamb,39,88,127
+Mercer,Hermitage NW-4,Auditor General,,DEM,Tracie Fountain,2,10,12
+Mercer,Hermitage NW-4,Auditor General,,DEM,Rose Rosie Marie Davis,6,7,13
+Mercer,Hermitage NW-4,Auditor General,,DEM,Nina Ahmad,5,5,10
+Mercer,Hermitage NW-4,Auditor General,,DEM,Christina M. Hartman,3,8,11
+Mercer,Hermitage NW-4,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-4,State Treasurer,,DEM,Joe Torsella,57,123,180
+Mercer,Hermitage NW-4,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-4,U.S. House,16,DEM,Kristy Gnibus,56,118,174
+Mercer,Hermitage NW-4,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Hermitage NW-4,General Assembly,7,DEM,Mark Longietti,66,137,203
+Mercer,Hermitage NW-4,General Assembly,7,DEM,Write-In,1,0,1
+Mercer,Hermitage NW-4,President,,REP,Donald J. Trump,67,52,119
+Mercer,Hermitage NW-4,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Hermitage NW-4,President,,REP,Bill Weld,2,2,4
+Mercer,Hermitage NW-4,President,,REP,Write-In,1,1,2
+Mercer,Hermitage NW-4,Attorney General,,REP,Heather Heidelbaugh,59,46,105
+Mercer,Hermitage NW-4,Attorney General,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-4,Auditor General,,REP,Timothy Defoor,58,49,107
+Mercer,Hermitage NW-4,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-4,State Treasurer,,REP,Stacy L. Garrity,59,49,108
+Mercer,Hermitage NW-4,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage NW-4,U.S. House,16,REP,Mike Kelly,66,49,115
+Mercer,Hermitage NW-4,U.S. House,16,REP,Write-In,1,2,3
+Mercer,Hermitage NW-4,General Assembly,7,REP,Write-In,9,13,22
+Mercer,Hermitage NW-4,General Assembly,7,REP,Mark Longietti,6,7,13
+Mercer,Hermitage NE-1,Registered Voters,,,,,,977
+Mercer,Hermitage NE-1,Registered Voters,,DEM,,,,452
+Mercer,Hermitage NE-1,Registered Voters,,REP,,,,525
+Mercer,Hermitage NE-1,Registered Voters,,NPA,,,,0
+Mercer,Hermitage NE-1,Ballots Cast,,,,133,209,342
+Mercer,Hermitage NE-1,Ballots Cast,,DEM,,47,131,178
+Mercer,Hermitage NE-1,Ballots Cast,,REP,,86,78,164
+Mercer,Hermitage NE-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage NE-1,President,,DEM,Bernie Sanders,8,5,13
+Mercer,Hermitage NE-1,President,,DEM,Joseph R. Biden,32,121,153
+Mercer,Hermitage NE-1,President,,DEM,Tulsi Gabbard,2,1,3
+Mercer,Hermitage NE-1,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,Hermitage NE-1,President,,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-1,Attorney General,,DEM,Josh Shapiro,36,114,150
+Mercer,Hermitage NE-1,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-1,Auditor General,,DEM,H. Scott Conklin,3,14,17
+Mercer,Hermitage NE-1,Auditor General,,DEM,Michael Lamb,30,68,98
+Mercer,Hermitage NE-1,Auditor General,,DEM,Tracie Fountain,3,7,10
+Mercer,Hermitage NE-1,Auditor General,,DEM,Rose Rosie Marie Davis,1,5,6
+Mercer,Hermitage NE-1,Auditor General,,DEM,Nina Ahmad,1,5,6
+Mercer,Hermitage NE-1,Auditor General,,DEM,Christina M. Hartman,2,12,14
+Mercer,Hermitage NE-1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-1,State Treasurer,,DEM,Joe Torsella,34,106,140
+Mercer,Hermitage NE-1,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-1,U.S. House,16,DEM,Kristy Gnibus,36,102,138
+Mercer,Hermitage NE-1,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-1,General Assembly,7,DEM,Mark Longietti,45,125,170
+Mercer,Hermitage NE-1,General Assembly,7,DEM,Write-In,0,2,2
+Mercer,Hermitage NE-1,President,,REP,Donald J. Trump,81,61,142
+Mercer,Hermitage NE-1,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,Hermitage NE-1,President,,REP,Bill Weld,1,9,10
+Mercer,Hermitage NE-1,President,,REP,Write-In,0,3,3
+Mercer,Hermitage NE-1,Attorney General,,REP,Heather Heidelbaugh,80,68,148
+Mercer,Hermitage NE-1,Attorney General,,REP,Write-In,2,0,2
+Mercer,Hermitage NE-1,Auditor General,,REP,Timothy Defoor,78,68,146
+Mercer,Hermitage NE-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage NE-1,State Treasurer,,REP,Stacy L. Garrity,81,67,148
+Mercer,Hermitage NE-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage NE-1,U.S. House,16,REP,Mike Kelly,84,73,157
+Mercer,Hermitage NE-1,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Hermitage NE-1,General Assembly,7,REP,Write-In,23,25,48
+Mercer,Hermitage NE-1,General Assembly,7,REP,Mark Longietti,19,17,36
+Mercer,Hermitage NE-2,Registered Voters,,,,,,832
+Mercer,Hermitage NE-2,Registered Voters,,DEM,,,,409
+Mercer,Hermitage NE-2,Registered Voters,,REP,,,,423
+Mercer,Hermitage NE-2,Registered Voters,,NPA,,,,0
+Mercer,Hermitage NE-2,Ballots Cast,,,,159,146,305
+Mercer,Hermitage NE-2,Ballots Cast,,DEM,,56,87,143
+Mercer,Hermitage NE-2,Ballots Cast,,REP,,103,59,162
+Mercer,Hermitage NE-2,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage NE-2,President,,DEM,Bernie Sanders,7,6,13
+Mercer,Hermitage NE-2,President,,DEM,Joseph R. Biden,41,78,119
+Mercer,Hermitage NE-2,President,,DEM,Tulsi Gabbard,4,2,6
+Mercer,Hermitage NE-2,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Hermitage NE-2,President,,DEM,Write-In,1,1,2
+Mercer,Hermitage NE-2,Attorney General,,DEM,Josh Shapiro,49,80,129
+Mercer,Hermitage NE-2,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-2,Auditor General,,DEM,H. Scott Conklin,2,3,5
+Mercer,Hermitage NE-2,Auditor General,,DEM,Michael Lamb,36,55,91
+Mercer,Hermitage NE-2,Auditor General,,DEM,Tracie Fountain,0,0,0
+Mercer,Hermitage NE-2,Auditor General,,DEM,Rose Rosie Marie Davis,4,2,6
+Mercer,Hermitage NE-2,Auditor General,,DEM,Nina Ahmad,1,12,13
+Mercer,Hermitage NE-2,Auditor General,,DEM,Christina M. Hartman,5,10,15
+Mercer,Hermitage NE-2,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-2,State Treasurer,,DEM,Joe Torsella,47,74,121
+Mercer,Hermitage NE-2,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-2,U.S. House,16,DEM,Kristy Gnibus,47,77,124
+Mercer,Hermitage NE-2,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-2,General Assembly,7,DEM,Mark Longietti,56,87,143
+Mercer,Hermitage NE-2,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Hermitage NE-2,President,,REP,Donald J. Trump,95,52,147
+Mercer,Hermitage NE-2,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Hermitage NE-2,President,,REP,Bill Weld,4,5,9
+Mercer,Hermitage NE-2,President,,REP,Write-In,2,1,3
+Mercer,Hermitage NE-2,Attorney General,,REP,Heather Heidelbaugh,88,54,142
+Mercer,Hermitage NE-2,Attorney General,,REP,Write-In,1,0,1
+Mercer,Hermitage NE-2,Auditor General,,REP,Timothy Defoor,82,53,135
+Mercer,Hermitage NE-2,Auditor General,,REP,Write-In,1,0,1
+Mercer,Hermitage NE-2,State Treasurer,,REP,Stacy L. Garrity,86,56,142
+Mercer,Hermitage NE-2,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Hermitage NE-2,U.S. House,16,REP,Mike Kelly,93,53,146
+Mercer,Hermitage NE-2,U.S. House,16,REP,Write-In,2,3,5
+Mercer,Hermitage NE-2,General Assembly,7,REP,Write-In,10,13,23
+Mercer,Hermitage NE-2,General Assembly,7,REP,Mark Longietti,6,9,15
+Mercer,Hermitage SW-1,Registered Voters,,,,,,776
+Mercer,Hermitage SW-1,Registered Voters,,DEM,,,,504
+Mercer,Hermitage SW-1,Registered Voters,,REP,,,,272
+Mercer,Hermitage SW-1,Registered Voters,,NPA,,,,0
+Mercer,Hermitage SW-1,Ballots Cast,,,,117,139,256
+Mercer,Hermitage SW-1,Ballots Cast,,DEM,,72,103,175
+Mercer,Hermitage SW-1,Ballots Cast,,REP,,45,36,81
+Mercer,Hermitage SW-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage SW-1,President,,DEM,Bernie Sanders,14,7,21
+Mercer,Hermitage SW-1,President,,DEM,Joseph R. Biden,48,91,139
+Mercer,Hermitage SW-1,President,,DEM,Tulsi Gabbard,5,2,7
+Mercer,Hermitage SW-1,President,,DEM,Elizabeth Warren,2,1,3
+Mercer,Hermitage SW-1,President,,DEM,Write-In,2,1,3
+Mercer,Hermitage SW-1,Attorney General,,DEM,Josh Shapiro,54,87,141
+Mercer,Hermitage SW-1,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-1,Auditor General,,DEM,H. Scott Conklin,5,1,6
+Mercer,Hermitage SW-1,Auditor General,,DEM,Michael Lamb,32,58,90
+Mercer,Hermitage SW-1,Auditor General,,DEM,Tracie Fountain,5,3,8
+Mercer,Hermitage SW-1,Auditor General,,DEM,Rose Rosie Marie Davis,3,5,8
+Mercer,Hermitage SW-1,Auditor General,,DEM,Nina Ahmad,8,10,18
+Mercer,Hermitage SW-1,Auditor General,,DEM,Christina M. Hartman,6,16,22
+Mercer,Hermitage SW-1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-1,State Treasurer,,DEM,Joe Torsella,54,84,138
+Mercer,Hermitage SW-1,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-1,U.S. House,16,DEM,Kristy Gnibus,53,88,141
+Mercer,Hermitage SW-1,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Hermitage SW-1,General Assembly,7,DEM,Mark Longietti,70,103,173
+Mercer,Hermitage SW-1,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-1,President,,REP,Donald J. Trump,40,29,69
+Mercer,Hermitage SW-1,President,,REP,Roque Rocky De La Fuente,1,2,3
+Mercer,Hermitage SW-1,President,,REP,Bill Weld,2,3,5
+Mercer,Hermitage SW-1,President,,REP,Write-In,2,1,3
+Mercer,Hermitage SW-1,Attorney General,,REP,Heather Heidelbaugh,41,34,75
+Mercer,Hermitage SW-1,Attorney General,,REP,Write-In,1,1,2
+Mercer,Hermitage SW-1,Auditor General,,REP,Timothy Defoor,40,34,74
+Mercer,Hermitage SW-1,Auditor General,,REP,Write-In,1,0,1
+Mercer,Hermitage SW-1,State Treasurer,,REP,Stacy L. Garrity,38,35,73
+Mercer,Hermitage SW-1,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Hermitage SW-1,U.S. House,16,REP,Mike Kelly,41,32,73
+Mercer,Hermitage SW-1,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Hermitage SW-1,General Assembly,7,REP,Write-In,12,6,18
+Mercer,Hermitage SW-1,General Assembly,7,REP,Mark Longietti,8,4,12
+Mercer,Hermitage SW-2,Registered Voters,,,,,,650
+Mercer,Hermitage SW-2,Registered Voters,,DEM,,,,424
+Mercer,Hermitage SW-2,Registered Voters,,REP,,,,226
+Mercer,Hermitage SW-2,Registered Voters,,NPA,,,,0
+Mercer,Hermitage SW-2,Ballots Cast,,,,107,112,219
+Mercer,Hermitage SW-2,Ballots Cast,,DEM,,55,84,139
+Mercer,Hermitage SW-2,Ballots Cast,,REP,,52,28,80
+Mercer,Hermitage SW-2,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage SW-2,President,,DEM,Bernie Sanders,9,3,12
+Mercer,Hermitage SW-2,President,,DEM,Joseph R. Biden,38,72,110
+Mercer,Hermitage SW-2,President,,DEM,Tulsi Gabbard,0,2,2
+Mercer,Hermitage SW-2,President,,DEM,Elizabeth Warren,2,1,3
+Mercer,Hermitage SW-2,President,,DEM,Write-In,1,2,3
+Mercer,Hermitage SW-2,Attorney General,,DEM,Josh Shapiro,46,78,124
+Mercer,Hermitage SW-2,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-2,Auditor General,,DEM,H. Scott Conklin,7,5,12
+Mercer,Hermitage SW-2,Auditor General,,DEM,Michael Lamb,19,51,70
+Mercer,Hermitage SW-2,Auditor General,,DEM,Tracie Fountain,3,8,11
+Mercer,Hermitage SW-2,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,6
+Mercer,Hermitage SW-2,Auditor General,,DEM,Nina Ahmad,6,5,11
+Mercer,Hermitage SW-2,Auditor General,,DEM,Christina M. Hartman,4,4,8
+Mercer,Hermitage SW-2,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-2,State Treasurer,,DEM,Joe Torsella,42,77,119
+Mercer,Hermitage SW-2,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-2,U.S. House,16,DEM,Kristy Gnibus,42,75,117
+Mercer,Hermitage SW-2,U.S. House,16,DEM,Write-In,0,2,2
+Mercer,Hermitage SW-2,General Assembly,7,DEM,Mark Longietti,52,82,134
+Mercer,Hermitage SW-2,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-2,President,,REP,Donald J. Trump,51,20,71
+Mercer,Hermitage SW-2,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Hermitage SW-2,President,,REP,Bill Weld,0,1,1
+Mercer,Hermitage SW-2,President,,REP,Write-In,0,3,3
+Mercer,Hermitage SW-2,Attorney General,,REP,Heather Heidelbaugh,41,21,62
+Mercer,Hermitage SW-2,Attorney General,,REP,Write-In,2,2,4
+Mercer,Hermitage SW-2,Auditor General,,REP,Timothy Defoor,39,24,63
+Mercer,Hermitage SW-2,Auditor General,,REP,Write-In,1,0,1
+Mercer,Hermitage SW-2,State Treasurer,,REP,Stacy L. Garrity,39,22,61
+Mercer,Hermitage SW-2,State Treasurer,,REP,Write-In,1,2,3
+Mercer,Hermitage SW-2,U.S. House,16,REP,Mike Kelly,46,21,67
+Mercer,Hermitage SW-2,U.S. House,16,REP,Write-In,2,3,5
+Mercer,Hermitage SW-2,General Assembly,7,REP,Write-In,13,10,23
+Mercer,Hermitage SW-2,General Assembly,7,REP,Mark Longietti,8,7,15
+Mercer,Hermitage SW-3,Registered Voters,,,,,,683
+Mercer,Hermitage SW-3,Registered Voters,,DEM,,,,392
+Mercer,Hermitage SW-3,Registered Voters,,REP,,,,291
+Mercer,Hermitage SW-3,Registered Voters,,NPA,,,,0
+Mercer,Hermitage SW-3,Ballots Cast,,,,96,109,205
+Mercer,Hermitage SW-3,Ballots Cast,,DEM,,47,73,120
+Mercer,Hermitage SW-3,Ballots Cast,,REP,,49,36,85
+Mercer,Hermitage SW-3,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage SW-3,President,,DEM,Bernie Sanders,5,7,12
+Mercer,Hermitage SW-3,President,,DEM,Joseph R. Biden,32,62,94
+Mercer,Hermitage SW-3,President,,DEM,Tulsi Gabbard,3,0,3
+Mercer,Hermitage SW-3,President,,DEM,Elizabeth Warren,2,1,3
+Mercer,Hermitage SW-3,President,,DEM,Write-In,1,0,1
+Mercer,Hermitage SW-3,Attorney General,,DEM,Josh Shapiro,32,62,94
+Mercer,Hermitage SW-3,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Hermitage SW-3,Auditor General,,DEM,H. Scott Conklin,3,3,6
+Mercer,Hermitage SW-3,Auditor General,,DEM,Michael Lamb,25,45,70
+Mercer,Hermitage SW-3,Auditor General,,DEM,Tracie Fountain,1,3,4
+Mercer,Hermitage SW-3,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,4
+Mercer,Hermitage SW-3,Auditor General,,DEM,Nina Ahmad,2,3,5
+Mercer,Hermitage SW-3,Auditor General,,DEM,Christina M. Hartman,2,8,10
+Mercer,Hermitage SW-3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-3,State Treasurer,,DEM,Joe Torsella,31,58,89
+Mercer,Hermitage SW-3,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Hermitage SW-3,U.S. House,16,DEM,Kristy Gnibus,30,59,89
+Mercer,Hermitage SW-3,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Hermitage SW-3,General Assembly,7,DEM,Mark Longietti,42,69,111
+Mercer,Hermitage SW-3,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Hermitage SW-3,President,,REP,Donald J. Trump,46,29,75
+Mercer,Hermitage SW-3,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Hermitage SW-3,President,,REP,Bill Weld,0,5,5
+Mercer,Hermitage SW-3,President,,REP,Write-In,2,0,2
+Mercer,Hermitage SW-3,Attorney General,,REP,Heather Heidelbaugh,45,26,71
+Mercer,Hermitage SW-3,Attorney General,,REP,Write-In,0,0,0
+Mercer,Hermitage SW-3,Auditor General,,REP,Timothy Defoor,43,23,66
+Mercer,Hermitage SW-3,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage SW-3,State Treasurer,,REP,Stacy L. Garrity,44,28,72
+Mercer,Hermitage SW-3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage SW-3,U.S. House,16,REP,Mike Kelly,46,29,75
+Mercer,Hermitage SW-3,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Hermitage SW-3,General Assembly,7,REP,Write-In,11,5,16
+Mercer,Hermitage SW-3,General Assembly,7,REP,Mark Longietti,6,4,10
+Mercer,Hermitage SE-1,Registered Voters,,,,,,553
+Mercer,Hermitage SE-1,Registered Voters,,DEM,,,,299
+Mercer,Hermitage SE-1,Registered Voters,,REP,,,,254
+Mercer,Hermitage SE-1,Registered Voters,,NPA,,,,0
+Mercer,Hermitage SE-1,Ballots Cast,,,,97,105,202
+Mercer,Hermitage SE-1,Ballots Cast,,DEM,,42,80,122
+Mercer,Hermitage SE-1,Ballots Cast,,REP,,55,25,80
+Mercer,Hermitage SE-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage SE-1,President,,DEM,Bernie Sanders,4,6,10
+Mercer,Hermitage SE-1,President,,DEM,Joseph R. Biden,29,71,100
+Mercer,Hermitage SE-1,President,,DEM,Tulsi Gabbard,3,0,3
+Mercer,Hermitage SE-1,President,,DEM,Elizabeth Warren,2,2,4
+Mercer,Hermitage SE-1,President,,DEM,Write-In,1,0,1
+Mercer,Hermitage SE-1,Attorney General,,DEM,Josh Shapiro,37,73,110
+Mercer,Hermitage SE-1,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-1,Auditor General,,DEM,H. Scott Conklin,4,1,5
+Mercer,Hermitage SE-1,Auditor General,,DEM,Michael Lamb,24,57,81
+Mercer,Hermitage SE-1,Auditor General,,DEM,Tracie Fountain,1,0,1
+Mercer,Hermitage SE-1,Auditor General,,DEM,Rose Rosie Marie Davis,1,4,5
+Mercer,Hermitage SE-1,Auditor General,,DEM,Nina Ahmad,3,4,7
+Mercer,Hermitage SE-1,Auditor General,,DEM,Christina M. Hartman,4,6,10
+Mercer,Hermitage SE-1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-1,State Treasurer,,DEM,Joe Torsella,35,71,106
+Mercer,Hermitage SE-1,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-1,U.S. House,16,DEM,Kristy Gnibus,37,74,111
+Mercer,Hermitage SE-1,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-1,General Assembly,7,DEM,Mark Longietti,41,78,119
+Mercer,Hermitage SE-1,General Assembly,7,DEM,Write-In,0,1,1
+Mercer,Hermitage SE-1,President,,REP,Donald J. Trump,54,18,72
+Mercer,Hermitage SE-1,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Hermitage SE-1,President,,REP,Bill Weld,1,4,5
+Mercer,Hermitage SE-1,President,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-1,Attorney General,,REP,Heather Heidelbaugh,50,22,72
+Mercer,Hermitage SE-1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-1,Auditor General,,REP,Timothy Defoor,45,21,66
+Mercer,Hermitage SE-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-1,State Treasurer,,REP,Stacy L. Garrity,48,21,69
+Mercer,Hermitage SE-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-1,U.S. House,16,REP,Mike Kelly,53,20,73
+Mercer,Hermitage SE-1,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Hermitage SE-1,General Assembly,7,REP,Write-In,10,3,13
+Mercer,Hermitage SE-1,General Assembly,7,REP,Mark Longietti,8,3,11
+Mercer,Hermitage SE-2,Registered Voters,,,,,,1222
+Mercer,Hermitage SE-2,Registered Voters,,DEM,,,,581
+Mercer,Hermitage SE-2,Registered Voters,,REP,,,,641
+Mercer,Hermitage SE-2,Registered Voters,,NPA,,,,0
+Mercer,Hermitage SE-2,Ballots Cast,,,,158,245,403
+Mercer,Hermitage SE-2,Ballots Cast,,DEM,,59,173,232
+Mercer,Hermitage SE-2,Ballots Cast,,REP,,99,72,171
+Mercer,Hermitage SE-2,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage SE-2,President,,DEM,Bernie Sanders,5,9,14
+Mercer,Hermitage SE-2,President,,DEM,Joseph R. Biden,45,154,199
+Mercer,Hermitage SE-2,President,,DEM,Tulsi Gabbard,1,3,4
+Mercer,Hermitage SE-2,President,,DEM,Elizabeth Warren,0,1,1
+Mercer,Hermitage SE-2,President,,DEM,Write-In,2,3,5
+Mercer,Hermitage SE-2,Attorney General,,DEM,Josh Shapiro,46,145,191
+Mercer,Hermitage SE-2,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Hermitage SE-2,Auditor General,,DEM,H. Scott Conklin,2,8,10
+Mercer,Hermitage SE-2,Auditor General,,DEM,Michael Lamb,23,116,139
+Mercer,Hermitage SE-2,Auditor General,,DEM,Tracie Fountain,1,7,8
+Mercer,Hermitage SE-2,Auditor General,,DEM,Rose Rosie Marie Davis,4,1,5
+Mercer,Hermitage SE-2,Auditor General,,DEM,Nina Ahmad,6,3,9
+Mercer,Hermitage SE-2,Auditor General,,DEM,Christina M. Hartman,11,11,22
+Mercer,Hermitage SE-2,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Hermitage SE-2,State Treasurer,,DEM,Joe Torsella,45,141,186
+Mercer,Hermitage SE-2,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-2,U.S. House,16,DEM,Kristy Gnibus,45,136,181
+Mercer,Hermitage SE-2,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-2,General Assembly,7,DEM,Mark Longietti,58,170,228
+Mercer,Hermitage SE-2,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-2,President,,REP,Donald J. Trump,95,60,155
+Mercer,Hermitage SE-2,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Hermitage SE-2,President,,REP,Bill Weld,1,7,8
+Mercer,Hermitage SE-2,President,,REP,Write-In,2,3,5
+Mercer,Hermitage SE-2,Attorney General,,REP,Heather Heidelbaugh,78,67,145
+Mercer,Hermitage SE-2,Attorney General,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-2,Auditor General,,REP,Timothy Defoor,75,65,140
+Mercer,Hermitage SE-2,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-2,State Treasurer,,REP,Stacy L. Garrity,75,66,141
+Mercer,Hermitage SE-2,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-2,U.S. House,16,REP,Mike Kelly,92,66,158
+Mercer,Hermitage SE-2,U.S. House,16,REP,Write-In,0,1,1
+Mercer,Hermitage SE-2,General Assembly,7,REP,Write-In,22,21,43
+Mercer,Hermitage SE-2,General Assembly,7,REP,Mark Longietti,16,20,36
+Mercer,Hermitage SE-3,Registered Voters,,,,,,914
+Mercer,Hermitage SE-3,Registered Voters,,DEM,,,,463
+Mercer,Hermitage SE-3,Registered Voters,,REP,,,,451
+Mercer,Hermitage SE-3,Registered Voters,,NPA,,,,0
+Mercer,Hermitage SE-3,Ballots Cast,,,,126,184,310
+Mercer,Hermitage SE-3,Ballots Cast,,DEM,,54,133,187
+Mercer,Hermitage SE-3,Ballots Cast,,REP,,72,51,123
+Mercer,Hermitage SE-3,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage SE-3,President,,DEM,Bernie Sanders,5,11,16
+Mercer,Hermitage SE-3,President,,DEM,Joseph R. Biden,37,111,148
+Mercer,Hermitage SE-3,President,,DEM,Tulsi Gabbard,0,1,1
+Mercer,Hermitage SE-3,President,,DEM,Elizabeth Warren,1,2,3
+Mercer,Hermitage SE-3,President,,DEM,Write-In,4,2,6
+Mercer,Hermitage SE-3,Attorney General,,DEM,Josh Shapiro,42,114,156
+Mercer,Hermitage SE-3,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Hermitage SE-3,Auditor General,,DEM,H. Scott Conklin,4,8,12
+Mercer,Hermitage SE-3,Auditor General,,DEM,Michael Lamb,31,85,116
+Mercer,Hermitage SE-3,Auditor General,,DEM,Tracie Fountain,2,5,7
+Mercer,Hermitage SE-3,Auditor General,,DEM,Rose Rosie Marie Davis,3,4,7
+Mercer,Hermitage SE-3,Auditor General,,DEM,Nina Ahmad,4,6,10
+Mercer,Hermitage SE-3,Auditor General,,DEM,Christina M. Hartman,5,9,14
+Mercer,Hermitage SE-3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-3,State Treasurer,,DEM,Joe Torsella,39,110,149
+Mercer,Hermitage SE-3,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-3,U.S. House,16,DEM,Kristy Gnibus,41,112,153
+Mercer,Hermitage SE-3,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Hermitage SE-3,General Assembly,7,DEM,Mark Longietti,54,130,184
+Mercer,Hermitage SE-3,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-3,President,,REP,Donald J. Trump,68,45,113
+Mercer,Hermitage SE-3,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Hermitage SE-3,President,,REP,Bill Weld,1,3,4
+Mercer,Hermitage SE-3,President,,REP,Write-In,2,2,4
+Mercer,Hermitage SE-3,Attorney General,,REP,Heather Heidelbaugh,60,46,106
+Mercer,Hermitage SE-3,Attorney General,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-3,Auditor General,,REP,Timothy Defoor,59,43,102
+Mercer,Hermitage SE-3,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-3,State Treasurer,,REP,Stacy L. Garrity,58,45,103
+Mercer,Hermitage SE-3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-3,U.S. House,16,REP,Mike Kelly,66,44,110
+Mercer,Hermitage SE-3,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Hermitage SE-3,General Assembly,7,REP,Write-In,18,14,32
+Mercer,Hermitage SE-3,General Assembly,7,REP,Mark Longietti,14,14,28
+Mercer,Hermitage SE-4,Registered Voters,,,,,,888
+Mercer,Hermitage SE-4,Registered Voters,,DEM,,,,375
+Mercer,Hermitage SE-4,Registered Voters,,REP,,,,513
+Mercer,Hermitage SE-4,Registered Voters,,NPA,,,,0
+Mercer,Hermitage SE-4,Ballots Cast,,,,157,173,330
+Mercer,Hermitage SE-4,Ballots Cast,,DEM,,40,111,151
+Mercer,Hermitage SE-4,Ballots Cast,,REP,,117,62,179
+Mercer,Hermitage SE-4,Ballots Cast,,NPA,,0,0,0
+Mercer,Hermitage SE-4,President,,DEM,Bernie Sanders,6,8,14
+Mercer,Hermitage SE-4,President,,DEM,Joseph R. Biden,28,99,127
+Mercer,Hermitage SE-4,President,,DEM,Tulsi Gabbard,1,3,4
+Mercer,Hermitage SE-4,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Hermitage SE-4,President,,DEM,Write-In,0,1,1
+Mercer,Hermitage SE-4,Attorney General,,DEM,Josh Shapiro,35,93,128
+Mercer,Hermitage SE-4,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-4,Auditor General,,DEM,H. Scott Conklin,7,4,11
+Mercer,Hermitage SE-4,Auditor General,,DEM,Michael Lamb,15,77,92
+Mercer,Hermitage SE-4,Auditor General,,DEM,Tracie Fountain,1,4,5
+Mercer,Hermitage SE-4,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,4
+Mercer,Hermitage SE-4,Auditor General,,DEM,Nina Ahmad,2,6,8
+Mercer,Hermitage SE-4,Auditor General,,DEM,Christina M. Hartman,6,4,10
+Mercer,Hermitage SE-4,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-4,State Treasurer,,DEM,Joe Torsella,33,93,126
+Mercer,Hermitage SE-4,State Treasurer,,DEM,Write-In,0,1,1
+Mercer,Hermitage SE-4,U.S. House,16,DEM,Kristy Gnibus,32,93,125
+Mercer,Hermitage SE-4,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Hermitage SE-4,General Assembly,7,DEM,Mark Longietti,39,108,147
+Mercer,Hermitage SE-4,General Assembly,7,DEM,Write-In,0,2,2
+Mercer,Hermitage SE-4,President,,REP,Donald J. Trump,106,49,155
+Mercer,Hermitage SE-4,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Hermitage SE-4,President,,REP,Bill Weld,4,7,11
+Mercer,Hermitage SE-4,President,,REP,Write-In,1,1,2
+Mercer,Hermitage SE-4,Attorney General,,REP,Heather Heidelbaugh,105,54,159
+Mercer,Hermitage SE-4,Attorney General,,REP,Write-In,1,0,1
+Mercer,Hermitage SE-4,Auditor General,,REP,Timothy Defoor,100,53,153
+Mercer,Hermitage SE-4,Auditor General,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-4,State Treasurer,,REP,Stacy L. Garrity,103,52,155
+Mercer,Hermitage SE-4,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Hermitage SE-4,U.S. House,16,REP,Mike Kelly,108,53,161
+Mercer,Hermitage SE-4,U.S. House,16,REP,Write-In,2,2,4
+Mercer,Hermitage SE-4,General Assembly,7,REP,Write-In,17,12,29
+Mercer,Hermitage SE-4,General Assembly,7,REP,Mark Longietti,14,8,22
+Mercer,Jackson Center,Registered Voters,,,,,,98
+Mercer,Jackson Center,Registered Voters,,DEM,,,,43
+Mercer,Jackson Center,Registered Voters,,REP,,,,55
+Mercer,Jackson Center,Registered Voters,,NPA,,,,0
+Mercer,Jackson Center,Ballots Cast,,,,33,18,51
+Mercer,Jackson Center,Ballots Cast,,DEM,,15,13,28
+Mercer,Jackson Center,Ballots Cast,,REP,,18,5,23
+Mercer,Jackson Center,Ballots Cast,,NPA,,0,0,0
+Mercer,Jackson Center,President,,DEM,Bernie Sanders,0,1,1
+Mercer,Jackson Center,President,,DEM,Joseph R. Biden,12,11,23
+Mercer,Jackson Center,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Jackson Center,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Jackson Center,President,,DEM,Write-In,1,0,1
+Mercer,Jackson Center,Attorney General,,DEM,Josh Shapiro,13,11,24
+Mercer,Jackson Center,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Jackson Center,Auditor General,,DEM,H. Scott Conklin,1,1,2
+Mercer,Jackson Center,Auditor General,,DEM,Michael Lamb,10,9,19
+Mercer,Jackson Center,Auditor General,,DEM,Tracie Fountain,0,1,1
+Mercer,Jackson Center,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Jackson Center,Auditor General,,DEM,Nina Ahmad,0,0,0
+Mercer,Jackson Center,Auditor General,,DEM,Christina M. Hartman,2,1,3
+Mercer,Jackson Center,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Jackson Center,State Treasurer,,DEM,Joe Torsella,13,11,24
+Mercer,Jackson Center,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Jackson Center,U.S. House,16,DEM,Kristy Gnibus,13,12,25
+Mercer,Jackson Center,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Jackson Center,General Assembly,8,DEM,Phil Heasley,12,13,25
+Mercer,Jackson Center,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Jackson Center,President,,REP,Donald J. Trump,18,5,23
+Mercer,Jackson Center,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Jackson Center,President,,REP,Bill Weld,0,0,0
+Mercer,Jackson Center,President,,REP,Write-In,0,0,0
+Mercer,Jackson Center,Attorney General,,REP,Heather Heidelbaugh,13,5,18
+Mercer,Jackson Center,Attorney General,,REP,Write-In,0,0,0
+Mercer,Jackson Center,Auditor General,,REP,Timothy Defoor,13,4,17
+Mercer,Jackson Center,Auditor General,,REP,Write-In,0,0,0
+Mercer,Jackson Center,State Treasurer,,REP,Stacy L. Garrity,12,5,17
+Mercer,Jackson Center,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Jackson Center,U.S. House,16,REP,Mike Kelly,17,5,22
+Mercer,Jackson Center,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Jackson Center,General Assembly,8,REP,Scott Jaillet,2,0,2
+Mercer,Jackson Center,General Assembly,8,REP,Tim Bonner,16,5,21
+Mercer,Jackson Center,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Jackson Township,Registered Voters,,,,,,745
+Mercer,Jackson Township,Registered Voters,,DEM,,,,215
+Mercer,Jackson Township,Registered Voters,,REP,,,,530
+Mercer,Jackson Township,Registered Voters,,NPA,,,,0
+Mercer,Jackson Township,Ballots Cast,,,,214,95,309
+Mercer,Jackson Township,Ballots Cast,,DEM,,35,41,76
+Mercer,Jackson Township,Ballots Cast,,REP,,179,54,233
+Mercer,Jackson Township,Ballots Cast,,NPA,,0,0,0
+Mercer,Jackson Township,President,,DEM,Bernie Sanders,5,3,8
+Mercer,Jackson Township,President,,DEM,Joseph R. Biden,12,35,47
+Mercer,Jackson Township,President,,DEM,Tulsi Gabbard,3,1,4
+Mercer,Jackson Township,President,,DEM,Elizabeth Warren,5,0,5
+Mercer,Jackson Township,President,,DEM,Write-In,4,1,5
+Mercer,Jackson Township,Attorney General,,DEM,Josh Shapiro,27,32,59
+Mercer,Jackson Township,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Jackson Township,Auditor General,,DEM,H. Scott Conklin,5,5,10
+Mercer,Jackson Township,Auditor General,,DEM,Michael Lamb,15,24,39
+Mercer,Jackson Township,Auditor General,,DEM,Tracie Fountain,1,4,5
+Mercer,Jackson Township,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2
+Mercer,Jackson Township,Auditor General,,DEM,Nina Ahmad,0,1,1
+Mercer,Jackson Township,Auditor General,,DEM,Christina M. Hartman,4,1,5
+Mercer,Jackson Township,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Jackson Township,State Treasurer,,DEM,Joe Torsella,26,33,59
+Mercer,Jackson Township,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Jackson Township,U.S. House,16,DEM,Kristy Gnibus,24,33,57
+Mercer,Jackson Township,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Jackson Township,General Assembly,8,DEM,Phil Heasley,29,33,62
+Mercer,Jackson Township,General Assembly,8,DEM,Write-In,1,1,2
+Mercer,Jackson Township,President,,REP,Donald J. Trump,173,45,218
+Mercer,Jackson Township,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Jackson Township,President,,REP,Bill Weld,1,4,5
+Mercer,Jackson Township,President,,REP,Write-In,2,2,4
+Mercer,Jackson Township,Attorney General,,REP,Heather Heidelbaugh,161,51,212
+Mercer,Jackson Township,Attorney General,,REP,Write-In,1,0,1
+Mercer,Jackson Township,Auditor General,,REP,Timothy Defoor,156,48,204
+Mercer,Jackson Township,Auditor General,,REP,Write-In,1,0,1
+Mercer,Jackson Township,State Treasurer,,REP,Stacy L. Garrity,159,50,209
+Mercer,Jackson Township,State Treasurer,,REP,Write-In,3,0,3
+Mercer,Jackson Township,U.S. House,16,REP,Mike Kelly,170,51,221
+Mercer,Jackson Township,U.S. House,16,REP,Write-In,0,1,1
+Mercer,Jackson Township,General Assembly,8,REP,Scott Jaillet,17,6,23
+Mercer,Jackson Township,General Assembly,8,REP,Tim Bonner,156,48,204
+Mercer,Jackson Township,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Jamestown,Registered Voters,,,,,,366
+Mercer,Jamestown,Registered Voters,,DEM,,,,173
+Mercer,Jamestown,Registered Voters,,REP,,,,193
+Mercer,Jamestown,Registered Voters,,NPA,,,,0
+Mercer,Jamestown,Ballots Cast,,,,78,48,126
+Mercer,Jamestown,Ballots Cast,,DEM,,32,23,55
+Mercer,Jamestown,Ballots Cast,,REP,,46,25,71
+Mercer,Jamestown,Ballots Cast,,NPA,,0,0,0
+Mercer,Jamestown,President,,DEM,Bernie Sanders,6,3,9
+Mercer,Jamestown,President,,DEM,Joseph R. Biden,17,20,37
+Mercer,Jamestown,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Jamestown,President,,DEM,Elizabeth Warren,6,0,6
+Mercer,Jamestown,President,,DEM,Write-In,1,0,1
+Mercer,Jamestown,Attorney General,,DEM,Josh Shapiro,22,20,42
+Mercer,Jamestown,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Jamestown,Auditor General,,DEM,H. Scott Conklin,1,3,4
+Mercer,Jamestown,Auditor General,,DEM,Michael Lamb,19,12,31
+Mercer,Jamestown,Auditor General,,DEM,Tracie Fountain,2,2,4
+Mercer,Jamestown,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Jamestown,Auditor General,,DEM,Nina Ahmad,1,4,5
+Mercer,Jamestown,Auditor General,,DEM,Christina M. Hartman,4,1,5
+Mercer,Jamestown,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Jamestown,State Treasurer,,DEM,Joe Torsella,28,19,47
+Mercer,Jamestown,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Jamestown,U.S. House,16,DEM,Kristy Gnibus,22,20,42
+Mercer,Jamestown,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Jamestown,General Assembly,17,DEM,Write-In,0,5,5
+Mercer,Jamestown,General Assembly,17,DEM,Jeff O'Melian,0,2,2
+Mercer,Jamestown,President,,REP,Donald J. Trump,43,18,61
+Mercer,Jamestown,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Jamestown,President,,REP,Bill Weld,0,4,4
+Mercer,Jamestown,President,,REP,Write-In,0,2,2
+Mercer,Jamestown,Attorney General,,REP,Heather Heidelbaugh,40,24,64
+Mercer,Jamestown,Attorney General,,REP,Write-In,0,0,0
+Mercer,Jamestown,Auditor General,,REP,Timothy Defoor,38,23,61
+Mercer,Jamestown,Auditor General,,REP,Write-In,0,0,0
+Mercer,Jamestown,State Treasurer,,REP,Stacy L. Garrity,38,24,62
+Mercer,Jamestown,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Jamestown,U.S. House,16,REP,Mike Kelly,42,22,64
+Mercer,Jamestown,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Jamestown,General Assembly,17,REP,Parke Wentling,40,24,64
+Mercer,Jamestown,General Assembly,17,REP,Write-In,0,0,0
+Mercer,Jefferson,Registered Voters,,,,,,1079
+Mercer,Jefferson,Registered Voters,,DEM,,,,413
+Mercer,Jefferson,Registered Voters,,REP,,,,666
+Mercer,Jefferson,Registered Voters,,NPA,,,,0
+Mercer,Jefferson,Ballots Cast,,,,235,139,374
+Mercer,Jefferson,Ballots Cast,,DEM,,53,73,126
+Mercer,Jefferson,Ballots Cast,,REP,,182,66,248
+Mercer,Jefferson,Ballots Cast,,NPA,,0,0,0
+Mercer,Jefferson,President,,DEM,Bernie Sanders,8,4,12
+Mercer,Jefferson,President,,DEM,Joseph R. Biden,30,60,90
+Mercer,Jefferson,President,,DEM,Tulsi Gabbard,4,0,4
+Mercer,Jefferson,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Jefferson,President,,DEM,Write-In,6,5,11
+Mercer,Jefferson,Attorney General,,DEM,Josh Shapiro,45,63,108
+Mercer,Jefferson,Attorney General,,DEM,Write-In,1,3,4
+Mercer,Jefferson,Auditor General,,DEM,H. Scott Conklin,4,3,7
+Mercer,Jefferson,Auditor General,,DEM,Michael Lamb,33,47,80
+Mercer,Jefferson,Auditor General,,DEM,Tracie Fountain,1,3,4
+Mercer,Jefferson,Auditor General,,DEM,Rose Rosie Marie Davis,6,4,10
+Mercer,Jefferson,Auditor General,,DEM,Nina Ahmad,0,2,2
+Mercer,Jefferson,Auditor General,,DEM,Christina M. Hartman,4,6,10
+Mercer,Jefferson,Auditor General,,DEM,Write-In,0,2,2
+Mercer,Jefferson,State Treasurer,,DEM,Joe Torsella,41,62,103
+Mercer,Jefferson,State Treasurer,,DEM,Write-In,1,2,3
+Mercer,Jefferson,U.S. House,16,DEM,Kristy Gnibus,41,63,104
+Mercer,Jefferson,U.S. House,16,DEM,Write-In,2,1,3
+Mercer,Jefferson,General Assembly,17,DEM,Write-In,2,13,15
+Mercer,Jefferson,General Assembly,17,DEM,Jeff O'Melian,0,4,4
+Mercer,Jefferson,President,,REP,Donald J. Trump,169,58,227
+Mercer,Jefferson,President,,REP,Roque Rocky De La Fuente,2,1,3
+Mercer,Jefferson,President,,REP,Bill Weld,3,2,5
+Mercer,Jefferson,President,,REP,Write-In,2,3,5
+Mercer,Jefferson,Attorney General,,REP,Heather Heidelbaugh,152,55,207
+Mercer,Jefferson,Attorney General,,REP,Write-In,0,0,0
+Mercer,Jefferson,Auditor General,,REP,Timothy Defoor,147,49,196
+Mercer,Jefferson,Auditor General,,REP,Write-In,2,2,4
+Mercer,Jefferson,State Treasurer,,REP,Stacy L. Garrity,149,54,203
+Mercer,Jefferson,State Treasurer,,REP,Write-In,0,2,2
+Mercer,Jefferson,U.S. House,16,REP,Mike Kelly,176,57,233
+Mercer,Jefferson,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Jefferson,General Assembly,17,REP,Parke Wentling,176,59,235
+Mercer,Jefferson,General Assembly,17,REP,Write-In,0,2,2
+Mercer,Lackawannock,Registered Voters,,,,,,1333
+Mercer,Lackawannock,Registered Voters,,DEM,,,,511
+Mercer,Lackawannock,Registered Voters,,REP,,,,822
+Mercer,Lackawannock,Registered Voters,,NPA,,,,0
+Mercer,Lackawannock,Ballots Cast,,,,242,156,398
+Mercer,Lackawannock,Ballots Cast,,DEM,,82,88,170
+Mercer,Lackawannock,Ballots Cast,,REP,,160,68,228
+Mercer,Lackawannock,Ballots Cast,,NPA,,0,0,0
+Mercer,Lackawannock,President,,DEM,Bernie Sanders,11,7,18
+Mercer,Lackawannock,President,,DEM,Joseph R. Biden,49,75,124
+Mercer,Lackawannock,President,,DEM,Tulsi Gabbard,5,1,6
+Mercer,Lackawannock,President,,DEM,Elizabeth Warren,3,1,4
+Mercer,Lackawannock,President,,DEM,Write-In,11,1,12
+Mercer,Lackawannock,Attorney General,,DEM,Josh Shapiro,60,74,134
+Mercer,Lackawannock,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Lackawannock,Auditor General,,DEM,H. Scott Conklin,3,6,9
+Mercer,Lackawannock,Auditor General,,DEM,Michael Lamb,40,52,92
+Mercer,Lackawannock,Auditor General,,DEM,Tracie Fountain,2,7,9
+Mercer,Lackawannock,Auditor General,,DEM,Rose Rosie Marie Davis,7,4,11
+Mercer,Lackawannock,Auditor General,,DEM,Nina Ahmad,5,1,6
+Mercer,Lackawannock,Auditor General,,DEM,Christina M. Hartman,9,3,12
+Mercer,Lackawannock,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Lackawannock,State Treasurer,,DEM,Joe Torsella,58,74,132
+Mercer,Lackawannock,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Lackawannock,U.S. House,16,DEM,Kristy Gnibus,59,74,133
+Mercer,Lackawannock,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Lackawannock,General Assembly,7,DEM,Mark Longietti,74,85,159
+Mercer,Lackawannock,General Assembly,7,DEM,Write-In,2,0,2
+Mercer,Lackawannock,President,,REP,Donald J. Trump,151,59,210
+Mercer,Lackawannock,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,Lackawannock,President,,REP,Bill Weld,3,4,7
+Mercer,Lackawannock,President,,REP,Write-In,1,2,3
+Mercer,Lackawannock,Attorney General,,REP,Heather Heidelbaugh,135,58,193
+Mercer,Lackawannock,Attorney General,,REP,Write-In,0,0,0
+Mercer,Lackawannock,Auditor General,,REP,Timothy Defoor,134,56,190
+Mercer,Lackawannock,Auditor General,,REP,Write-In,1,0,1
+Mercer,Lackawannock,State Treasurer,,REP,Stacy L. Garrity,135,57,192
+Mercer,Lackawannock,State Treasurer,,REP,Write-In,0,1,1
+Mercer,Lackawannock,U.S. House,16,REP,Mike Kelly,144,57,201
+Mercer,Lackawannock,U.S. House,16,REP,Write-In,2,0,2
+Mercer,Lackawannock,General Assembly,7,REP,Write-In,26,3,29
+Mercer,Lackawannock,General Assembly,7,REP,Mark Longietti,18,2,20
+Mercer,Lake,Registered Voters,,,,,,333
+Mercer,Lake,Registered Voters,,DEM,,,,87
+Mercer,Lake,Registered Voters,,REP,,,,246
+Mercer,Lake,Registered Voters,,NPA,,,,0
+Mercer,Lake,Ballots Cast,,,,106,32,138
+Mercer,Lake,Ballots Cast,,DEM,,20,14,34
+Mercer,Lake,Ballots Cast,,REP,,86,18,104
+Mercer,Lake,Ballots Cast,,NPA,,0,0,0
+Mercer,Lake,President,,DEM,Bernie Sanders,2,1,3
+Mercer,Lake,President,,DEM,Joseph R. Biden,16,13,29
+Mercer,Lake,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Lake,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Lake,President,,DEM,Write-In,1,0,1
+Mercer,Lake,Attorney General,,DEM,Josh Shapiro,18,14,32
+Mercer,Lake,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Lake,Auditor General,,DEM,H. Scott Conklin,1,0,1
+Mercer,Lake,Auditor General,,DEM,Michael Lamb,12,7,19
+Mercer,Lake,Auditor General,,DEM,Tracie Fountain,1,1,2
+Mercer,Lake,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Lake,Auditor General,,DEM,Nina Ahmad,3,2,5
+Mercer,Lake,Auditor General,,DEM,Christina M. Hartman,1,4,5
+Mercer,Lake,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Lake,State Treasurer,,DEM,Joe Torsella,18,14,32
+Mercer,Lake,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Lake,U.S. House,16,DEM,Kristy Gnibus,18,14,32
+Mercer,Lake,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Lake,General Assembly,8,DEM,Phil Heasley,17,14,31
+Mercer,Lake,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Lake,President,,REP,Donald J. Trump,82,12,94
+Mercer,Lake,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Lake,President,,REP,Bill Weld,1,5,6
+Mercer,Lake,President,,REP,Write-In,1,1,2
+Mercer,Lake,Attorney General,,REP,Heather Heidelbaugh,78,14,92
+Mercer,Lake,Attorney General,,REP,Write-In,0,0,0
+Mercer,Lake,Auditor General,,REP,Timothy Defoor,76,14,90
+Mercer,Lake,Auditor General,,REP,Write-In,0,0,0
+Mercer,Lake,State Treasurer,,REP,Stacy L. Garrity,76,15,91
+Mercer,Lake,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Lake,U.S. House,16,REP,Mike Kelly,82,15,97
+Mercer,Lake,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Lake,General Assembly,8,REP,Scott Jaillet,9,4,13
+Mercer,Lake,General Assembly,8,REP,Tim Bonner,75,13,88
+Mercer,Lake,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Liberty,Registered Voters,,,,,,885
+Mercer,Liberty,Registered Voters,,DEM,,,,247
+Mercer,Liberty,Registered Voters,,REP,,,,638
+Mercer,Liberty,Registered Voters,,NPA,,,,0
+Mercer,Liberty,Ballots Cast,,,,236,136,372
+Mercer,Liberty,Ballots Cast,,DEM,,33,67,100
+Mercer,Liberty,Ballots Cast,,REP,,203,69,272
+Mercer,Liberty,Ballots Cast,,NPA,,0,0,0
+Mercer,Liberty,President,,DEM,Bernie Sanders,6,8,14
+Mercer,Liberty,President,,DEM,Joseph R. Biden,23,56,79
+Mercer,Liberty,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,Liberty,President,,DEM,Elizabeth Warren,2,1,3
+Mercer,Liberty,President,,DEM,Write-In,0,2,2
+Mercer,Liberty,Attorney General,,DEM,Josh Shapiro,28,59,87
+Mercer,Liberty,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Liberty,Auditor General,,DEM,H. Scott Conklin,5,3,8
+Mercer,Liberty,Auditor General,,DEM,Michael Lamb,17,44,61
+Mercer,Liberty,Auditor General,,DEM,Tracie Fountain,0,6,6
+Mercer,Liberty,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,5
+Mercer,Liberty,Auditor General,,DEM,Nina Ahmad,5,7,12
+Mercer,Liberty,Auditor General,,DEM,Christina M. Hartman,0,2,2
+Mercer,Liberty,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Liberty,State Treasurer,,DEM,Joe Torsella,28,57,85
+Mercer,Liberty,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Liberty,U.S. House,16,DEM,Kristy Gnibus,29,58,87
+Mercer,Liberty,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Liberty,General Assembly,8,DEM,Phil Heasley,29,58,87
+Mercer,Liberty,General Assembly,8,DEM,Write-In,2,1,3
+Mercer,Liberty,President,,REP,Donald J. Trump,189,50,239
+Mercer,Liberty,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Liberty,President,,REP,Bill Weld,4,11,15
+Mercer,Liberty,President,,REP,Write-In,3,2,5
+Mercer,Liberty,Attorney General,,REP,Heather Heidelbaugh,169,62,231
+Mercer,Liberty,Attorney General,,REP,Write-In,1,0,1
+Mercer,Liberty,Auditor General,,REP,Timothy Defoor,164,63,227
+Mercer,Liberty,Auditor General,,REP,Write-In,1,0,1
+Mercer,Liberty,State Treasurer,,REP,Stacy L. Garrity,170,62,232
+Mercer,Liberty,State Treasurer,,REP,Write-In,2,0,2
+Mercer,Liberty,U.S. House,16,REP,Mike Kelly,188,61,249
+Mercer,Liberty,U.S. House,16,REP,Write-In,2,0,2
+Mercer,Liberty,General Assembly,8,REP,Scott Jaillet,11,6,17
+Mercer,Liberty,General Assembly,8,REP,Tim Bonner,189,62,251
+Mercer,Liberty,General Assembly,8,REP,Write-In,1,1,2
+Mercer,Mercer North,Registered Voters,,,,,,547
+Mercer,Mercer North,Registered Voters,,DEM,,,,210
+Mercer,Mercer North,Registered Voters,,REP,,,,337
+Mercer,Mercer North,Registered Voters,,NPA,,,,0
+Mercer,Mercer North,Ballots Cast,,,,122,71,193
+Mercer,Mercer North,Ballots Cast,,DEM,,26,37,63
+Mercer,Mercer North,Ballots Cast,,REP,,96,34,130
+Mercer,Mercer North,Ballots Cast,,NPA,,0,0,0
+Mercer,Mercer North,President,,DEM,Bernie Sanders,6,3,9
+Mercer,Mercer North,President,,DEM,Joseph R. Biden,16,34,50
+Mercer,Mercer North,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,Mercer North,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Mercer North,President,,DEM,Write-In,1,0,1
+Mercer,Mercer North,Attorney General,,DEM,Josh Shapiro,24,36,60
+Mercer,Mercer North,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Mercer North,Auditor General,,DEM,H. Scott Conklin,0,3,3
+Mercer,Mercer North,Auditor General,,DEM,Michael Lamb,15,25,40
+Mercer,Mercer North,Auditor General,,DEM,Tracie Fountain,0,1,1
+Mercer,Mercer North,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2
+Mercer,Mercer North,Auditor General,,DEM,Nina Ahmad,4,4,8
+Mercer,Mercer North,Auditor General,,DEM,Christina M. Hartman,2,1,3
+Mercer,Mercer North,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Mercer North,State Treasurer,,DEM,Joe Torsella,22,33,55
+Mercer,Mercer North,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Mercer North,U.S. House,16,DEM,Kristy Gnibus,21,35,56
+Mercer,Mercer North,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Mercer North,General Assembly,8,DEM,Phil Heasley,25,35,60
+Mercer,Mercer North,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Mercer North,President,,REP,Donald J. Trump,90,28,118
+Mercer,Mercer North,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Mercer North,President,,REP,Bill Weld,2,3,5
+Mercer,Mercer North,President,,REP,Write-In,0,0,0
+Mercer,Mercer North,Attorney General,,REP,Heather Heidelbaugh,81,33,114
+Mercer,Mercer North,Attorney General,,REP,Write-In,0,0,0
+Mercer,Mercer North,Auditor General,,REP,Timothy Defoor,79,32,111
+Mercer,Mercer North,Auditor General,,REP,Write-In,0,0,0
+Mercer,Mercer North,State Treasurer,,REP,Stacy L. Garrity,79,33,112
+Mercer,Mercer North,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Mercer North,U.S. House,16,REP,Mike Kelly,91,33,124
+Mercer,Mercer North,U.S. House,16,REP,Write-In,0,1,1
+Mercer,Mercer North,General Assembly,8,REP,Scott Jaillet,9,2,11
+Mercer,Mercer North,General Assembly,8,REP,Tim Bonner,86,32,118
+Mercer,Mercer North,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Mercer South,Registered Voters,,,,,,550
+Mercer,Mercer South,Registered Voters,,DEM,,,,226
+Mercer,Mercer South,Registered Voters,,REP,,,,324
+Mercer,Mercer South,Registered Voters,,NPA,,,,0
+Mercer,Mercer South,Ballots Cast,,,,118,81,199
+Mercer,Mercer South,Ballots Cast,,DEM,,35,48,83
+Mercer,Mercer South,Ballots Cast,,REP,,83,33,116
+Mercer,Mercer South,Ballots Cast,,NPA,,0,0,0
+Mercer,Mercer South,President,,DEM,Bernie Sanders,6,4,10
+Mercer,Mercer South,President,,DEM,Joseph R. Biden,26,44,70
+Mercer,Mercer South,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,Mercer South,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Mercer South,President,,DEM,Write-In,1,0,1
+Mercer,Mercer South,Attorney General,,DEM,Josh Shapiro,31,47,78
+Mercer,Mercer South,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Mercer South,Auditor General,,DEM,H. Scott Conklin,0,1,1
+Mercer,Mercer South,Auditor General,,DEM,Michael Lamb,22,34,56
+Mercer,Mercer South,Auditor General,,DEM,Tracie Fountain,3,2,5
+Mercer,Mercer South,Auditor General,,DEM,Rose Rosie Marie Davis,0,2,2
+Mercer,Mercer South,Auditor General,,DEM,Nina Ahmad,2,1,3
+Mercer,Mercer South,Auditor General,,DEM,Christina M. Hartman,7,5,12
+Mercer,Mercer South,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Mercer South,State Treasurer,,DEM,Joe Torsella,32,46,78
+Mercer,Mercer South,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Mercer South,U.S. House,16,DEM,Kristy Gnibus,32,47,79
+Mercer,Mercer South,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Mercer South,General Assembly,8,DEM,Phil Heasley,31,46,77
+Mercer,Mercer South,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Mercer South,President,,REP,Donald J. Trump,79,22,101
+Mercer,Mercer South,President,,REP,Roque Rocky De La Fuente,1,2,3
+Mercer,Mercer South,President,,REP,Bill Weld,1,6,7
+Mercer,Mercer South,President,,REP,Write-In,0,1,1
+Mercer,Mercer South,Attorney General,,REP,Heather Heidelbaugh,71,32,103
+Mercer,Mercer South,Attorney General,,REP,Write-In,0,0,0
+Mercer,Mercer South,Auditor General,,REP,Timothy Defoor,69,32,101
+Mercer,Mercer South,Auditor General,,REP,Write-In,0,0,0
+Mercer,Mercer South,State Treasurer,,REP,Stacy L. Garrity,69,32,101
+Mercer,Mercer South,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Mercer South,U.S. House,16,REP,Mike Kelly,81,32,113
+Mercer,Mercer South,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Mercer South,General Assembly,8,REP,Scott Jaillet,9,2,11
+Mercer,Mercer South,General Assembly,8,REP,Tim Bonner,71,30,101
+Mercer,Mercer South,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Mill Creek,Registered Voters,,,,,,410
+Mercer,Mill Creek,Registered Voters,,DEM,,,,100
+Mercer,Mill Creek,Registered Voters,,REP,,,,310
+Mercer,Mill Creek,Registered Voters,,NPA,,,,0
+Mercer,Mill Creek,Ballots Cast,,,,125,32,157
+Mercer,Mill Creek,Ballots Cast,,DEM,,16,15,31
+Mercer,Mill Creek,Ballots Cast,,REP,,109,17,126
+Mercer,Mill Creek,Ballots Cast,,NPA,,0,0,0
+Mercer,Mill Creek,President,,DEM,Bernie Sanders,2,0,2
+Mercer,Mill Creek,President,,DEM,Joseph R. Biden,11,13,24
+Mercer,Mill Creek,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Mill Creek,President,,DEM,Elizabeth Warren,0,1,1
+Mercer,Mill Creek,President,,DEM,Write-In,3,0,3
+Mercer,Mill Creek,Attorney General,,DEM,Josh Shapiro,11,15,26
+Mercer,Mill Creek,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Mill Creek,Auditor General,,DEM,H. Scott Conklin,2,3,5
+Mercer,Mill Creek,Auditor General,,DEM,Michael Lamb,9,9,18
+Mercer,Mill Creek,Auditor General,,DEM,Tracie Fountain,0,0,0
+Mercer,Mill Creek,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2
+Mercer,Mill Creek,Auditor General,,DEM,Nina Ahmad,0,1,1
+Mercer,Mill Creek,Auditor General,,DEM,Christina M. Hartman,0,1,1
+Mercer,Mill Creek,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Mill Creek,State Treasurer,,DEM,Joe Torsella,11,15,26
+Mercer,Mill Creek,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Mill Creek,U.S. House,16,DEM,Kristy Gnibus,13,15,28
+Mercer,Mill Creek,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Mill Creek,General Assembly,8,DEM,Phil Heasley,13,15,28
+Mercer,Mill Creek,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Mill Creek,President,,REP,Donald J. Trump,107,15,122
+Mercer,Mill Creek,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Mill Creek,President,,REP,Bill Weld,2,2,4
+Mercer,Mill Creek,President,,REP,Write-In,0,0,0
+Mercer,Mill Creek,Attorney General,,REP,Heather Heidelbaugh,93,14,107
+Mercer,Mill Creek,Attorney General,,REP,Write-In,0,0,0
+Mercer,Mill Creek,Auditor General,,REP,Timothy Defoor,91,15,106
+Mercer,Mill Creek,Auditor General,,REP,Write-In,1,0,1
+Mercer,Mill Creek,State Treasurer,,REP,Stacy L. Garrity,92,15,107
+Mercer,Mill Creek,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Mill Creek,U.S. House,16,REP,Mike Kelly,100,16,116
+Mercer,Mill Creek,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Mill Creek,General Assembly,8,REP,Scott Jaillet,10,0,10
+Mercer,Mill Creek,General Assembly,8,REP,Tim Bonner,95,17,112
+Mercer,Mill Creek,General Assembly,8,REP,Write-In,0,0,0
+Mercer,New Lebanon,Registered Voters,,,,,,82
+Mercer,New Lebanon,Registered Voters,,DEM,,,,28
+Mercer,New Lebanon,Registered Voters,,REP,,,,54
+Mercer,New Lebanon,Registered Voters,,NPA,,,,0
+Mercer,New Lebanon,Ballots Cast,,,,24,10,34
+Mercer,New Lebanon,Ballots Cast,,DEM,,5,7,12
+Mercer,New Lebanon,Ballots Cast,,REP,,19,3,22
+Mercer,New Lebanon,Ballots Cast,,NPA,,0,0,0
+Mercer,New Lebanon,President,,DEM,Bernie Sanders,0,1,1
+Mercer,New Lebanon,President,,DEM,Joseph R. Biden,4,6,10
+Mercer,New Lebanon,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,New Lebanon,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,New Lebanon,President,,DEM,Write-In,0,0,0
+Mercer,New Lebanon,Attorney General,,DEM,Josh Shapiro,5,7,12
+Mercer,New Lebanon,Attorney General,,DEM,Write-In,0,0,0
+Mercer,New Lebanon,Auditor General,,DEM,H. Scott Conklin,1,0,1
+Mercer,New Lebanon,Auditor General,,DEM,Michael Lamb,2,5,7
+Mercer,New Lebanon,Auditor General,,DEM,Tracie Fountain,1,1,2
+Mercer,New Lebanon,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0
+Mercer,New Lebanon,Auditor General,,DEM,Nina Ahmad,0,1,1
+Mercer,New Lebanon,Auditor General,,DEM,Christina M. Hartman,0,0,0
+Mercer,New Lebanon,Auditor General,,DEM,Write-In,0,0,0
+Mercer,New Lebanon,State Treasurer,,DEM,Joe Torsella,4,7,11
+Mercer,New Lebanon,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,New Lebanon,U.S. House,16,DEM,Kristy Gnibus,5,7,12
+Mercer,New Lebanon,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,New Lebanon,General Assembly,8,DEM,Phil Heasley,4,7,11
+Mercer,New Lebanon,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,New Lebanon,President,,REP,Donald J. Trump,19,3,22
+Mercer,New Lebanon,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,New Lebanon,President,,REP,Bill Weld,0,0,0
+Mercer,New Lebanon,President,,REP,Write-In,0,0,0
+Mercer,New Lebanon,Attorney General,,REP,Heather Heidelbaugh,18,3,21
+Mercer,New Lebanon,Attorney General,,REP,Write-In,0,0,0
+Mercer,New Lebanon,Auditor General,,REP,Timothy Defoor,16,3,19
+Mercer,New Lebanon,Auditor General,,REP,Write-In,0,0,0
+Mercer,New Lebanon,State Treasurer,,REP,Stacy L. Garrity,16,3,19
+Mercer,New Lebanon,State Treasurer,,REP,Write-In,0,0,0
+Mercer,New Lebanon,U.S. House,16,REP,Mike Kelly,18,3,21
+Mercer,New Lebanon,U.S. House,16,REP,Write-In,0,0,0
+Mercer,New Lebanon,General Assembly,8,REP,Scott Jaillet,1,0,1
+Mercer,New Lebanon,General Assembly,8,REP,Tim Bonner,18,3,21
+Mercer,New Lebanon,General Assembly,8,REP,Write-In,0,0,0
+Mercer,New Vernon,Registered Voters,,,,,,304
+Mercer,New Vernon,Registered Voters,,DEM,,,,87
+Mercer,New Vernon,Registered Voters,,REP,,,,217
+Mercer,New Vernon,Registered Voters,,NPA,,,,0
+Mercer,New Vernon,Ballots Cast,,,,118,34,152
+Mercer,New Vernon,Ballots Cast,,DEM,,24,12,36
+Mercer,New Vernon,Ballots Cast,,REP,,94,22,116
+Mercer,New Vernon,Ballots Cast,,NPA,,0,0,0
+Mercer,New Vernon,President,,DEM,Bernie Sanders,3,1,4
+Mercer,New Vernon,President,,DEM,Joseph R. Biden,12,11,23
+Mercer,New Vernon,President,,DEM,Tulsi Gabbard,3,0,3
+Mercer,New Vernon,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,New Vernon,President,,DEM,Write-In,3,0,3
+Mercer,New Vernon,Attorney General,,DEM,Josh Shapiro,19,12,31
+Mercer,New Vernon,Attorney General,,DEM,Write-In,0,0,0
+Mercer,New Vernon,Auditor General,,DEM,H. Scott Conklin,0,0,0
+Mercer,New Vernon,Auditor General,,DEM,Michael Lamb,10,6,16
+Mercer,New Vernon,Auditor General,,DEM,Tracie Fountain,2,0,2
+Mercer,New Vernon,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,4
+Mercer,New Vernon,Auditor General,,DEM,Nina Ahmad,2,0,2
+Mercer,New Vernon,Auditor General,,DEM,Christina M. Hartman,6,1,7
+Mercer,New Vernon,Auditor General,,DEM,Write-In,0,0,0
+Mercer,New Vernon,State Treasurer,,DEM,Joe Torsella,18,12,30
+Mercer,New Vernon,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,New Vernon,U.S. House,16,DEM,Kristy Gnibus,18,12,30
+Mercer,New Vernon,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,New Vernon,General Assembly,8,DEM,Phil Heasley,19,12,31
+Mercer,New Vernon,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,New Vernon,President,,REP,Donald J. Trump,90,21,111
+Mercer,New Vernon,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,New Vernon,President,,REP,Bill Weld,2,1,3
+Mercer,New Vernon,President,,REP,Write-In,1,0,1
+Mercer,New Vernon,Attorney General,,REP,Heather Heidelbaugh,86,19,105
+Mercer,New Vernon,Attorney General,,REP,Write-In,0,0,0
+Mercer,New Vernon,Auditor General,,REP,Timothy Defoor,83,20,103
+Mercer,New Vernon,Auditor General,,REP,Write-In,0,0,0
+Mercer,New Vernon,State Treasurer,,REP,Stacy L. Garrity,85,21,106
+Mercer,New Vernon,State Treasurer,,REP,Write-In,0,0,0
+Mercer,New Vernon,U.S. House,16,REP,Mike Kelly,90,21,111
+Mercer,New Vernon,U.S. House,16,REP,Write-In,0,0,0
+Mercer,New Vernon,General Assembly,8,REP,Scott Jaillet,8,1,9
+Mercer,New Vernon,General Assembly,8,REP,Tim Bonner,86,21,107
+Mercer,New Vernon,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Otter Creek,Registered Voters,,,,,,288
+Mercer,Otter Creek,Registered Voters,,DEM,,,,92
+Mercer,Otter Creek,Registered Voters,,REP,,,,196
+Mercer,Otter Creek,Registered Voters,,NPA,,,,0
+Mercer,Otter Creek,Ballots Cast,,,,81,25,106
+Mercer,Otter Creek,Ballots Cast,,DEM,,12,9,21
+Mercer,Otter Creek,Ballots Cast,,REP,,69,16,85
+Mercer,Otter Creek,Ballots Cast,,NPA,,0,0,0
+Mercer,Otter Creek,President,,DEM,Bernie Sanders,1,0,1
+Mercer,Otter Creek,President,,DEM,Joseph R. Biden,8,9,17
+Mercer,Otter Creek,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,Otter Creek,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Otter Creek,President,,DEM,Write-In,1,0,1
+Mercer,Otter Creek,Attorney General,,DEM,Josh Shapiro,10,9,19
+Mercer,Otter Creek,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Otter Creek,Auditor General,,DEM,H. Scott Conklin,1,1,2
+Mercer,Otter Creek,Auditor General,,DEM,Michael Lamb,5,5,10
+Mercer,Otter Creek,Auditor General,,DEM,Tracie Fountain,1,0,1
+Mercer,Otter Creek,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Otter Creek,Auditor General,,DEM,Nina Ahmad,0,0,0
+Mercer,Otter Creek,Auditor General,,DEM,Christina M. Hartman,1,3,4
+Mercer,Otter Creek,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Otter Creek,State Treasurer,,DEM,Joe Torsella,8,9,17
+Mercer,Otter Creek,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Otter Creek,U.S. House,16,DEM,Kristy Gnibus,7,9,16
+Mercer,Otter Creek,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Otter Creek,General Assembly,17,DEM,Write-In,0,1,1
+Mercer,Otter Creek,General Assembly,17,DEM,Jeff O'Melian,0,1,1
+Mercer,Otter Creek,President,,REP,Donald J. Trump,66,16,82
+Mercer,Otter Creek,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Otter Creek,President,,REP,Bill Weld,1,0,1
+Mercer,Otter Creek,President,,REP,Write-In,1,0,1
+Mercer,Otter Creek,Attorney General,,REP,Heather Heidelbaugh,58,15,73
+Mercer,Otter Creek,Attorney General,,REP,Write-In,0,0,0
+Mercer,Otter Creek,Auditor General,,REP,Timothy Defoor,56,15,71
+Mercer,Otter Creek,Auditor General,,REP,Write-In,0,0,0
+Mercer,Otter Creek,State Treasurer,,REP,Stacy L. Garrity,59,16,75
+Mercer,Otter Creek,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Otter Creek,U.S. House,16,REP,Mike Kelly,64,15,79
+Mercer,Otter Creek,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Otter Creek,General Assembly,17,REP,Parke Wentling,66,16,82
+Mercer,Otter Creek,General Assembly,17,REP,Write-In,2,0,2
+Mercer,Perry,Registered Voters,,,,,,758
+Mercer,Perry,Registered Voters,,DEM,,,,223
+Mercer,Perry,Registered Voters,,REP,,,,535
+Mercer,Perry,Registered Voters,,NPA,,,,0
+Mercer,Perry,Ballots Cast,,,,205,98,303
+Mercer,Perry,Ballots Cast,,DEM,,44,28,72
+Mercer,Perry,Ballots Cast,,REP,,161,70,231
+Mercer,Perry,Ballots Cast,,NPA,,0,0,0
+Mercer,Perry,President,,DEM,Bernie Sanders,9,3,12
+Mercer,Perry,President,,DEM,Joseph R. Biden,22,23,45
+Mercer,Perry,President,,DEM,Tulsi Gabbard,3,0,3
+Mercer,Perry,President,,DEM,Elizabeth Warren,4,1,5
+Mercer,Perry,President,,DEM,Write-In,4,0,4
+Mercer,Perry,Attorney General,,DEM,Josh Shapiro,42,28,70
+Mercer,Perry,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Perry,Auditor General,,DEM,H. Scott Conklin,4,2,6
+Mercer,Perry,Auditor General,,DEM,Michael Lamb,22,16,38
+Mercer,Perry,Auditor General,,DEM,Tracie Fountain,0,2,2
+Mercer,Perry,Auditor General,,DEM,Rose Rosie Marie Davis,6,1,7
+Mercer,Perry,Auditor General,,DEM,Nina Ahmad,2,1,3
+Mercer,Perry,Auditor General,,DEM,Christina M. Hartman,10,3,13
+Mercer,Perry,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Perry,State Treasurer,,DEM,Joe Torsella,42,24,66
+Mercer,Perry,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Perry,U.S. House,16,DEM,Kristy Gnibus,40,24,64
+Mercer,Perry,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,Perry,General Assembly,8,DEM,Phil Heasley,40,24,64
+Mercer,Perry,General Assembly,8,DEM,Write-In,1,0,1
+Mercer,Perry,President,,REP,Donald J. Trump,157,55,212
+Mercer,Perry,President,,REP,Roque Rocky De La Fuente,1,2,3
+Mercer,Perry,President,,REP,Bill Weld,2,8,10
+Mercer,Perry,President,,REP,Write-In,0,1,1
+Mercer,Perry,Attorney General,,REP,Heather Heidelbaugh,150,54,204
+Mercer,Perry,Attorney General,,REP,Write-In,0,0,0
+Mercer,Perry,Auditor General,,REP,Timothy Defoor,149,50,199
+Mercer,Perry,Auditor General,,REP,Write-In,0,1,1
+Mercer,Perry,State Treasurer,,REP,Stacy L. Garrity,151,52,203
+Mercer,Perry,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Perry,U.S. House,16,REP,Mike Kelly,156,62,218
+Mercer,Perry,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Perry,General Assembly,8,REP,Scott Jaillet,19,11,30
+Mercer,Perry,General Assembly,8,REP,Tim Bonner,137,56,193
+Mercer,Perry,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Pine 1,Registered Voters,,,,,,1344
+Mercer,Pine 1,Registered Voters,,DEM,,,,344
+Mercer,Pine 1,Registered Voters,,REP,,,,1000
+Mercer,Pine 1,Registered Voters,,NPA,,,,0
+Mercer,Pine 1,Ballots Cast,,,,321,227,548
+Mercer,Pine 1,Ballots Cast,,DEM,,42,79,121
+Mercer,Pine 1,Ballots Cast,,REP,,279,148,427
+Mercer,Pine 1,Ballots Cast,,NPA,,0,0,0
+Mercer,Pine 1,President,,DEM,Bernie Sanders,8,4,12
+Mercer,Pine 1,President,,DEM,Joseph R. Biden,26,70,96
+Mercer,Pine 1,President,,DEM,Tulsi Gabbard,1,3,4
+Mercer,Pine 1,President,,DEM,Elizabeth Warren,0,1,1
+Mercer,Pine 1,President,,DEM,Write-In,3,1,4
+Mercer,Pine 1,Attorney General,,DEM,Josh Shapiro,37,72,109
+Mercer,Pine 1,Attorney General,,DEM,Write-In,1,1,2
+Mercer,Pine 1,Auditor General,,DEM,H. Scott Conklin,6,6,12
+Mercer,Pine 1,Auditor General,,DEM,Michael Lamb,20,54,74
+Mercer,Pine 1,Auditor General,,DEM,Tracie Fountain,1,1,2
+Mercer,Pine 1,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2
+Mercer,Pine 1,Auditor General,,DEM,Nina Ahmad,8,9,17
+Mercer,Pine 1,Auditor General,,DEM,Christina M. Hartman,2,2,4
+Mercer,Pine 1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Pine 1,State Treasurer,,DEM,Joe Torsella,36,69,105
+Mercer,Pine 1,State Treasurer,,DEM,Write-In,0,1,1
+Mercer,Pine 1,U.S. House,16,DEM,Kristy Gnibus,35,73,108
+Mercer,Pine 1,U.S. House,16,DEM,Write-In,2,1,3
+Mercer,Pine 1,General Assembly,8,DEM,Phil Heasley,34,67,101
+Mercer,Pine 1,General Assembly,8,DEM,Write-In,2,3,5
+Mercer,Pine 1,President,,REP,Donald J. Trump,259,120,379
+Mercer,Pine 1,President,,REP,Roque Rocky De La Fuente,1,2,3
+Mercer,Pine 1,President,,REP,Bill Weld,11,16,27
+Mercer,Pine 1,President,,REP,Write-In,0,3,3
+Mercer,Pine 1,Attorney General,,REP,Heather Heidelbaugh,247,124,371
+Mercer,Pine 1,Attorney General,,REP,Write-In,1,1,2
+Mercer,Pine 1,Auditor General,,REP,Timothy Defoor,246,118,364
+Mercer,Pine 1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Pine 1,State Treasurer,,REP,Stacy L. Garrity,249,124,373
+Mercer,Pine 1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Pine 1,U.S. House,16,REP,Mike Kelly,264,136,400
+Mercer,Pine 1,U.S. House,16,REP,Write-In,3,1,4
+Mercer,Pine 1,General Assembly,8,REP,Scott Jaillet,18,7,25
+Mercer,Pine 1,General Assembly,8,REP,Tim Bonner,259,139,398
+Mercer,Pine 1,General Assembly,8,REP,Write-In,1,0,1
+Mercer,Pine 2,Registered Voters,,,,,,1417
+Mercer,Pine 2,Registered Voters,,DEM,,,,410
+Mercer,Pine 2,Registered Voters,,REP,,,,1007
+Mercer,Pine 2,Registered Voters,,NPA,,,,0
+Mercer,Pine 2,Ballots Cast,,,,348,199,547
+Mercer,Pine 2,Ballots Cast,,DEM,,64,82,146
+Mercer,Pine 2,Ballots Cast,,REP,,284,117,401
+Mercer,Pine 2,Ballots Cast,,NPA,,0,0,0
+Mercer,Pine 2,President,,DEM,Bernie Sanders,7,12,19
+Mercer,Pine 2,President,,DEM,Joseph R. Biden,38,64,102
+Mercer,Pine 2,President,,DEM,Tulsi Gabbard,3,3,6
+Mercer,Pine 2,President,,DEM,Elizabeth Warren,4,0,4
+Mercer,Pine 2,President,,DEM,Write-In,8,2,10
+Mercer,Pine 2,Attorney General,,DEM,Josh Shapiro,56,75,131
+Mercer,Pine 2,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Pine 2,Auditor General,,DEM,H. Scott Conklin,4,8,12
+Mercer,Pine 2,Auditor General,,DEM,Michael Lamb,41,48,89
+Mercer,Pine 2,Auditor General,,DEM,Tracie Fountain,1,6,7
+Mercer,Pine 2,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2
+Mercer,Pine 2,Auditor General,,DEM,Nina Ahmad,1,8,9
+Mercer,Pine 2,Auditor General,,DEM,Christina M. Hartman,8,3,11
+Mercer,Pine 2,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Pine 2,State Treasurer,,DEM,Joe Torsella,56,71,127
+Mercer,Pine 2,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Pine 2,U.S. House,16,DEM,Kristy Gnibus,53,71,124
+Mercer,Pine 2,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,Pine 2,General Assembly,8,DEM,Phil Heasley,53,71,124
+Mercer,Pine 2,General Assembly,8,DEM,Write-In,4,2,6
+Mercer,Pine 2,President,,REP,Donald J. Trump,263,90,353
+Mercer,Pine 2,President,,REP,Roque Rocky De La Fuente,1,2,3
+Mercer,Pine 2,President,,REP,Bill Weld,9,11,20
+Mercer,Pine 2,President,,REP,Write-In,4,5,9
+Mercer,Pine 2,Attorney General,,REP,Heather Heidelbaugh,244,105,349
+Mercer,Pine 2,Attorney General,,REP,Write-In,0,0,0
+Mercer,Pine 2,Auditor General,,REP,Timothy Defoor,241,97,338
+Mercer,Pine 2,Auditor General,,REP,Write-In,0,1,1
+Mercer,Pine 2,State Treasurer,,REP,Stacy L. Garrity,243,100,343
+Mercer,Pine 2,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Pine 2,U.S. House,16,REP,Mike Kelly,265,103,368
+Mercer,Pine 2,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Pine 2,General Assembly,8,REP,Scott Jaillet,31,20,51
+Mercer,Pine 2,General Assembly,8,REP,Tim Bonner,251,94,345
+Mercer,Pine 2,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Pymatuning 1,Registered Voters,,,,,,765
+Mercer,Pymatuning 1,Registered Voters,,DEM,,,,376
+Mercer,Pymatuning 1,Registered Voters,,REP,,,,389
+Mercer,Pymatuning 1,Registered Voters,,NPA,,,,0
+Mercer,Pymatuning 1,Ballots Cast,,,,142,95,237
+Mercer,Pymatuning 1,Ballots Cast,,DEM,,54,58,112
+Mercer,Pymatuning 1,Ballots Cast,,REP,,88,37,125
+Mercer,Pymatuning 1,Ballots Cast,,NPA,,0,0,0
+Mercer,Pymatuning 1,President,,DEM,Bernie Sanders,7,3,10
+Mercer,Pymatuning 1,President,,DEM,Joseph R. Biden,31,52,83
+Mercer,Pymatuning 1,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Pymatuning 1,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Pymatuning 1,President,,DEM,Write-In,4,2,6
+Mercer,Pymatuning 1,Attorney General,,DEM,Josh Shapiro,41,53,94
+Mercer,Pymatuning 1,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Pymatuning 1,Auditor General,,DEM,H. Scott Conklin,3,5,8
+Mercer,Pymatuning 1,Auditor General,,DEM,Michael Lamb,26,39,65
+Mercer,Pymatuning 1,Auditor General,,DEM,Tracie Fountain,4,2,6
+Mercer,Pymatuning 1,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,6
+Mercer,Pymatuning 1,Auditor General,,DEM,Nina Ahmad,0,2,2
+Mercer,Pymatuning 1,Auditor General,,DEM,Christina M. Hartman,9,2,11
+Mercer,Pymatuning 1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Pymatuning 1,State Treasurer,,DEM,Joe Torsella,44,51,95
+Mercer,Pymatuning 1,State Treasurer,,DEM,Write-In,0,1,1
+Mercer,Pymatuning 1,U.S. House,16,DEM,Kristy Gnibus,42,52,94
+Mercer,Pymatuning 1,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Pymatuning 1,General Assembly,7,DEM,Mark Longietti,51,58,109
+Mercer,Pymatuning 1,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Pymatuning 1,President,,REP,Donald J. Trump,85,33,118
+Mercer,Pymatuning 1,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Pymatuning 1,President,,REP,Bill Weld,0,2,2
+Mercer,Pymatuning 1,President,,REP,Write-In,1,1,2
+Mercer,Pymatuning 1,Attorney General,,REP,Heather Heidelbaugh,81,34,115
+Mercer,Pymatuning 1,Attorney General,,REP,Write-In,0,1,1
+Mercer,Pymatuning 1,Auditor General,,REP,Timothy Defoor,82,33,115
+Mercer,Pymatuning 1,Auditor General,,REP,Write-In,0,1,1
+Mercer,Pymatuning 1,State Treasurer,,REP,Stacy L. Garrity,81,34,115
+Mercer,Pymatuning 1,State Treasurer,,REP,Write-In,0,1,1
+Mercer,Pymatuning 1,U.S. House,16,REP,Mike Kelly,82,31,113
+Mercer,Pymatuning 1,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Pymatuning 1,General Assembly,7,REP,Write-In,17,9,26
+Mercer,Pymatuning 1,General Assembly,7,REP,Mark Longietti,12,8,20
+Mercer,Pymatuning 2,Registered Voters,,,,,,803
+Mercer,Pymatuning 2,Registered Voters,,DEM,,,,411
+Mercer,Pymatuning 2,Registered Voters,,REP,,,,392
+Mercer,Pymatuning 2,Registered Voters,,NPA,,,,0
+Mercer,Pymatuning 2,Ballots Cast,,,,145,90,235
+Mercer,Pymatuning 2,Ballots Cast,,DEM,,58,61,119
+Mercer,Pymatuning 2,Ballots Cast,,REP,,87,29,116
+Mercer,Pymatuning 2,Ballots Cast,,NPA,,0,0,0
+Mercer,Pymatuning 2,President,,DEM,Bernie Sanders,5,7,12
+Mercer,Pymatuning 2,President,,DEM,Joseph R. Biden,33,50,83
+Mercer,Pymatuning 2,President,,DEM,Tulsi Gabbard,3,2,5
+Mercer,Pymatuning 2,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Pymatuning 2,President,,DEM,Write-In,8,1,9
+Mercer,Pymatuning 2,Attorney General,,DEM,Josh Shapiro,48,57,105
+Mercer,Pymatuning 2,Attorney General,,DEM,Write-In,1,1,2
+Mercer,Pymatuning 2,Auditor General,,DEM,H. Scott Conklin,7,6,13
+Mercer,Pymatuning 2,Auditor General,,DEM,Michael Lamb,35,32,67
+Mercer,Pymatuning 2,Auditor General,,DEM,Tracie Fountain,3,6,9
+Mercer,Pymatuning 2,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,3
+Mercer,Pymatuning 2,Auditor General,,DEM,Nina Ahmad,3,5,8
+Mercer,Pymatuning 2,Auditor General,,DEM,Christina M. Hartman,4,6,10
+Mercer,Pymatuning 2,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Pymatuning 2,State Treasurer,,DEM,Joe Torsella,45,57,102
+Mercer,Pymatuning 2,State Treasurer,,DEM,Write-In,1,1,2
+Mercer,Pymatuning 2,U.S. House,16,DEM,Kristy Gnibus,50,56,106
+Mercer,Pymatuning 2,U.S. House,16,DEM,Write-In,1,1,2
+Mercer,Pymatuning 2,General Assembly,7,DEM,Mark Longietti,55,60,115
+Mercer,Pymatuning 2,General Assembly,7,DEM,Write-In,1,0,1
+Mercer,Pymatuning 2,President,,REP,Donald J. Trump,83,27,110
+Mercer,Pymatuning 2,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Pymatuning 2,President,,REP,Bill Weld,2,1,3
+Mercer,Pymatuning 2,President,,REP,Write-In,1,1,2
+Mercer,Pymatuning 2,Attorney General,,REP,Heather Heidelbaugh,81,27,108
+Mercer,Pymatuning 2,Attorney General,,REP,Write-In,0,0,0
+Mercer,Pymatuning 2,Auditor General,,REP,Timothy Defoor,75,28,103
+Mercer,Pymatuning 2,Auditor General,,REP,Write-In,0,0,0
+Mercer,Pymatuning 2,State Treasurer,,REP,Stacy L. Garrity,76,27,103
+Mercer,Pymatuning 2,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Pymatuning 2,U.S. House,16,REP,Mike Kelly,80,28,108
+Mercer,Pymatuning 2,U.S. House,16,REP,Write-In,0,1,1
+Mercer,Pymatuning 2,General Assembly,7,REP,Write-In,8,1,9
+Mercer,Pymatuning 2,General Assembly,7,REP,Mark Longietti,4,1,5
+Mercer,Salem,Registered Voters,,,,,,402
+Mercer,Salem,Registered Voters,,DEM,,,,97
+Mercer,Salem,Registered Voters,,REP,,,,305
+Mercer,Salem,Registered Voters,,NPA,,,,0
+Mercer,Salem,Ballots Cast,,,,135,38,173
+Mercer,Salem,Ballots Cast,,DEM,,21,15,36
+Mercer,Salem,Ballots Cast,,REP,,114,23,137
+Mercer,Salem,Ballots Cast,,NPA,,0,0,0
+Mercer,Salem,President,,DEM,Bernie Sanders,1,1,2
+Mercer,Salem,President,,DEM,Joseph R. Biden,14,14,28
+Mercer,Salem,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Salem,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Salem,President,,DEM,Write-In,2,0,2
+Mercer,Salem,Attorney General,,DEM,Josh Shapiro,15,13,28
+Mercer,Salem,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Salem,Auditor General,,DEM,H. Scott Conklin,1,1,2
+Mercer,Salem,Auditor General,,DEM,Michael Lamb,11,9,20
+Mercer,Salem,Auditor General,,DEM,Tracie Fountain,2,0,2
+Mercer,Salem,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Salem,Auditor General,,DEM,Nina Ahmad,0,1,1
+Mercer,Salem,Auditor General,,DEM,Christina M. Hartman,1,2,3
+Mercer,Salem,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Salem,State Treasurer,,DEM,Joe Torsella,13,13,26
+Mercer,Salem,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Salem,U.S. House,16,DEM,Kristy Gnibus,16,13,29
+Mercer,Salem,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Salem,General Assembly,17,DEM,Write-In,3,1,4
+Mercer,Salem,General Assembly,17,DEM,Jeff O'Melian,0,0,0
+Mercer,Salem,President,,REP,Donald J. Trump,109,17,126
+Mercer,Salem,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Salem,President,,REP,Bill Weld,4,2,6
+Mercer,Salem,President,,REP,Write-In,0,2,2
+Mercer,Salem,Attorney General,,REP,Heather Heidelbaugh,102,22,124
+Mercer,Salem,Attorney General,,REP,Write-In,0,0,0
+Mercer,Salem,Auditor General,,REP,Timothy Defoor,100,22,122
+Mercer,Salem,Auditor General,,REP,Write-In,0,0,0
+Mercer,Salem,State Treasurer,,REP,Stacy L. Garrity,99,22,121
+Mercer,Salem,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Salem,U.S. House,16,REP,Mike Kelly,110,23,133
+Mercer,Salem,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Salem,General Assembly,17,REP,Parke Wentling,113,23,136
+Mercer,Salem,General Assembly,17,REP,Write-In,0,0,0
+Mercer,Sandy Creek,Registered Voters,,,,,,439
+Mercer,Sandy Creek,Registered Voters,,DEM,,,,115
+Mercer,Sandy Creek,Registered Voters,,REP,,,,324
+Mercer,Sandy Creek,Registered Voters,,NPA,,,,0
+Mercer,Sandy Creek,Ballots Cast,,,,127,29,156
+Mercer,Sandy Creek,Ballots Cast,,DEM,,14,13,27
+Mercer,Sandy Creek,Ballots Cast,,REP,,113,16,129
+Mercer,Sandy Creek,Ballots Cast,,NPA,,0,0,0
+Mercer,Sandy Creek,President,,DEM,Bernie Sanders,2,2,4
+Mercer,Sandy Creek,President,,DEM,Joseph R. Biden,9,10,19
+Mercer,Sandy Creek,President,,DEM,Tulsi Gabbard,0,1,1
+Mercer,Sandy Creek,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Sandy Creek,President,,DEM,Write-In,1,0,1
+Mercer,Sandy Creek,Attorney General,,DEM,Josh Shapiro,10,13,23
+Mercer,Sandy Creek,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Sandy Creek,Auditor General,,DEM,H. Scott Conklin,1,0,1
+Mercer,Sandy Creek,Auditor General,,DEM,Michael Lamb,6,12,18
+Mercer,Sandy Creek,Auditor General,,DEM,Tracie Fountain,0,0,0
+Mercer,Sandy Creek,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2
+Mercer,Sandy Creek,Auditor General,,DEM,Nina Ahmad,0,0,0
+Mercer,Sandy Creek,Auditor General,,DEM,Christina M. Hartman,3,1,4
+Mercer,Sandy Creek,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sandy Creek,State Treasurer,,DEM,Joe Torsella,10,13,23
+Mercer,Sandy Creek,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Sandy Creek,U.S. House,16,DEM,Kristy Gnibus,11,12,23
+Mercer,Sandy Creek,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Sandy Creek,General Assembly,8,DEM,Phil Heasley,10,13,23
+Mercer,Sandy Creek,General Assembly,8,DEM,Write-In,1,0,1
+Mercer,Sandy Creek,President,,REP,Donald J. Trump,111,11,122
+Mercer,Sandy Creek,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Sandy Creek,President,,REP,Bill Weld,0,4,4
+Mercer,Sandy Creek,President,,REP,Write-In,1,0,1
+Mercer,Sandy Creek,Attorney General,,REP,Heather Heidelbaugh,107,15,122
+Mercer,Sandy Creek,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sandy Creek,Auditor General,,REP,Timothy Defoor,107,16,123
+Mercer,Sandy Creek,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sandy Creek,State Treasurer,,REP,Stacy L. Garrity,108,16,124
+Mercer,Sandy Creek,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sandy Creek,U.S. House,16,REP,Mike Kelly,109,13,122
+Mercer,Sandy Creek,U.S. House,16,REP,Write-In,0,3,3
+Mercer,Sandy Creek,General Assembly,8,REP,Scott Jaillet,20,1,21
+Mercer,Sandy Creek,General Assembly,8,REP,Tim Bonner,92,15,107
+Mercer,Sandy Creek,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Sandy Lake Borough,Registered Voters,,,,,,329
+Mercer,Sandy Lake Borough,Registered Voters,,DEM,,,,95
+Mercer,Sandy Lake Borough,Registered Voters,,REP,,,,234
+Mercer,Sandy Lake Borough,Registered Voters,,NPA,,,,0
+Mercer,Sandy Lake Borough,Ballots Cast,,,,105,25,130
+Mercer,Sandy Lake Borough,Ballots Cast,,DEM,,18,13,31
+Mercer,Sandy Lake Borough,Ballots Cast,,REP,,87,12,99
+Mercer,Sandy Lake Borough,Ballots Cast,,NPA,,0,0,0
+Mercer,Sandy Lake Borough,President,,DEM,Bernie Sanders,5,3,8
+Mercer,Sandy Lake Borough,President,,DEM,Joseph R. Biden,11,8,19
+Mercer,Sandy Lake Borough,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Sandy Lake Borough,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Sandy Lake Borough,President,,DEM,Write-In,0,1,1
+Mercer,Sandy Lake Borough,Attorney General,,DEM,Josh Shapiro,18,13,31
+Mercer,Sandy Lake Borough,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Sandy Lake Borough,Auditor General,,DEM,H. Scott Conklin,2,1,3
+Mercer,Sandy Lake Borough,Auditor General,,DEM,Michael Lamb,13,7,20
+Mercer,Sandy Lake Borough,Auditor General,,DEM,Tracie Fountain,0,1,1
+Mercer,Sandy Lake Borough,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0
+Mercer,Sandy Lake Borough,Auditor General,,DEM,Nina Ahmad,2,1,3
+Mercer,Sandy Lake Borough,Auditor General,,DEM,Christina M. Hartman,1,3,4
+Mercer,Sandy Lake Borough,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sandy Lake Borough,State Treasurer,,DEM,Joe Torsella,18,11,29
+Mercer,Sandy Lake Borough,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Sandy Lake Borough,U.S. House,16,DEM,Kristy Gnibus,18,13,31
+Mercer,Sandy Lake Borough,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Sandy Lake Borough,General Assembly,8,DEM,Phil Heasley,18,13,31
+Mercer,Sandy Lake Borough,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Sandy Lake Borough,President,,REP,Donald J. Trump,80,12,92
+Mercer,Sandy Lake Borough,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Sandy Lake Borough,President,,REP,Bill Weld,4,0,4
+Mercer,Sandy Lake Borough,President,,REP,Write-In,1,0,1
+Mercer,Sandy Lake Borough,Attorney General,,REP,Heather Heidelbaugh,79,10,89
+Mercer,Sandy Lake Borough,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sandy Lake Borough,Auditor General,,REP,Timothy Defoor,76,9,85
+Mercer,Sandy Lake Borough,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sandy Lake Borough,State Treasurer,,REP,Stacy L. Garrity,79,9,88
+Mercer,Sandy Lake Borough,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sandy Lake Borough,U.S. House,16,REP,Mike Kelly,83,12,95
+Mercer,Sandy Lake Borough,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Sandy Lake Borough,General Assembly,8,REP,Scott Jaillet,15,0,15
+Mercer,Sandy Lake Borough,General Assembly,8,REP,Tim Bonner,71,11,82
+Mercer,Sandy Lake Borough,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Sandy Lake Township,Registered Voters,,,,,,702
+Mercer,Sandy Lake Township,Registered Voters,,DEM,,,,188
+Mercer,Sandy Lake Township,Registered Voters,,REP,,,,514
+Mercer,Sandy Lake Township,Registered Voters,,NPA,,,,0
+Mercer,Sandy Lake Township,Ballots Cast,,,,222,81,303
+Mercer,Sandy Lake Township,Ballots Cast,,DEM,,31,35,66
+Mercer,Sandy Lake Township,Ballots Cast,,REP,,191,46,237
+Mercer,Sandy Lake Township,Ballots Cast,,NPA,,0,0,0
+Mercer,Sandy Lake Township,President,,DEM,Bernie Sanders,6,3,9
+Mercer,Sandy Lake Township,President,,DEM,Joseph R. Biden,18,30,48
+Mercer,Sandy Lake Township,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,Sandy Lake Township,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,Sandy Lake Township,President,,DEM,Write-In,2,0,2
+Mercer,Sandy Lake Township,Attorney General,,DEM,Josh Shapiro,28,34,62
+Mercer,Sandy Lake Township,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Sandy Lake Township,Auditor General,,DEM,H. Scott Conklin,6,5,11
+Mercer,Sandy Lake Township,Auditor General,,DEM,Michael Lamb,17,18,35
+Mercer,Sandy Lake Township,Auditor General,,DEM,Tracie Fountain,0,1,1
+Mercer,Sandy Lake Township,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Sandy Lake Township,Auditor General,,DEM,Nina Ahmad,1,6,7
+Mercer,Sandy Lake Township,Auditor General,,DEM,Christina M. Hartman,4,4,8
+Mercer,Sandy Lake Township,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Sandy Lake Township,State Treasurer,,DEM,Joe Torsella,25,32,57
+Mercer,Sandy Lake Township,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Sandy Lake Township,U.S. House,16,DEM,Kristy Gnibus,27,34,61
+Mercer,Sandy Lake Township,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Sandy Lake Township,General Assembly,8,DEM,Phil Heasley,25,35,60
+Mercer,Sandy Lake Township,General Assembly,8,DEM,Write-In,2,0,2
+Mercer,Sandy Lake Township,President,,REP,Donald J. Trump,183,37,220
+Mercer,Sandy Lake Township,President,,REP,Roque Rocky De La Fuente,2,1,3
+Mercer,Sandy Lake Township,President,,REP,Bill Weld,2,4,6
+Mercer,Sandy Lake Township,President,,REP,Write-In,3,3,6
+Mercer,Sandy Lake Township,Attorney General,,REP,Heather Heidelbaugh,174,35,209
+Mercer,Sandy Lake Township,Attorney General,,REP,Write-In,0,1,1
+Mercer,Sandy Lake Township,Auditor General,,REP,Timothy Defoor,167,35,202
+Mercer,Sandy Lake Township,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sandy Lake Township,State Treasurer,,REP,Stacy L. Garrity,169,35,204
+Mercer,Sandy Lake Township,State Treasurer,,REP,Write-In,0,1,1
+Mercer,Sandy Lake Township,U.S. House,16,REP,Mike Kelly,181,39,220
+Mercer,Sandy Lake Township,U.S. House,16,REP,Write-In,0,1,1
+Mercer,Sandy Lake Township,General Assembly,8,REP,Scott Jaillet,15,6,21
+Mercer,Sandy Lake Township,General Assembly,8,REP,Tim Bonner,175,38,213
+Mercer,Sandy Lake Township,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Sharon 1-1,Registered Voters,,,,,,410
+Mercer,Sharon 1-1,Registered Voters,,DEM,,,,290
+Mercer,Sharon 1-1,Registered Voters,,REP,,,,120
+Mercer,Sharon 1-1,Registered Voters,,NPA,,,,0
+Mercer,Sharon 1-1,Ballots Cast,,,,73,25,98
+Mercer,Sharon 1-1,Ballots Cast,,DEM,,48,14,62
+Mercer,Sharon 1-1,Ballots Cast,,REP,,25,11,36
+Mercer,Sharon 1-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 1-1,President,,DEM,Bernie Sanders,9,1,10
+Mercer,Sharon 1-1,President,,DEM,Joseph R. Biden,30,12,42
+Mercer,Sharon 1-1,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Sharon 1-1,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Sharon 1-1,President,,DEM,Write-In,5,1,6
+Mercer,Sharon 1-1,Attorney General,,DEM,Josh Shapiro,41,11,52
+Mercer,Sharon 1-1,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Sharon 1-1,Auditor General,,DEM,H. Scott Conklin,2,0,2
+Mercer,Sharon 1-1,Auditor General,,DEM,Michael Lamb,23,8,31
+Mercer,Sharon 1-1,Auditor General,,DEM,Tracie Fountain,2,2,4
+Mercer,Sharon 1-1,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,6
+Mercer,Sharon 1-1,Auditor General,,DEM,Nina Ahmad,2,2,4
+Mercer,Sharon 1-1,Auditor General,,DEM,Christina M. Hartman,10,0,10
+Mercer,Sharon 1-1,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Sharon 1-1,State Treasurer,,DEM,Joe Torsella,41,10,51
+Mercer,Sharon 1-1,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Sharon 1-1,U.S. House,16,DEM,Kristy Gnibus,40,11,51
+Mercer,Sharon 1-1,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Sharon 1-1,General Assembly,7,DEM,Mark Longietti,47,13,60
+Mercer,Sharon 1-1,General Assembly,7,DEM,Write-In,1,0,1
+Mercer,Sharon 1-1,President,,REP,Donald J. Trump,23,8,31
+Mercer,Sharon 1-1,President,,REP,Roque Rocky De La Fuente,1,1,2
+Mercer,Sharon 1-1,President,,REP,Bill Weld,0,1,1
+Mercer,Sharon 1-1,President,,REP,Write-In,1,1,2
+Mercer,Sharon 1-1,Attorney General,,REP,Heather Heidelbaugh,25,9,34
+Mercer,Sharon 1-1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 1-1,Auditor General,,REP,Timothy Defoor,24,11,35
+Mercer,Sharon 1-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 1-1,State Treasurer,,REP,Stacy L. Garrity,25,9,34
+Mercer,Sharon 1-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 1-1,U.S. House,16,REP,Mike Kelly,24,11,35
+Mercer,Sharon 1-1,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Sharon 1-1,General Assembly,7,REP,Write-In,11,2,13
+Mercer,Sharon 1-1,General Assembly,7,REP,Mark Longietti,7,2,9
+Mercer,Sharon 2-1,Registered Voters,,,,,,768
+Mercer,Sharon 2-1,Registered Voters,,DEM,,,,589
+Mercer,Sharon 2-1,Registered Voters,,REP,,,,179
+Mercer,Sharon 2-1,Registered Voters,,NPA,,,,0
+Mercer,Sharon 2-1,Ballots Cast,,,,107,61,168
+Mercer,Sharon 2-1,Ballots Cast,,DEM,,75,54,129
+Mercer,Sharon 2-1,Ballots Cast,,REP,,32,7,39
+Mercer,Sharon 2-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 2-1,President,,DEM,Bernie Sanders,18,8,26
+Mercer,Sharon 2-1,President,,DEM,Joseph R. Biden,48,43,91
+Mercer,Sharon 2-1,President,,DEM,Tulsi Gabbard,2,0,2
+Mercer,Sharon 2-1,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,Sharon 2-1,President,,DEM,Write-In,4,1,5
+Mercer,Sharon 2-1,Attorney General,,DEM,Josh Shapiro,62,46,108
+Mercer,Sharon 2-1,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Sharon 2-1,Auditor General,,DEM,H. Scott Conklin,10,3,13
+Mercer,Sharon 2-1,Auditor General,,DEM,Michael Lamb,21,27,48
+Mercer,Sharon 2-1,Auditor General,,DEM,Tracie Fountain,7,6,13
+Mercer,Sharon 2-1,Auditor General,,DEM,Rose Rosie Marie Davis,8,3,11
+Mercer,Sharon 2-1,Auditor General,,DEM,Nina Ahmad,9,3,12
+Mercer,Sharon 2-1,Auditor General,,DEM,Christina M. Hartman,5,6,11
+Mercer,Sharon 2-1,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Sharon 2-1,State Treasurer,,DEM,Joe Torsella,58,44,102
+Mercer,Sharon 2-1,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Sharon 2-1,U.S. House,16,DEM,Kristy Gnibus,58,42,100
+Mercer,Sharon 2-1,U.S. House,16,DEM,Write-In,1,3,4
+Mercer,Sharon 2-1,General Assembly,7,DEM,Mark Longietti,71,52,123
+Mercer,Sharon 2-1,General Assembly,7,DEM,Write-In,3,0,3
+Mercer,Sharon 2-1,President,,REP,Donald J. Trump,30,5,35
+Mercer,Sharon 2-1,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Sharon 2-1,President,,REP,Bill Weld,1,0,1
+Mercer,Sharon 2-1,President,,REP,Write-In,0,0,0
+Mercer,Sharon 2-1,Attorney General,,REP,Heather Heidelbaugh,28,5,33
+Mercer,Sharon 2-1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 2-1,Auditor General,,REP,Timothy Defoor,28,6,34
+Mercer,Sharon 2-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 2-1,State Treasurer,,REP,Stacy L. Garrity,27,6,33
+Mercer,Sharon 2-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 2-1,U.S. House,16,REP,Mike Kelly,30,7,37
+Mercer,Sharon 2-1,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Sharon 2-1,General Assembly,7,REP,Write-In,8,1,9
+Mercer,Sharon 2-1,General Assembly,7,REP,Mark Longietti,3,0,3
+Mercer,Sharon 2-2,Registered Voters,,,,,,661
+Mercer,Sharon 2-2,Registered Voters,,DEM,,,,439
+Mercer,Sharon 2-2,Registered Voters,,REP,,,,222
+Mercer,Sharon 2-2,Registered Voters,,NPA,,,,0
+Mercer,Sharon 2-2,Ballots Cast,,,,118,117,235
+Mercer,Sharon 2-2,Ballots Cast,,DEM,,81,90,171
+Mercer,Sharon 2-2,Ballots Cast,,REP,,37,27,64
+Mercer,Sharon 2-2,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 2-2,President,,DEM,Bernie Sanders,18,7,25
+Mercer,Sharon 2-2,President,,DEM,Joseph R. Biden,52,81,133
+Mercer,Sharon 2-2,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,Sharon 2-2,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,Sharon 2-2,President,,DEM,Write-In,1,1,2
+Mercer,Sharon 2-2,Attorney General,,DEM,Josh Shapiro,68,81,149
+Mercer,Sharon 2-2,Attorney General,,DEM,Write-In,0,1,1
+Mercer,Sharon 2-2,Auditor General,,DEM,H. Scott Conklin,8,3,11
+Mercer,Sharon 2-2,Auditor General,,DEM,Michael Lamb,37,64,101
+Mercer,Sharon 2-2,Auditor General,,DEM,Tracie Fountain,1,2,3
+Mercer,Sharon 2-2,Auditor General,,DEM,Rose Rosie Marie Davis,5,7,12
+Mercer,Sharon 2-2,Auditor General,,DEM,Nina Ahmad,9,2,11
+Mercer,Sharon 2-2,Auditor General,,DEM,Christina M. Hartman,6,6,12
+Mercer,Sharon 2-2,Auditor General,,DEM,Write-In,0,1,1
+Mercer,Sharon 2-2,State Treasurer,,DEM,Joe Torsella,64,78,142
+Mercer,Sharon 2-2,State Treasurer,,DEM,Write-In,0,1,1
+Mercer,Sharon 2-2,U.S. House,16,DEM,Kristy Gnibus,64,82,146
+Mercer,Sharon 2-2,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Sharon 2-2,General Assembly,7,DEM,Mark Longietti,80,87,167
+Mercer,Sharon 2-2,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Sharon 2-2,President,,REP,Donald J. Trump,36,24,60
+Mercer,Sharon 2-2,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Sharon 2-2,President,,REP,Bill Weld,0,0,0
+Mercer,Sharon 2-2,President,,REP,Write-In,1,2,3
+Mercer,Sharon 2-2,Attorney General,,REP,Heather Heidelbaugh,29,25,54
+Mercer,Sharon 2-2,Attorney General,,REP,Write-In,0,1,1
+Mercer,Sharon 2-2,Auditor General,,REP,Timothy Defoor,27,25,52
+Mercer,Sharon 2-2,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 2-2,State Treasurer,,REP,Stacy L. Garrity,29,24,53
+Mercer,Sharon 2-2,State Treasurer,,REP,Write-In,0,1,1
+Mercer,Sharon 2-2,U.S. House,16,REP,Mike Kelly,33,26,59
+Mercer,Sharon 2-2,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Sharon 2-2,General Assembly,7,REP,Write-In,6,4,10
+Mercer,Sharon 2-2,General Assembly,7,REP,Mark Longietti,6,3,9
+Mercer,Sharon 2-3,Registered Voters,,,,,,641
+Mercer,Sharon 2-3,Registered Voters,,DEM,,,,387
+Mercer,Sharon 2-3,Registered Voters,,REP,,,,254
+Mercer,Sharon 2-3,Registered Voters,,NPA,,,,0
+Mercer,Sharon 2-3,Ballots Cast,,,,126,104,230
+Mercer,Sharon 2-3,Ballots Cast,,DEM,,76,81,157
+Mercer,Sharon 2-3,Ballots Cast,,REP,,50,23,73
+Mercer,Sharon 2-3,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 2-3,President,,DEM,Bernie Sanders,17,8,25
+Mercer,Sharon 2-3,President,,DEM,Joseph R. Biden,48,65,113
+Mercer,Sharon 2-3,President,,DEM,Tulsi Gabbard,4,3,7
+Mercer,Sharon 2-3,President,,DEM,Elizabeth Warren,4,2,6
+Mercer,Sharon 2-3,President,,DEM,Write-In,1,2,3
+Mercer,Sharon 2-3,Attorney General,,DEM,Josh Shapiro,63,66,129
+Mercer,Sharon 2-3,Attorney General,,DEM,Write-In,0,1,1
+Mercer,Sharon 2-3,Auditor General,,DEM,H. Scott Conklin,6,4,10
+Mercer,Sharon 2-3,Auditor General,,DEM,Michael Lamb,32,40,72
+Mercer,Sharon 2-3,Auditor General,,DEM,Tracie Fountain,2,5,7
+Mercer,Sharon 2-3,Auditor General,,DEM,Rose Rosie Marie Davis,1,7,8
+Mercer,Sharon 2-3,Auditor General,,DEM,Nina Ahmad,15,9,24
+Mercer,Sharon 2-3,Auditor General,,DEM,Christina M. Hartman,5,4,9
+Mercer,Sharon 2-3,Auditor General,,DEM,Write-In,0,1,1
+Mercer,Sharon 2-3,State Treasurer,,DEM,Joe Torsella,56,62,118
+Mercer,Sharon 2-3,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Sharon 2-3,U.S. House,16,DEM,Kristy Gnibus,58,66,124
+Mercer,Sharon 2-3,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Sharon 2-3,General Assembly,7,DEM,Mark Longietti,73,77,150
+Mercer,Sharon 2-3,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Sharon 2-3,President,,REP,Donald J. Trump,47,19,66
+Mercer,Sharon 2-3,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Sharon 2-3,President,,REP,Bill Weld,0,3,3
+Mercer,Sharon 2-3,President,,REP,Write-In,2,1,3
+Mercer,Sharon 2-3,Attorney General,,REP,Heather Heidelbaugh,47,20,67
+Mercer,Sharon 2-3,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 2-3,Auditor General,,REP,Timothy Defoor,46,21,67
+Mercer,Sharon 2-3,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 2-3,State Treasurer,,REP,Stacy L. Garrity,45,20,65
+Mercer,Sharon 2-3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 2-3,U.S. House,16,REP,Mike Kelly,47,20,67
+Mercer,Sharon 2-3,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Sharon 2-3,General Assembly,7,REP,Write-In,12,9,21
+Mercer,Sharon 2-3,General Assembly,7,REP,Mark Longietti,9,8,17
+Mercer,Sharon 2-4,Registered Voters,,,,,,629
+Mercer,Sharon 2-4,Registered Voters,,DEM,,,,349
+Mercer,Sharon 2-4,Registered Voters,,REP,,,,280
+Mercer,Sharon 2-4,Registered Voters,,NPA,,,,0
+Mercer,Sharon 2-4,Ballots Cast,,,,145,113,258
+Mercer,Sharon 2-4,Ballots Cast,,DEM,,78,79,157
+Mercer,Sharon 2-4,Ballots Cast,,REP,,67,34,101
+Mercer,Sharon 2-4,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 2-4,President,,DEM,Bernie Sanders,8,6,14
+Mercer,Sharon 2-4,President,,DEM,Joseph R. Biden,54,65,119
+Mercer,Sharon 2-4,President,,DEM,Tulsi Gabbard,4,1,5
+Mercer,Sharon 2-4,President,,DEM,Elizabeth Warren,4,1,5
+Mercer,Sharon 2-4,President,,DEM,Write-In,2,2,4
+Mercer,Sharon 2-4,Attorney General,,DEM,Josh Shapiro,67,67,134
+Mercer,Sharon 2-4,Attorney General,,DEM,Write-In,0,1,1
+Mercer,Sharon 2-4,Auditor General,,DEM,H. Scott Conklin,7,5,12
+Mercer,Sharon 2-4,Auditor General,,DEM,Michael Lamb,54,50,104
+Mercer,Sharon 2-4,Auditor General,,DEM,Tracie Fountain,0,6,6
+Mercer,Sharon 2-4,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2
+Mercer,Sharon 2-4,Auditor General,,DEM,Nina Ahmad,6,4,10
+Mercer,Sharon 2-4,Auditor General,,DEM,Christina M. Hartman,5,4,9
+Mercer,Sharon 2-4,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sharon 2-4,State Treasurer,,DEM,Joe Torsella,64,61,125
+Mercer,Sharon 2-4,State Treasurer,,DEM,Write-In,0,1,1
+Mercer,Sharon 2-4,U.S. House,16,DEM,Kristy Gnibus,65,67,132
+Mercer,Sharon 2-4,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Sharon 2-4,General Assembly,7,DEM,Mark Longietti,75,77,152
+Mercer,Sharon 2-4,General Assembly,7,DEM,Write-In,0,1,1
+Mercer,Sharon 2-4,President,,REP,Donald J. Trump,61,23,84
+Mercer,Sharon 2-4,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Sharon 2-4,President,,REP,Bill Weld,1,6,7
+Mercer,Sharon 2-4,President,,REP,Write-In,0,1,1
+Mercer,Sharon 2-4,Attorney General,,REP,Heather Heidelbaugh,62,32,94
+Mercer,Sharon 2-4,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 2-4,Auditor General,,REP,Timothy Defoor,59,29,88
+Mercer,Sharon 2-4,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 2-4,State Treasurer,,REP,Stacy L. Garrity,59,31,90
+Mercer,Sharon 2-4,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 2-4,U.S. House,16,REP,Mike Kelly,64,31,95
+Mercer,Sharon 2-4,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Sharon 2-4,General Assembly,7,REP,Write-In,17,6,23
+Mercer,Sharon 2-4,General Assembly,7,REP,Mark Longietti,17,6,23
+Mercer,Sharon 3-1,Registered Voters,,,,,,748
+Mercer,Sharon 3-1,Registered Voters,,DEM,,,,575
+Mercer,Sharon 3-1,Registered Voters,,REP,,,,173
+Mercer,Sharon 3-1,Registered Voters,,NPA,,,,0
+Mercer,Sharon 3-1,Ballots Cast,,,,71,73,144
+Mercer,Sharon 3-1,Ballots Cast,,DEM,,54,58,112
+Mercer,Sharon 3-1,Ballots Cast,,REP,,17,15,32
+Mercer,Sharon 3-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 3-1,President,,DEM,Bernie Sanders,3,11,14
+Mercer,Sharon 3-1,President,,DEM,Joseph R. Biden,46,45,91
+Mercer,Sharon 3-1,President,,DEM,Tulsi Gabbard,0,2,2
+Mercer,Sharon 3-1,President,,DEM,Elizabeth Warren,3,0,3
+Mercer,Sharon 3-1,President,,DEM,Write-In,1,0,1
+Mercer,Sharon 3-1,Attorney General,,DEM,Josh Shapiro,41,50,91
+Mercer,Sharon 3-1,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Sharon 3-1,Auditor General,,DEM,H. Scott Conklin,2,2,4
+Mercer,Sharon 3-1,Auditor General,,DEM,Michael Lamb,19,27,46
+Mercer,Sharon 3-1,Auditor General,,DEM,Tracie Fountain,3,6,9
+Mercer,Sharon 3-1,Auditor General,,DEM,Rose Rosie Marie Davis,5,4,9
+Mercer,Sharon 3-1,Auditor General,,DEM,Nina Ahmad,8,9,17
+Mercer,Sharon 3-1,Auditor General,,DEM,Christina M. Hartman,3,4,7
+Mercer,Sharon 3-1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sharon 3-1,State Treasurer,,DEM,Joe Torsella,41,53,94
+Mercer,Sharon 3-1,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Sharon 3-1,U.S. House,16,DEM,Kristy Gnibus,39,50,89
+Mercer,Sharon 3-1,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Sharon 3-1,General Assembly,7,DEM,Mark Longietti,53,56,109
+Mercer,Sharon 3-1,General Assembly,7,DEM,Write-In,0,1,1
+Mercer,Sharon 3-1,President,,REP,Donald J. Trump,16,11,27
+Mercer,Sharon 3-1,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Sharon 3-1,President,,REP,Bill Weld,1,2,3
+Mercer,Sharon 3-1,President,,REP,Write-In,0,1,1
+Mercer,Sharon 3-1,Attorney General,,REP,Heather Heidelbaugh,16,13,29
+Mercer,Sharon 3-1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 3-1,Auditor General,,REP,Timothy Defoor,16,13,29
+Mercer,Sharon 3-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 3-1,State Treasurer,,REP,Stacy L. Garrity,16,13,29
+Mercer,Sharon 3-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 3-1,U.S. House,16,REP,Mike Kelly,15,13,28
+Mercer,Sharon 3-1,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Sharon 3-1,General Assembly,7,REP,Write-In,2,3,5
+Mercer,Sharon 3-1,General Assembly,7,REP,Mark Longietti,2,3,5
+Mercer,Sharon 4-1,Registered Voters,,,,,,761
+Mercer,Sharon 4-1,Registered Voters,,DEM,,,,645
+Mercer,Sharon 4-1,Registered Voters,,REP,,,,116
+Mercer,Sharon 4-1,Registered Voters,,NPA,,,,0
+Mercer,Sharon 4-1,Ballots Cast,,,,100,68,168
+Mercer,Sharon 4-1,Ballots Cast,,DEM,,84,61,145
+Mercer,Sharon 4-1,Ballots Cast,,REP,,16,7,23
+Mercer,Sharon 4-1,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 4-1,President,,DEM,Bernie Sanders,9,13,22
+Mercer,Sharon 4-1,President,,DEM,Joseph R. Biden,70,43,113
+Mercer,Sharon 4-1,President,,DEM,Tulsi Gabbard,2,3,5
+Mercer,Sharon 4-1,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,Sharon 4-1,President,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-1,Attorney General,,DEM,Josh Shapiro,69,50,119
+Mercer,Sharon 4-1,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-1,Auditor General,,DEM,H. Scott Conklin,10,5,15
+Mercer,Sharon 4-1,Auditor General,,DEM,Michael Lamb,38,30,68
+Mercer,Sharon 4-1,Auditor General,,DEM,Tracie Fountain,5,1,6
+Mercer,Sharon 4-1,Auditor General,,DEM,Rose Rosie Marie Davis,4,6,10
+Mercer,Sharon 4-1,Auditor General,,DEM,Nina Ahmad,13,8,21
+Mercer,Sharon 4-1,Auditor General,,DEM,Christina M. Hartman,8,7,15
+Mercer,Sharon 4-1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sharon 4-1,State Treasurer,,DEM,Joe Torsella,73,51,124
+Mercer,Sharon 4-1,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-1,U.S. House,16,DEM,Kristy Gnibus,73,50,123
+Mercer,Sharon 4-1,U.S. House,16,DEM,Write-In,1,1,2
+Mercer,Sharon 4-1,General Assembly,7,DEM,Mark Longietti,80,56,136
+Mercer,Sharon 4-1,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Sharon 4-1,President,,REP,Donald J. Trump,15,6,21
+Mercer,Sharon 4-1,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Sharon 4-1,President,,REP,Bill Weld,0,1,1
+Mercer,Sharon 4-1,President,,REP,Write-In,0,0,0
+Mercer,Sharon 4-1,Attorney General,,REP,Heather Heidelbaugh,13,6,19
+Mercer,Sharon 4-1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 4-1,Auditor General,,REP,Timothy Defoor,12,6,18
+Mercer,Sharon 4-1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 4-1,State Treasurer,,REP,Stacy L. Garrity,13,6,19
+Mercer,Sharon 4-1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 4-1,U.S. House,16,REP,Mike Kelly,15,7,22
+Mercer,Sharon 4-1,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Sharon 4-1,General Assembly,7,REP,Write-In,3,1,4
+Mercer,Sharon 4-1,General Assembly,7,REP,Mark Longietti,2,0,2
+Mercer,Sharon 4-2,Registered Voters,,,,,,528
+Mercer,Sharon 4-2,Registered Voters,,DEM,,,,400
+Mercer,Sharon 4-2,Registered Voters,,REP,,,,128
+Mercer,Sharon 4-2,Registered Voters,,NPA,,,,0
+Mercer,Sharon 4-2,Ballots Cast,,,,71,51,122
+Mercer,Sharon 4-2,Ballots Cast,,DEM,,49,37,86
+Mercer,Sharon 4-2,Ballots Cast,,REP,,22,14,36
+Mercer,Sharon 4-2,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 4-2,President,,DEM,Bernie Sanders,10,5,15
+Mercer,Sharon 4-2,President,,DEM,Joseph R. Biden,36,30,66
+Mercer,Sharon 4-2,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Sharon 4-2,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Sharon 4-2,President,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-2,Attorney General,,DEM,Josh Shapiro,40,35,75
+Mercer,Sharon 4-2,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-2,Auditor General,,DEM,H. Scott Conklin,4,2,6
+Mercer,Sharon 4-2,Auditor General,,DEM,Michael Lamb,23,20,43
+Mercer,Sharon 4-2,Auditor General,,DEM,Tracie Fountain,1,0,1
+Mercer,Sharon 4-2,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,6
+Mercer,Sharon 4-2,Auditor General,,DEM,Nina Ahmad,10,5,15
+Mercer,Sharon 4-2,Auditor General,,DEM,Christina M. Hartman,5,5,10
+Mercer,Sharon 4-2,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sharon 4-2,State Treasurer,,DEM,Joe Torsella,40,34,74
+Mercer,Sharon 4-2,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-2,U.S. House,16,DEM,Kristy Gnibus,39,33,72
+Mercer,Sharon 4-2,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Sharon 4-2,General Assembly,7,DEM,Mark Longietti,47,37,84
+Mercer,Sharon 4-2,General Assembly,7,DEM,Write-In,1,0,1
+Mercer,Sharon 4-2,President,,REP,Donald J. Trump,20,11,31
+Mercer,Sharon 4-2,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Sharon 4-2,President,,REP,Bill Weld,0,1,1
+Mercer,Sharon 4-2,President,,REP,Write-In,0,0,0
+Mercer,Sharon 4-2,Attorney General,,REP,Heather Heidelbaugh,21,12,33
+Mercer,Sharon 4-2,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 4-2,Auditor General,,REP,Timothy Defoor,19,12,31
+Mercer,Sharon 4-2,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 4-2,State Treasurer,,REP,Stacy L. Garrity,20,12,32
+Mercer,Sharon 4-2,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 4-2,U.S. House,16,REP,Mike Kelly,20,13,33
+Mercer,Sharon 4-2,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Sharon 4-2,General Assembly,7,REP,Write-In,6,5,11
+Mercer,Sharon 4-2,General Assembly,7,REP,Mark Longietti,4,2,6
+Mercer,Sharon 4-3,Registered Voters,,,,,,630
+Mercer,Sharon 4-3,Registered Voters,,DEM,,,,437
+Mercer,Sharon 4-3,Registered Voters,,REP,,,,193
+Mercer,Sharon 4-3,Registered Voters,,NPA,,,,0
+Mercer,Sharon 4-3,Ballots Cast,,,,95,103,198
+Mercer,Sharon 4-3,Ballots Cast,,DEM,,56,91,147
+Mercer,Sharon 4-3,Ballots Cast,,REP,,39,12,51
+Mercer,Sharon 4-3,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 4-3,President,,DEM,Bernie Sanders,8,13,21
+Mercer,Sharon 4-3,President,,DEM,Joseph R. Biden,34,75,109
+Mercer,Sharon 4-3,President,,DEM,Tulsi Gabbard,2,1,3
+Mercer,Sharon 4-3,President,,DEM,Elizabeth Warren,5,1,6
+Mercer,Sharon 4-3,President,,DEM,Write-In,2,0,2
+Mercer,Sharon 4-3,Attorney General,,DEM,Josh Shapiro,43,79,122
+Mercer,Sharon 4-3,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-3,Auditor General,,DEM,H. Scott Conklin,3,2,5
+Mercer,Sharon 4-3,Auditor General,,DEM,Michael Lamb,30,60,90
+Mercer,Sharon 4-3,Auditor General,,DEM,Tracie Fountain,1,5,6
+Mercer,Sharon 4-3,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,6
+Mercer,Sharon 4-3,Auditor General,,DEM,Nina Ahmad,3,6,9
+Mercer,Sharon 4-3,Auditor General,,DEM,Christina M. Hartman,6,8,14
+Mercer,Sharon 4-3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sharon 4-3,State Treasurer,,DEM,Joe Torsella,45,78,123
+Mercer,Sharon 4-3,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-3,U.S. House,16,DEM,Kristy Gnibus,44,78,122
+Mercer,Sharon 4-3,U.S. House,16,DEM,Write-In,1,1,2
+Mercer,Sharon 4-3,General Assembly,7,DEM,Mark Longietti,52,90,142
+Mercer,Sharon 4-3,General Assembly,7,DEM,Write-In,2,1,3
+Mercer,Sharon 4-3,President,,REP,Donald J. Trump,37,5,42
+Mercer,Sharon 4-3,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Sharon 4-3,President,,REP,Bill Weld,1,0,1
+Mercer,Sharon 4-3,President,,REP,Write-In,0,3,3
+Mercer,Sharon 4-3,Attorney General,,REP,Heather Heidelbaugh,36,8,44
+Mercer,Sharon 4-3,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 4-3,Auditor General,,REP,Timothy Defoor,32,4,36
+Mercer,Sharon 4-3,Auditor General,,REP,Write-In,0,2,2
+Mercer,Sharon 4-3,State Treasurer,,REP,Stacy L. Garrity,33,7,40
+Mercer,Sharon 4-3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 4-3,U.S. House,16,REP,Mike Kelly,34,10,44
+Mercer,Sharon 4-3,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Sharon 4-3,General Assembly,7,REP,Write-In,5,6,11
+Mercer,Sharon 4-3,General Assembly,7,REP,Mark Longietti,4,5,9
+Mercer,Sharon 4-5,Registered Voters,,,,,,892
+Mercer,Sharon 4-5,Registered Voters,,DEM,,,,644
+Mercer,Sharon 4-5,Registered Voters,,REP,,,,248
+Mercer,Sharon 4-5,Registered Voters,,NPA,,,,0
+Mercer,Sharon 4-5,Ballots Cast,,,,149,141,290
+Mercer,Sharon 4-5,Ballots Cast,,DEM,,104,124,228
+Mercer,Sharon 4-5,Ballots Cast,,REP,,45,17,62
+Mercer,Sharon 4-5,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharon 4-5,President,,DEM,Bernie Sanders,15,14,29
+Mercer,Sharon 4-5,President,,DEM,Joseph R. Biden,82,101,183
+Mercer,Sharon 4-5,President,,DEM,Tulsi Gabbard,5,2,7
+Mercer,Sharon 4-5,President,,DEM,Elizabeth Warren,0,1,1
+Mercer,Sharon 4-5,President,,DEM,Write-In,1,2,3
+Mercer,Sharon 4-5,Attorney General,,DEM,Josh Shapiro,90,110,200
+Mercer,Sharon 4-5,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Sharon 4-5,Auditor General,,DEM,H. Scott Conklin,4,1,5
+Mercer,Sharon 4-5,Auditor General,,DEM,Michael Lamb,51,82,133
+Mercer,Sharon 4-5,Auditor General,,DEM,Tracie Fountain,2,3,5
+Mercer,Sharon 4-5,Auditor General,,DEM,Rose Rosie Marie Davis,7,10,17
+Mercer,Sharon 4-5,Auditor General,,DEM,Nina Ahmad,13,4,17
+Mercer,Sharon 4-5,Auditor General,,DEM,Christina M. Hartman,9,10,19
+Mercer,Sharon 4-5,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-5,State Treasurer,,DEM,Joe Torsella,84,107,191
+Mercer,Sharon 4-5,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Sharon 4-5,U.S. House,16,DEM,Kristy Gnibus,90,110,200
+Mercer,Sharon 4-5,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Sharon 4-5,General Assembly,7,DEM,Mark Longietti,102,122,224
+Mercer,Sharon 4-5,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Sharon 4-5,President,,REP,Donald J. Trump,39,10,49
+Mercer,Sharon 4-5,President,,REP,Roque Rocky De La Fuente,2,1,3
+Mercer,Sharon 4-5,President,,REP,Bill Weld,2,3,5
+Mercer,Sharon 4-5,President,,REP,Write-In,1,3,4
+Mercer,Sharon 4-5,Attorney General,,REP,Heather Heidelbaugh,41,14,55
+Mercer,Sharon 4-5,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharon 4-5,Auditor General,,REP,Timothy Defoor,39,15,54
+Mercer,Sharon 4-5,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharon 4-5,State Treasurer,,REP,Stacy L. Garrity,41,16,57
+Mercer,Sharon 4-5,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharon 4-5,U.S. House,16,REP,Mike Kelly,39,15,54
+Mercer,Sharon 4-5,U.S. House,16,REP,Write-In,3,0,3
+Mercer,Sharon 4-5,General Assembly,7,REP,Write-In,9,4,13
+Mercer,Sharon 4-5,General Assembly,7,REP,Mark Longietti,6,4,10
+Mercer,Sharpsville 1,Registered Voters,,,,,,823
+Mercer,Sharpsville 1,Registered Voters,,DEM,,,,471
+Mercer,Sharpsville 1,Registered Voters,,REP,,,,352
+Mercer,Sharpsville 1,Registered Voters,,NPA,,,,0
+Mercer,Sharpsville 1,Ballots Cast,,,,147,156,303
+Mercer,Sharpsville 1,Ballots Cast,,DEM,,76,111,187
+Mercer,Sharpsville 1,Ballots Cast,,REP,,71,45,116
+Mercer,Sharpsville 1,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharpsville 1,President,,DEM,Bernie Sanders,18,13,31
+Mercer,Sharpsville 1,President,,DEM,Joseph R. Biden,46,91,137
+Mercer,Sharpsville 1,President,,DEM,Tulsi Gabbard,2,3,5
+Mercer,Sharpsville 1,President,,DEM,Elizabeth Warren,5,0,5
+Mercer,Sharpsville 1,President,,DEM,Write-In,3,1,4
+Mercer,Sharpsville 1,Attorney General,,DEM,Josh Shapiro,67,90,157
+Mercer,Sharpsville 1,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Sharpsville 1,Auditor General,,DEM,H. Scott Conklin,4,4,8
+Mercer,Sharpsville 1,Auditor General,,DEM,Michael Lamb,36,62,98
+Mercer,Sharpsville 1,Auditor General,,DEM,Tracie Fountain,1,6,7
+Mercer,Sharpsville 1,Auditor General,,DEM,Rose Rosie Marie Davis,5,4,9
+Mercer,Sharpsville 1,Auditor General,,DEM,Nina Ahmad,9,7,16
+Mercer,Sharpsville 1,Auditor General,,DEM,Christina M. Hartman,10,12,22
+Mercer,Sharpsville 1,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sharpsville 1,State Treasurer,,DEM,Joe Torsella,60,91,151
+Mercer,Sharpsville 1,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Sharpsville 1,U.S. House,16,DEM,Kristy Gnibus,62,93,155
+Mercer,Sharpsville 1,U.S. House,16,DEM,Write-In,0,1,1
+Mercer,Sharpsville 1,General Assembly,7,DEM,Mark Longietti,71,107,178
+Mercer,Sharpsville 1,General Assembly,7,DEM,Write-In,1,1,2
+Mercer,Sharpsville 1,President,,REP,Donald J. Trump,66,35,101
+Mercer,Sharpsville 1,President,,REP,Roque Rocky De La Fuente,0,2,2
+Mercer,Sharpsville 1,President,,REP,Bill Weld,0,4,4
+Mercer,Sharpsville 1,President,,REP,Write-In,1,0,1
+Mercer,Sharpsville 1,Attorney General,,REP,Heather Heidelbaugh,60,39,99
+Mercer,Sharpsville 1,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharpsville 1,Auditor General,,REP,Timothy Defoor,57,39,96
+Mercer,Sharpsville 1,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharpsville 1,State Treasurer,,REP,Stacy L. Garrity,60,39,99
+Mercer,Sharpsville 1,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharpsville 1,U.S. House,16,REP,Mike Kelly,64,40,104
+Mercer,Sharpsville 1,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Sharpsville 1,General Assembly,7,REP,Write-In,26,9,35
+Mercer,Sharpsville 1,General Assembly,7,REP,Mark Longietti,19,6,25
+Mercer,Sharpsville 2,Registered Voters,,,,,,742
+Mercer,Sharpsville 2,Registered Voters,,DEM,,,,491
+Mercer,Sharpsville 2,Registered Voters,,REP,,,,251
+Mercer,Sharpsville 2,Registered Voters,,NPA,,,,0
+Mercer,Sharpsville 2,Ballots Cast,,,,128,101,229
+Mercer,Sharpsville 2,Ballots Cast,,DEM,,72,79,151
+Mercer,Sharpsville 2,Ballots Cast,,REP,,56,22,78
+Mercer,Sharpsville 2,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharpsville 2,President,,DEM,Bernie Sanders,14,13,27
+Mercer,Sharpsville 2,President,,DEM,Joseph R. Biden,45,63,108
+Mercer,Sharpsville 2,President,,DEM,Tulsi Gabbard,3,1,4
+Mercer,Sharpsville 2,President,,DEM,Elizabeth Warren,4,0,4
+Mercer,Sharpsville 2,President,,DEM,Write-In,4,1,5
+Mercer,Sharpsville 2,Attorney General,,DEM,Josh Shapiro,51,69,120
+Mercer,Sharpsville 2,Attorney General,,DEM,Write-In,1,1,2
+Mercer,Sharpsville 2,Auditor General,,DEM,H. Scott Conklin,5,3,8
+Mercer,Sharpsville 2,Auditor General,,DEM,Michael Lamb,31,48,79
+Mercer,Sharpsville 2,Auditor General,,DEM,Tracie Fountain,2,4,6
+Mercer,Sharpsville 2,Auditor General,,DEM,Rose Rosie Marie Davis,8,3,11
+Mercer,Sharpsville 2,Auditor General,,DEM,Nina Ahmad,3,5,8
+Mercer,Sharpsville 2,Auditor General,,DEM,Christina M. Hartman,10,9,19
+Mercer,Sharpsville 2,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sharpsville 2,State Treasurer,,DEM,Joe Torsella,52,68,120
+Mercer,Sharpsville 2,State Treasurer,,DEM,Write-In,1,1,2
+Mercer,Sharpsville 2,U.S. House,16,DEM,Kristy Gnibus,48,68,116
+Mercer,Sharpsville 2,U.S. House,16,DEM,Write-In,2,1,3
+Mercer,Sharpsville 2,General Assembly,7,DEM,Mark Longietti,66,78,144
+Mercer,Sharpsville 2,General Assembly,7,DEM,Write-In,0,1,1
+Mercer,Sharpsville 2,President,,REP,Donald J. Trump,53,18,71
+Mercer,Sharpsville 2,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Sharpsville 2,President,,REP,Bill Weld,2,1,3
+Mercer,Sharpsville 2,President,,REP,Write-In,0,0,0
+Mercer,Sharpsville 2,Attorney General,,REP,Heather Heidelbaugh,49,19,68
+Mercer,Sharpsville 2,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharpsville 2,Auditor General,,REP,Timothy Defoor,49,18,67
+Mercer,Sharpsville 2,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sharpsville 2,State Treasurer,,REP,Stacy L. Garrity,49,19,68
+Mercer,Sharpsville 2,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharpsville 2,U.S. House,16,REP,Mike Kelly,48,20,68
+Mercer,Sharpsville 2,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Sharpsville 2,General Assembly,7,REP,Write-In,9,3,12
+Mercer,Sharpsville 2,General Assembly,7,REP,Mark Longietti,4,1,5
+Mercer,Sharpsville 3,Registered Voters,,,,,,932
+Mercer,Sharpsville 3,Registered Voters,,DEM,,,,638
+Mercer,Sharpsville 3,Registered Voters,,REP,,,,294
+Mercer,Sharpsville 3,Registered Voters,,NPA,,,,0
+Mercer,Sharpsville 3,Ballots Cast,,,,193,141,334
+Mercer,Sharpsville 3,Ballots Cast,,DEM,,113,126,239
+Mercer,Sharpsville 3,Ballots Cast,,REP,,80,15,95
+Mercer,Sharpsville 3,Ballots Cast,,NPA,,0,0,0
+Mercer,Sharpsville 3,President,,DEM,Bernie Sanders,15,12,27
+Mercer,Sharpsville 3,President,,DEM,Joseph R. Biden,73,107,180
+Mercer,Sharpsville 3,President,,DEM,Tulsi Gabbard,4,1,5
+Mercer,Sharpsville 3,President,,DEM,Elizabeth Warren,4,1,5
+Mercer,Sharpsville 3,President,,DEM,Write-In,9,1,10
+Mercer,Sharpsville 3,Attorney General,,DEM,Josh Shapiro,95,101,196
+Mercer,Sharpsville 3,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Sharpsville 3,Auditor General,,DEM,H. Scott Conklin,10,5,15
+Mercer,Sharpsville 3,Auditor General,,DEM,Michael Lamb,57,83,140
+Mercer,Sharpsville 3,Auditor General,,DEM,Tracie Fountain,2,4,6
+Mercer,Sharpsville 3,Auditor General,,DEM,Rose Rosie Marie Davis,7,4,11
+Mercer,Sharpsville 3,Auditor General,,DEM,Nina Ahmad,8,6,14
+Mercer,Sharpsville 3,Auditor General,,DEM,Christina M. Hartman,11,6,17
+Mercer,Sharpsville 3,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sharpsville 3,State Treasurer,,DEM,Joe Torsella,89,99,188
+Mercer,Sharpsville 3,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Sharpsville 3,U.S. House,16,DEM,Kristy Gnibus,92,99,191
+Mercer,Sharpsville 3,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Sharpsville 3,General Assembly,7,DEM,Mark Longietti,110,120,230
+Mercer,Sharpsville 3,General Assembly,7,DEM,Write-In,1,1,2
+Mercer,Sharpsville 3,President,,REP,Donald J. Trump,75,8,83
+Mercer,Sharpsville 3,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Sharpsville 3,President,,REP,Bill Weld,3,1,4
+Mercer,Sharpsville 3,President,,REP,Write-In,0,4,4
+Mercer,Sharpsville 3,Attorney General,,REP,Heather Heidelbaugh,68,14,82
+Mercer,Sharpsville 3,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sharpsville 3,Auditor General,,REP,Timothy Defoor,65,12,77
+Mercer,Sharpsville 3,Auditor General,,REP,Write-In,0,2,2
+Mercer,Sharpsville 3,State Treasurer,,REP,Stacy L. Garrity,63,15,78
+Mercer,Sharpsville 3,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sharpsville 3,U.S. House,16,REP,Mike Kelly,76,13,89
+Mercer,Sharpsville 3,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Sharpsville 3,General Assembly,7,REP,Write-In,16,6,22
+Mercer,Sharpsville 3,General Assembly,7,REP,Mark Longietti,10,5,15
+Mercer,Sheakleyville,Registered Voters,,,,,,65
+Mercer,Sheakleyville,Registered Voters,,DEM,,,,15
+Mercer,Sheakleyville,Registered Voters,,REP,,,,50
+Mercer,Sheakleyville,Registered Voters,,NPA,,,,0
+Mercer,Sheakleyville,Ballots Cast,,,,19,7,26
+Mercer,Sheakleyville,Ballots Cast,,DEM,,3,1,4
+Mercer,Sheakleyville,Ballots Cast,,REP,,16,6,22
+Mercer,Sheakleyville,Ballots Cast,,NPA,,0,0,0
+Mercer,Sheakleyville,President,,DEM,Bernie Sanders,1,0,1
+Mercer,Sheakleyville,President,,DEM,Joseph R. Biden,2,1,3
+Mercer,Sheakleyville,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Sheakleyville,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Sheakleyville,President,,DEM,Write-In,0,0,0
+Mercer,Sheakleyville,Attorney General,,DEM,Josh Shapiro,3,1,4
+Mercer,Sheakleyville,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Sheakleyville,Auditor General,,DEM,H. Scott Conklin,1,0,1
+Mercer,Sheakleyville,Auditor General,,DEM,Michael Lamb,1,0,1
+Mercer,Sheakleyville,Auditor General,,DEM,Tracie Fountain,0,0,0
+Mercer,Sheakleyville,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0
+Mercer,Sheakleyville,Auditor General,,DEM,Nina Ahmad,0,1,1
+Mercer,Sheakleyville,Auditor General,,DEM,Christina M. Hartman,1,0,1
+Mercer,Sheakleyville,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Sheakleyville,State Treasurer,,DEM,Joe Torsella,3,1,4
+Mercer,Sheakleyville,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Sheakleyville,U.S. House,16,DEM,Kristy Gnibus,3,1,4
+Mercer,Sheakleyville,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Sheakleyville,General Assembly,8,DEM,Phil Heasley,3,1,4
+Mercer,Sheakleyville,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Sheakleyville,President,,REP,Donald J. Trump,15,6,21
+Mercer,Sheakleyville,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Sheakleyville,President,,REP,Bill Weld,0,0,0
+Mercer,Sheakleyville,President,,REP,Write-In,1,0,1
+Mercer,Sheakleyville,Attorney General,,REP,Heather Heidelbaugh,14,6,20
+Mercer,Sheakleyville,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sheakleyville,Auditor General,,REP,Timothy Defoor,14,6,20
+Mercer,Sheakleyville,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sheakleyville,State Treasurer,,REP,Stacy L. Garrity,14,6,20
+Mercer,Sheakleyville,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sheakleyville,U.S. House,16,REP,Mike Kelly,14,6,20
+Mercer,Sheakleyville,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Sheakleyville,General Assembly,8,REP,Scott Jaillet,1,0,1
+Mercer,Sheakleyville,General Assembly,8,REP,Tim Bonner,14,6,20
+Mercer,Sheakleyville,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Shenango East,Registered Voters,,,,,,1042
+Mercer,Shenango East,Registered Voters,,DEM,,,,495
+Mercer,Shenango East,Registered Voters,,REP,,,,547
+Mercer,Shenango East,Registered Voters,,NPA,,,,0
+Mercer,Shenango East,Ballots Cast,,,,179,167,346
+Mercer,Shenango East,Ballots Cast,,DEM,,80,110,190
+Mercer,Shenango East,Ballots Cast,,REP,,99,57,156
+Mercer,Shenango East,Ballots Cast,,NPA,,0,0,0
+Mercer,Shenango East,President,,DEM,Bernie Sanders,12,12,24
+Mercer,Shenango East,President,,DEM,Joseph R. Biden,51,94,145
+Mercer,Shenango East,President,,DEM,Tulsi Gabbard,0,1,1
+Mercer,Shenango East,President,,DEM,Elizabeth Warren,3,1,4
+Mercer,Shenango East,President,,DEM,Write-In,8,0,8
+Mercer,Shenango East,Attorney General,,DEM,Josh Shapiro,62,102,164
+Mercer,Shenango East,Attorney General,,DEM,Write-In,2,0,2
+Mercer,Shenango East,Auditor General,,DEM,H. Scott Conklin,6,0,6
+Mercer,Shenango East,Auditor General,,DEM,Michael Lamb,35,72,107
+Mercer,Shenango East,Auditor General,,DEM,Tracie Fountain,2,3,5
+Mercer,Shenango East,Auditor General,,DEM,Rose Rosie Marie Davis,3,4,7
+Mercer,Shenango East,Auditor General,,DEM,Nina Ahmad,6,6,12
+Mercer,Shenango East,Auditor General,,DEM,Christina M. Hartman,14,12,26
+Mercer,Shenango East,Auditor General,,DEM,Write-In,2,0,2
+Mercer,Shenango East,State Treasurer,,DEM,Joe Torsella,62,96,158
+Mercer,Shenango East,State Treasurer,,DEM,Write-In,2,0,2
+Mercer,Shenango East,U.S. House,16,DEM,Kristy Gnibus,61,99,160
+Mercer,Shenango East,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,Shenango East,General Assembly,7,DEM,Mark Longietti,71,107,178
+Mercer,Shenango East,General Assembly,7,DEM,Write-In,1,1,2
+Mercer,Shenango East,President,,REP,Donald J. Trump,98,52,150
+Mercer,Shenango East,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Shenango East,President,,REP,Bill Weld,0,4,4
+Mercer,Shenango East,President,,REP,Write-In,0,1,1
+Mercer,Shenango East,Attorney General,,REP,Heather Heidelbaugh,86,53,139
+Mercer,Shenango East,Attorney General,,REP,Write-In,0,0,0
+Mercer,Shenango East,Auditor General,,REP,Timothy Defoor,81,53,134
+Mercer,Shenango East,Auditor General,,REP,Write-In,0,0,0
+Mercer,Shenango East,State Treasurer,,REP,Stacy L. Garrity,86,53,139
+Mercer,Shenango East,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Shenango East,U.S. House,16,REP,Mike Kelly,93,53,146
+Mercer,Shenango East,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Shenango East,General Assembly,7,REP,Write-In,12,12,24
+Mercer,Shenango East,General Assembly,7,REP,Mark Longietti,9,9,18
+Mercer,Shenango West,Registered Voters,,,,,,1210
+Mercer,Shenango West,Registered Voters,,DEM,,,,590
+Mercer,Shenango West,Registered Voters,,REP,,,,620
+Mercer,Shenango West,Registered Voters,,NPA,,,,0
+Mercer,Shenango West,Ballots Cast,,,,183,192,375
+Mercer,Shenango West,Ballots Cast,,DEM,,75,139,214
+Mercer,Shenango West,Ballots Cast,,REP,,108,53,161
+Mercer,Shenango West,Ballots Cast,,NPA,,0,0,0
+Mercer,Shenango West,President,,DEM,Bernie Sanders,13,10,23
+Mercer,Shenango West,President,,DEM,Joseph R. Biden,40,117,157
+Mercer,Shenango West,President,,DEM,Tulsi Gabbard,3,3,6
+Mercer,Shenango West,President,,DEM,Elizabeth Warren,6,1,7
+Mercer,Shenango West,President,,DEM,Write-In,3,4,7
+Mercer,Shenango West,Attorney General,,DEM,Josh Shapiro,60,119,179
+Mercer,Shenango West,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Shenango West,Auditor General,,DEM,H. Scott Conklin,5,7,12
+Mercer,Shenango West,Auditor General,,DEM,Michael Lamb,32,93,125
+Mercer,Shenango West,Auditor General,,DEM,Tracie Fountain,4,6,10
+Mercer,Shenango West,Auditor General,,DEM,Rose Rosie Marie Davis,4,3,7
+Mercer,Shenango West,Auditor General,,DEM,Nina Ahmad,3,1,4
+Mercer,Shenango West,Auditor General,,DEM,Christina M. Hartman,10,6,16
+Mercer,Shenango West,Auditor General,,DEM,Write-In,0,2,2
+Mercer,Shenango West,State Treasurer,,DEM,Joe Torsella,53,111,164
+Mercer,Shenango West,State Treasurer,,DEM,Write-In,0,1,1
+Mercer,Shenango West,U.S. House,16,DEM,Kristy Gnibus,55,115,170
+Mercer,Shenango West,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Shenango West,General Assembly,7,DEM,Mark Longietti,69,136,205
+Mercer,Shenango West,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Shenango West,President,,REP,Donald J. Trump,108,48,156
+Mercer,Shenango West,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Shenango West,President,,REP,Bill Weld,0,2,2
+Mercer,Shenango West,President,,REP,Write-In,0,1,1
+Mercer,Shenango West,Attorney General,,REP,Heather Heidelbaugh,92,47,139
+Mercer,Shenango West,Attorney General,,REP,Write-In,0,0,0
+Mercer,Shenango West,Auditor General,,REP,Timothy Defoor,91,47,138
+Mercer,Shenango West,Auditor General,,REP,Write-In,0,0,0
+Mercer,Shenango West,State Treasurer,,REP,Stacy L. Garrity,89,47,136
+Mercer,Shenango West,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Shenango West,U.S. House,16,REP,Mike Kelly,98,50,148
+Mercer,Shenango West,U.S. House,16,REP,Write-In,1,1,2
+Mercer,Shenango West,General Assembly,7,REP,Write-In,16,7,23
+Mercer,Shenango West,General Assembly,7,REP,Mark Longietti,7,6,13
+Mercer,South Pymatuning 1,Registered Voters,,,,,,964
+Mercer,South Pymatuning 1,Registered Voters,,DEM,,,,502
+Mercer,South Pymatuning 1,Registered Voters,,REP,,,,462
+Mercer,South Pymatuning 1,Registered Voters,,NPA,,,,0
+Mercer,South Pymatuning 1,Ballots Cast,,,,155,154,309
+Mercer,South Pymatuning 1,Ballots Cast,,DEM,,61,96,157
+Mercer,South Pymatuning 1,Ballots Cast,,REP,,94,58,152
+Mercer,South Pymatuning 1,Ballots Cast,,NPA,,0,0,0
+Mercer,South Pymatuning 1,President,,DEM,Bernie Sanders,13,10,23
+Mercer,South Pymatuning 1,President,,DEM,Joseph R. Biden,34,85,119
+Mercer,South Pymatuning 1,President,,DEM,Tulsi Gabbard,2,0,2
+Mercer,South Pymatuning 1,President,,DEM,Elizabeth Warren,3,1,4
+Mercer,South Pymatuning 1,President,,DEM,Write-In,3,0,3
+Mercer,South Pymatuning 1,Attorney General,,DEM,Josh Shapiro,52,89,141
+Mercer,South Pymatuning 1,Attorney General,,DEM,Write-In,1,0,1
+Mercer,South Pymatuning 1,Auditor General,,DEM,H. Scott Conklin,5,5,10
+Mercer,South Pymatuning 1,Auditor General,,DEM,Michael Lamb,29,65,94
+Mercer,South Pymatuning 1,Auditor General,,DEM,Tracie Fountain,3,4,7
+Mercer,South Pymatuning 1,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,4
+Mercer,South Pymatuning 1,Auditor General,,DEM,Nina Ahmad,3,9,12
+Mercer,South Pymatuning 1,Auditor General,,DEM,Christina M. Hartman,10,3,13
+Mercer,South Pymatuning 1,Auditor General,,DEM,Write-In,1,0,1
+Mercer,South Pymatuning 1,State Treasurer,,DEM,Joe Torsella,53,86,139
+Mercer,South Pymatuning 1,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,South Pymatuning 1,U.S. House,16,DEM,Kristy Gnibus,52,87,139
+Mercer,South Pymatuning 1,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,South Pymatuning 1,General Assembly,7,DEM,Mark Longietti,61,94,155
+Mercer,South Pymatuning 1,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,South Pymatuning 1,President,,REP,Donald J. Trump,88,49,137
+Mercer,South Pymatuning 1,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,South Pymatuning 1,President,,REP,Bill Weld,3,4,7
+Mercer,South Pymatuning 1,President,,REP,Write-In,0,2,2
+Mercer,South Pymatuning 1,Attorney General,,REP,Heather Heidelbaugh,79,45,124
+Mercer,South Pymatuning 1,Attorney General,,REP,Write-In,2,0,2
+Mercer,South Pymatuning 1,Auditor General,,REP,Timothy Defoor,78,44,122
+Mercer,South Pymatuning 1,Auditor General,,REP,Write-In,1,0,1
+Mercer,South Pymatuning 1,State Treasurer,,REP,Stacy L. Garrity,76,44,120
+Mercer,South Pymatuning 1,State Treasurer,,REP,Write-In,2,0,2
+Mercer,South Pymatuning 1,U.S. House,16,REP,Mike Kelly,87,49,136
+Mercer,South Pymatuning 1,U.S. House,16,REP,Write-In,1,0,1
+Mercer,South Pymatuning 1,General Assembly,7,REP,Write-In,27,16,43
+Mercer,South Pymatuning 1,General Assembly,7,REP,Mark Longietti,20,13,33
+Mercer,South Pymatuning 2,Registered Voters,,,,,,733
+Mercer,South Pymatuning 2,Registered Voters,,DEM,,,,411
+Mercer,South Pymatuning 2,Registered Voters,,REP,,,,322
+Mercer,South Pymatuning 2,Registered Voters,,NPA,,,,0
+Mercer,South Pymatuning 2,Ballots Cast,,,,106,111,217
+Mercer,South Pymatuning 2,Ballots Cast,,DEM,,45,80,125
+Mercer,South Pymatuning 2,Ballots Cast,,REP,,61,31,92
+Mercer,South Pymatuning 2,Ballots Cast,,NPA,,0,0,0
+Mercer,South Pymatuning 2,President,,DEM,Bernie Sanders,10,10,20
+Mercer,South Pymatuning 2,President,,DEM,Joseph R. Biden,26,67,93
+Mercer,South Pymatuning 2,President,,DEM,Tulsi Gabbard,0,1,1
+Mercer,South Pymatuning 2,President,,DEM,Elizabeth Warren,2,1,3
+Mercer,South Pymatuning 2,President,,DEM,Write-In,5,1,6
+Mercer,South Pymatuning 2,Attorney General,,DEM,Josh Shapiro,41,69,110
+Mercer,South Pymatuning 2,Attorney General,,DEM,Write-In,1,0,1
+Mercer,South Pymatuning 2,Auditor General,,DEM,H. Scott Conklin,3,4,7
+Mercer,South Pymatuning 2,Auditor General,,DEM,Michael Lamb,23,48,71
+Mercer,South Pymatuning 2,Auditor General,,DEM,Tracie Fountain,0,4,4
+Mercer,South Pymatuning 2,Auditor General,,DEM,Rose Rosie Marie Davis,5,2,7
+Mercer,South Pymatuning 2,Auditor General,,DEM,Nina Ahmad,2,4,6
+Mercer,South Pymatuning 2,Auditor General,,DEM,Christina M. Hartman,7,8,15
+Mercer,South Pymatuning 2,Auditor General,,DEM,Write-In,1,0,1
+Mercer,South Pymatuning 2,State Treasurer,,DEM,Joe Torsella,36,65,101
+Mercer,South Pymatuning 2,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,South Pymatuning 2,U.S. House,16,DEM,Kristy Gnibus,37,66,103
+Mercer,South Pymatuning 2,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,South Pymatuning 2,General Assembly,7,DEM,Mark Longietti,43,79,122
+Mercer,South Pymatuning 2,General Assembly,7,DEM,Write-In,0,1,1
+Mercer,South Pymatuning 2,President,,REP,Donald J. Trump,60,22,82
+Mercer,South Pymatuning 2,President,,REP,Roque Rocky De La Fuente,1,1,2
+Mercer,South Pymatuning 2,President,,REP,Bill Weld,0,5,5
+Mercer,South Pymatuning 2,President,,REP,Write-In,0,2,2
+Mercer,South Pymatuning 2,Attorney General,,REP,Heather Heidelbaugh,52,22,74
+Mercer,South Pymatuning 2,Attorney General,,REP,Write-In,0,0,0
+Mercer,South Pymatuning 2,Auditor General,,REP,Timothy Defoor,50,23,73
+Mercer,South Pymatuning 2,Auditor General,,REP,Write-In,0,0,0
+Mercer,South Pymatuning 2,State Treasurer,,REP,Stacy L. Garrity,49,24,73
+Mercer,South Pymatuning 2,State Treasurer,,REP,Write-In,0,0,0
+Mercer,South Pymatuning 2,U.S. House,16,REP,Mike Kelly,53,25,78
+Mercer,South Pymatuning 2,U.S. House,16,REP,Write-In,2,0,2
+Mercer,South Pymatuning 2,General Assembly,7,REP,Write-In,15,12,27
+Mercer,South Pymatuning 2,General Assembly,7,REP,Mark Longietti,14,9,23
+Mercer,Springfield,Registered Voters,,,,,,1057
+Mercer,Springfield,Registered Voters,,DEM,,,,336
+Mercer,Springfield,Registered Voters,,REP,,,,721
+Mercer,Springfield,Registered Voters,,NPA,,,,0
+Mercer,Springfield,Ballots Cast,,,,296,103,399
+Mercer,Springfield,Ballots Cast,,DEM,,53,48,101
+Mercer,Springfield,Ballots Cast,,REP,,243,55,298
+Mercer,Springfield,Ballots Cast,,NPA,,0,0,0
+Mercer,Springfield,President,,DEM,Bernie Sanders,5,1,6
+Mercer,Springfield,President,,DEM,Joseph R. Biden,31,44,75
+Mercer,Springfield,President,,DEM,Tulsi Gabbard,3,0,3
+Mercer,Springfield,President,,DEM,Elizabeth Warren,3,0,3
+Mercer,Springfield,President,,DEM,Write-In,6,1,7
+Mercer,Springfield,Attorney General,,DEM,Josh Shapiro,47,47,94
+Mercer,Springfield,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Springfield,Auditor General,,DEM,H. Scott Conklin,9,8,17
+Mercer,Springfield,Auditor General,,DEM,Michael Lamb,25,31,56
+Mercer,Springfield,Auditor General,,DEM,Tracie Fountain,4,0,4
+Mercer,Springfield,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,6
+Mercer,Springfield,Auditor General,,DEM,Nina Ahmad,5,4,9
+Mercer,Springfield,Auditor General,,DEM,Christina M. Hartman,4,1,5
+Mercer,Springfield,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Springfield,State Treasurer,,DEM,Joe Torsella,44,46,90
+Mercer,Springfield,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,Springfield,U.S. House,16,DEM,Kristy Gnibus,45,47,92
+Mercer,Springfield,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Springfield,General Assembly,8,DEM,Phil Heasley,45,45,90
+Mercer,Springfield,General Assembly,8,DEM,Write-In,1,0,1
+Mercer,Springfield,President,,REP,Donald J. Trump,235,50,285
+Mercer,Springfield,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Springfield,President,,REP,Bill Weld,1,3,4
+Mercer,Springfield,President,,REP,Write-In,1,2,3
+Mercer,Springfield,Attorney General,,REP,Heather Heidelbaugh,213,48,261
+Mercer,Springfield,Attorney General,,REP,Write-In,1,0,1
+Mercer,Springfield,Auditor General,,REP,Timothy Defoor,209,45,254
+Mercer,Springfield,Auditor General,,REP,Write-In,0,0,0
+Mercer,Springfield,State Treasurer,,REP,Stacy L. Garrity,214,47,261
+Mercer,Springfield,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Springfield,U.S. House,16,REP,Mike Kelly,231,49,280
+Mercer,Springfield,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Springfield,General Assembly,8,REP,Scott Jaillet,16,8,24
+Mercer,Springfield,General Assembly,8,REP,Tim Bonner,219,46,265
+Mercer,Springfield,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Stoneboro,Registered Voters,,,,,,575
+Mercer,Stoneboro,Registered Voters,,DEM,,,,195
+Mercer,Stoneboro,Registered Voters,,REP,,,,380
+Mercer,Stoneboro,Registered Voters,,NPA,,,,0
+Mercer,Stoneboro,Ballots Cast,,,,139,59,198
+Mercer,Stoneboro,Ballots Cast,,DEM,,38,25,63
+Mercer,Stoneboro,Ballots Cast,,REP,,101,34,135
+Mercer,Stoneboro,Ballots Cast,,NPA,,0,0,0
+Mercer,Stoneboro,President,,DEM,Bernie Sanders,6,0,6
+Mercer,Stoneboro,President,,DEM,Joseph R. Biden,25,24,49
+Mercer,Stoneboro,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,Stoneboro,President,,DEM,Elizabeth Warren,2,0,2
+Mercer,Stoneboro,President,,DEM,Write-In,2,0,2
+Mercer,Stoneboro,Attorney General,,DEM,Josh Shapiro,35,22,57
+Mercer,Stoneboro,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Stoneboro,Auditor General,,DEM,H. Scott Conklin,4,1,5
+Mercer,Stoneboro,Auditor General,,DEM,Michael Lamb,21,16,37
+Mercer,Stoneboro,Auditor General,,DEM,Tracie Fountain,0,1,1
+Mercer,Stoneboro,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Stoneboro,Auditor General,,DEM,Nina Ahmad,3,0,3
+Mercer,Stoneboro,Auditor General,,DEM,Christina M. Hartman,7,5,12
+Mercer,Stoneboro,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Stoneboro,State Treasurer,,DEM,Joe Torsella,32,21,53
+Mercer,Stoneboro,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Stoneboro,U.S. House,16,DEM,Kristy Gnibus,34,22,56
+Mercer,Stoneboro,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Stoneboro,General Assembly,8,DEM,Phil Heasley,34,22,56
+Mercer,Stoneboro,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Stoneboro,President,,REP,Donald J. Trump,97,30,127
+Mercer,Stoneboro,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Stoneboro,President,,REP,Bill Weld,3,4,7
+Mercer,Stoneboro,President,,REP,Write-In,0,0,0
+Mercer,Stoneboro,Attorney General,,REP,Heather Heidelbaugh,91,33,124
+Mercer,Stoneboro,Attorney General,,REP,Write-In,0,0,0
+Mercer,Stoneboro,Auditor General,,REP,Timothy Defoor,87,33,120
+Mercer,Stoneboro,Auditor General,,REP,Write-In,0,0,0
+Mercer,Stoneboro,State Treasurer,,REP,Stacy L. Garrity,89,33,122
+Mercer,Stoneboro,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Stoneboro,U.S. House,16,REP,Mike Kelly,91,34,125
+Mercer,Stoneboro,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Stoneboro,General Assembly,8,REP,Scott Jaillet,10,4,14
+Mercer,Stoneboro,General Assembly,8,REP,Tim Bonner,88,30,118
+Mercer,Stoneboro,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Sugar Grove,Registered Voters,,,,,,564
+Mercer,Sugar Grove,Registered Voters,,DEM,,,,214
+Mercer,Sugar Grove,Registered Voters,,REP,,,,350
+Mercer,Sugar Grove,Registered Voters,,NPA,,,,0
+Mercer,Sugar Grove,Ballots Cast,,,,151,51,202
+Mercer,Sugar Grove,Ballots Cast,,DEM,,42,30,72
+Mercer,Sugar Grove,Ballots Cast,,REP,,109,21,130
+Mercer,Sugar Grove,Ballots Cast,,NPA,,0,0,0
+Mercer,Sugar Grove,President,,DEM,Bernie Sanders,9,2,11
+Mercer,Sugar Grove,President,,DEM,Joseph R. Biden,19,24,43
+Mercer,Sugar Grove,President,,DEM,Tulsi Gabbard,0,2,2
+Mercer,Sugar Grove,President,,DEM,Elizabeth Warren,0,0,0
+Mercer,Sugar Grove,President,,DEM,Write-In,9,1,10
+Mercer,Sugar Grove,Attorney General,,DEM,Josh Shapiro,33,25,58
+Mercer,Sugar Grove,Attorney General,,DEM,Write-In,5,0,5
+Mercer,Sugar Grove,Auditor General,,DEM,H. Scott Conklin,2,2,4
+Mercer,Sugar Grove,Auditor General,,DEM,Michael Lamb,15,12,27
+Mercer,Sugar Grove,Auditor General,,DEM,Tracie Fountain,1,4,5
+Mercer,Sugar Grove,Auditor General,,DEM,Rose Rosie Marie Davis,5,2,7
+Mercer,Sugar Grove,Auditor General,,DEM,Nina Ahmad,1,0,1
+Mercer,Sugar Grove,Auditor General,,DEM,Christina M. Hartman,10,6,16
+Mercer,Sugar Grove,Auditor General,,DEM,Write-In,4,0,4
+Mercer,Sugar Grove,State Treasurer,,DEM,Joe Torsella,34,23,57
+Mercer,Sugar Grove,State Treasurer,,DEM,Write-In,2,0,2
+Mercer,Sugar Grove,U.S. House,16,DEM,Kristy Gnibus,31,23,54
+Mercer,Sugar Grove,U.S. House,16,DEM,Write-In,4,0,4
+Mercer,Sugar Grove,General Assembly,17,DEM,Write-In,5,3,8
+Mercer,Sugar Grove,General Assembly,17,DEM,Jeff O'Melian,0,0,0
+Mercer,Sugar Grove,President,,REP,Donald J. Trump,104,17,121
+Mercer,Sugar Grove,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Sugar Grove,President,,REP,Bill Weld,1,1,2
+Mercer,Sugar Grove,President,,REP,Write-In,0,1,1
+Mercer,Sugar Grove,Attorney General,,REP,Heather Heidelbaugh,95,19,114
+Mercer,Sugar Grove,Attorney General,,REP,Write-In,0,0,0
+Mercer,Sugar Grove,Auditor General,,REP,Timothy Defoor,92,19,111
+Mercer,Sugar Grove,Auditor General,,REP,Write-In,0,0,0
+Mercer,Sugar Grove,State Treasurer,,REP,Stacy L. Garrity,95,19,114
+Mercer,Sugar Grove,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Sugar Grove,U.S. House,16,REP,Mike Kelly,104,21,125
+Mercer,Sugar Grove,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Sugar Grove,General Assembly,17,REP,Parke Wentling,100,21,121
+Mercer,Sugar Grove,General Assembly,17,REP,Write-In,0,0,0
+Mercer,West Middlesex,Registered Voters,,,,,,518
+Mercer,West Middlesex,Registered Voters,,DEM,,,,256
+Mercer,West Middlesex,Registered Voters,,REP,,,,262
+Mercer,West Middlesex,Registered Voters,,NPA,,,,0
+Mercer,West Middlesex,Ballots Cast,,,,144,36,180
+Mercer,West Middlesex,Ballots Cast,,DEM,,60,20,80
+Mercer,West Middlesex,Ballots Cast,,REP,,84,16,100
+Mercer,West Middlesex,Ballots Cast,,NPA,,0,0,0
+Mercer,West Middlesex,President,,DEM,Bernie Sanders,12,2,14
+Mercer,West Middlesex,President,,DEM,Joseph R. Biden,36,16,52
+Mercer,West Middlesex,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,West Middlesex,President,,DEM,Elizabeth Warren,4,0,4
+Mercer,West Middlesex,President,,DEM,Write-In,1,0,1
+Mercer,West Middlesex,Attorney General,,DEM,Josh Shapiro,47,19,66
+Mercer,West Middlesex,Attorney General,,DEM,Write-In,0,0,0
+Mercer,West Middlesex,Auditor General,,DEM,H. Scott Conklin,4,0,4
+Mercer,West Middlesex,Auditor General,,DEM,Michael Lamb,31,13,44
+Mercer,West Middlesex,Auditor General,,DEM,Tracie Fountain,0,1,1
+Mercer,West Middlesex,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,3
+Mercer,West Middlesex,Auditor General,,DEM,Nina Ahmad,3,4,7
+Mercer,West Middlesex,Auditor General,,DEM,Christina M. Hartman,8,1,9
+Mercer,West Middlesex,Auditor General,,DEM,Write-In,0,0,0
+Mercer,West Middlesex,State Treasurer,,DEM,Joe Torsella,48,18,66
+Mercer,West Middlesex,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,West Middlesex,U.S. House,16,DEM,Kristy Gnibus,48,18,66
+Mercer,West Middlesex,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,West Middlesex,General Assembly,7,DEM,Mark Longietti,60,19,79
+Mercer,West Middlesex,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,West Middlesex,President,,REP,Donald J. Trump,77,12,89
+Mercer,West Middlesex,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,West Middlesex,President,,REP,Bill Weld,2,1,3
+Mercer,West Middlesex,President,,REP,Write-In,1,2,3
+Mercer,West Middlesex,Attorney General,,REP,Heather Heidelbaugh,79,15,94
+Mercer,West Middlesex,Attorney General,,REP,Write-In,1,0,1
+Mercer,West Middlesex,Auditor General,,REP,Timothy Defoor,76,15,91
+Mercer,West Middlesex,Auditor General,,REP,Write-In,1,0,1
+Mercer,West Middlesex,State Treasurer,,REP,Stacy L. Garrity,78,15,93
+Mercer,West Middlesex,State Treasurer,,REP,Write-In,1,0,1
+Mercer,West Middlesex,U.S. House,16,REP,Mike Kelly,80,14,94
+Mercer,West Middlesex,U.S. House,16,REP,Write-In,0,0,0
+Mercer,West Middlesex,General Assembly,7,REP,Write-In,19,5,24
+Mercer,West Middlesex,General Assembly,7,REP,Mark Longietti,15,5,20
+Mercer,West Salem East,Registered Voters,,,,,,674
+Mercer,West Salem East,Registered Voters,,DEM,,,,282
+Mercer,West Salem East,Registered Voters,,REP,,,,392
+Mercer,West Salem East,Registered Voters,,NPA,,,,0
+Mercer,West Salem East,Ballots Cast,,,,135,128,263
+Mercer,West Salem East,Ballots Cast,,DEM,,32,69,101
+Mercer,West Salem East,Ballots Cast,,REP,,103,59,162
+Mercer,West Salem East,Ballots Cast,,NPA,,0,0,0
+Mercer,West Salem East,President,,DEM,Bernie Sanders,2,3,5
+Mercer,West Salem East,President,,DEM,Joseph R. Biden,25,62,87
+Mercer,West Salem East,President,,DEM,Tulsi Gabbard,1,1,2
+Mercer,West Salem East,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,West Salem East,President,,DEM,Write-In,1,0,1
+Mercer,West Salem East,Attorney General,,DEM,Josh Shapiro,25,60,85
+Mercer,West Salem East,Attorney General,,DEM,Write-In,0,0,0
+Mercer,West Salem East,Auditor General,,DEM,H. Scott Conklin,2,3,5
+Mercer,West Salem East,Auditor General,,DEM,Michael Lamb,20,45,65
+Mercer,West Salem East,Auditor General,,DEM,Tracie Fountain,0,4,4
+Mercer,West Salem East,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,6
+Mercer,West Salem East,Auditor General,,DEM,Nina Ahmad,0,0,0
+Mercer,West Salem East,Auditor General,,DEM,Christina M. Hartman,4,6,10
+Mercer,West Salem East,Auditor General,,DEM,Write-In,0,0,0
+Mercer,West Salem East,State Treasurer,,DEM,Joe Torsella,24,58,82
+Mercer,West Salem East,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,West Salem East,U.S. House,16,DEM,Kristy Gnibus,24,62,86
+Mercer,West Salem East,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,West Salem East,General Assembly,7,DEM,Mark Longietti,31,68,99
+Mercer,West Salem East,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,West Salem East,President,,REP,Donald J. Trump,97,46,143
+Mercer,West Salem East,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,West Salem East,President,,REP,Bill Weld,1,8,9
+Mercer,West Salem East,President,,REP,Write-In,0,4,4
+Mercer,West Salem East,Attorney General,,REP,Heather Heidelbaugh,99,50,149
+Mercer,West Salem East,Attorney General,,REP,Write-In,1,1,2
+Mercer,West Salem East,Auditor General,,REP,Timothy Defoor,99,51,150
+Mercer,West Salem East,Auditor General,,REP,Write-In,1,0,1
+Mercer,West Salem East,State Treasurer,,REP,Stacy L. Garrity,98,52,150
+Mercer,West Salem East,State Treasurer,,REP,Write-In,0,0,0
+Mercer,West Salem East,U.S. House,16,REP,Mike Kelly,101,51,152
+Mercer,West Salem East,U.S. House,16,REP,Write-In,0,3,3
+Mercer,West Salem East,General Assembly,7,REP,Write-In,28,15,43
+Mercer,West Salem East,General Assembly,7,REP,Mark Longietti,21,11,32
+Mercer,West Salem West,Registered Voters,,,,,,1028
+Mercer,West Salem West,Registered Voters,,DEM,,,,439
+Mercer,West Salem West,Registered Voters,,REP,,,,589
+Mercer,West Salem West,Registered Voters,,NPA,,,,0
+Mercer,West Salem West,Ballots Cast,,,,195,97,292
+Mercer,West Salem West,Ballots Cast,,DEM,,63,55,118
+Mercer,West Salem West,Ballots Cast,,REP,,132,42,174
+Mercer,West Salem West,Ballots Cast,,NPA,,0,0,0
+Mercer,West Salem West,President,,DEM,Bernie Sanders,6,8,14
+Mercer,West Salem West,President,,DEM,Joseph R. Biden,47,42,89
+Mercer,West Salem West,President,,DEM,Tulsi Gabbard,2,3,5
+Mercer,West Salem West,President,,DEM,Elizabeth Warren,2,2,4
+Mercer,West Salem West,President,,DEM,Write-In,6,0,6
+Mercer,West Salem West,Attorney General,,DEM,Josh Shapiro,54,47,101
+Mercer,West Salem West,Attorney General,,DEM,Write-In,0,0,0
+Mercer,West Salem West,Auditor General,,DEM,H. Scott Conklin,6,2,8
+Mercer,West Salem West,Auditor General,,DEM,Michael Lamb,29,32,61
+Mercer,West Salem West,Auditor General,,DEM,Tracie Fountain,3,3,6
+Mercer,West Salem West,Auditor General,,DEM,Rose Rosie Marie Davis,4,1,5
+Mercer,West Salem West,Auditor General,,DEM,Nina Ahmad,2,3,5
+Mercer,West Salem West,Auditor General,,DEM,Christina M. Hartman,12,8,20
+Mercer,West Salem West,Auditor General,,DEM,Write-In,0,0,0
+Mercer,West Salem West,State Treasurer,,DEM,Joe Torsella,53,46,99
+Mercer,West Salem West,State Treasurer,,DEM,Write-In,1,0,1
+Mercer,West Salem West,U.S. House,16,DEM,Kristy Gnibus,53,48,101
+Mercer,West Salem West,U.S. House,16,DEM,Write-In,2,0,2
+Mercer,West Salem West,General Assembly,7,DEM,Mark Longietti,60,51,111
+Mercer,West Salem West,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,West Salem West,President,,REP,Donald J. Trump,122,35,157
+Mercer,West Salem West,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,West Salem West,President,,REP,Bill Weld,3,2,5
+Mercer,West Salem West,President,,REP,Write-In,3,2,5
+Mercer,West Salem West,Attorney General,,REP,Heather Heidelbaugh,127,38,165
+Mercer,West Salem West,Attorney General,,REP,Write-In,1,0,1
+Mercer,West Salem West,Auditor General,,REP,Timothy Defoor,121,36,157
+Mercer,West Salem West,Auditor General,,REP,Write-In,1,0,1
+Mercer,West Salem West,State Treasurer,,REP,Stacy L. Garrity,122,38,160
+Mercer,West Salem West,State Treasurer,,REP,Write-In,2,0,2
+Mercer,West Salem West,U.S. House,16,REP,Mike Kelly,125,39,164
+Mercer,West Salem West,U.S. House,16,REP,Write-In,1,1,2
+Mercer,West Salem West,General Assembly,7,REP,Write-In,22,5,27
+Mercer,West Salem West,General Assembly,7,REP,Mark Longietti,16,3,19
+Mercer,Wheatland,Registered Voters,,,,,,403
+Mercer,Wheatland,Registered Voters,,DEM,,,,254
+Mercer,Wheatland,Registered Voters,,REP,,,,95
+Mercer,Wheatland,Registered Voters,,NPA,,,,54
+Mercer,Wheatland,Ballots Cast,,,,68,43,111
+Mercer,Wheatland,Ballots Cast,,DEM,,54,29,83
+Mercer,Wheatland,Ballots Cast,,REP,,12,13,25
+Mercer,Wheatland,Ballots Cast,,NPA,,2,1,3
+Mercer,Wheatland,President,,DEM,Bernie Sanders,3,1,4
+Mercer,Wheatland,President,,DEM,Joseph R. Biden,43,25,68
+Mercer,Wheatland,President,,DEM,Tulsi Gabbard,1,0,1
+Mercer,Wheatland,President,,DEM,Elizabeth Warren,1,1,2
+Mercer,Wheatland,President,,DEM,Write-In,5,1,6
+Mercer,Wheatland,Attorney General,,DEM,Josh Shapiro,43,24,67
+Mercer,Wheatland,Attorney General,,DEM,Write-In,1,0,1
+Mercer,Wheatland,Auditor General,,DEM,H. Scott Conklin,4,1,5
+Mercer,Wheatland,Auditor General,,DEM,Michael Lamb,28,17,45
+Mercer,Wheatland,Auditor General,,DEM,Tracie Fountain,2,0,2
+Mercer,Wheatland,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Wheatland,Auditor General,,DEM,Nina Ahmad,4,3,7
+Mercer,Wheatland,Auditor General,,DEM,Christina M. Hartman,6,5,11
+Mercer,Wheatland,Auditor General,,DEM,Write-In,1,0,1
+Mercer,Wheatland,State Treasurer,,DEM,Joe Torsella,44,25,69
+Mercer,Wheatland,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Wheatland,U.S. House,16,DEM,Kristy Gnibus,47,25,72
+Mercer,Wheatland,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Wheatland,General Assembly,7,DEM,Mark Longietti,49,26,75
+Mercer,Wheatland,General Assembly,7,DEM,Write-In,0,0,0
+Mercer,Wheatland,President,,REP,Donald J. Trump,11,11,22
+Mercer,Wheatland,President,,REP,Roque Rocky De La Fuente,0,0,0
+Mercer,Wheatland,President,,REP,Bill Weld,1,2,3
+Mercer,Wheatland,President,,REP,Write-In,0,0,0
+Mercer,Wheatland,Attorney General,,REP,Heather Heidelbaugh,11,10,21
+Mercer,Wheatland,Attorney General,,REP,Write-In,0,0,0
+Mercer,Wheatland,Auditor General,,REP,Timothy Defoor,11,10,21
+Mercer,Wheatland,Auditor General,,REP,Write-In,0,0,0
+Mercer,Wheatland,State Treasurer,,REP,Stacy L. Garrity,11,11,22
+Mercer,Wheatland,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Wheatland,U.S. House,16,REP,Mike Kelly,10,10,20
+Mercer,Wheatland,U.S. House,16,REP,Write-In,0,0,0
+Mercer,Wheatland,General Assembly,7,REP,Write-In,3,1,4
+Mercer,Wheatland,General Assembly,7,REP,Mark Longietti,3,0,3
+Mercer,Wilmington,Registered Voters,,,,,,761
+Mercer,Wilmington,Registered Voters,,DEM,,,,162
+Mercer,Wilmington,Registered Voters,,REP,,,,599
+Mercer,Wilmington,Registered Voters,,NPA,,,,0
+Mercer,Wilmington,Ballots Cast,,,,140,110,250
+Mercer,Wilmington,Ballots Cast,,DEM,,25,35,60
+Mercer,Wilmington,Ballots Cast,,REP,,115,75,190
+Mercer,Wilmington,Ballots Cast,,NPA,,0,0,0
+Mercer,Wilmington,President,,DEM,Bernie Sanders,4,3,7
+Mercer,Wilmington,President,,DEM,Joseph R. Biden,17,29,46
+Mercer,Wilmington,President,,DEM,Tulsi Gabbard,0,1,1
+Mercer,Wilmington,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Wilmington,President,,DEM,Write-In,3,1,4
+Mercer,Wilmington,Attorney General,,DEM,Josh Shapiro,18,33,51
+Mercer,Wilmington,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Wilmington,Auditor General,,DEM,H. Scott Conklin,1,3,4
+Mercer,Wilmington,Auditor General,,DEM,Michael Lamb,17,25,42
+Mercer,Wilmington,Auditor General,,DEM,Tracie Fountain,0,0,0
+Mercer,Wilmington,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1
+Mercer,Wilmington,Auditor General,,DEM,Nina Ahmad,4,3,7
+Mercer,Wilmington,Auditor General,,DEM,Christina M. Hartman,0,3,3
+Mercer,Wilmington,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Wilmington,State Treasurer,,DEM,Joe Torsella,20,32,52
+Mercer,Wilmington,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Wilmington,U.S. House,16,DEM,Kristy Gnibus,19,33,52
+Mercer,Wilmington,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Wilmington,General Assembly,17,DEM,Write-In,0,3,3
+Mercer,Wilmington,General Assembly,17,DEM,Jeff O'Melian,0,0,0
+Mercer,Wilmington,President,,REP,Donald J. Trump,112,65,177
+Mercer,Wilmington,President,,REP,Roque Rocky De La Fuente,0,1,1
+Mercer,Wilmington,President,,REP,Bill Weld,2,5,7
+Mercer,Wilmington,President,,REP,Write-In,0,3,3
+Mercer,Wilmington,Attorney General,,REP,Heather Heidelbaugh,95,62,157
+Mercer,Wilmington,Attorney General,,REP,Write-In,0,1,1
+Mercer,Wilmington,Auditor General,,REP,Timothy Defoor,90,58,148
+Mercer,Wilmington,Auditor General,,REP,Write-In,0,1,1
+Mercer,Wilmington,State Treasurer,,REP,Stacy L. Garrity,93,59,152
+Mercer,Wilmington,State Treasurer,,REP,Write-In,0,1,1
+Mercer,Wilmington,U.S. House,16,REP,Mike Kelly,103,73,176
+Mercer,Wilmington,U.S. House,16,REP,Write-In,0,1,1
+Mercer,Wilmington,General Assembly,17,REP,Parke Wentling,101,72,173
+Mercer,Wilmington,General Assembly,17,REP,Write-In,0,0,0
+Mercer,Wolf Creek,Registered Voters,,,,,,455
+Mercer,Wolf Creek,Registered Voters,,DEM,,,,114
+Mercer,Wolf Creek,Registered Voters,,REP,,,,341
+Mercer,Wolf Creek,Registered Voters,,NPA,,,,0
+Mercer,Wolf Creek,Ballots Cast,,,,131,59,190
+Mercer,Wolf Creek,Ballots Cast,,DEM,,16,24,40
+Mercer,Wolf Creek,Ballots Cast,,REP,,115,35,150
+Mercer,Wolf Creek,Ballots Cast,,NPA,,0,0,0
+Mercer,Wolf Creek,President,,DEM,Bernie Sanders,2,3,5
+Mercer,Wolf Creek,President,,DEM,Joseph R. Biden,12,19,31
+Mercer,Wolf Creek,President,,DEM,Tulsi Gabbard,0,2,2
+Mercer,Wolf Creek,President,,DEM,Elizabeth Warren,1,0,1
+Mercer,Wolf Creek,President,,DEM,Write-In,0,0,0
+Mercer,Wolf Creek,Attorney General,,DEM,Josh Shapiro,13,22,35
+Mercer,Wolf Creek,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Wolf Creek,Auditor General,,DEM,H. Scott Conklin,2,2,4
+Mercer,Wolf Creek,Auditor General,,DEM,Michael Lamb,9,15,24
+Mercer,Wolf Creek,Auditor General,,DEM,Tracie Fountain,0,0,0
+Mercer,Wolf Creek,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,2
+Mercer,Wolf Creek,Auditor General,,DEM,Nina Ahmad,0,3,3
+Mercer,Wolf Creek,Auditor General,,DEM,Christina M. Hartman,0,1,1
+Mercer,Wolf Creek,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Wolf Creek,State Treasurer,,DEM,Joe Torsella,11,21,32
+Mercer,Wolf Creek,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Wolf Creek,U.S. House,16,DEM,Kristy Gnibus,12,22,34
+Mercer,Wolf Creek,U.S. House,16,DEM,Write-In,0,0,0
+Mercer,Wolf Creek,General Assembly,8,DEM,Phil Heasley,13,22,35
+Mercer,Wolf Creek,General Assembly,8,DEM,Write-In,0,0,0
+Mercer,Wolf Creek,President,,REP,Donald J. Trump,110,25,135
+Mercer,Wolf Creek,President,,REP,Roque Rocky De La Fuente,1,0,1
+Mercer,Wolf Creek,President,,REP,Bill Weld,2,5,7
+Mercer,Wolf Creek,President,,REP,Write-In,1,2,3
+Mercer,Wolf Creek,Attorney General,,REP,Heather Heidelbaugh,104,28,132
+Mercer,Wolf Creek,Attorney General,,REP,Write-In,0,0,0
+Mercer,Wolf Creek,Auditor General,,REP,Timothy Defoor,100,28,128
+Mercer,Wolf Creek,Auditor General,,REP,Write-In,0,0,0
+Mercer,Wolf Creek,State Treasurer,,REP,Stacy L. Garrity,100,28,128
+Mercer,Wolf Creek,State Treasurer,,REP,Write-In,0,0,0
+Mercer,Wolf Creek,U.S. House,16,REP,Mike Kelly,111,29,140
+Mercer,Wolf Creek,U.S. House,16,REP,Write-In,0,2,2
+Mercer,Wolf Creek,General Assembly,8,REP,Scott Jaillet,18,10,28
+Mercer,Wolf Creek,General Assembly,8,REP,Tim Bonner,96,25,121
+Mercer,Wolf Creek,General Assembly,8,REP,Write-In,0,0,0
+Mercer,Worth,Registered Voters,,,,,,488
+Mercer,Worth,Registered Voters,,DEM,,,,137
+Mercer,Worth,Registered Voters,,REP,,,,351
+Mercer,Worth,Registered Voters,,NPA,,,,0
+Mercer,Worth,Ballots Cast,,,,165,43,208
+Mercer,Worth,Ballots Cast,,DEM,,31,17,48
+Mercer,Worth,Ballots Cast,,REP,,134,26,160
+Mercer,Worth,Ballots Cast,,NPA,,0,0,0
+Mercer,Worth,President,,DEM,Bernie Sanders,4,0,4
+Mercer,Worth,President,,DEM,Joseph R. Biden,19,16,35
+Mercer,Worth,President,,DEM,Tulsi Gabbard,0,0,0
+Mercer,Worth,President,,DEM,Elizabeth Warren,3,0,3
+Mercer,Worth,President,,DEM,Write-In,3,0,3
+Mercer,Worth,Attorney General,,DEM,Josh Shapiro,24,16,40
+Mercer,Worth,Attorney General,,DEM,Write-In,0,0,0
+Mercer,Worth,Auditor General,,DEM,H. Scott Conklin,2,2,4
+Mercer,Worth,Auditor General,,DEM,Michael Lamb,11,12,23
+Mercer,Worth,Auditor General,,DEM,Tracie Fountain,1,0,1
+Mercer,Worth,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0
+Mercer,Worth,Auditor General,,DEM,Nina Ahmad,3,0,3
+Mercer,Worth,Auditor General,,DEM,Christina M. Hartman,4,2,6
+Mercer,Worth,Auditor General,,DEM,Write-In,0,0,0
+Mercer,Worth,State Treasurer,,DEM,Joe Torsella,21,16,37
+Mercer,Worth,State Treasurer,,DEM,Write-In,0,0,0
+Mercer,Worth,U.S. House,16,DEM,Kristy Gnibus,22,16,38
+Mercer,Worth,U.S. House,16,DEM,Write-In,1,0,1
+Mercer,Worth,General Assembly,8,DEM,Phil Heasley,23,16,39
+Mercer,Worth,General Assembly,8,DEM,Write-In,1,0,1
+Mercer,Worth,President,,REP,Donald J. Trump,130,22,152
+Mercer,Worth,President,,REP,Roque Rocky De La Fuente,2,0,2
+Mercer,Worth,President,,REP,Bill Weld,1,4,5
+Mercer,Worth,President,,REP,Write-In,0,0,0
+Mercer,Worth,Attorney General,,REP,Heather Heidelbaugh,114,21,135
+Mercer,Worth,Attorney General,,REP,Write-In,2,0,2
+Mercer,Worth,Auditor General,,REP,Timothy Defoor,109,21,130
+Mercer,Worth,Auditor General,,REP,Write-In,1,0,1
+Mercer,Worth,State Treasurer,,REP,Stacy L. Garrity,114,21,135
+Mercer,Worth,State Treasurer,,REP,Write-In,1,0,1
+Mercer,Worth,U.S. House,16,REP,Mike Kelly,122,25,147
+Mercer,Worth,U.S. House,16,REP,Write-In,1,0,1
+Mercer,Worth,General Assembly,8,REP,Scott Jaillet,13,4,17
+Mercer,Worth,General Assembly,8,REP,Tim Bonner,120,22,142
+Mercer,Worth,General Assembly,8,REP,Write-In,0,0,0

--- a/2020/20200602__pa__primary__schuylkill__precinct.csv
+++ b/2020/20200602__pa__primary__schuylkill__precinct.csv
@@ -1,0 +1,5761 @@
+county,precinct,office,district,party,candidate,election_day,mail_in,absentee,provisional,votes
+Schuylkill,Ashland 1st,Registered Voters,,,,,,,,774
+Schuylkill,Ashland 1st,Registered Voters,,DEM,,,,,,333
+Schuylkill,Ashland 1st,Registered Voters,,REP,,,,,,334
+Schuylkill,Ashland 1st,Registered Voters,,NPA,,,,,,107
+Schuylkill,Ashland 1st,Ballots Cast,,,,177,75,17,2,271
+Schuylkill,Ashland 1st,Ballots Cast,,DEM,,67,42,14,0,123
+Schuylkill,Ashland 1st,Ballots Cast,,REP,,110,33,3,2,148
+Schuylkill,Ashland 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Ashland 1st,President,,DEM,Bernie Sanders,12,5,2,0,19
+Schuylkill,Ashland 1st,President,,DEM,Joseph R. Biden,42,36,11,0,89
+Schuylkill,Ashland 1st,President,,DEM,Tulsi Gabbard,5,1,0,0,6
+Schuylkill,Ashland 1st,President,,DEM,Write-in,7,0,1,0,8
+Schuylkill,Ashland 1st,Attorney General,,DEM,Josh Shapiro,60,39,13,0,112
+Schuylkill,Ashland 1st,Attorney General,,DEM,Write-in,1,0,1,0,2
+Schuylkill,Ashland 1st,Auditor General,,DEM,H. Scott Conklin,10,3,2,0,15
+Schuylkill,Ashland 1st,Auditor General,,DEM,Michael Lamb,12,9,0,0,21
+Schuylkill,Ashland 1st,Auditor General,,DEM,Tracie Fountain,8,8,3,0,19
+Schuylkill,Ashland 1st,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,1,0,6
+Schuylkill,Ashland 1st,Auditor General,,DEM,Nina Ahmad,8,7,1,0,16
+Schuylkill,Ashland 1st,Auditor General,,DEM,Christina M. Hartman,20,11,7,0,38
+Schuylkill,Ashland 1st,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Ashland 1st,State Treasurer,,DEM,Joe Torsella,55,37,13,0,105
+Schuylkill,Ashland 1st,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Schuylkill,Ashland 1st,Representative In Congress,,DEM,Laura Quick,28,18,6,0,52
+Schuylkill,Ashland 1st,Representative In Congress,,DEM,Gary Wegman,31,22,8,0,61
+Schuylkill,Ashland 1st,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Ashland 1st,State Senate,29,DEM,Write-in,8,8,4,0,20
+Schuylkill,Ashland 1st,General Assembly,123,DEM,Peter PJ Symons Jr.,62,37,11,0,110
+Schuylkill,Ashland 1st,General Assembly,123,DEM,Write-in,0,1,2,0,3
+Schuylkill,Ashland 1st,President,,REP,Donald J. Trump,104,27,1,2,134
+Schuylkill,Ashland 1st,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Ashland 1st,President,,REP,Bill Weld,2,4,2,0,8
+Schuylkill,Ashland 1st,President,,REP,Write-in,2,1,0,0,3
+Schuylkill,Ashland 1st,Attorney General,,REP,Heather Heidelbaugh,102,27,3,2,134
+Schuylkill,Ashland 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Ashland 1st,Auditor General,,REP,Timothy Defoor,101,26,2,2,131
+Schuylkill,Ashland 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Ashland 1st,State Treasurer,,REP,Stacy L. Garrity,102,26,3,2,133
+Schuylkill,Ashland 1st,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Ashland 1st,Representative In Congress,,REP,Dan Meuser,100,28,3,2,133
+Schuylkill,Ashland 1st,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,Ashland 1st,State Senate,29,REP,Dave Argall,101,29,2,2,134
+Schuylkill,Ashland 1st,State Senate,29,REP,Write-in,1,0,1,0,2
+Schuylkill,Ashland 1st,General Assembly,123,REP,John Leshko,24,6,0,1,31
+Schuylkill,Ashland 1st,General Assembly,123,REP,Tim Twardzik,82,26,3,1,112
+Schuylkill,Ashland 1st,General Assembly,123,REP,Write-in,3,0,0,0,3
+Schuylkill,Ashland 2nd,Registered Voters,,,,,,,,627
+Schuylkill,Ashland 2nd,Registered Voters,,DEM,,,,,,241
+Schuylkill,Ashland 2nd,Registered Voters,,REP,,,,,,315
+Schuylkill,Ashland 2nd,Registered Voters,,NPA,,,,,,71
+Schuylkill,Ashland 2nd,Ballots Cast,,,,162,58,15,3,238
+Schuylkill,Ashland 2nd,Ballots Cast,,DEM,,53,34,10,0,97
+Schuylkill,Ashland 2nd,Ballots Cast,,REP,,109,24,5,3,141
+Schuylkill,Ashland 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Ashland 2nd,President,,DEM,Bernie Sanders,7,4,2,0,13
+Schuylkill,Ashland 2nd,President,,DEM,Joseph R. Biden,32,27,7,0,66
+Schuylkill,Ashland 2nd,President,,DEM,Tulsi Gabbard,8,0,0,0,8
+Schuylkill,Ashland 2nd,President,,DEM,Write-in,3,2,0,0,5
+Schuylkill,Ashland 2nd,Attorney General,,DEM,Josh Shapiro,47,29,10,0,86
+Schuylkill,Ashland 2nd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Ashland 2nd,Auditor General,,DEM,H. Scott Conklin,11,3,4,0,18
+Schuylkill,Ashland 2nd,Auditor General,,DEM,Michael Lamb,7,6,0,0,13
+Schuylkill,Ashland 2nd,Auditor General,,DEM,Tracie Fountain,8,7,2,0,17
+Schuylkill,Ashland 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,0,0,4
+Schuylkill,Ashland 2nd,Auditor General,,DEM,Nina Ahmad,13,3,2,0,18
+Schuylkill,Ashland 2nd,Auditor General,,DEM,Christina M. Hartman,7,11,2,0,20
+Schuylkill,Ashland 2nd,Auditor General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Ashland 2nd,State Treasurer,,DEM,Joe Torsella,47,27,10,0,84
+Schuylkill,Ashland 2nd,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Ashland 2nd,Representative In Congress,,DEM,Laura Quick,25,14,8,0,47
+Schuylkill,Ashland 2nd,Representative In Congress,,DEM,Gary Wegman,23,15,2,0,40
+Schuylkill,Ashland 2nd,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Ashland 2nd,State Senate,29,DEM,Write-in,2,2,1,0,5
+Schuylkill,Ashland 2nd,General Assembly,123,DEM,Peter PJ Symons Jr.,50,28,9,0,87
+Schuylkill,Ashland 2nd,General Assembly,123,DEM,Write-in,0,2,0,0,2
+Schuylkill,Ashland 2nd,President,,REP,Donald J. Trump,106,13,2,3,124
+Schuylkill,Ashland 2nd,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,Ashland 2nd,President,,REP,Bill Weld,1,5,2,0,8
+Schuylkill,Ashland 2nd,President,,REP,Write-in,0,2,1,0,3
+Schuylkill,Ashland 2nd,Attorney General,,REP,Heather Heidelbaugh,94,21,3,3,121
+Schuylkill,Ashland 2nd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Ashland 2nd,Auditor General,,REP,Timothy Defoor,95,21,3,3,122
+Schuylkill,Ashland 2nd,Auditor General,,REP,Write-in,0,0,1,0,1
+Schuylkill,Ashland 2nd,State Treasurer,,REP,Stacy L. Garrity,96,21,3,3,123
+Schuylkill,Ashland 2nd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Ashland 2nd,Representative In Congress,,REP,Dan Meuser,95,23,3,3,124
+Schuylkill,Ashland 2nd,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,Ashland 2nd,State Senate,29,REP,Dave Argall,100,24,4,3,131
+Schuylkill,Ashland 2nd,State Senate,29,REP,Write-in,3,0,0,0,3
+Schuylkill,Ashland 2nd,General Assembly,123,REP,John Leshko,36,4,0,0,40
+Schuylkill,Ashland 2nd,General Assembly,123,REP,Tim Twardzik,70,20,4,3,97
+Schuylkill,Ashland 2nd,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,Blythe Twp,Registered Voters,,,,,,,,547
+Schuylkill,Blythe Twp,Registered Voters,,DEM,,,,,,254
+Schuylkill,Blythe Twp,Registered Voters,,REP,,,,,,258
+Schuylkill,Blythe Twp,Registered Voters,,NPA,,,,,,35
+Schuylkill,Blythe Twp,Ballots Cast,,,,122,72,23,1,218
+Schuylkill,Blythe Twp,Ballots Cast,,DEM,,47,37,15,0,99
+Schuylkill,Blythe Twp,Ballots Cast,,REP,,75,35,8,1,119
+Schuylkill,Blythe Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Blythe Twp,President,,DEM,Bernie Sanders,6,4,3,0,13
+Schuylkill,Blythe Twp,President,,DEM,Joseph R. Biden,19,22,11,0,52
+Schuylkill,Blythe Twp,President,,DEM,Tulsi Gabbard,4,2,0,0,6
+Schuylkill,Blythe Twp,President,,DEM,Write-in,16,4,0,0,20
+Schuylkill,Blythe Twp,Attorney General,,DEM,Josh Shapiro,31,28,13,0,72
+Schuylkill,Blythe Twp,Attorney General,,DEM,Write-in,3,2,0,0,5
+Schuylkill,Blythe Twp,Auditor General,,DEM,H. Scott Conklin,6,1,0,0,7
+Schuylkill,Blythe Twp,Auditor General,,DEM,Michael Lamb,4,7,1,0,12
+Schuylkill,Blythe Twp,Auditor General,,DEM,Tracie Fountain,5,6,3,0,14
+Schuylkill,Blythe Twp,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,2,0,4
+Schuylkill,Blythe Twp,Auditor General,,DEM,Nina Ahmad,3,5,3,0,11
+Schuylkill,Blythe Twp,Auditor General,,DEM,Christina M. Hartman,17,8,3,0,28
+Schuylkill,Blythe Twp,Auditor General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Blythe Twp,State Treasurer,,DEM,Joe Torsella,32,25,13,0,70
+Schuylkill,Blythe Twp,State Treasurer,,DEM,Write-in,2,2,0,0,4
+Schuylkill,Blythe Twp,Representative In Congress,,DEM,Laura Quick,13,9,5,0,27
+Schuylkill,Blythe Twp,Representative In Congress,,DEM,Gary Wegman,25,21,6,0,52
+Schuylkill,Blythe Twp,Representative In Congress,,DEM,Write-in,2,2,1,0,5
+Schuylkill,Blythe Twp,State Senate,29,DEM,Write-in,7,4,3,0,14
+Schuylkill,Blythe Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,33,34,12,0,79
+Schuylkill,Blythe Twp,General Assembly,123,DEM,Write-in,5,3,2,0,10
+Schuylkill,Blythe Twp,President,,REP,Donald J. Trump,72,28,8,0,108
+Schuylkill,Blythe Twp,President,,REP,Roque Rocky De La Fuente,0,4,0,0,4
+Schuylkill,Blythe Twp,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Blythe Twp,President,,REP,Write-in,1,3,0,1,5
+Schuylkill,Blythe Twp,Attorney General,,REP,Heather Heidelbaugh,58,29,7,0,94
+Schuylkill,Blythe Twp,Attorney General,,REP,Write-in,2,0,1,0,3
+Schuylkill,Blythe Twp,Auditor General,,REP,Timothy Defoor,57,29,7,0,93
+Schuylkill,Blythe Twp,Auditor General,,REP,Write-in,0,0,1,0,1
+Schuylkill,Blythe Twp,State Treasurer,,REP,Stacy L. Garrity,58,29,8,0,95
+Schuylkill,Blythe Twp,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Blythe Twp,Representative In Congress,,REP,Dan Meuser,64,30,8,0,102
+Schuylkill,Blythe Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Blythe Twp,State Senate,29,REP,Dave Argall,66,28,8,0,102
+Schuylkill,Blythe Twp,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Blythe Twp,General Assembly,123,REP,John Leshko,35,18,5,1,59
+Schuylkill,Blythe Twp,General Assembly,123,REP,Tim Twardzik,34,14,3,0,51
+Schuylkill,Blythe Twp,General Assembly,123,REP,Write-in,2,0,0,0,2
+Schuylkill,Branch Twp,Registered Voters,,,,,,,,1188
+Schuylkill,Branch Twp,Registered Voters,,DEM,,,,,,568
+Schuylkill,Branch Twp,Registered Voters,,REP,,,,,,508
+Schuylkill,Branch Twp,Registered Voters,,NPA,,,,,,112
+Schuylkill,Branch Twp,Ballots Cast,,,,257,161,31,5,454
+Schuylkill,Branch Twp,Ballots Cast,,DEM,,115,107,24,0,246
+Schuylkill,Branch Twp,Ballots Cast,,REP,,142,54,7,5,208
+Schuylkill,Branch Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Branch Twp,President,,DEM,Bernie Sanders,19,10,1,0,30
+Schuylkill,Branch Twp,President,,DEM,Joseph R. Biden,69,91,21,0,181
+Schuylkill,Branch Twp,President,,DEM,Tulsi Gabbard,5,3,0,0,8
+Schuylkill,Branch Twp,President,,DEM,Write-in,6,1,1,0,8
+Schuylkill,Branch Twp,Attorney General,,DEM,Josh Shapiro,94,102,22,0,218
+Schuylkill,Branch Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Branch Twp,Auditor General,,DEM,H. Scott Conklin,12,7,1,0,20
+Schuylkill,Branch Twp,Auditor General,,DEM,Michael Lamb,24,10,5,0,39
+Schuylkill,Branch Twp,Auditor General,,DEM,Tracie Fountain,13,29,3,0,45
+Schuylkill,Branch Twp,Auditor General,,DEM,Rose Rosie Marie Davis,9,10,1,0,20
+Schuylkill,Branch Twp,Auditor General,,DEM,Nina Ahmad,15,11,6,0,32
+Schuylkill,Branch Twp,Auditor General,,DEM,Christina M. Hartman,26,34,7,0,67
+Schuylkill,Branch Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Branch Twp,State Treasurer,,DEM,Joe Torsella,91,100,22,0,213
+Schuylkill,Branch Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Branch Twp,Representative In Congress,,DEM,Laura Quick,38,48,14,0,100
+Schuylkill,Branch Twp,Representative In Congress,,DEM,Gary Wegman,60,54,10,0,124
+Schuylkill,Branch Twp,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Branch Twp,State Senate,29,DEM,Write-in,6,11,3,0,20
+Schuylkill,Branch Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,95,102,22,0,219
+Schuylkill,Branch Twp,General Assembly,123,DEM,Write-in,10,0,1,0,11
+Schuylkill,Branch Twp,President,,REP,Donald J. Trump,129,46,5,5,185
+Schuylkill,Branch Twp,President,,REP,Roque Rocky De La Fuente,4,1,0,0,5
+Schuylkill,Branch Twp,President,,REP,Bill Weld,6,4,0,0,10
+Schuylkill,Branch Twp,President,,REP,Write-in,2,1,0,0,3
+Schuylkill,Branch Twp,Attorney General,,REP,Heather Heidelbaugh,129,46,3,5,183
+Schuylkill,Branch Twp,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Branch Twp,Auditor General,,REP,Timothy Defoor,123,44,3,4,174
+Schuylkill,Branch Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Branch Twp,State Treasurer,,REP,Stacy L. Garrity,128,46,3,3,180
+Schuylkill,Branch Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Branch Twp,Representative In Congress,,REP,Dan Meuser,133,47,4,4,188
+Schuylkill,Branch Twp,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Branch Twp,State Senate,29,REP,Dave Argall,132,47,5,5,189
+Schuylkill,Branch Twp,State Senate,29,REP,Write-in,1,1,0,0,2
+Schuylkill,Branch Twp,General Assembly,123,REP,John Leshko,86,34,4,3,127
+Schuylkill,Branch Twp,General Assembly,123,REP,Tim Twardzik,53,20,2,2,77
+Schuylkill,Branch Twp,General Assembly,123,REP,Write-in,0,0,1,0,1
+Schuylkill,Butler Twp Englewood,Registered Voters,,,,,,,,383
+Schuylkill,Butler Twp Englewood,Registered Voters,,DEM,,,,,,136
+Schuylkill,Butler Twp Englewood,Registered Voters,,REP,,,,,,219
+Schuylkill,Butler Twp Englewood,Registered Voters,,NPA,,,,,,28
+Schuylkill,Butler Twp Englewood,Ballots Cast,,,,135,52,16,0,203
+Schuylkill,Butler Twp Englewood,Ballots Cast,,DEM,,43,21,6,0,70
+Schuylkill,Butler Twp Englewood,Ballots Cast,,REP,,92,31,10,0,133
+Schuylkill,Butler Twp Englewood,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Butler Twp Englewood,President,,DEM,Bernie Sanders,4,3,2,0,9
+Schuylkill,Butler Twp Englewood,President,,DEM,Joseph R. Biden,27,18,3,0,48
+Schuylkill,Butler Twp Englewood,President,,DEM,Tulsi Gabbard,5,0,1,0,6
+Schuylkill,Butler Twp Englewood,President,,DEM,Write-in,5,0,0,0,5
+Schuylkill,Butler Twp Englewood,Attorney General,,DEM,Josh Shapiro,41,21,6,0,68
+Schuylkill,Butler Twp Englewood,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Englewood,Auditor General,,DEM,H. Scott Conklin,4,2,0,0,6
+Schuylkill,Butler Twp Englewood,Auditor General,,DEM,Michael Lamb,5,5,0,0,10
+Schuylkill,Butler Twp Englewood,Auditor General,,DEM,Tracie Fountain,7,6,2,0,15
+Schuylkill,Butler Twp Englewood,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,0,0,6
+Schuylkill,Butler Twp Englewood,Auditor General,,DEM,Nina Ahmad,6,3,1,0,10
+Schuylkill,Butler Twp Englewood,Auditor General,,DEM,Christina M. Hartman,15,1,3,0,19
+Schuylkill,Butler Twp Englewood,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Englewood,State Treasurer,,DEM,Joe Torsella,35,19,6,0,60
+Schuylkill,Butler Twp Englewood,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Butler Twp Englewood,Representative In Congress,,DEM,Laura Quick,21,10,4,0,35
+Schuylkill,Butler Twp Englewood,Representative In Congress,,DEM,Gary Wegman,19,11,2,0,32
+Schuylkill,Butler Twp Englewood,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Englewood,State Senate,29,DEM,Write-in,4,0,1,0,5
+Schuylkill,Butler Twp Englewood,General Assembly,123,DEM,Peter PJ Symons Jr.,40,21,6,0,67
+Schuylkill,Butler Twp Englewood,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Englewood,President,,REP,Donald J. Trump,84,28,10,0,122
+Schuylkill,Butler Twp Englewood,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Butler Twp Englewood,President,,REP,Bill Weld,1,1,0,0,2
+Schuylkill,Butler Twp Englewood,President,,REP,Write-in,3,1,0,0,4
+Schuylkill,Butler Twp Englewood,Attorney General,,REP,Heather Heidelbaugh,79,29,9,0,117
+Schuylkill,Butler Twp Englewood,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Englewood,Auditor General,,REP,Timothy Defoor,78,28,10,0,116
+Schuylkill,Butler Twp Englewood,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Englewood,State Treasurer,,REP,Stacy L. Garrity,80,27,10,0,117
+Schuylkill,Butler Twp Englewood,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Englewood,Representative In Congress,,REP,Dan Meuser,79,27,10,0,116
+Schuylkill,Butler Twp Englewood,Representative In Congress,,REP,Write-in,2,1,0,0,3
+Schuylkill,Butler Twp Englewood,State Senate,29,REP,Dave Argall,82,27,10,0,119
+Schuylkill,Butler Twp Englewood,State Senate,29,REP,Write-in,2,1,0,0,3
+Schuylkill,Butler Twp Englewood,General Assembly,123,REP,John Leshko,10,1,1,0,12
+Schuylkill,Butler Twp Englewood,General Assembly,123,REP,Tim Twardzik,78,29,8,0,115
+Schuylkill,Butler Twp Englewood,General Assembly,123,REP,Write-in,2,1,1,0,4
+Schuylkill,Butler Twp Ft. Springs,Registered Voters,,,,,,,,959
+Schuylkill,Butler Twp Ft. Springs,Registered Voters,,DEM,,,,,,290
+Schuylkill,Butler Twp Ft. Springs,Registered Voters,,REP,,,,,,569
+Schuylkill,Butler Twp Ft. Springs,Registered Voters,,NPA,,,,,,100
+Schuylkill,Butler Twp Ft. Springs,Ballots Cast,,,,270,121,22,0,413
+Schuylkill,Butler Twp Ft. Springs,Ballots Cast,,DEM,,69,55,10,0,134
+Schuylkill,Butler Twp Ft. Springs,Ballots Cast,,REP,,201,66,12,0,279
+Schuylkill,Butler Twp Ft. Springs,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Butler Twp Ft. Springs,President,,DEM,Bernie Sanders,13,7,5,0,25
+Schuylkill,Butler Twp Ft. Springs,President,,DEM,Joseph R. Biden,42,46,5,0,93
+Schuylkill,Butler Twp Ft. Springs,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Schuylkill,Butler Twp Ft. Springs,President,,DEM,Write-in,5,0,0,0,5
+Schuylkill,Butler Twp Ft. Springs,Attorney General,,DEM,Josh Shapiro,60,49,8,0,117
+Schuylkill,Butler Twp Ft. Springs,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,DEM,H. Scott Conklin,16,14,1,0,31
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,DEM,Michael Lamb,13,4,0,0,17
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,DEM,Tracie Fountain,13,12,3,0,28
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,DEM,Rose Rosie Marie Davis,5,3,0,0,8
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,DEM,Nina Ahmad,3,7,1,0,11
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,DEM,Christina M. Hartman,12,8,4,0,24
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Ft. Springs,State Treasurer,,DEM,Joe Torsella,52,44,8,0,104
+Schuylkill,Butler Twp Ft. Springs,State Treasurer,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Butler Twp Ft. Springs,Representative In Congress,,DEM,Laura Quick,31,29,5,0,65
+Schuylkill,Butler Twp Ft. Springs,Representative In Congress,,DEM,Gary Wegman,30,20,4,0,54
+Schuylkill,Butler Twp Ft. Springs,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Ft. Springs,State Senate,29,DEM,Write-in,4,4,1,0,9
+Schuylkill,Butler Twp Ft. Springs,General Assembly,123,DEM,Peter PJ Symons Jr.,61,54,8,0,123
+Schuylkill,Butler Twp Ft. Springs,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Ft. Springs,President,,REP,Donald J. Trump,190,53,7,0,250
+Schuylkill,Butler Twp Ft. Springs,President,,REP,Roque Rocky De La Fuente,4,1,3,0,8
+Schuylkill,Butler Twp Ft. Springs,President,,REP,Bill Weld,2,7,2,0,11
+Schuylkill,Butler Twp Ft. Springs,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Butler Twp Ft. Springs,Attorney General,,REP,Heather Heidelbaugh,173,51,12,0,236
+Schuylkill,Butler Twp Ft. Springs,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,REP,Timothy Defoor,174,48,12,0,234
+Schuylkill,Butler Twp Ft. Springs,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Butler Twp Ft. Springs,State Treasurer,,REP,Stacy L. Garrity,174,50,12,0,236
+Schuylkill,Butler Twp Ft. Springs,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Ft. Springs,Representative In Congress,,REP,Dan Meuser,185,51,12,0,248
+Schuylkill,Butler Twp Ft. Springs,Representative In Congress,,REP,Write-in,1,1,0,0,2
+Schuylkill,Butler Twp Ft. Springs,State Senate,29,REP,Dave Argall,183,55,12,0,250
+Schuylkill,Butler Twp Ft. Springs,State Senate,29,REP,Write-in,1,3,0,0,4
+Schuylkill,Butler Twp Ft. Springs,General Assembly,123,REP,John Leshko,81,3,2,0,86
+Schuylkill,Butler Twp Ft. Springs,General Assembly,123,REP,Tim Twardzik,119,58,10,0,187
+Schuylkill,Butler Twp Ft. Springs,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Lavelle,Registered Voters,,,,,,,,927
+Schuylkill,Butler Twp Lavelle,Registered Voters,,DEM,,,,,,249
+Schuylkill,Butler Twp Lavelle,Registered Voters,,REP,,,,,,569
+Schuylkill,Butler Twp Lavelle,Registered Voters,,NPA,,,,,,109
+Schuylkill,Butler Twp Lavelle,Ballots Cast,,,,276,71,11,2,360
+Schuylkill,Butler Twp Lavelle,Ballots Cast,,DEM,,62,26,7,0,95
+Schuylkill,Butler Twp Lavelle,Ballots Cast,,REP,,214,45,4,2,265
+Schuylkill,Butler Twp Lavelle,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Butler Twp Lavelle,President,,DEM,Bernie Sanders,14,2,0,0,16
+Schuylkill,Butler Twp Lavelle,President,,DEM,Joseph R. Biden,33,23,7,0,63
+Schuylkill,Butler Twp Lavelle,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Schuylkill,Butler Twp Lavelle,President,,DEM,Write-in,6,1,0,0,7
+Schuylkill,Butler Twp Lavelle,Attorney General,,DEM,Josh Shapiro,50,25,6,0,81
+Schuylkill,Butler Twp Lavelle,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Lavelle,Auditor General,,DEM,H. Scott Conklin,9,1,0,0,10
+Schuylkill,Butler Twp Lavelle,Auditor General,,DEM,Michael Lamb,11,6,1,0,18
+Schuylkill,Butler Twp Lavelle,Auditor General,,DEM,Tracie Fountain,11,5,2,0,18
+Schuylkill,Butler Twp Lavelle,Auditor General,,DEM,Rose Rosie Marie Davis,3,1,0,0,4
+Schuylkill,Butler Twp Lavelle,Auditor General,,DEM,Nina Ahmad,7,5,2,0,14
+Schuylkill,Butler Twp Lavelle,Auditor General,,DEM,Christina M. Hartman,14,6,2,0,22
+Schuylkill,Butler Twp Lavelle,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Lavelle,State Treasurer,,DEM,Joe Torsella,53,23,6,0,82
+Schuylkill,Butler Twp Lavelle,State Treasurer,,DEM,Write-in,2,1,0,0,3
+Schuylkill,Butler Twp Lavelle,Representative In Congress,,DEM,Laura Quick,32,11,3,0,46
+Schuylkill,Butler Twp Lavelle,Representative In Congress,,DEM,Gary Wegman,22,13,4,0,39
+Schuylkill,Butler Twp Lavelle,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Butler Twp Lavelle,State Senate,29,DEM,Write-in,8,1,0,0,9
+Schuylkill,Butler Twp Lavelle,General Assembly,123,DEM,Peter PJ Symons Jr.,60,24,6,0,90
+Schuylkill,Butler Twp Lavelle,General Assembly,123,DEM,Write-in,2,1,0,0,3
+Schuylkill,Butler Twp Lavelle,President,,REP,Donald J. Trump,206,42,4,2,254
+Schuylkill,Butler Twp Lavelle,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,Butler Twp Lavelle,President,,REP,Bill Weld,5,1,0,0,6
+Schuylkill,Butler Twp Lavelle,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Lavelle,Attorney General,,REP,Heather Heidelbaugh,183,42,3,1,229
+Schuylkill,Butler Twp Lavelle,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Lavelle,Auditor General,,REP,Timothy Defoor,183,41,3,2,229
+Schuylkill,Butler Twp Lavelle,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Butler Twp Lavelle,State Treasurer,,REP,Stacy L. Garrity,185,42,3,1,231
+Schuylkill,Butler Twp Lavelle,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Lavelle,Representative In Congress,,REP,Dan Meuser,191,44,3,2,240
+Schuylkill,Butler Twp Lavelle,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Butler Twp Lavelle,State Senate,29,REP,Dave Argall,199,43,2,2,246
+Schuylkill,Butler Twp Lavelle,State Senate,29,REP,Write-in,1,0,1,0,2
+Schuylkill,Butler Twp Lavelle,General Assembly,123,REP,John Leshko,26,3,0,0,29
+Schuylkill,Butler Twp Lavelle,General Assembly,123,REP,Tim Twardzik,179,40,4,2,225
+Schuylkill,Butler Twp Lavelle,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,Registered Voters,,,,,,,,200
+Schuylkill,Butler Twp Northeast,Registered Voters,,DEM,,,,,,97
+Schuylkill,Butler Twp Northeast,Registered Voters,,REP,,,,,,76
+Schuylkill,Butler Twp Northeast,Registered Voters,,NPA,,,,,,27
+Schuylkill,Butler Twp Northeast,Ballots Cast,,,,41,16,7,2,66
+Schuylkill,Butler Twp Northeast,Ballots Cast,,DEM,,23,12,2,0,37
+Schuylkill,Butler Twp Northeast,Ballots Cast,,REP,,18,4,5,2,29
+Schuylkill,Butler Twp Northeast,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,President,,DEM,Bernie Sanders,6,2,0,0,8
+Schuylkill,Butler Twp Northeast,President,,DEM,Joseph R. Biden,7,10,2,0,19
+Schuylkill,Butler Twp Northeast,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Butler Twp Northeast,President,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Butler Twp Northeast,Attorney General,,DEM,Josh Shapiro,20,11,1,0,32
+Schuylkill,Butler Twp Northeast,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,Auditor General,,DEM,H. Scott Conklin,3,1,0,0,4
+Schuylkill,Butler Twp Northeast,Auditor General,,DEM,Michael Lamb,4,3,0,0,7
+Schuylkill,Butler Twp Northeast,Auditor General,,DEM,Tracie Fountain,2,3,0,0,5
+Schuylkill,Butler Twp Northeast,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,0,0,4
+Schuylkill,Butler Twp Northeast,Auditor General,,DEM,Nina Ahmad,3,2,1,0,6
+Schuylkill,Butler Twp Northeast,Auditor General,,DEM,Christina M. Hartman,6,3,0,0,9
+Schuylkill,Butler Twp Northeast,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,State Treasurer,,DEM,Joe Torsella,21,11,1,0,33
+Schuylkill,Butler Twp Northeast,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,Representative In Congress,,DEM,Laura Quick,8,6,0,0,14
+Schuylkill,Butler Twp Northeast,Representative In Congress,,DEM,Gary Wegman,11,6,2,0,19
+Schuylkill,Butler Twp Northeast,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,State Senate,29,DEM,Write-in,2,2,1,0,5
+Schuylkill,Butler Twp Northeast,General Assembly,123,DEM,Peter PJ Symons Jr.,22,12,2,0,36
+Schuylkill,Butler Twp Northeast,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,Butler Twp Northeast,President,,REP,Donald J. Trump,18,3,5,2,28
+Schuylkill,Butler Twp Northeast,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,Attorney General,,REP,Heather Heidelbaugh,16,4,5,2,27
+Schuylkill,Butler Twp Northeast,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,Auditor General,,REP,Timothy Defoor,17,4,5,0,26
+Schuylkill,Butler Twp Northeast,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,State Treasurer,,REP,Stacy L. Garrity,18,4,5,0,27
+Schuylkill,Butler Twp Northeast,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,Representative In Congress,,REP,Dan Meuser,18,4,5,2,29
+Schuylkill,Butler Twp Northeast,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Butler Twp Northeast,State Senate,29,REP,Dave Argall,16,4,4,0,24
+Schuylkill,Butler Twp Northeast,State Senate,29,REP,Write-in,1,0,1,0,2
+Schuylkill,Butler Twp Northeast,General Assembly,123,REP,John Leshko,10,1,1,0,12
+Schuylkill,Butler Twp Northeast,General Assembly,123,REP,Tim Twardzik,8,3,3,2,16
+Schuylkill,Butler Twp Northeast,General Assembly,123,REP,Write-in,0,0,1,0,1
+Schuylkill,Cass Twp North,Registered Voters,,,,,,,,254
+Schuylkill,Cass Twp North,Registered Voters,,DEM,,,,,,128
+Schuylkill,Cass Twp North,Registered Voters,,REP,,,,,,98
+Schuylkill,Cass Twp North,Registered Voters,,NPA,,,,,,28
+Schuylkill,Cass Twp North,Ballots Cast,,,,55,17,1,0,73
+Schuylkill,Cass Twp North,Ballots Cast,,DEM,,28,15,0,0,43
+Schuylkill,Cass Twp North,Ballots Cast,,REP,,27,2,1,0,30
+Schuylkill,Cass Twp North,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Cass Twp North,President,,DEM,Bernie Sanders,5,2,0,0,7
+Schuylkill,Cass Twp North,President,,DEM,Joseph R. Biden,15,12,0,0,27
+Schuylkill,Cass Twp North,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Schuylkill,Cass Twp North,President,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Cass Twp North,Attorney General,,DEM,Josh Shapiro,19,9,0,0,28
+Schuylkill,Cass Twp North,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Cass Twp North,Auditor General,,DEM,H. Scott Conklin,3,0,0,0,3
+Schuylkill,Cass Twp North,Auditor General,,DEM,Michael Lamb,5,2,0,0,7
+Schuylkill,Cass Twp North,Auditor General,,DEM,Tracie Fountain,4,5,0,0,9
+Schuylkill,Cass Twp North,Auditor General,,DEM,Rose Rosie Marie Davis,3,3,0,0,6
+Schuylkill,Cass Twp North,Auditor General,,DEM,Nina Ahmad,3,0,0,0,3
+Schuylkill,Cass Twp North,Auditor General,,DEM,Christina M. Hartman,3,2,0,0,5
+Schuylkill,Cass Twp North,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Cass Twp North,State Treasurer,,DEM,Joe Torsella,18,10,0,0,28
+Schuylkill,Cass Twp North,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp North,Representative In Congress,,DEM,Laura Quick,16,9,0,0,25
+Schuylkill,Cass Twp North,Representative In Congress,,DEM,Gary Wegman,7,1,0,0,8
+Schuylkill,Cass Twp North,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp North,State Senate,29,DEM,Write-in,3,0,0,0,3
+Schuylkill,Cass Twp North,General Assembly,123,DEM,Peter PJ Symons Jr.,24,12,0,0,36
+Schuylkill,Cass Twp North,General Assembly,123,DEM,Write-in,2,0,0,0,2
+Schuylkill,Cass Twp North,President,,REP,Donald J. Trump,24,2,1,0,27
+Schuylkill,Cass Twp North,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Cass Twp North,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,Cass Twp North,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Cass Twp North,Attorney General,,REP,Heather Heidelbaugh,24,1,1,0,26
+Schuylkill,Cass Twp North,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp North,Auditor General,,REP,Timothy Defoor,24,1,1,0,26
+Schuylkill,Cass Twp North,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp North,State Treasurer,,REP,Stacy L. Garrity,24,1,1,0,26
+Schuylkill,Cass Twp North,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp North,Representative In Congress,,REP,Dan Meuser,24,1,1,0,26
+Schuylkill,Cass Twp North,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp North,State Senate,29,REP,Dave Argall,24,1,1,0,26
+Schuylkill,Cass Twp North,State Senate,29,REP,Write-in,1,1,0,0,2
+Schuylkill,Cass Twp North,General Assembly,123,REP,John Leshko,16,1,1,0,18
+Schuylkill,Cass Twp North,General Assembly,123,REP,Tim Twardzik,9,1,0,0,10
+Schuylkill,Cass Twp North,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp South,Registered Voters,,,,,,,,891
+Schuylkill,Cass Twp South,Registered Voters,,DEM,,,,,,419
+Schuylkill,Cass Twp South,Registered Voters,,REP,,,,,,394
+Schuylkill,Cass Twp South,Registered Voters,,NPA,,,,,,78
+Schuylkill,Cass Twp South,Ballots Cast,,,,188,85,12,1,286
+Schuylkill,Cass Twp South,Ballots Cast,,DEM,,76,53,4,1,134
+Schuylkill,Cass Twp South,Ballots Cast,,REP,,112,32,8,0,152
+Schuylkill,Cass Twp South,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Cass Twp South,President,,DEM,Bernie Sanders,12,3,1,0,16
+Schuylkill,Cass Twp South,President,,DEM,Joseph R. Biden,36,44,3,0,83
+Schuylkill,Cass Twp South,President,,DEM,Tulsi Gabbard,6,3,0,0,9
+Schuylkill,Cass Twp South,President,,DEM,Write-in,11,0,0,1,12
+Schuylkill,Cass Twp South,Attorney General,,DEM,Josh Shapiro,65,52,4,1,122
+Schuylkill,Cass Twp South,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Cass Twp South,Auditor General,,DEM,H. Scott Conklin,7,3,0,0,10
+Schuylkill,Cass Twp South,Auditor General,,DEM,Michael Lamb,11,10,0,0,21
+Schuylkill,Cass Twp South,Auditor General,,DEM,Tracie Fountain,18,20,0,0,38
+Schuylkill,Cass Twp South,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,0,0,5
+Schuylkill,Cass Twp South,Auditor General,,DEM,Nina Ahmad,8,7,2,0,17
+Schuylkill,Cass Twp South,Auditor General,,DEM,Christina M. Hartman,20,6,2,1,29
+Schuylkill,Cass Twp South,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp South,State Treasurer,,DEM,Joe Torsella,60,48,4,1,113
+Schuylkill,Cass Twp South,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp South,Representative In Congress,,DEM,Laura Quick,31,23,2,0,56
+Schuylkill,Cass Twp South,Representative In Congress,,DEM,Gary Wegman,34,28,2,1,65
+Schuylkill,Cass Twp South,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Cass Twp South,State Senate,29,DEM,Write-in,6,3,0,0,9
+Schuylkill,Cass Twp South,General Assembly,123,DEM,Peter PJ Symons Jr.,70,50,4,1,125
+Schuylkill,Cass Twp South,General Assembly,123,DEM,Write-in,2,0,0,0,2
+Schuylkill,Cass Twp South,President,,REP,Donald J. Trump,106,30,8,0,144
+Schuylkill,Cass Twp South,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Cass Twp South,President,,REP,Bill Weld,3,1,0,0,4
+Schuylkill,Cass Twp South,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,Cass Twp South,Attorney General,,REP,Heather Heidelbaugh,100,30,7,0,137
+Schuylkill,Cass Twp South,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Cass Twp South,Auditor General,,REP,Timothy Defoor,100,30,7,0,137
+Schuylkill,Cass Twp South,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Cass Twp South,State Treasurer,,REP,Stacy L. Garrity,102,30,7,0,139
+Schuylkill,Cass Twp South,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Cass Twp South,Representative In Congress,,REP,Dan Meuser,107,30,8,0,145
+Schuylkill,Cass Twp South,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Cass Twp South,State Senate,29,REP,Dave Argall,108,29,8,0,145
+Schuylkill,Cass Twp South,State Senate,29,REP,Write-in,0,1,0,0,1
+Schuylkill,Cass Twp South,General Assembly,123,REP,John Leshko,56,17,4,0,77
+Schuylkill,Cass Twp South,General Assembly,123,REP,Tim Twardzik,54,12,2,0,68
+Schuylkill,Cass Twp South,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,Registered Voters,,,,,,,,244
+Schuylkill,Delano Twp,Registered Voters,,DEM,,,,,,115
+Schuylkill,Delano Twp,Registered Voters,,REP,,,,,,103
+Schuylkill,Delano Twp,Registered Voters,,NPA,,,,,,26
+Schuylkill,Delano Twp,Ballots Cast,,,,54,20,3,0,77
+Schuylkill,Delano Twp,Ballots Cast,,DEM,,25,15,2,0,42
+Schuylkill,Delano Twp,Ballots Cast,,REP,,29,5,1,0,35
+Schuylkill,Delano Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Delano Twp,President,,DEM,Bernie Sanders,6,2,1,0,9
+Schuylkill,Delano Twp,President,,DEM,Joseph R. Biden,16,10,1,0,27
+Schuylkill,Delano Twp,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Schuylkill,Delano Twp,President,,DEM,Write-in,1,3,0,0,4
+Schuylkill,Delano Twp,Attorney General,,DEM,Josh Shapiro,23,14,2,0,39
+Schuylkill,Delano Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,Auditor General,,DEM,H. Scott Conklin,2,3,0,0,5
+Schuylkill,Delano Twp,Auditor General,,DEM,Michael Lamb,6,4,0,0,10
+Schuylkill,Delano Twp,Auditor General,,DEM,Tracie Fountain,4,1,1,0,6
+Schuylkill,Delano Twp,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,1,0,7
+Schuylkill,Delano Twp,Auditor General,,DEM,Nina Ahmad,4,2,0,0,6
+Schuylkill,Delano Twp,Auditor General,,DEM,Christina M. Hartman,4,2,0,0,6
+Schuylkill,Delano Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,State Treasurer,,DEM,Joe Torsella,24,14,2,0,40
+Schuylkill,Delano Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,Representative In Congress,,DEM,Laura Quick,17,12,0,0,29
+Schuylkill,Delano Twp,Representative In Congress,,DEM,Gary Wegman,8,2,2,0,12
+Schuylkill,Delano Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,State Senate,29,DEM,Write-in,1,2,0,0,3
+Schuylkill,Delano Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,25,14,2,0,41
+Schuylkill,Delano Twp,General Assembly,123,DEM,Write-in,0,1,0,0,1
+Schuylkill,Delano Twp,President,,REP,Donald J. Trump,28,5,1,0,34
+Schuylkill,Delano Twp,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Delano Twp,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Delano Twp,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,Attorney General,,REP,Heather Heidelbaugh,25,5,1,0,31
+Schuylkill,Delano Twp,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,Auditor General,,REP,Timothy Defoor,25,5,1,0,31
+Schuylkill,Delano Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,State Treasurer,,REP,Stacy L. Garrity,25,5,1,0,31
+Schuylkill,Delano Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,Representative In Congress,,REP,Dan Meuser,28,5,1,0,34
+Schuylkill,Delano Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,State Senate,29,REP,Dave Argall,27,5,1,0,33
+Schuylkill,Delano Twp,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Delano Twp,General Assembly,123,REP,John Leshko,5,1,1,0,7
+Schuylkill,Delano Twp,General Assembly,123,REP,Tim Twardzik,23,4,0,0,27
+Schuylkill,Delano Twp,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,East Norwegian Twp,Registered Voters,,,,,,,,690
+Schuylkill,East Norwegian Twp,Registered Voters,,DEM,,,,,,337
+Schuylkill,East Norwegian Twp,Registered Voters,,REP,,,,,,294
+Schuylkill,East Norwegian Twp,Registered Voters,,NPA,,,,,,59
+Schuylkill,East Norwegian Twp,Ballots Cast,,,,141,105,46,2,294
+Schuylkill,East Norwegian Twp,Ballots Cast,,DEM,,63,76,25,0,164
+Schuylkill,East Norwegian Twp,Ballots Cast,,REP,,78,29,21,2,130
+Schuylkill,East Norwegian Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,East Norwegian Twp,President,,DEM,Bernie Sanders,7,6,1,0,14
+Schuylkill,East Norwegian Twp,President,,DEM,Joseph R. Biden,32,55,17,0,104
+Schuylkill,East Norwegian Twp,President,,DEM,Tulsi Gabbard,10,4,2,0,16
+Schuylkill,East Norwegian Twp,President,,DEM,Write-in,6,5,1,0,12
+Schuylkill,East Norwegian Twp,Attorney General,,DEM,Josh Shapiro,55,70,22,0,147
+Schuylkill,East Norwegian Twp,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,East Norwegian Twp,Auditor General,,DEM,H. Scott Conklin,3,6,2,0,11
+Schuylkill,East Norwegian Twp,Auditor General,,DEM,Michael Lamb,15,11,3,0,29
+Schuylkill,East Norwegian Twp,Auditor General,,DEM,Tracie Fountain,6,12,4,0,22
+Schuylkill,East Norwegian Twp,Auditor General,,DEM,Rose Rosie Marie Davis,6,5,3,0,14
+Schuylkill,East Norwegian Twp,Auditor General,,DEM,Nina Ahmad,8,10,2,0,20
+Schuylkill,East Norwegian Twp,Auditor General,,DEM,Christina M. Hartman,16,26,9,0,51
+Schuylkill,East Norwegian Twp,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,East Norwegian Twp,State Treasurer,,DEM,Joe Torsella,48,69,22,0,139
+Schuylkill,East Norwegian Twp,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Schuylkill,East Norwegian Twp,Representative In Congress,,DEM,Laura Quick,17,32,8,0,57
+Schuylkill,East Norwegian Twp,Representative In Congress,,DEM,Gary Wegman,41,38,15,0,94
+Schuylkill,East Norwegian Twp,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,East Norwegian Twp,State Senate,29,DEM,Write-in,5,6,4,0,15
+Schuylkill,East Norwegian Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,57,74,21,0,152
+Schuylkill,East Norwegian Twp,General Assembly,123,DEM,Write-in,1,1,0,0,2
+Schuylkill,East Norwegian Twp,President,,REP,Donald J. Trump,75,22,18,2,117
+Schuylkill,East Norwegian Twp,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,East Norwegian Twp,President,,REP,Bill Weld,2,3,2,0,7
+Schuylkill,East Norwegian Twp,President,,REP,Write-in,0,2,0,0,2
+Schuylkill,East Norwegian Twp,Attorney General,,REP,Heather Heidelbaugh,65,26,13,1,105
+Schuylkill,East Norwegian Twp,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,East Norwegian Twp,Auditor General,,REP,Timothy Defoor,65,27,11,1,104
+Schuylkill,East Norwegian Twp,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,East Norwegian Twp,State Treasurer,,REP,Stacy L. Garrity,67,27,14,1,109
+Schuylkill,East Norwegian Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,East Norwegian Twp,Representative In Congress,,REP,Dan Meuser,69,28,14,2,113
+Schuylkill,East Norwegian Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,East Norwegian Twp,State Senate,29,REP,Dave Argall,72,27,20,1,120
+Schuylkill,East Norwegian Twp,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,East Norwegian Twp,General Assembly,123,REP,John Leshko,33,8,11,1,53
+Schuylkill,East Norwegian Twp,General Assembly,123,REP,Tim Twardzik,43,17,8,0,68
+Schuylkill,East Norwegian Twp,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Frackville North,Registered Voters,,,,,,,,696
+Schuylkill,Frackville North,Registered Voters,,DEM,,,,,,250
+Schuylkill,Frackville North,Registered Voters,,REP,,,,,,352
+Schuylkill,Frackville North,Registered Voters,,NPA,,,,,,94
+Schuylkill,Frackville North,Ballots Cast,,,,173,80,16,4,273
+Schuylkill,Frackville North,Ballots Cast,,DEM,,52,36,9,2,99
+Schuylkill,Frackville North,Ballots Cast,,REP,,121,44,7,2,174
+Schuylkill,Frackville North,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Frackville North,President,,DEM,Bernie Sanders,9,3,2,0,14
+Schuylkill,Frackville North,President,,DEM,Joseph R. Biden,26,31,6,1,64
+Schuylkill,Frackville North,President,,DEM,Tulsi Gabbard,6,0,0,0,6
+Schuylkill,Frackville North,President,,DEM,Write-in,8,2,0,0,10
+Schuylkill,Frackville North,Attorney General,,DEM,Josh Shapiro,40,33,8,1,82
+Schuylkill,Frackville North,Attorney General,,DEM,Write-in,5,0,0,0,5
+Schuylkill,Frackville North,Auditor General,,DEM,H. Scott Conklin,2,1,0,0,3
+Schuylkill,Frackville North,Auditor General,,DEM,Michael Lamb,5,7,1,0,13
+Schuylkill,Frackville North,Auditor General,,DEM,Tracie Fountain,7,7,1,0,15
+Schuylkill,Frackville North,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,0,0,5
+Schuylkill,Frackville North,Auditor General,,DEM,Nina Ahmad,10,9,1,1,21
+Schuylkill,Frackville North,Auditor General,,DEM,Christina M. Hartman,18,7,5,0,30
+Schuylkill,Frackville North,Auditor General,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Frackville North,State Treasurer,,DEM,Joe Torsella,41,34,8,1,84
+Schuylkill,Frackville North,State Treasurer,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Frackville North,Representative In Congress,,DEM,Laura Quick,21,17,5,1,44
+Schuylkill,Frackville North,Representative In Congress,,DEM,Gary Wegman,21,17,3,0,41
+Schuylkill,Frackville North,Representative In Congress,,DEM,Write-in,6,0,0,0,6
+Schuylkill,Frackville North,State Senate,29,DEM,Write-in,7,3,1,0,11
+Schuylkill,Frackville North,General Assembly,123,DEM,Peter PJ Symons Jr.,35,33,8,1,77
+Schuylkill,Frackville North,General Assembly,123,DEM,Write-in,10,1,0,0,11
+Schuylkill,Frackville North,President,,REP,Donald J. Trump,111,38,4,2,155
+Schuylkill,Frackville North,President,,REP,Roque Rocky De La Fuente,4,1,0,0,5
+Schuylkill,Frackville North,President,,REP,Bill Weld,2,5,1,0,8
+Schuylkill,Frackville North,President,,REP,Write-in,2,0,2,0,4
+Schuylkill,Frackville North,Attorney General,,REP,Heather Heidelbaugh,106,35,7,2,150
+Schuylkill,Frackville North,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Frackville North,Auditor General,,REP,Timothy Defoor,106,36,7,2,151
+Schuylkill,Frackville North,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Frackville North,State Treasurer,,REP,Stacy L. Garrity,105,36,7,2,150
+Schuylkill,Frackville North,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Frackville North,Representative In Congress,,REP,Dan Meuser,112,40,7,2,161
+Schuylkill,Frackville North,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Frackville North,State Senate,29,REP,Dave Argall,114,40,7,2,163
+Schuylkill,Frackville North,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Frackville North,General Assembly,123,REP,John Leshko,20,7,0,0,27
+Schuylkill,Frackville North,General Assembly,123,REP,Tim Twardzik,101,37,7,2,147
+Schuylkill,Frackville North,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Frackville Middle,Registered Voters,,,,,,,,551
+Schuylkill,Frackville Middle,Registered Voters,,DEM,,,,,,212
+Schuylkill,Frackville Middle,Registered Voters,,REP,,,,,,269
+Schuylkill,Frackville Middle,Registered Voters,,NPA,,,,,,70
+Schuylkill,Frackville Middle,Ballots Cast,,,,147,52,19,2,220
+Schuylkill,Frackville Middle,Ballots Cast,,DEM,,51,31,12,0,94
+Schuylkill,Frackville Middle,Ballots Cast,,REP,,96,21,7,2,126
+Schuylkill,Frackville Middle,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Frackville Middle,President,,DEM,Bernie Sanders,13,3,0,0,16
+Schuylkill,Frackville Middle,President,,DEM,Joseph R. Biden,29,25,11,0,65
+Schuylkill,Frackville Middle,President,,DEM,Tulsi Gabbard,4,0,1,0,5
+Schuylkill,Frackville Middle,President,,DEM,Write-in,3,1,0,0,4
+Schuylkill,Frackville Middle,Attorney General,,DEM,Josh Shapiro,46,27,11,0,84
+Schuylkill,Frackville Middle,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Frackville Middle,Auditor General,,DEM,H. Scott Conklin,3,2,1,0,6
+Schuylkill,Frackville Middle,Auditor General,,DEM,Michael Lamb,8,7,0,0,15
+Schuylkill,Frackville Middle,Auditor General,,DEM,Tracie Fountain,4,7,4,0,15
+Schuylkill,Frackville Middle,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,0,0,5
+Schuylkill,Frackville Middle,Auditor General,,DEM,Nina Ahmad,12,1,2,0,15
+Schuylkill,Frackville Middle,Auditor General,,DEM,Christina M. Hartman,19,7,4,0,30
+Schuylkill,Frackville Middle,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Frackville Middle,State Treasurer,,DEM,Joe Torsella,42,26,10,0,78
+Schuylkill,Frackville Middle,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Frackville Middle,Representative In Congress,,DEM,Laura Quick,30,12,6,0,48
+Schuylkill,Frackville Middle,Representative In Congress,,DEM,Gary Wegman,20,16,5,0,41
+Schuylkill,Frackville Middle,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Frackville Middle,State Senate,29,DEM,Write-in,3,5,2,0,10
+Schuylkill,Frackville Middle,General Assembly,123,DEM,Peter PJ Symons Jr.,47,28,10,0,85
+Schuylkill,Frackville Middle,General Assembly,123,DEM,Write-in,1,2,1,0,4
+Schuylkill,Frackville Middle,President,,REP,Donald J. Trump,89,13,7,2,111
+Schuylkill,Frackville Middle,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Frackville Middle,President,,REP,Bill Weld,2,3,0,0,5
+Schuylkill,Frackville Middle,President,,REP,Write-in,3,4,0,0,7
+Schuylkill,Frackville Middle,Attorney General,,REP,Heather Heidelbaugh,87,18,6,1,112
+Schuylkill,Frackville Middle,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Frackville Middle,Auditor General,,REP,Timothy Defoor,87,19,6,1,113
+Schuylkill,Frackville Middle,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Frackville Middle,State Treasurer,,REP,Stacy L. Garrity,87,18,5,1,111
+Schuylkill,Frackville Middle,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Frackville Middle,Representative In Congress,,REP,Dan Meuser,85,18,7,1,111
+Schuylkill,Frackville Middle,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Frackville Middle,State Senate,29,REP,Dave Argall,84,19,7,2,112
+Schuylkill,Frackville Middle,State Senate,29,REP,Write-in,2,0,0,0,2
+Schuylkill,Frackville Middle,General Assembly,123,REP,John Leshko,21,9,0,0,30
+Schuylkill,Frackville Middle,General Assembly,123,REP,Tim Twardzik,75,10,6,2,93
+Schuylkill,Frackville Middle,General Assembly,123,REP,Write-in,0,2,0,0,2
+Schuylkill,Frackville South,Registered Voters,,,,,,,,1051
+Schuylkill,Frackville South,Registered Voters,,DEM,,,,,,390
+Schuylkill,Frackville South,Registered Voters,,REP,,,,,,558
+Schuylkill,Frackville South,Registered Voters,,NPA,,,,,,103
+Schuylkill,Frackville South,Ballots Cast,,,,267,130,42,10,449
+Schuylkill,Frackville South,Ballots Cast,,DEM,,76,52,23,2,153
+Schuylkill,Frackville South,Ballots Cast,,REP,,191,78,19,8,296
+Schuylkill,Frackville South,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Frackville South,President,,DEM,Bernie Sanders,14,3,3,0,20
+Schuylkill,Frackville South,President,,DEM,Joseph R. Biden,43,43,19,2,107
+Schuylkill,Frackville South,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Schuylkill,Frackville South,President,,DEM,Write-in,15,4,0,0,19
+Schuylkill,Frackville South,Attorney General,,DEM,Josh Shapiro,61,48,21,2,132
+Schuylkill,Frackville South,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Frackville South,Auditor General,,DEM,H. Scott Conklin,5,4,2,1,12
+Schuylkill,Frackville South,Auditor General,,DEM,Michael Lamb,14,5,1,0,20
+Schuylkill,Frackville South,Auditor General,,DEM,Tracie Fountain,15,8,3,0,26
+Schuylkill,Frackville South,Auditor General,,DEM,Rose Rosie Marie Davis,0,5,7,0,12
+Schuylkill,Frackville South,Auditor General,,DEM,Nina Ahmad,16,7,1,0,24
+Schuylkill,Frackville South,Auditor General,,DEM,Christina M. Hartman,15,20,8,0,43
+Schuylkill,Frackville South,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Frackville South,State Treasurer,,DEM,Joe Torsella,59,48,21,2,130
+Schuylkill,Frackville South,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Frackville South,Representative In Congress,,DEM,Laura Quick,30,25,11,0,66
+Schuylkill,Frackville South,Representative In Congress,,DEM,Gary Wegman,27,25,10,1,63
+Schuylkill,Frackville South,Representative In Congress,,DEM,Write-in,9,2,0,0,11
+Schuylkill,Frackville South,State Senate,29,DEM,Write-in,11,3,1,0,15
+Schuylkill,Frackville South,General Assembly,123,DEM,Peter PJ Symons Jr.,62,47,19,1,129
+Schuylkill,Frackville South,General Assembly,123,DEM,Write-in,10,2,1,1,14
+Schuylkill,Frackville South,President,,REP,Donald J. Trump,178,67,17,8,270
+Schuylkill,Frackville South,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Schuylkill,Frackville South,President,,REP,Bill Weld,3,5,2,0,10
+Schuylkill,Frackville South,President,,REP,Write-in,2,0,0,0,2
+Schuylkill,Frackville South,Attorney General,,REP,Heather Heidelbaugh,159,69,16,7,251
+Schuylkill,Frackville South,Attorney General,,REP,Write-in,3,1,0,0,4
+Schuylkill,Frackville South,Auditor General,,REP,Timothy Defoor,160,70,17,7,254
+Schuylkill,Frackville South,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Frackville South,State Treasurer,,REP,Stacy L. Garrity,161,69,17,7,254
+Schuylkill,Frackville South,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Frackville South,Representative In Congress,,REP,Dan Meuser,172,73,19,8,272
+Schuylkill,Frackville South,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Frackville South,State Senate,29,REP,Dave Argall,173,71,18,8,270
+Schuylkill,Frackville South,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Frackville South,General Assembly,123,REP,John Leshko,28,7,4,2,41
+Schuylkill,Frackville South,General Assembly,123,REP,Tim Twardzik,160,69,15,5,249
+Schuylkill,Frackville South,General Assembly,123,REP,Write-in,2,0,0,0,2
+Schuylkill,Gilberton,Registered Voters,,,,,,,,367
+Schuylkill,Gilberton,Registered Voters,,DEM,,,,,,164
+Schuylkill,Gilberton,Registered Voters,,REP,,,,,,173
+Schuylkill,Gilberton,Registered Voters,,NPA,,,,,,30
+Schuylkill,Gilberton,Ballots Cast,,,,67,54,16,1,138
+Schuylkill,Gilberton,Ballots Cast,,DEM,,28,31,9,1,69
+Schuylkill,Gilberton,Ballots Cast,,REP,,39,23,7,0,69
+Schuylkill,Gilberton,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Gilberton,President,,DEM,Bernie Sanders,5,7,4,0,16
+Schuylkill,Gilberton,President,,DEM,Joseph R. Biden,12,21,4,1,38
+Schuylkill,Gilberton,President,,DEM,Tulsi Gabbard,1,3,0,0,4
+Schuylkill,Gilberton,President,,DEM,Write-in,5,0,1,0,6
+Schuylkill,Gilberton,Attorney General,,DEM,Josh Shapiro,20,29,9,1,59
+Schuylkill,Gilberton,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Gilberton,Auditor General,,DEM,H. Scott Conklin,1,3,3,0,7
+Schuylkill,Gilberton,Auditor General,,DEM,Michael Lamb,3,5,1,0,9
+Schuylkill,Gilberton,Auditor General,,DEM,Tracie Fountain,1,5,0,0,6
+Schuylkill,Gilberton,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,3,0,6
+Schuylkill,Gilberton,Auditor General,,DEM,Nina Ahmad,3,1,1,1,6
+Schuylkill,Gilberton,Auditor General,,DEM,Christina M. Hartman,12,11,1,0,24
+Schuylkill,Gilberton,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Gilberton,State Treasurer,,DEM,Joe Torsella,20,27,9,1,57
+Schuylkill,Gilberton,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Gilberton,Representative In Congress,,DEM,Laura Quick,13,12,6,1,32
+Schuylkill,Gilberton,Representative In Congress,,DEM,Gary Wegman,9,15,3,0,27
+Schuylkill,Gilberton,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Gilberton,State Senate,29,DEM,Write-in,4,3,3,0,10
+Schuylkill,Gilberton,General Assembly,123,DEM,Peter PJ Symons Jr.,21,29,9,1,60
+Schuylkill,Gilberton,General Assembly,123,DEM,Write-in,3,0,0,0,3
+Schuylkill,Gilberton,President,,REP,Donald J. Trump,30,19,7,0,56
+Schuylkill,Gilberton,President,,REP,Roque Rocky De La Fuente,6,1,0,0,7
+Schuylkill,Gilberton,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Gilberton,President,,REP,Write-in,2,1,0,0,3
+Schuylkill,Gilberton,Attorney General,,REP,Heather Heidelbaugh,28,18,5,0,51
+Schuylkill,Gilberton,Attorney General,,REP,Write-in,0,0,1,0,1
+Schuylkill,Gilberton,Auditor General,,REP,Timothy Defoor,28,18,5,0,51
+Schuylkill,Gilberton,Auditor General,,REP,Write-in,0,0,1,0,1
+Schuylkill,Gilberton,State Treasurer,,REP,Stacy L. Garrity,29,18,5,0,52
+Schuylkill,Gilberton,State Treasurer,,REP,Write-in,0,0,1,0,1
+Schuylkill,Gilberton,Representative In Congress,,REP,Dan Meuser,31,19,7,0,57
+Schuylkill,Gilberton,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Gilberton,State Senate,29,REP,Dave Argall,29,19,7,0,55
+Schuylkill,Gilberton,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Gilberton,General Assembly,123,REP,John Leshko,10,4,1,0,15
+Schuylkill,Gilberton,General Assembly,123,REP,Tim Twardzik,28,18,5,0,51
+Schuylkill,Gilberton,General Assembly,123,REP,Write-in,0,0,1,0,1
+Schuylkill,Girardville,Registered Voters,,,,,,,,754
+Schuylkill,Girardville,Registered Voters,,DEM,,,,,,382
+Schuylkill,Girardville,Registered Voters,,REP,,,,,,286
+Schuylkill,Girardville,Registered Voters,,NPA,,,,,,86
+Schuylkill,Girardville,Ballots Cast,,,,153,83,15,3,254
+Schuylkill,Girardville,Ballots Cast,,DEM,,76,57,8,1,142
+Schuylkill,Girardville,Ballots Cast,,REP,,77,26,7,2,112
+Schuylkill,Girardville,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Girardville,President,,DEM,Bernie Sanders,11,12,1,0,24
+Schuylkill,Girardville,President,,DEM,Joseph R. Biden,33,41,7,0,81
+Schuylkill,Girardville,President,,DEM,Tulsi Gabbard,4,1,0,0,5
+Schuylkill,Girardville,President,,DEM,Write-in,19,0,0,1,20
+Schuylkill,Girardville,Attorney General,,DEM,Josh Shapiro,57,50,7,0,114
+Schuylkill,Girardville,Attorney General,,DEM,Write-in,5,1,0,1,7
+Schuylkill,Girardville,Auditor General,,DEM,H. Scott Conklin,7,3,1,0,11
+Schuylkill,Girardville,Auditor General,,DEM,Michael Lamb,11,7,0,0,18
+Schuylkill,Girardville,Auditor General,,DEM,Tracie Fountain,7,10,0,0,17
+Schuylkill,Girardville,Auditor General,,DEM,Rose Rosie Marie Davis,6,12,3,0,21
+Schuylkill,Girardville,Auditor General,,DEM,Nina Ahmad,9,12,1,0,22
+Schuylkill,Girardville,Auditor General,,DEM,Christina M. Hartman,20,9,2,0,31
+Schuylkill,Girardville,Auditor General,,DEM,Write-in,4,0,0,1,5
+Schuylkill,Girardville,State Treasurer,,DEM,Joe Torsella,51,53,7,0,111
+Schuylkill,Girardville,State Treasurer,,DEM,Write-in,6,0,0,1,7
+Schuylkill,Girardville,Representative In Congress,,DEM,Laura Quick,30,32,5,0,67
+Schuylkill,Girardville,Representative In Congress,,DEM,Gary Wegman,30,21,2,0,53
+Schuylkill,Girardville,Representative In Congress,,DEM,Write-in,5,0,0,1,6
+Schuylkill,Girardville,State Senate,29,DEM,Write-in,12,8,1,1,22
+Schuylkill,Girardville,General Assembly,123,DEM,Peter PJ Symons Jr.,59,56,8,0,123
+Schuylkill,Girardville,General Assembly,123,DEM,Write-in,8,1,0,1,10
+Schuylkill,Girardville,President,,REP,Donald J. Trump,69,21,7,2,99
+Schuylkill,Girardville,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Girardville,President,,REP,Bill Weld,3,3,0,0,6
+Schuylkill,Girardville,President,,REP,Write-in,3,2,0,0,5
+Schuylkill,Girardville,Attorney General,,REP,Heather Heidelbaugh,67,19,7,2,95
+Schuylkill,Girardville,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Girardville,Auditor General,,REP,Timothy Defoor,66,19,7,2,94
+Schuylkill,Girardville,Auditor General,,REP,Write-in,2,1,0,0,3
+Schuylkill,Girardville,State Treasurer,,REP,Stacy L. Garrity,67,19,6,2,94
+Schuylkill,Girardville,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Girardville,Representative In Congress,,REP,Dan Meuser,71,23,6,2,102
+Schuylkill,Girardville,Representative In Congress,,REP,Write-in,0,2,0,0,2
+Schuylkill,Girardville,State Senate,29,REP,Dave Argall,71,23,7,2,103
+Schuylkill,Girardville,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Girardville,General Assembly,123,REP,John Leshko,17,6,1,2,26
+Schuylkill,Girardville,General Assembly,123,REP,Tim Twardzik,57,19,6,0,82
+Schuylkill,Girardville,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,Gordon,Registered Voters,,,,,,,,490
+Schuylkill,Gordon,Registered Voters,,DEM,,,,,,160
+Schuylkill,Gordon,Registered Voters,,REP,,,,,,284
+Schuylkill,Gordon,Registered Voters,,NPA,,,,,,46
+Schuylkill,Gordon,Ballots Cast,,,,141,57,7,2,207
+Schuylkill,Gordon,Ballots Cast,,DEM,,45,23,3,0,71
+Schuylkill,Gordon,Ballots Cast,,REP,,96,34,4,2,136
+Schuylkill,Gordon,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Gordon,President,,DEM,Bernie Sanders,12,4,1,0,17
+Schuylkill,Gordon,President,,DEM,Joseph R. Biden,22,15,2,0,39
+Schuylkill,Gordon,President,,DEM,Tulsi Gabbard,3,1,0,0,4
+Schuylkill,Gordon,President,,DEM,Write-in,5,2,0,0,7
+Schuylkill,Gordon,Attorney General,,DEM,Josh Shapiro,28,20,2,0,50
+Schuylkill,Gordon,Attorney General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Gordon,Auditor General,,DEM,H. Scott Conklin,5,3,0,0,8
+Schuylkill,Gordon,Auditor General,,DEM,Michael Lamb,6,2,0,0,8
+Schuylkill,Gordon,Auditor General,,DEM,Tracie Fountain,6,4,0,0,10
+Schuylkill,Gordon,Auditor General,,DEM,Rose Rosie Marie Davis,2,5,1,0,8
+Schuylkill,Gordon,Auditor General,,DEM,Nina Ahmad,7,2,1,0,10
+Schuylkill,Gordon,Auditor General,,DEM,Christina M. Hartman,8,5,1,0,14
+Schuylkill,Gordon,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Gordon,State Treasurer,,DEM,Joe Torsella,29,20,2,0,51
+Schuylkill,Gordon,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Gordon,Representative In Congress,,DEM,Laura Quick,20,9,2,0,31
+Schuylkill,Gordon,Representative In Congress,,DEM,Gary Wegman,13,12,1,0,26
+Schuylkill,Gordon,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Gordon,State Senate,29,DEM,Write-in,0,3,0,0,3
+Schuylkill,Gordon,General Assembly,123,DEM,Peter PJ Symons Jr.,40,23,2,0,65
+Schuylkill,Gordon,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,Gordon,President,,REP,Donald J. Trump,90,30,3,2,125
+Schuylkill,Gordon,President,,REP,Roque Rocky De La Fuente,0,1,1,0,2
+Schuylkill,Gordon,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,Gordon,President,,REP,Write-in,1,2,0,0,3
+Schuylkill,Gordon,Attorney General,,REP,Heather Heidelbaugh,87,27,4,2,120
+Schuylkill,Gordon,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Gordon,Auditor General,,REP,Timothy Defoor,84,27,4,2,117
+Schuylkill,Gordon,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Gordon,State Treasurer,,REP,Stacy L. Garrity,87,28,4,2,121
+Schuylkill,Gordon,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Gordon,Representative In Congress,,REP,Dan Meuser,86,32,3,2,123
+Schuylkill,Gordon,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Gordon,State Senate,29,REP,Dave Argall,91,30,3,2,126
+Schuylkill,Gordon,State Senate,29,REP,Write-in,1,1,0,0,2
+Schuylkill,Gordon,General Assembly,123,REP,John Leshko,16,2,3,1,22
+Schuylkill,Gordon,General Assembly,123,REP,Tim Twardzik,77,29,1,1,108
+Schuylkill,Gordon,General Assembly,123,REP,Write-in,0,1,0,0,1
+Schuylkill,Mahanoy City 1st,Registered Voters,,,,,,,,251
+Schuylkill,Mahanoy City 1st,Registered Voters,,DEM,,,,,,136
+Schuylkill,Mahanoy City 1st,Registered Voters,,REP,,,,,,83
+Schuylkill,Mahanoy City 1st,Registered Voters,,NPA,,,,,,32
+Schuylkill,Mahanoy City 1st,Ballots Cast,,,,64,15,3,0,82
+Schuylkill,Mahanoy City 1st,Ballots Cast,,DEM,,30,10,3,0,43
+Schuylkill,Mahanoy City 1st,Ballots Cast,,REP,,32,4,0,0,36
+Schuylkill,Mahanoy City 1st,Ballots Cast,,NPA,,2,1,0,0,3
+Schuylkill,Mahanoy City 1st,President,,DEM,Bernie Sanders,5,1,0,0,6
+Schuylkill,Mahanoy City 1st,President,,DEM,Joseph R. Biden,12,8,3,0,23
+Schuylkill,Mahanoy City 1st,President,,DEM,Tulsi Gabbard,5,1,0,0,6
+Schuylkill,Mahanoy City 1st,President,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Mahanoy City 1st,Attorney General,,DEM,Josh Shapiro,21,10,3,0,34
+Schuylkill,Mahanoy City 1st,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,Auditor General,,DEM,H. Scott Conklin,2,1,0,0,3
+Schuylkill,Mahanoy City 1st,Auditor General,,DEM,Michael Lamb,3,0,0,0,3
+Schuylkill,Mahanoy City 1st,Auditor General,,DEM,Tracie Fountain,4,2,0,0,6
+Schuylkill,Mahanoy City 1st,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,0,5
+Schuylkill,Mahanoy City 1st,Auditor General,,DEM,Nina Ahmad,5,1,0,0,6
+Schuylkill,Mahanoy City 1st,Auditor General,,DEM,Christina M. Hartman,5,3,3,0,11
+Schuylkill,Mahanoy City 1st,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,State Treasurer,,DEM,Joe Torsella,16,10,3,0,29
+Schuylkill,Mahanoy City 1st,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,Representative In Congress,,DEM,Laura Quick,12,4,3,0,19
+Schuylkill,Mahanoy City 1st,Representative In Congress,,DEM,Gary Wegman,9,6,0,0,15
+Schuylkill,Mahanoy City 1st,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,State Senate,29,DEM,Write-in,2,1,0,0,3
+Schuylkill,Mahanoy City 1st,General Assembly,123,DEM,Peter PJ Symons Jr.,20,10,3,0,33
+Schuylkill,Mahanoy City 1st,General Assembly,123,DEM,Write-in,4,0,0,0,4
+Schuylkill,Mahanoy City 1st,President,,REP,Donald J. Trump,32,3,0,0,35
+Schuylkill,Mahanoy City 1st,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,President,,REP,Bill Weld,0,1,0,0,1
+Schuylkill,Mahanoy City 1st,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,Attorney General,,REP,Heather Heidelbaugh,25,3,0,0,28
+Schuylkill,Mahanoy City 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,Auditor General,,REP,Timothy Defoor,24,3,0,0,27
+Schuylkill,Mahanoy City 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,State Treasurer,,REP,Stacy L. Garrity,23,3,0,0,26
+Schuylkill,Mahanoy City 1st,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,Representative In Congress,,REP,Dan Meuser,27,3,0,0,30
+Schuylkill,Mahanoy City 1st,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 1st,State Senate,29,REP,Dave Argall,26,4,0,0,30
+Schuylkill,Mahanoy City 1st,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 1st,General Assembly,123,REP,John Leshko,8,3,0,0,11
+Schuylkill,Mahanoy City 1st,General Assembly,123,REP,Tim Twardzik,22,1,0,0,23
+Schuylkill,Mahanoy City 1st,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 2nd,Registered Voters,,,,,,,,597
+Schuylkill,Mahanoy City 2nd,Registered Voters,,DEM,,,,,,293
+Schuylkill,Mahanoy City 2nd,Registered Voters,,REP,,,,,,231
+Schuylkill,Mahanoy City 2nd,Registered Voters,,NPA,,,,,,73
+Schuylkill,Mahanoy City 2nd,Ballots Cast,,,,143,70,11,1,225
+Schuylkill,Mahanoy City 2nd,Ballots Cast,,DEM,,56,46,6,1,109
+Schuylkill,Mahanoy City 2nd,Ballots Cast,,REP,,77,23,5,0,105
+Schuylkill,Mahanoy City 2nd,Ballots Cast,,NPA,,10,1,0,0,11
+Schuylkill,Mahanoy City 2nd,President,,DEM,Bernie Sanders,3,1,0,0,4
+Schuylkill,Mahanoy City 2nd,President,,DEM,Joseph R. Biden,32,41,6,0,79
+Schuylkill,Mahanoy City 2nd,President,,DEM,Tulsi Gabbard,6,2,0,0,8
+Schuylkill,Mahanoy City 2nd,President,,DEM,Write-in,8,1,0,1,10
+Schuylkill,Mahanoy City 2nd,Attorney General,,DEM,Josh Shapiro,45,44,6,0,95
+Schuylkill,Mahanoy City 2nd,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 2nd,Auditor General,,DEM,H. Scott Conklin,3,6,0,0,9
+Schuylkill,Mahanoy City 2nd,Auditor General,,DEM,Michael Lamb,10,8,0,0,18
+Schuylkill,Mahanoy City 2nd,Auditor General,,DEM,Tracie Fountain,8,11,1,0,20
+Schuylkill,Mahanoy City 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,9,2,1,0,12
+Schuylkill,Mahanoy City 2nd,Auditor General,,DEM,Nina Ahmad,7,4,1,0,12
+Schuylkill,Mahanoy City 2nd,Auditor General,,DEM,Christina M. Hartman,12,11,2,0,25
+Schuylkill,Mahanoy City 2nd,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 2nd,State Treasurer,,DEM,Joe Torsella,45,42,6,0,93
+Schuylkill,Mahanoy City 2nd,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 2nd,Representative In Congress,,DEM,Laura Quick,19,18,2,0,39
+Schuylkill,Mahanoy City 2nd,Representative In Congress,,DEM,Gary Wegman,27,25,2,0,54
+Schuylkill,Mahanoy City 2nd,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 2nd,State Senate,29,DEM,Write-in,7,6,0,1,14
+Schuylkill,Mahanoy City 2nd,General Assembly,123,DEM,Peter PJ Symons Jr.,48,46,5,0,99
+Schuylkill,Mahanoy City 2nd,General Assembly,123,DEM,Write-in,1,0,0,1,2
+Schuylkill,Mahanoy City 2nd,President,,REP,Donald J. Trump,70,15,4,0,89
+Schuylkill,Mahanoy City 2nd,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Mahanoy City 2nd,President,,REP,Bill Weld,3,2,0,0,5
+Schuylkill,Mahanoy City 2nd,President,,REP,Write-in,2,1,1,0,4
+Schuylkill,Mahanoy City 2nd,Attorney General,,REP,Heather Heidelbaugh,65,18,5,0,88
+Schuylkill,Mahanoy City 2nd,Attorney General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Mahanoy City 2nd,Auditor General,,REP,Timothy Defoor,64,18,5,0,87
+Schuylkill,Mahanoy City 2nd,Auditor General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Mahanoy City 2nd,State Treasurer,,REP,Stacy L. Garrity,64,18,5,0,87
+Schuylkill,Mahanoy City 2nd,State Treasurer,,REP,Write-in,2,0,0,0,2
+Schuylkill,Mahanoy City 2nd,Representative In Congress,,REP,Dan Meuser,70,19,5,0,94
+Schuylkill,Mahanoy City 2nd,Representative In Congress,,REP,Write-in,3,0,0,0,3
+Schuylkill,Mahanoy City 2nd,State Senate,29,REP,Dave Argall,73,21,4,0,98
+Schuylkill,Mahanoy City 2nd,State Senate,29,REP,Write-in,1,0,1,0,2
+Schuylkill,Mahanoy City 2nd,General Assembly,123,REP,John Leshko,33,2,3,0,38
+Schuylkill,Mahanoy City 2nd,General Assembly,123,REP,Tim Twardzik,41,21,2,0,64
+Schuylkill,Mahanoy City 2nd,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 3rd,Registered Voters,,,,,,,,375
+Schuylkill,Mahanoy City 3rd,Registered Voters,,DEM,,,,,,178
+Schuylkill,Mahanoy City 3rd,Registered Voters,,REP,,,,,,133
+Schuylkill,Mahanoy City 3rd,Registered Voters,,NPA,,,,,,64
+Schuylkill,Mahanoy City 3rd,Ballots Cast,,,,100,29,6,2,137
+Schuylkill,Mahanoy City 3rd,Ballots Cast,,DEM,,40,18,3,0,61
+Schuylkill,Mahanoy City 3rd,Ballots Cast,,REP,,52,11,3,2,68
+Schuylkill,Mahanoy City 3rd,Ballots Cast,,NPA,,8,0,0,0,8
+Schuylkill,Mahanoy City 3rd,President,,DEM,Bernie Sanders,9,1,2,0,12
+Schuylkill,Mahanoy City 3rd,President,,DEM,Joseph R. Biden,16,14,1,0,31
+Schuylkill,Mahanoy City 3rd,President,,DEM,Tulsi Gabbard,3,1,0,0,4
+Schuylkill,Mahanoy City 3rd,President,,DEM,Write-in,7,2,0,0,9
+Schuylkill,Mahanoy City 3rd,Attorney General,,DEM,Josh Shapiro,26,17,3,0,46
+Schuylkill,Mahanoy City 3rd,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 3rd,Auditor General,,DEM,H. Scott Conklin,6,5,0,0,11
+Schuylkill,Mahanoy City 3rd,Auditor General,,DEM,Michael Lamb,5,3,0,0,8
+Schuylkill,Mahanoy City 3rd,Auditor General,,DEM,Tracie Fountain,8,2,0,0,10
+Schuylkill,Mahanoy City 3rd,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,0,0,4
+Schuylkill,Mahanoy City 3rd,Auditor General,,DEM,Nina Ahmad,4,1,0,0,5
+Schuylkill,Mahanoy City 3rd,Auditor General,,DEM,Christina M. Hartman,7,4,2,0,13
+Schuylkill,Mahanoy City 3rd,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 3rd,State Treasurer,,DEM,Joe Torsella,26,16,3,0,45
+Schuylkill,Mahanoy City 3rd,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 3rd,Representative In Congress,,DEM,Laura Quick,18,5,2,0,25
+Schuylkill,Mahanoy City 3rd,Representative In Congress,,DEM,Gary Wegman,15,12,1,0,28
+Schuylkill,Mahanoy City 3rd,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 3rd,State Senate,29,DEM,Write-in,9,1,0,0,10
+Schuylkill,Mahanoy City 3rd,General Assembly,123,DEM,Peter PJ Symons Jr.,30,17,3,0,50
+Schuylkill,Mahanoy City 3rd,General Assembly,123,DEM,Write-in,2,0,0,0,2
+Schuylkill,Mahanoy City 3rd,President,,REP,Donald J. Trump,51,7,2,2,62
+Schuylkill,Mahanoy City 3rd,President,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Schuylkill,Mahanoy City 3rd,President,,REP,Bill Weld,1,2,0,0,3
+Schuylkill,Mahanoy City 3rd,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Mahanoy City 3rd,Attorney General,,REP,Heather Heidelbaugh,44,10,3,2,59
+Schuylkill,Mahanoy City 3rd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 3rd,Auditor General,,REP,Timothy Defoor,43,10,3,2,58
+Schuylkill,Mahanoy City 3rd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 3rd,State Treasurer,,REP,Stacy L. Garrity,44,10,3,2,59
+Schuylkill,Mahanoy City 3rd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 3rd,Representative In Congress,,REP,Dan Meuser,49,10,3,2,64
+Schuylkill,Mahanoy City 3rd,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 3rd,State Senate,29,REP,Dave Argall,49,11,3,2,65
+Schuylkill,Mahanoy City 3rd,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 3rd,General Assembly,123,REP,John Leshko,21,1,1,0,23
+Schuylkill,Mahanoy City 3rd,General Assembly,123,REP,Tim Twardzik,30,10,2,2,44
+Schuylkill,Mahanoy City 3rd,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 4th,Registered Voters,,,,,,,,724
+Schuylkill,Mahanoy City 4th,Registered Voters,,DEM,,,,,,309
+Schuylkill,Mahanoy City 4th,Registered Voters,,REP,,,,,,303
+Schuylkill,Mahanoy City 4th,Registered Voters,,NPA,,,,,,112
+Schuylkill,Mahanoy City 4th,Ballots Cast,,,,186,83,14,1,284
+Schuylkill,Mahanoy City 4th,Ballots Cast,,DEM,,77,52,8,0,137
+Schuylkill,Mahanoy City 4th,Ballots Cast,,REP,,94,31,5,1,131
+Schuylkill,Mahanoy City 4th,Ballots Cast,,NPA,,15,0,1,0,16
+Schuylkill,Mahanoy City 4th,President,,DEM,Bernie Sanders,14,10,0,0,24
+Schuylkill,Mahanoy City 4th,President,,DEM,Joseph R. Biden,33,35,6,0,74
+Schuylkill,Mahanoy City 4th,President,,DEM,Tulsi Gabbard,4,1,2,0,7
+Schuylkill,Mahanoy City 4th,President,,DEM,Write-in,10,3,0,0,13
+Schuylkill,Mahanoy City 4th,Attorney General,,DEM,Josh Shapiro,60,44,7,0,111
+Schuylkill,Mahanoy City 4th,Attorney General,,DEM,Write-in,0,1,1,0,2
+Schuylkill,Mahanoy City 4th,Auditor General,,DEM,H. Scott Conklin,2,4,2,0,8
+Schuylkill,Mahanoy City 4th,Auditor General,,DEM,Michael Lamb,14,9,1,0,24
+Schuylkill,Mahanoy City 4th,Auditor General,,DEM,Tracie Fountain,7,11,2,0,20
+Schuylkill,Mahanoy City 4th,Auditor General,,DEM,Rose Rosie Marie Davis,8,4,0,0,12
+Schuylkill,Mahanoy City 4th,Auditor General,,DEM,Nina Ahmad,8,5,1,0,14
+Schuylkill,Mahanoy City 4th,Auditor General,,DEM,Christina M. Hartman,22,12,2,0,36
+Schuylkill,Mahanoy City 4th,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 4th,State Treasurer,,DEM,Joe Torsella,57,43,7,0,107
+Schuylkill,Mahanoy City 4th,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Schuylkill,Mahanoy City 4th,Representative In Congress,,DEM,Laura Quick,34,21,3,0,58
+Schuylkill,Mahanoy City 4th,Representative In Congress,,DEM,Gary Wegman,27,27,4,0,58
+Schuylkill,Mahanoy City 4th,Representative In Congress,,DEM,Write-in,0,0,1,0,1
+Schuylkill,Mahanoy City 4th,State Senate,29,DEM,Write-in,5,6,2,0,13
+Schuylkill,Mahanoy City 4th,General Assembly,123,DEM,Peter PJ Symons Jr.,55,46,7,0,108
+Schuylkill,Mahanoy City 4th,General Assembly,123,DEM,Write-in,7,1,1,0,9
+Schuylkill,Mahanoy City 4th,President,,REP,Donald J. Trump,90,24,5,1,120
+Schuylkill,Mahanoy City 4th,President,,REP,Roque Rocky De La Fuente,3,0,0,0,3
+Schuylkill,Mahanoy City 4th,President,,REP,Bill Weld,1,1,0,0,2
+Schuylkill,Mahanoy City 4th,President,,REP,Write-in,0,3,0,0,3
+Schuylkill,Mahanoy City 4th,Attorney General,,REP,Heather Heidelbaugh,78,26,2,1,107
+Schuylkill,Mahanoy City 4th,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 4th,Auditor General,,REP,Timothy Defoor,76,25,2,1,104
+Schuylkill,Mahanoy City 4th,Auditor General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Mahanoy City 4th,State Treasurer,,REP,Stacy L. Garrity,78,26,2,1,107
+Schuylkill,Mahanoy City 4th,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 4th,Representative In Congress,,REP,Dan Meuser,81,27,3,1,112
+Schuylkill,Mahanoy City 4th,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Mahanoy City 4th,State Senate,29,REP,Dave Argall,88,30,5,1,124
+Schuylkill,Mahanoy City 4th,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy City 4th,General Assembly,123,REP,John Leshko,27,6,2,0,35
+Schuylkill,Mahanoy City 4th,General Assembly,123,REP,Tim Twardzik,63,24,1,1,89
+Schuylkill,Mahanoy City 4th,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy Twp,Registered Voters,,,,,,,,575
+Schuylkill,Mahanoy Twp,Registered Voters,,DEM,,,,,,266
+Schuylkill,Mahanoy Twp,Registered Voters,,REP,,,,,,263
+Schuylkill,Mahanoy Twp,Registered Voters,,NPA,,,,,,46
+Schuylkill,Mahanoy Twp,Ballots Cast,,,,148,79,12,1,240
+Schuylkill,Mahanoy Twp,Ballots Cast,,DEM,,53,47,8,0,108
+Schuylkill,Mahanoy Twp,Ballots Cast,,REP,,95,32,4,1,132
+Schuylkill,Mahanoy Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Mahanoy Twp,President,,DEM,Bernie Sanders,6,3,1,0,10
+Schuylkill,Mahanoy Twp,President,,DEM,Joseph R. Biden,21,27,6,0,54
+Schuylkill,Mahanoy Twp,President,,DEM,Tulsi Gabbard,3,3,0,0,6
+Schuylkill,Mahanoy Twp,President,,DEM,Write-in,15,12,0,0,27
+Schuylkill,Mahanoy Twp,Attorney General,,DEM,Josh Shapiro,39,42,8,0,89
+Schuylkill,Mahanoy Twp,Attorney General,,DEM,Write-in,6,0,0,0,6
+Schuylkill,Mahanoy Twp,Auditor General,,DEM,H. Scott Conklin,5,6,2,0,13
+Schuylkill,Mahanoy Twp,Auditor General,,DEM,Michael Lamb,9,10,0,0,19
+Schuylkill,Mahanoy Twp,Auditor General,,DEM,Tracie Fountain,7,8,2,0,17
+Schuylkill,Mahanoy Twp,Auditor General,,DEM,Rose Rosie Marie Davis,6,2,1,0,9
+Schuylkill,Mahanoy Twp,Auditor General,,DEM,Nina Ahmad,5,2,0,0,7
+Schuylkill,Mahanoy Twp,Auditor General,,DEM,Christina M. Hartman,12,14,2,0,28
+Schuylkill,Mahanoy Twp,Auditor General,,DEM,Write-in,5,0,0,0,5
+Schuylkill,Mahanoy Twp,State Treasurer,,DEM,Joe Torsella,37,44,8,0,89
+Schuylkill,Mahanoy Twp,State Treasurer,,DEM,Write-in,5,0,0,0,5
+Schuylkill,Mahanoy Twp,Representative In Congress,,DEM,Laura Quick,20,17,5,0,42
+Schuylkill,Mahanoy Twp,Representative In Congress,,DEM,Gary Wegman,22,23,1,0,46
+Schuylkill,Mahanoy Twp,Representative In Congress,,DEM,Write-in,6,5,0,0,11
+Schuylkill,Mahanoy Twp,State Senate,29,DEM,Write-in,8,10,0,0,18
+Schuylkill,Mahanoy Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,44,37,8,0,89
+Schuylkill,Mahanoy Twp,General Assembly,123,DEM,Write-in,7,10,0,0,17
+Schuylkill,Mahanoy Twp,President,,REP,Donald J. Trump,90,21,1,1,113
+Schuylkill,Mahanoy Twp,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Mahanoy Twp,President,,REP,Bill Weld,1,8,2,0,11
+Schuylkill,Mahanoy Twp,President,,REP,Write-in,0,1,1,0,2
+Schuylkill,Mahanoy Twp,Attorney General,,REP,Heather Heidelbaugh,82,24,3,1,110
+Schuylkill,Mahanoy Twp,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy Twp,Auditor General,,REP,Timothy Defoor,80,24,3,1,108
+Schuylkill,Mahanoy Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mahanoy Twp,State Treasurer,,REP,Stacy L. Garrity,82,23,3,1,109
+Schuylkill,Mahanoy Twp,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Mahanoy Twp,Representative In Congress,,REP,Dan Meuser,87,22,3,1,113
+Schuylkill,Mahanoy Twp,Representative In Congress,,REP,Write-in,1,2,0,0,3
+Schuylkill,Mahanoy Twp,State Senate,29,REP,Dave Argall,85,25,4,1,115
+Schuylkill,Mahanoy Twp,State Senate,29,REP,Write-in,1,1,0,0,2
+Schuylkill,Mahanoy Twp,General Assembly,123,REP,John Leshko,31,9,1,0,41
+Schuylkill,Mahanoy Twp,General Assembly,123,REP,Tim Twardzik,60,17,3,1,81
+Schuylkill,Mahanoy Twp,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Middleport,Registered Voters,,,,,,,,266
+Schuylkill,Middleport,Registered Voters,,DEM,,,,,,106
+Schuylkill,Middleport,Registered Voters,,REP,,,,,,133
+Schuylkill,Middleport,Registered Voters,,NPA,,,,,,27
+Schuylkill,Middleport,Ballots Cast,,,,74,25,5,5,109
+Schuylkill,Middleport,Ballots Cast,,DEM,,33,10,2,3,48
+Schuylkill,Middleport,Ballots Cast,,REP,,41,15,3,2,61
+Schuylkill,Middleport,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Middleport,President,,DEM,Bernie Sanders,4,0,0,0,4
+Schuylkill,Middleport,President,,DEM,Joseph R. Biden,18,9,2,3,32
+Schuylkill,Middleport,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Middleport,President,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Middleport,Attorney General,,DEM,Josh Shapiro,27,9,2,3,41
+Schuylkill,Middleport,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Middleport,Auditor General,,DEM,H. Scott Conklin,2,0,0,1,3
+Schuylkill,Middleport,Auditor General,,DEM,Michael Lamb,5,2,0,0,7
+Schuylkill,Middleport,Auditor General,,DEM,Tracie Fountain,3,3,0,0,6
+Schuylkill,Middleport,Auditor General,,DEM,Rose Rosie Marie Davis,1,1,0,0,2
+Schuylkill,Middleport,Auditor General,,DEM,Nina Ahmad,1,0,1,0,2
+Schuylkill,Middleport,Auditor General,,DEM,Christina M. Hartman,12,3,0,2,17
+Schuylkill,Middleport,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Middleport,State Treasurer,,DEM,Joe Torsella,26,9,1,3,39
+Schuylkill,Middleport,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Middleport,Representative In Congress,,DEM,Laura Quick,7,0,0,0,7
+Schuylkill,Middleport,Representative In Congress,,DEM,Gary Wegman,20,9,1,3,33
+Schuylkill,Middleport,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Middleport,State Senate,29,DEM,Write-in,4,0,0,0,4
+Schuylkill,Middleport,General Assembly,123,DEM,Peter PJ Symons Jr.,25,10,2,3,40
+Schuylkill,Middleport,General Assembly,123,DEM,Write-in,2,0,0,0,2
+Schuylkill,Middleport,President,,REP,Donald J. Trump,37,14,3,2,56
+Schuylkill,Middleport,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,Middleport,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Middleport,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Middleport,Attorney General,,REP,Heather Heidelbaugh,34,14,2,2,52
+Schuylkill,Middleport,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Middleport,Auditor General,,REP,Timothy Defoor,35,13,2,2,52
+Schuylkill,Middleport,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Middleport,State Treasurer,,REP,Stacy L. Garrity,35,13,2,2,52
+Schuylkill,Middleport,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Middleport,Representative In Congress,,REP,Dan Meuser,38,13,3,2,56
+Schuylkill,Middleport,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Middleport,State Senate,29,REP,Dave Argall,39,14,3,2,58
+Schuylkill,Middleport,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Middleport,General Assembly,123,REP,John Leshko,29,15,3,0,47
+Schuylkill,Middleport,General Assembly,123,REP,Tim Twardzik,11,0,0,2,13
+Schuylkill,Middleport,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,Minersville 1st,Registered Voters,,,,,,,,506
+Schuylkill,Minersville 1st,Registered Voters,,DEM,,,,,,214
+Schuylkill,Minersville 1st,Registered Voters,,REP,,,,,,227
+Schuylkill,Minersville 1st,Registered Voters,,NPA,,,,,,65
+Schuylkill,Minersville 1st,Ballots Cast,,,,112,73,13,0,198
+Schuylkill,Minersville 1st,Ballots Cast,,DEM,,44,42,11,0,97
+Schuylkill,Minersville 1st,Ballots Cast,,REP,,68,31,2,0,101
+Schuylkill,Minersville 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Minersville 1st,President,,DEM,Bernie Sanders,9,2,0,0,11
+Schuylkill,Minersville 1st,President,,DEM,Joseph R. Biden,24,33,8,0,65
+Schuylkill,Minersville 1st,President,,DEM,Tulsi Gabbard,1,6,2,0,9
+Schuylkill,Minersville 1st,President,,DEM,Write-in,6,1,1,0,8
+Schuylkill,Minersville 1st,Attorney General,,DEM,Josh Shapiro,40,36,9,0,85
+Schuylkill,Minersville 1st,Attorney General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Minersville 1st,Auditor General,,DEM,H. Scott Conklin,2,5,0,0,7
+Schuylkill,Minersville 1st,Auditor General,,DEM,Michael Lamb,11,7,5,0,23
+Schuylkill,Minersville 1st,Auditor General,,DEM,Tracie Fountain,6,6,2,0,14
+Schuylkill,Minersville 1st,Auditor General,,DEM,Rose Rosie Marie Davis,1,4,1,0,6
+Schuylkill,Minersville 1st,Auditor General,,DEM,Nina Ahmad,4,9,0,0,13
+Schuylkill,Minersville 1st,Auditor General,,DEM,Christina M. Hartman,17,8,3,0,28
+Schuylkill,Minersville 1st,Auditor General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Minersville 1st,State Treasurer,,DEM,Joe Torsella,40,35,10,0,85
+Schuylkill,Minersville 1st,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Minersville 1st,Representative In Congress,,DEM,Laura Quick,20,12,3,0,35
+Schuylkill,Minersville 1st,Representative In Congress,,DEM,Gary Wegman,22,23,3,0,48
+Schuylkill,Minersville 1st,Representative In Congress,,DEM,Write-in,0,2,3,0,5
+Schuylkill,Minersville 1st,State Senate,29,DEM,Write-in,2,7,1,0,10
+Schuylkill,Minersville 1st,General Assembly,123,DEM,Peter PJ Symons Jr.,38,38,11,0,87
+Schuylkill,Minersville 1st,General Assembly,123,DEM,Write-in,2,2,0,0,4
+Schuylkill,Minersville 1st,President,,REP,Donald J. Trump,65,21,1,0,87
+Schuylkill,Minersville 1st,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Minersville 1st,President,,REP,Bill Weld,2,6,0,0,8
+Schuylkill,Minersville 1st,President,,REP,Write-in,0,2,1,0,3
+Schuylkill,Minersville 1st,Attorney General,,REP,Heather Heidelbaugh,62,28,2,0,92
+Schuylkill,Minersville 1st,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 1st,Auditor General,,REP,Timothy Defoor,63,27,2,0,92
+Schuylkill,Minersville 1st,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 1st,State Treasurer,,REP,Stacy L. Garrity,63,28,2,0,93
+Schuylkill,Minersville 1st,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 1st,Representative In Congress,,REP,Dan Meuser,66,30,1,0,97
+Schuylkill,Minersville 1st,Representative In Congress,,REP,Write-in,0,1,1,0,2
+Schuylkill,Minersville 1st,State Senate,29,REP,Dave Argall,66,28,1,0,95
+Schuylkill,Minersville 1st,State Senate,29,REP,Write-in,0,1,1,0,2
+Schuylkill,Minersville 1st,General Assembly,123,REP,John Leshko,39,12,2,0,53
+Schuylkill,Minersville 1st,General Assembly,123,REP,Tim Twardzik,29,17,0,0,46
+Schuylkill,Minersville 1st,General Assembly,123,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 2nd,Registered Voters,,,,,,,,758
+Schuylkill,Minersville 2nd,Registered Voters,,DEM,,,,,,352
+Schuylkill,Minersville 2nd,Registered Voters,,REP,,,,,,297
+Schuylkill,Minersville 2nd,Registered Voters,,NPA,,,,,,109
+Schuylkill,Minersville 2nd,Ballots Cast,,,,140,62,6,3,211
+Schuylkill,Minersville 2nd,Ballots Cast,,DEM,,66,36,5,0,107
+Schuylkill,Minersville 2nd,Ballots Cast,,REP,,74,26,1,3,104
+Schuylkill,Minersville 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Minersville 2nd,President,,DEM,Bernie Sanders,20,8,0,0,28
+Schuylkill,Minersville 2nd,President,,DEM,Joseph R. Biden,29,25,5,0,59
+Schuylkill,Minersville 2nd,President,,DEM,Tulsi Gabbard,5,2,0,0,7
+Schuylkill,Minersville 2nd,President,,DEM,Write-in,6,0,0,0,6
+Schuylkill,Minersville 2nd,Attorney General,,DEM,Josh Shapiro,53,33,5,0,91
+Schuylkill,Minersville 2nd,Attorney General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Minersville 2nd,Auditor General,,DEM,H. Scott Conklin,8,2,0,0,10
+Schuylkill,Minersville 2nd,Auditor General,,DEM,Michael Lamb,13,4,1,0,18
+Schuylkill,Minersville 2nd,Auditor General,,DEM,Tracie Fountain,9,10,3,0,22
+Schuylkill,Minersville 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,5,2,0,0,7
+Schuylkill,Minersville 2nd,Auditor General,,DEM,Nina Ahmad,9,4,0,0,13
+Schuylkill,Minersville 2nd,Auditor General,,DEM,Christina M. Hartman,17,12,1,0,30
+Schuylkill,Minersville 2nd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Minersville 2nd,State Treasurer,,DEM,Joe Torsella,57,29,4,0,90
+Schuylkill,Minersville 2nd,State Treasurer,,DEM,Write-in,1,3,0,0,4
+Schuylkill,Minersville 2nd,Representative In Congress,,DEM,Laura Quick,33,20,0,0,53
+Schuylkill,Minersville 2nd,Representative In Congress,,DEM,Gary Wegman,25,15,5,0,45
+Schuylkill,Minersville 2nd,Representative In Congress,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Minersville 2nd,State Senate,29,DEM,Write-in,8,3,0,0,11
+Schuylkill,Minersville 2nd,General Assembly,123,DEM,Peter PJ Symons Jr.,58,34,4,0,96
+Schuylkill,Minersville 2nd,General Assembly,123,DEM,Write-in,2,1,0,0,3
+Schuylkill,Minersville 2nd,President,,REP,Donald J. Trump,72,16,1,3,92
+Schuylkill,Minersville 2nd,President,,REP,Roque Rocky De La Fuente,0,3,0,0,3
+Schuylkill,Minersville 2nd,President,,REP,Bill Weld,1,1,0,0,2
+Schuylkill,Minersville 2nd,President,,REP,Write-in,0,2,0,0,2
+Schuylkill,Minersville 2nd,Attorney General,,REP,Heather Heidelbaugh,68,20,1,3,92
+Schuylkill,Minersville 2nd,Attorney General,,REP,Write-in,0,2,0,0,2
+Schuylkill,Minersville 2nd,Auditor General,,REP,Timothy Defoor,68,21,1,3,93
+Schuylkill,Minersville 2nd,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 2nd,State Treasurer,,REP,Stacy L. Garrity,68,21,1,3,93
+Schuylkill,Minersville 2nd,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 2nd,Representative In Congress,,REP,Dan Meuser,65,23,1,3,92
+Schuylkill,Minersville 2nd,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 2nd,State Senate,29,REP,Dave Argall,70,24,1,3,98
+Schuylkill,Minersville 2nd,State Senate,29,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 2nd,General Assembly,123,REP,John Leshko,50,11,0,1,62
+Schuylkill,Minersville 2nd,General Assembly,123,REP,Tim Twardzik,22,15,1,2,40
+Schuylkill,Minersville 2nd,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 3rd,Registered Voters,,,,,,,,633
+Schuylkill,Minersville 3rd,Registered Voters,,DEM,,,,,,289
+Schuylkill,Minersville 3rd,Registered Voters,,REP,,,,,,240
+Schuylkill,Minersville 3rd,Registered Voters,,NPA,,,,,,104
+Schuylkill,Minersville 3rd,Ballots Cast,,,,113,54,13,1,181
+Schuylkill,Minersville 3rd,Ballots Cast,,DEM,,48,40,8,0,96
+Schuylkill,Minersville 3rd,Ballots Cast,,REP,,65,14,5,1,85
+Schuylkill,Minersville 3rd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Minersville 3rd,President,,DEM,Bernie Sanders,7,7,0,0,14
+Schuylkill,Minersville 3rd,President,,DEM,Joseph R. Biden,30,30,8,0,68
+Schuylkill,Minersville 3rd,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Schuylkill,Minersville 3rd,President,,DEM,Write-in,6,1,0,0,7
+Schuylkill,Minersville 3rd,Attorney General,,DEM,Josh Shapiro,41,37,8,0,86
+Schuylkill,Minersville 3rd,Attorney General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Minersville 3rd,Auditor General,,DEM,H. Scott Conklin,3,4,1,0,8
+Schuylkill,Minersville 3rd,Auditor General,,DEM,Michael Lamb,5,7,0,0,12
+Schuylkill,Minersville 3rd,Auditor General,,DEM,Tracie Fountain,12,7,2,0,21
+Schuylkill,Minersville 3rd,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,1,0,6
+Schuylkill,Minersville 3rd,Auditor General,,DEM,Nina Ahmad,11,2,2,0,15
+Schuylkill,Minersville 3rd,Auditor General,,DEM,Christina M. Hartman,10,15,1,0,26
+Schuylkill,Minersville 3rd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Minersville 3rd,State Treasurer,,DEM,Joe Torsella,39,34,8,0,81
+Schuylkill,Minersville 3rd,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Minersville 3rd,Representative In Congress,,DEM,Laura Quick,22,20,2,0,44
+Schuylkill,Minersville 3rd,Representative In Congress,,DEM,Gary Wegman,21,17,5,0,43
+Schuylkill,Minersville 3rd,Representative In Congress,,DEM,Write-in,1,0,1,0,2
+Schuylkill,Minersville 3rd,State Senate,29,DEM,Write-in,5,4,0,0,9
+Schuylkill,Minersville 3rd,General Assembly,123,DEM,Peter PJ Symons Jr.,37,38,8,0,83
+Schuylkill,Minersville 3rd,General Assembly,123,DEM,Write-in,5,0,0,0,5
+Schuylkill,Minersville 3rd,President,,REP,Donald J. Trump,61,14,4,1,80
+Schuylkill,Minersville 3rd,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,Minersville 3rd,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Minersville 3rd,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Minersville 3rd,Attorney General,,REP,Heather Heidelbaugh,57,13,3,1,74
+Schuylkill,Minersville 3rd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 3rd,Auditor General,,REP,Timothy Defoor,57,13,4,1,75
+Schuylkill,Minersville 3rd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 3rd,State Treasurer,,REP,Stacy L. Garrity,55,13,3,1,72
+Schuylkill,Minersville 3rd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 3rd,Representative In Congress,,REP,Dan Meuser,59,13,4,1,77
+Schuylkill,Minersville 3rd,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 3rd,State Senate,29,REP,Dave Argall,62,13,4,1,80
+Schuylkill,Minersville 3rd,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 3rd,General Assembly,123,REP,John Leshko,38,10,3,1,52
+Schuylkill,Minersville 3rd,General Assembly,123,REP,Tim Twardzik,25,4,1,0,30
+Schuylkill,Minersville 3rd,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,Minersville 4th,Registered Voters,,,,,,,,537
+Schuylkill,Minersville 4th,Registered Voters,,DEM,,,,,,231
+Schuylkill,Minersville 4th,Registered Voters,,REP,,,,,,221
+Schuylkill,Minersville 4th,Registered Voters,,NPA,,,,,,85
+Schuylkill,Minersville 4th,Ballots Cast,,,,128,34,11,3,176
+Schuylkill,Minersville 4th,Ballots Cast,,DEM,,55,15,6,0,76
+Schuylkill,Minersville 4th,Ballots Cast,,REP,,73,19,5,3,100
+Schuylkill,Minersville 4th,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Minersville 4th,President,,DEM,Bernie Sanders,17,2,1,0,20
+Schuylkill,Minersville 4th,President,,DEM,Joseph R. Biden,26,13,5,0,44
+Schuylkill,Minersville 4th,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Minersville 4th,President,,DEM,Write-in,7,0,0,0,7
+Schuylkill,Minersville 4th,Attorney General,,DEM,Josh Shapiro,47,15,3,0,65
+Schuylkill,Minersville 4th,Attorney General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Minersville 4th,Auditor General,,DEM,H. Scott Conklin,5,2,0,0,7
+Schuylkill,Minersville 4th,Auditor General,,DEM,Michael Lamb,8,1,1,0,10
+Schuylkill,Minersville 4th,Auditor General,,DEM,Tracie Fountain,9,3,2,0,14
+Schuylkill,Minersville 4th,Auditor General,,DEM,Rose Rosie Marie Davis,6,0,0,0,6
+Schuylkill,Minersville 4th,Auditor General,,DEM,Nina Ahmad,12,3,0,0,15
+Schuylkill,Minersville 4th,Auditor General,,DEM,Christina M. Hartman,10,6,0,0,16
+Schuylkill,Minersville 4th,Auditor General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Minersville 4th,State Treasurer,,DEM,Joe Torsella,45,14,3,0,62
+Schuylkill,Minersville 4th,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Minersville 4th,Representative In Congress,,DEM,Laura Quick,29,9,2,0,40
+Schuylkill,Minersville 4th,Representative In Congress,,DEM,Gary Wegman,21,6,2,0,29
+Schuylkill,Minersville 4th,Representative In Congress,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Minersville 4th,State Senate,29,DEM,Write-in,6,1,1,0,8
+Schuylkill,Minersville 4th,General Assembly,123,DEM,Peter PJ Symons Jr.,46,15,3,0,64
+Schuylkill,Minersville 4th,General Assembly,123,DEM,Write-in,5,0,0,0,5
+Schuylkill,Minersville 4th,President,,REP,Donald J. Trump,63,15,5,3,86
+Schuylkill,Minersville 4th,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Schuylkill,Minersville 4th,President,,REP,Bill Weld,6,2,0,0,8
+Schuylkill,Minersville 4th,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 4th,Attorney General,,REP,Heather Heidelbaugh,63,17,5,3,88
+Schuylkill,Minersville 4th,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 4th,Auditor General,,REP,Timothy Defoor,61,17,5,3,86
+Schuylkill,Minersville 4th,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 4th,State Treasurer,,REP,Stacy L. Garrity,62,18,5,3,88
+Schuylkill,Minersville 4th,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Minersville 4th,Representative In Congress,,REP,Dan Meuser,66,18,5,3,92
+Schuylkill,Minersville 4th,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Minersville 4th,State Senate,29,REP,Dave Argall,70,17,5,3,95
+Schuylkill,Minersville 4th,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Minersville 4th,General Assembly,123,REP,John Leshko,52,12,0,2,66
+Schuylkill,Minersville 4th,General Assembly,123,REP,Tim Twardzik,18,7,5,1,31
+Schuylkill,Minersville 4th,General Assembly,123,REP,Write-in,2,0,0,0,2
+Schuylkill,New Castle Twp,Registered Voters,,,,,,,,208
+Schuylkill,New Castle Twp,Registered Voters,,DEM,,,,,,126
+Schuylkill,New Castle Twp,Registered Voters,,REP,,,,,,63
+Schuylkill,New Castle Twp,Registered Voters,,NPA,,,,,,19
+Schuylkill,New Castle Twp,Ballots Cast,,,,44,23,2,0,69
+Schuylkill,New Castle Twp,Ballots Cast,,DEM,,28,16,2,0,46
+Schuylkill,New Castle Twp,Ballots Cast,,REP,,16,7,0,0,23
+Schuylkill,New Castle Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,New Castle Twp,President,,DEM,Bernie Sanders,8,1,0,0,9
+Schuylkill,New Castle Twp,President,,DEM,Joseph R. Biden,12,12,2,0,26
+Schuylkill,New Castle Twp,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Schuylkill,New Castle Twp,President,,DEM,Write-in,3,2,0,0,5
+Schuylkill,New Castle Twp,Attorney General,,DEM,Josh Shapiro,22,14,2,0,38
+Schuylkill,New Castle Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,Auditor General,,DEM,H. Scott Conklin,4,1,0,0,5
+Schuylkill,New Castle Twp,Auditor General,,DEM,Michael Lamb,3,0,0,0,3
+Schuylkill,New Castle Twp,Auditor General,,DEM,Tracie Fountain,3,5,0,0,8
+Schuylkill,New Castle Twp,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,0,0,4
+Schuylkill,New Castle Twp,Auditor General,,DEM,Nina Ahmad,5,3,0,0,8
+Schuylkill,New Castle Twp,Auditor General,,DEM,Christina M. Hartman,7,4,2,0,13
+Schuylkill,New Castle Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,State Treasurer,,DEM,Joe Torsella,20,13,1,0,34
+Schuylkill,New Castle Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,Representative In Congress,,DEM,Laura Quick,8,11,2,0,21
+Schuylkill,New Castle Twp,Representative In Congress,,DEM,Gary Wegman,14,4,0,0,18
+Schuylkill,New Castle Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,State Senate,29,DEM,Write-in,1,1,0,0,2
+Schuylkill,New Castle Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,25,14,2,0,41
+Schuylkill,New Castle Twp,General Assembly,123,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,President,,REP,Donald J. Trump,14,7,0,0,21
+Schuylkill,New Castle Twp,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,New Castle Twp,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,New Castle Twp,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,Attorney General,,REP,Heather Heidelbaugh,12,5,0,0,17
+Schuylkill,New Castle Twp,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,Auditor General,,REP,Timothy Defoor,11,5,0,0,16
+Schuylkill,New Castle Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,State Treasurer,,REP,Stacy L. Garrity,12,5,0,0,17
+Schuylkill,New Castle Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,Representative In Congress,,REP,Dan Meuser,15,7,0,0,22
+Schuylkill,New Castle Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,State Senate,29,REP,Dave Argall,14,6,0,0,20
+Schuylkill,New Castle Twp,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,New Castle Twp,General Assembly,123,REP,John Leshko,10,3,0,0,13
+Schuylkill,New Castle Twp,General Assembly,123,REP,Tim Twardzik,6,3,0,0,9
+Schuylkill,New Castle Twp,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,New Philadelphia,Registered Voters,,,,,,,,662
+Schuylkill,New Philadelphia,Registered Voters,,DEM,,,,,,341
+Schuylkill,New Philadelphia,Registered Voters,,REP,,,,,,245
+Schuylkill,New Philadelphia,Registered Voters,,NPA,,,,,,76
+Schuylkill,New Philadelphia,Ballots Cast,,,,149,72,9,1,231
+Schuylkill,New Philadelphia,Ballots Cast,,DEM,,71,39,9,1,120
+Schuylkill,New Philadelphia,Ballots Cast,,REP,,78,33,0,0,111
+Schuylkill,New Philadelphia,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,New Philadelphia,President,,DEM,Bernie Sanders,11,3,2,0,16
+Schuylkill,New Philadelphia,President,,DEM,Joseph R. Biden,47,30,7,1,85
+Schuylkill,New Philadelphia,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Schuylkill,New Philadelphia,President,,DEM,Write-in,4,6,0,0,10
+Schuylkill,New Philadelphia,Attorney General,,DEM,Josh Shapiro,56,36,7,1,100
+Schuylkill,New Philadelphia,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Philadelphia,Auditor General,,DEM,H. Scott Conklin,3,4,0,0,7
+Schuylkill,New Philadelphia,Auditor General,,DEM,Michael Lamb,17,6,1,0,24
+Schuylkill,New Philadelphia,Auditor General,,DEM,Tracie Fountain,11,4,2,0,17
+Schuylkill,New Philadelphia,Auditor General,,DEM,Rose Rosie Marie Davis,8,3,4,0,15
+Schuylkill,New Philadelphia,Auditor General,,DEM,Nina Ahmad,5,7,0,0,12
+Schuylkill,New Philadelphia,Auditor General,,DEM,Christina M. Hartman,14,11,1,1,27
+Schuylkill,New Philadelphia,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Philadelphia,State Treasurer,,DEM,Joe Torsella,53,35,7,1,96
+Schuylkill,New Philadelphia,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Philadelphia,Representative In Congress,,DEM,Laura Quick,20,13,5,0,38
+Schuylkill,New Philadelphia,Representative In Congress,,DEM,Gary Wegman,41,22,3,1,67
+Schuylkill,New Philadelphia,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,New Philadelphia,State Senate,29,DEM,Write-in,5,0,1,1,7
+Schuylkill,New Philadelphia,General Assembly,123,DEM,Peter PJ Symons Jr.,62,37,6,1,106
+Schuylkill,New Philadelphia,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,New Philadelphia,President,,REP,Donald J. Trump,71,31,0,0,102
+Schuylkill,New Philadelphia,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,New Philadelphia,President,,REP,Bill Weld,4,0,0,0,4
+Schuylkill,New Philadelphia,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,New Philadelphia,Attorney General,,REP,Heather Heidelbaugh,63,29,0,0,92
+Schuylkill,New Philadelphia,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Philadelphia,Auditor General,,REP,Timothy Defoor,61,28,0,0,89
+Schuylkill,New Philadelphia,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Philadelphia,State Treasurer,,REP,Stacy L. Garrity,63,28,0,0,91
+Schuylkill,New Philadelphia,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Philadelphia,Representative In Congress,,REP,Dan Meuser,66,29,0,0,95
+Schuylkill,New Philadelphia,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,New Philadelphia,State Senate,29,REP,Dave Argall,72,32,0,0,104
+Schuylkill,New Philadelphia,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,New Philadelphia,General Assembly,123,REP,John Leshko,43,19,0,0,62
+Schuylkill,New Philadelphia,General Assembly,123,REP,Tim Twardzik,34,13,0,0,47
+Schuylkill,New Philadelphia,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Norwegian Twp Currans,Registered Voters,,,,,,,,1114
+Schuylkill,Norwegian Twp Currans,Registered Voters,,DEM,,,,,,468
+Schuylkill,Norwegian Twp Currans,Registered Voters,,REP,,,,,,551
+Schuylkill,Norwegian Twp Currans,Registered Voters,,NPA,,,,,,95
+Schuylkill,Norwegian Twp Currans,Ballots Cast,,,,279,125,24,0,428
+Schuylkill,Norwegian Twp Currans,Ballots Cast,,DEM,,86,71,17,0,174
+Schuylkill,Norwegian Twp Currans,Ballots Cast,,REP,,193,54,7,0,254
+Schuylkill,Norwegian Twp Currans,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Norwegian Twp Currans,President,,DEM,Bernie Sanders,16,5,3,0,24
+Schuylkill,Norwegian Twp Currans,President,,DEM,Joseph R. Biden,34,62,11,0,107
+Schuylkill,Norwegian Twp Currans,President,,DEM,Tulsi Gabbard,14,2,1,0,17
+Schuylkill,Norwegian Twp Currans,President,,DEM,Write-in,15,1,0,0,16
+Schuylkill,Norwegian Twp Currans,Attorney General,,DEM,Josh Shapiro,75,65,16,0,156
+Schuylkill,Norwegian Twp Currans,Attorney General,,DEM,Write-in,2,2,0,0,4
+Schuylkill,Norwegian Twp Currans,Auditor General,,DEM,H. Scott Conklin,6,6,1,0,13
+Schuylkill,Norwegian Twp Currans,Auditor General,,DEM,Michael Lamb,17,9,1,0,27
+Schuylkill,Norwegian Twp Currans,Auditor General,,DEM,Tracie Fountain,10,13,4,0,27
+Schuylkill,Norwegian Twp Currans,Auditor General,,DEM,Rose Rosie Marie Davis,7,3,2,0,12
+Schuylkill,Norwegian Twp Currans,Auditor General,,DEM,Nina Ahmad,13,7,4,0,24
+Schuylkill,Norwegian Twp Currans,Auditor General,,DEM,Christina M. Hartman,24,28,4,0,56
+Schuylkill,Norwegian Twp Currans,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Norwegian Twp Currans,State Treasurer,,DEM,Joe Torsella,72,64,17,0,153
+Schuylkill,Norwegian Twp Currans,State Treasurer,,DEM,Write-in,2,1,0,0,3
+Schuylkill,Norwegian Twp Currans,Representative In Congress,,DEM,Laura Quick,32,35,10,0,77
+Schuylkill,Norwegian Twp Currans,Representative In Congress,,DEM,Gary Wegman,48,32,6,0,86
+Schuylkill,Norwegian Twp Currans,Representative In Congress,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Norwegian Twp Currans,State Senate,29,DEM,Write-in,9,4,0,0,13
+Schuylkill,Norwegian Twp Currans,General Assembly,125,DEM,Write-in,12,6,0,0,18
+Schuylkill,Norwegian Twp Currans,President,,REP,Donald J. Trump,180,36,7,0,223
+Schuylkill,Norwegian Twp Currans,President,,REP,Roque Rocky De La Fuente,3,1,0,0,4
+Schuylkill,Norwegian Twp Currans,President,,REP,Bill Weld,2,11,0,0,13
+Schuylkill,Norwegian Twp Currans,President,,REP,Write-in,6,4,0,0,10
+Schuylkill,Norwegian Twp Currans,Attorney General,,REP,Heather Heidelbaugh,159,41,7,0,207
+Schuylkill,Norwegian Twp Currans,Attorney General,,REP,Write-in,1,2,0,0,3
+Schuylkill,Norwegian Twp Currans,Auditor General,,REP,Timothy Defoor,158,39,7,0,204
+Schuylkill,Norwegian Twp Currans,Auditor General,,REP,Write-in,0,2,0,0,2
+Schuylkill,Norwegian Twp Currans,State Treasurer,,REP,Stacy L. Garrity,163,41,7,0,211
+Schuylkill,Norwegian Twp Currans,State Treasurer,,REP,Write-in,0,2,0,0,2
+Schuylkill,Norwegian Twp Currans,Representative In Congress,,REP,Dan Meuser,180,43,7,0,230
+Schuylkill,Norwegian Twp Currans,Representative In Congress,,REP,Write-in,1,2,0,0,3
+Schuylkill,Norwegian Twp Currans,State Senate,29,REP,Dave Argall,177,42,7,0,226
+Schuylkill,Norwegian Twp Currans,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Norwegian Twp Currans,General Assembly,125,REP,Herv Breault,6,1,0,0,7
+Schuylkill,Norwegian Twp Currans,General Assembly,125,REP,Theresa Gaffney,31,9,3,0,43
+Schuylkill,Norwegian Twp Currans,General Assembly,125,REP,Christy Joy,102,31,4,0,137
+Schuylkill,Norwegian Twp Currans,General Assembly,125,REP,Joe Kerwin,53,12,0,0,65
+Schuylkill,Norwegian Twp Currans,General Assembly,125,REP,Write-in,1,0,0,0,1
+Schuylkill,Norwegian Twp Marlin,Registered Voters,,,,,,,,582
+Schuylkill,Norwegian Twp Marlin,Registered Voters,,DEM,,,,,,238
+Schuylkill,Norwegian Twp Marlin,Registered Voters,,REP,,,,,,297
+Schuylkill,Norwegian Twp Marlin,Registered Voters,,NPA,,,,,,47
+Schuylkill,Norwegian Twp Marlin,Ballots Cast,,,,180,79,6,1,266
+Schuylkill,Norwegian Twp Marlin,Ballots Cast,,DEM,,68,46,3,0,117
+Schuylkill,Norwegian Twp Marlin,Ballots Cast,,REP,,112,33,3,1,149
+Schuylkill,Norwegian Twp Marlin,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Norwegian Twp Marlin,President,,DEM,Bernie Sanders,9,3,0,0,12
+Schuylkill,Norwegian Twp Marlin,President,,DEM,Joseph R. Biden,34,38,3,0,75
+Schuylkill,Norwegian Twp Marlin,President,,DEM,Tulsi Gabbard,10,4,0,0,14
+Schuylkill,Norwegian Twp Marlin,President,,DEM,Write-in,10,1,0,0,11
+Schuylkill,Norwegian Twp Marlin,Attorney General,,DEM,Josh Shapiro,53,41,3,0,97
+Schuylkill,Norwegian Twp Marlin,Attorney General,,DEM,Write-in,2,1,0,0,3
+Schuylkill,Norwegian Twp Marlin,Auditor General,,DEM,H. Scott Conklin,6,2,1,0,9
+Schuylkill,Norwegian Twp Marlin,Auditor General,,DEM,Michael Lamb,8,2,1,0,11
+Schuylkill,Norwegian Twp Marlin,Auditor General,,DEM,Tracie Fountain,10,8,0,0,18
+Schuylkill,Norwegian Twp Marlin,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,0,0,6
+Schuylkill,Norwegian Twp Marlin,Auditor General,,DEM,Nina Ahmad,8,3,0,0,11
+Schuylkill,Norwegian Twp Marlin,Auditor General,,DEM,Christina M. Hartman,24,22,1,0,47
+Schuylkill,Norwegian Twp Marlin,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Norwegian Twp Marlin,State Treasurer,,DEM,Joe Torsella,51,40,3,0,94
+Schuylkill,Norwegian Twp Marlin,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Norwegian Twp Marlin,Representative In Congress,,DEM,Laura Quick,21,22,1,0,44
+Schuylkill,Norwegian Twp Marlin,Representative In Congress,,DEM,Gary Wegman,39,21,2,0,62
+Schuylkill,Norwegian Twp Marlin,Representative In Congress,,DEM,Write-in,3,1,0,0,4
+Schuylkill,Norwegian Twp Marlin,State Senate,29,DEM,Write-in,3,2,0,0,5
+Schuylkill,Norwegian Twp Marlin,General Assembly,125,DEM,Write-in,4,6,0,0,10
+Schuylkill,Norwegian Twp Marlin,President,,REP,Donald J. Trump,106,25,3,1,135
+Schuylkill,Norwegian Twp Marlin,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Schuylkill,Norwegian Twp Marlin,President,,REP,Bill Weld,1,2,0,0,3
+Schuylkill,Norwegian Twp Marlin,President,,REP,Write-in,1,2,0,0,3
+Schuylkill,Norwegian Twp Marlin,Attorney General,,REP,Heather Heidelbaugh,81,29,2,1,113
+Schuylkill,Norwegian Twp Marlin,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Norwegian Twp Marlin,Auditor General,,REP,Timothy Defoor,81,30,2,1,114
+Schuylkill,Norwegian Twp Marlin,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Norwegian Twp Marlin,State Treasurer,,REP,Stacy L. Garrity,83,30,2,1,116
+Schuylkill,Norwegian Twp Marlin,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Norwegian Twp Marlin,Representative In Congress,,REP,Dan Meuser,92,29,3,1,125
+Schuylkill,Norwegian Twp Marlin,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Norwegian Twp Marlin,State Senate,29,REP,Dave Argall,95,31,3,1,130
+Schuylkill,Norwegian Twp Marlin,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Norwegian Twp Marlin,General Assembly,125,REP,Herv Breault,2,1,0,0,3
+Schuylkill,Norwegian Twp Marlin,General Assembly,125,REP,Theresa Gaffney,25,5,0,0,30
+Schuylkill,Norwegian Twp Marlin,General Assembly,125,REP,Christy Joy,68,22,3,1,94
+Schuylkill,Norwegian Twp Marlin,General Assembly,125,REP,Joe Kerwin,17,4,0,0,21
+Schuylkill,Norwegian Twp Marlin,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 1st,Registered Voters,,,,,,,,280
+Schuylkill,Palo Alto 1st,Registered Voters,,DEM,,,,,,138
+Schuylkill,Palo Alto 1st,Registered Voters,,REP,,,,,,101
+Schuylkill,Palo Alto 1st,Registered Voters,,NPA,,,,,,41
+Schuylkill,Palo Alto 1st,Ballots Cast,,,,58,12,6,1,77
+Schuylkill,Palo Alto 1st,Ballots Cast,,DEM,,30,11,5,0,46
+Schuylkill,Palo Alto 1st,Ballots Cast,,REP,,28,1,1,1,31
+Schuylkill,Palo Alto 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Palo Alto 1st,President,,DEM,Bernie Sanders,5,1,0,0,6
+Schuylkill,Palo Alto 1st,President,,DEM,Joseph R. Biden,14,7,5,0,26
+Schuylkill,Palo Alto 1st,President,,DEM,Tulsi Gabbard,1,3,0,0,4
+Schuylkill,Palo Alto 1st,President,,DEM,Write-in,5,0,0,0,5
+Schuylkill,Palo Alto 1st,Attorney General,,DEM,Josh Shapiro,25,9,0,0,34
+Schuylkill,Palo Alto 1st,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Palo Alto 1st,Auditor General,,DEM,H. Scott Conklin,4,1,0,0,5
+Schuylkill,Palo Alto 1st,Auditor General,,DEM,Michael Lamb,10,1,4,0,15
+Schuylkill,Palo Alto 1st,Auditor General,,DEM,Tracie Fountain,2,3,1,0,6
+Schuylkill,Palo Alto 1st,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,0,3
+Schuylkill,Palo Alto 1st,Auditor General,,DEM,Nina Ahmad,3,0,0,0,3
+Schuylkill,Palo Alto 1st,Auditor General,,DEM,Christina M. Hartman,3,5,0,0,8
+Schuylkill,Palo Alto 1st,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Palo Alto 1st,State Treasurer,,DEM,Joe Torsella,24,8,4,0,36
+Schuylkill,Palo Alto 1st,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Palo Alto 1st,Representative In Congress,,DEM,Laura Quick,12,2,0,0,14
+Schuylkill,Palo Alto 1st,Representative In Congress,,DEM,Gary Wegman,14,9,4,0,27
+Schuylkill,Palo Alto 1st,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Palo Alto 1st,State Senate,29,DEM,Write-in,5,0,0,0,5
+Schuylkill,Palo Alto 1st,General Assembly,123,DEM,Peter PJ Symons Jr.,26,8,5,0,39
+Schuylkill,Palo Alto 1st,General Assembly,123,DEM,Write-in,3,0,0,0,3
+Schuylkill,Palo Alto 1st,President,,REP,Donald J. Trump,24,1,1,1,27
+Schuylkill,Palo Alto 1st,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Palo Alto 1st,President,,REP,Bill Weld,2,0,0,0,2
+Schuylkill,Palo Alto 1st,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Palo Alto 1st,Attorney General,,REP,Heather Heidelbaugh,25,1,1,1,28
+Schuylkill,Palo Alto 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 1st,Auditor General,,REP,Timothy Defoor,23,1,1,1,26
+Schuylkill,Palo Alto 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 1st,State Treasurer,,REP,Stacy L. Garrity,23,1,1,1,26
+Schuylkill,Palo Alto 1st,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 1st,Representative In Congress,,REP,Dan Meuser,24,1,1,1,27
+Schuylkill,Palo Alto 1st,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 1st,State Senate,29,REP,Dave Argall,26,1,1,1,29
+Schuylkill,Palo Alto 1st,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 1st,General Assembly,123,REP,John Leshko,11,1,0,0,12
+Schuylkill,Palo Alto 1st,General Assembly,123,REP,Tim Twardzik,15,0,1,1,17
+Schuylkill,Palo Alto 1st,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,Registered Voters,,,,,,,,335
+Schuylkill,Palo Alto 2nd,Registered Voters,,DEM,,,,,,164
+Schuylkill,Palo Alto 2nd,Registered Voters,,REP,,,,,,136
+Schuylkill,Palo Alto 2nd,Registered Voters,,NPA,,,,,,35
+Schuylkill,Palo Alto 2nd,Ballots Cast,,,,86,26,10,0,122
+Schuylkill,Palo Alto 2nd,Ballots Cast,,DEM,,43,19,9,0,71
+Schuylkill,Palo Alto 2nd,Ballots Cast,,REP,,43,7,1,0,51
+Schuylkill,Palo Alto 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,President,,DEM,Bernie Sanders,6,1,0,0,7
+Schuylkill,Palo Alto 2nd,President,,DEM,Joseph R. Biden,25,13,8,0,46
+Schuylkill,Palo Alto 2nd,President,,DEM,Tulsi Gabbard,6,2,0,0,8
+Schuylkill,Palo Alto 2nd,President,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Palo Alto 2nd,Attorney General,,DEM,Josh Shapiro,36,14,6,0,56
+Schuylkill,Palo Alto 2nd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,Auditor General,,DEM,H. Scott Conklin,3,0,0,0,3
+Schuylkill,Palo Alto 2nd,Auditor General,,DEM,Michael Lamb,8,3,5,0,16
+Schuylkill,Palo Alto 2nd,Auditor General,,DEM,Tracie Fountain,6,4,0,0,10
+Schuylkill,Palo Alto 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,2,5,0,0,7
+Schuylkill,Palo Alto 2nd,Auditor General,,DEM,Nina Ahmad,8,0,0,0,8
+Schuylkill,Palo Alto 2nd,Auditor General,,DEM,Christina M. Hartman,8,4,2,0,14
+Schuylkill,Palo Alto 2nd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,State Treasurer,,DEM,Joe Torsella,34,14,8,0,56
+Schuylkill,Palo Alto 2nd,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,Representative In Congress,,DEM,Laura Quick,16,5,1,0,22
+Schuylkill,Palo Alto 2nd,Representative In Congress,,DEM,Gary Wegman,22,11,7,0,40
+Schuylkill,Palo Alto 2nd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,State Senate,29,DEM,Write-in,1,1,1,0,3
+Schuylkill,Palo Alto 2nd,General Assembly,123,DEM,Peter PJ Symons Jr.,38,19,9,0,66
+Schuylkill,Palo Alto 2nd,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,Palo Alto 2nd,President,,REP,Donald J. Trump,39,7,1,0,47
+Schuylkill,Palo Alto 2nd,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Palo Alto 2nd,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,Palo Alto 2nd,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Palo Alto 2nd,Attorney General,,REP,Heather Heidelbaugh,37,6,1,0,44
+Schuylkill,Palo Alto 2nd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,Auditor General,,REP,Timothy Defoor,38,6,1,0,45
+Schuylkill,Palo Alto 2nd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,State Treasurer,,REP,Stacy L. Garrity,38,6,1,0,45
+Schuylkill,Palo Alto 2nd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,Representative In Congress,,REP,Dan Meuser,41,7,1,0,49
+Schuylkill,Palo Alto 2nd,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,State Senate,29,REP,Dave Argall,39,7,1,0,47
+Schuylkill,Palo Alto 2nd,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Palo Alto 2nd,General Assembly,123,REP,John Leshko,16,4,1,0,21
+Schuylkill,Palo Alto 2nd,General Assembly,123,REP,Tim Twardzik,25,3,0,0,28
+Schuylkill,Palo Alto 2nd,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 1st,Registered Voters,,,,,,,,357
+Schuylkill,Port Carbon 1st,Registered Voters,,DEM,,,,,,145
+Schuylkill,Port Carbon 1st,Registered Voters,,REP,,,,,,169
+Schuylkill,Port Carbon 1st,Registered Voters,,NPA,,,,,,43
+Schuylkill,Port Carbon 1st,Ballots Cast,,,,83,41,7,2,133
+Schuylkill,Port Carbon 1st,Ballots Cast,,DEM,,24,20,4,1,49
+Schuylkill,Port Carbon 1st,Ballots Cast,,REP,,59,21,3,1,84
+Schuylkill,Port Carbon 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Port Carbon 1st,President,,DEM,Bernie Sanders,7,3,2,1,13
+Schuylkill,Port Carbon 1st,President,,DEM,Joseph R. Biden,13,17,2,0,32
+Schuylkill,Port Carbon 1st,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Schuylkill,Port Carbon 1st,President,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Port Carbon 1st,Attorney General,,DEM,Josh Shapiro,20,18,3,1,42
+Schuylkill,Port Carbon 1st,Attorney General,,DEM,Write-in,2,0,1,0,3
+Schuylkill,Port Carbon 1st,Auditor General,,DEM,H. Scott Conklin,2,1,0,0,3
+Schuylkill,Port Carbon 1st,Auditor General,,DEM,Michael Lamb,2,0,0,0,2
+Schuylkill,Port Carbon 1st,Auditor General,,DEM,Tracie Fountain,5,4,1,0,10
+Schuylkill,Port Carbon 1st,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,1,0,6
+Schuylkill,Port Carbon 1st,Auditor General,,DEM,Nina Ahmad,4,4,0,0,8
+Schuylkill,Port Carbon 1st,Auditor General,,DEM,Christina M. Hartman,7,9,2,1,19
+Schuylkill,Port Carbon 1st,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Port Carbon 1st,State Treasurer,,DEM,Joe Torsella,23,17,3,1,44
+Schuylkill,Port Carbon 1st,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 1st,Representative In Congress,,DEM,Laura Quick,10,15,3,1,29
+Schuylkill,Port Carbon 1st,Representative In Congress,,DEM,Gary Wegman,13,5,1,0,19
+Schuylkill,Port Carbon 1st,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Port Carbon 1st,State Senate,29,DEM,Write-in,2,1,0,0,3
+Schuylkill,Port Carbon 1st,General Assembly,123,DEM,Peter PJ Symons Jr.,22,18,4,1,45
+Schuylkill,Port Carbon 1st,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,Port Carbon 1st,President,,REP,Donald J. Trump,54,13,3,1,71
+Schuylkill,Port Carbon 1st,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Schuylkill,Port Carbon 1st,President,,REP,Bill Weld,1,5,0,0,6
+Schuylkill,Port Carbon 1st,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,Port Carbon 1st,Attorney General,,REP,Heather Heidelbaugh,51,18,2,0,71
+Schuylkill,Port Carbon 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 1st,Auditor General,,REP,Timothy Defoor,53,18,3,0,74
+Schuylkill,Port Carbon 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 1st,State Treasurer,,REP,Stacy L. Garrity,52,17,3,0,72
+Schuylkill,Port Carbon 1st,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Port Carbon 1st,Representative In Congress,,REP,Dan Meuser,57,19,3,0,79
+Schuylkill,Port Carbon 1st,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 1st,State Senate,29,REP,Dave Argall,55,18,3,0,76
+Schuylkill,Port Carbon 1st,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 1st,General Assembly,123,REP,John Leshko,25,13,2,0,40
+Schuylkill,Port Carbon 1st,General Assembly,123,REP,Tim Twardzik,32,7,1,1,41
+Schuylkill,Port Carbon 1st,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 2nd,Registered Voters,,,,,,,,743
+Schuylkill,Port Carbon 2nd,Registered Voters,,DEM,,,,,,297
+Schuylkill,Port Carbon 2nd,Registered Voters,,REP,,,,,,361
+Schuylkill,Port Carbon 2nd,Registered Voters,,NPA,,,,,,85
+Schuylkill,Port Carbon 2nd,Ballots Cast,,,,180,91,6,6,283
+Schuylkill,Port Carbon 2nd,Ballots Cast,,DEM,,61,53,6,1,121
+Schuylkill,Port Carbon 2nd,Ballots Cast,,REP,,119,38,0,5,162
+Schuylkill,Port Carbon 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Port Carbon 2nd,President,,DEM,Bernie Sanders,8,5,3,0,16
+Schuylkill,Port Carbon 2nd,President,,DEM,Joseph R. Biden,43,41,3,1,88
+Schuylkill,Port Carbon 2nd,President,,DEM,Tulsi Gabbard,3,2,0,0,5
+Schuylkill,Port Carbon 2nd,President,,DEM,Write-in,6,5,0,0,11
+Schuylkill,Port Carbon 2nd,Attorney General,,DEM,Josh Shapiro,50,50,5,1,106
+Schuylkill,Port Carbon 2nd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 2nd,Auditor General,,DEM,H. Scott Conklin,7,4,0,0,11
+Schuylkill,Port Carbon 2nd,Auditor General,,DEM,Michael Lamb,13,11,1,1,26
+Schuylkill,Port Carbon 2nd,Auditor General,,DEM,Tracie Fountain,9,14,0,0,23
+Schuylkill,Port Carbon 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,3,5,0,0,8
+Schuylkill,Port Carbon 2nd,Auditor General,,DEM,Nina Ahmad,5,2,2,0,9
+Schuylkill,Port Carbon 2nd,Auditor General,,DEM,Christina M. Hartman,17,15,2,0,34
+Schuylkill,Port Carbon 2nd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 2nd,State Treasurer,,DEM,Joe Torsella,50,47,5,1,103
+Schuylkill,Port Carbon 2nd,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 2nd,Representative In Congress,,DEM,Laura Quick,18,15,2,0,35
+Schuylkill,Port Carbon 2nd,Representative In Congress,,DEM,Gary Wegman,35,37,3,1,76
+Schuylkill,Port Carbon 2nd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Carbon 2nd,State Senate,29,DEM,Write-in,6,10,1,0,17
+Schuylkill,Port Carbon 2nd,General Assembly,123,DEM,Peter PJ Symons Jr.,53,51,5,1,110
+Schuylkill,Port Carbon 2nd,General Assembly,123,DEM,Write-in,1,1,0,0,2
+Schuylkill,Port Carbon 2nd,President,,REP,Donald J. Trump,110,28,0,5,143
+Schuylkill,Port Carbon 2nd,President,,REP,Roque Rocky De La Fuente,3,1,0,0,4
+Schuylkill,Port Carbon 2nd,President,,REP,Bill Weld,4,4,0,0,8
+Schuylkill,Port Carbon 2nd,President,,REP,Write-in,0,4,0,0,4
+Schuylkill,Port Carbon 2nd,Attorney General,,REP,Heather Heidelbaugh,95,33,0,3,131
+Schuylkill,Port Carbon 2nd,Attorney General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Port Carbon 2nd,Auditor General,,REP,Timothy Defoor,90,32,0,3,125
+Schuylkill,Port Carbon 2nd,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Port Carbon 2nd,State Treasurer,,REP,Stacy L. Garrity,94,32,0,3,129
+Schuylkill,Port Carbon 2nd,State Treasurer,,REP,Write-in,2,1,0,0,3
+Schuylkill,Port Carbon 2nd,Representative In Congress,,REP,Dan Meuser,104,32,0,4,140
+Schuylkill,Port Carbon 2nd,Representative In Congress,,REP,Write-in,1,1,0,0,2
+Schuylkill,Port Carbon 2nd,State Senate,29,REP,Dave Argall,104,33,0,4,141
+Schuylkill,Port Carbon 2nd,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Port Carbon 2nd,General Assembly,123,REP,John Leshko,63,16,0,1,80
+Schuylkill,Port Carbon 2nd,General Assembly,123,REP,Tim Twardzik,49,18,0,4,71
+Schuylkill,Port Carbon 2nd,General Assembly,123,REP,Write-in,4,0,0,0,4
+Schuylkill,Reilly Twp,Registered Voters,,,,,,,,414
+Schuylkill,Reilly Twp,Registered Voters,,DEM,,,,,,166
+Schuylkill,Reilly Twp,Registered Voters,,REP,,,,,,201
+Schuylkill,Reilly Twp,Registered Voters,,NPA,,,,,,47
+Schuylkill,Reilly Twp,Ballots Cast,,,,121,20,3,0,144
+Schuylkill,Reilly Twp,Ballots Cast,,DEM,,50,16,3,0,69
+Schuylkill,Reilly Twp,Ballots Cast,,REP,,71,4,0,0,75
+Schuylkill,Reilly Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Reilly Twp,President,,DEM,Bernie Sanders,3,3,1,0,7
+Schuylkill,Reilly Twp,President,,DEM,Joseph R. Biden,28,11,2,0,41
+Schuylkill,Reilly Twp,President,,DEM,Tulsi Gabbard,8,1,0,0,9
+Schuylkill,Reilly Twp,President,,DEM,Write-in,4,1,0,0,5
+Schuylkill,Reilly Twp,Attorney General,,DEM,Josh Shapiro,42,15,3,0,60
+Schuylkill,Reilly Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,Auditor General,,DEM,H. Scott Conklin,14,1,2,0,17
+Schuylkill,Reilly Twp,Auditor General,,DEM,Michael Lamb,5,1,1,0,7
+Schuylkill,Reilly Twp,Auditor General,,DEM,Tracie Fountain,5,6,0,0,11
+Schuylkill,Reilly Twp,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,0,1
+Schuylkill,Reilly Twp,Auditor General,,DEM,Nina Ahmad,2,3,0,0,5
+Schuylkill,Reilly Twp,Auditor General,,DEM,Christina M. Hartman,17,3,0,0,20
+Schuylkill,Reilly Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,State Treasurer,,DEM,Joe Torsella,41,14,3,0,58
+Schuylkill,Reilly Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,Representative In Congress,,DEM,Laura Quick,20,6,1,0,27
+Schuylkill,Reilly Twp,Representative In Congress,,DEM,Gary Wegman,27,8,2,0,37
+Schuylkill,Reilly Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,State Senate,29,DEM,Write-in,0,2,0,0,2
+Schuylkill,Reilly Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,47,13,3,0,63
+Schuylkill,Reilly Twp,General Assembly,123,DEM,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,President,,REP,Donald J. Trump,70,2,0,0,72
+Schuylkill,Reilly Twp,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Reilly Twp,President,,REP,Bill Weld,1,2,0,0,3
+Schuylkill,Reilly Twp,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,Attorney General,,REP,Heather Heidelbaugh,60,3,0,0,63
+Schuylkill,Reilly Twp,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,Auditor General,,REP,Timothy Defoor,63,3,0,0,66
+Schuylkill,Reilly Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,State Treasurer,,REP,Stacy L. Garrity,61,3,0,0,64
+Schuylkill,Reilly Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,Representative In Congress,,REP,Dan Meuser,64,3,0,0,67
+Schuylkill,Reilly Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,State Senate,29,REP,Dave Argall,67,3,0,0,70
+Schuylkill,Reilly Twp,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Reilly Twp,General Assembly,123,REP,John Leshko,35,1,0,0,36
+Schuylkill,Reilly Twp,General Assembly,123,REP,Tim Twardzik,34,3,0,0,37
+Schuylkill,Reilly Twp,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Ryan Twp,Registered Voters,,,,,,,,1064
+Schuylkill,Ryan Twp,Registered Voters,,DEM,,,,,,333
+Schuylkill,Ryan Twp,Registered Voters,,REP,,,,,,628
+Schuylkill,Ryan Twp,Registered Voters,,NPA,,,,,,103
+Schuylkill,Ryan Twp,Ballots Cast,,,,267,137,25,5,434
+Schuylkill,Ryan Twp,Ballots Cast,,DEM,,63,65,11,1,140
+Schuylkill,Ryan Twp,Ballots Cast,,REP,,204,72,14,4,294
+Schuylkill,Ryan Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Ryan Twp,President,,DEM,Bernie Sanders,14,14,1,0,29
+Schuylkill,Ryan Twp,President,,DEM,Joseph R. Biden,30,45,8,1,84
+Schuylkill,Ryan Twp,President,,DEM,Tulsi Gabbard,8,0,0,0,8
+Schuylkill,Ryan Twp,President,,DEM,Write-in,9,3,1,0,13
+Schuylkill,Ryan Twp,Attorney General,,DEM,Josh Shapiro,46,60,10,1,117
+Schuylkill,Ryan Twp,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Ryan Twp,Auditor General,,DEM,H. Scott Conklin,8,8,0,0,16
+Schuylkill,Ryan Twp,Auditor General,,DEM,Michael Lamb,11,8,4,0,23
+Schuylkill,Ryan Twp,Auditor General,,DEM,Tracie Fountain,7,11,1,1,20
+Schuylkill,Ryan Twp,Auditor General,,DEM,Rose Rosie Marie Davis,5,10,0,0,15
+Schuylkill,Ryan Twp,Auditor General,,DEM,Nina Ahmad,5,10,0,0,15
+Schuylkill,Ryan Twp,Auditor General,,DEM,Christina M. Hartman,17,16,4,0,37
+Schuylkill,Ryan Twp,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Ryan Twp,State Treasurer,,DEM,Joe Torsella,46,60,10,1,117
+Schuylkill,Ryan Twp,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Ryan Twp,Representative In Congress,,DEM,Laura Quick,24,29,4,0,57
+Schuylkill,Ryan Twp,Representative In Congress,,DEM,Gary Wegman,25,31,6,0,62
+Schuylkill,Ryan Twp,Representative In Congress,,DEM,Write-in,3,2,0,0,5
+Schuylkill,Ryan Twp,State Senate,29,DEM,Write-in,9,7,0,0,16
+Schuylkill,Ryan Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,54,59,10,1,124
+Schuylkill,Ryan Twp,General Assembly,123,DEM,Write-in,3,2,0,0,5
+Schuylkill,Ryan Twp,President,,REP,Donald J. Trump,199,65,12,4,280
+Schuylkill,Ryan Twp,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,Ryan Twp,President,,REP,Bill Weld,0,3,0,0,3
+Schuylkill,Ryan Twp,President,,REP,Write-in,0,0,1,0,1
+Schuylkill,Ryan Twp,Attorney General,,REP,Heather Heidelbaugh,181,63,14,4,262
+Schuylkill,Ryan Twp,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Ryan Twp,Auditor General,,REP,Timothy Defoor,178,63,13,4,258
+Schuylkill,Ryan Twp,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Ryan Twp,State Treasurer,,REP,Stacy L. Garrity,182,62,14,4,262
+Schuylkill,Ryan Twp,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Ryan Twp,Representative In Congress,,REP,Dan Meuser,189,64,13,4,270
+Schuylkill,Ryan Twp,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Ryan Twp,State Senate,29,REP,Dave Argall,185,60,13,4,262
+Schuylkill,Ryan Twp,State Senate,29,REP,Write-in,3,1,0,0,4
+Schuylkill,Ryan Twp,General Assembly,123,REP,John Leshko,77,24,4,0,105
+Schuylkill,Ryan Twp,General Assembly,123,REP,Tim Twardzik,122,45,8,4,179
+Schuylkill,Ryan Twp,General Assembly,123,REP,Write-in,2,1,0,0,3
+Schuylkill,St. Clair Middle,Registered Voters,,,,,,,,490
+Schuylkill,St. Clair Middle,Registered Voters,,DEM,,,,,,253
+Schuylkill,St. Clair Middle,Registered Voters,,REP,,,,,,174
+Schuylkill,St. Clair Middle,Registered Voters,,NPA,,,,,,63
+Schuylkill,St. Clair Middle,Ballots Cast,,,,99,52,12,3,166
+Schuylkill,St. Clair Middle,Ballots Cast,,DEM,,59,35,9,2,105
+Schuylkill,St. Clair Middle,Ballots Cast,,REP,,40,17,3,1,61
+Schuylkill,St. Clair Middle,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,St. Clair Middle,President,,DEM,Bernie Sanders,14,3,0,0,17
+Schuylkill,St. Clair Middle,President,,DEM,Joseph R. Biden,32,25,8,2,67
+Schuylkill,St. Clair Middle,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Schuylkill,St. Clair Middle,President,,DEM,Write-in,6,3,0,0,9
+Schuylkill,St. Clair Middle,Attorney General,,DEM,Josh Shapiro,53,30,8,1,92
+Schuylkill,St. Clair Middle,Attorney General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,St. Clair Middle,Auditor General,,DEM,H. Scott Conklin,9,2,1,0,12
+Schuylkill,St. Clair Middle,Auditor General,,DEM,Michael Lamb,9,7,0,0,16
+Schuylkill,St. Clair Middle,Auditor General,,DEM,Tracie Fountain,12,8,1,0,21
+Schuylkill,St. Clair Middle,Auditor General,,DEM,Rose Rosie Marie Davis,5,0,1,0,6
+Schuylkill,St. Clair Middle,Auditor General,,DEM,Nina Ahmad,8,3,0,1,12
+Schuylkill,St. Clair Middle,Auditor General,,DEM,Christina M. Hartman,11,9,3,0,23
+Schuylkill,St. Clair Middle,Auditor General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,St. Clair Middle,State Treasurer,,DEM,Joe Torsella,52,29,7,1,89
+Schuylkill,St. Clair Middle,State Treasurer,,DEM,Write-in,0,2,0,0,2
+Schuylkill,St. Clair Middle,Representative In Congress,,DEM,Laura Quick,24,9,4,1,38
+Schuylkill,St. Clair Middle,Representative In Congress,,DEM,Gary Wegman,30,21,4,0,55
+Schuylkill,St. Clair Middle,Representative In Congress,,DEM,Write-in,0,2,0,0,2
+Schuylkill,St. Clair Middle,State Senate,29,DEM,Write-in,4,4,1,0,9
+Schuylkill,St. Clair Middle,General Assembly,123,DEM,Peter PJ Symons Jr.,57,32,8,2,99
+Schuylkill,St. Clair Middle,General Assembly,123,DEM,Write-in,1,2,0,0,3
+Schuylkill,St. Clair Middle,President,,REP,Donald J. Trump,37,11,2,1,51
+Schuylkill,St. Clair Middle,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,St. Clair Middle,President,,REP,Bill Weld,1,1,0,0,2
+Schuylkill,St. Clair Middle,President,,REP,Write-in,0,2,0,0,2
+Schuylkill,St. Clair Middle,Attorney General,,REP,Heather Heidelbaugh,32,15,2,1,50
+Schuylkill,St. Clair Middle,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair Middle,Auditor General,,REP,Timothy Defoor,31,14,2,1,48
+Schuylkill,St. Clair Middle,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair Middle,State Treasurer,,REP,Stacy L. Garrity,32,14,2,1,49
+Schuylkill,St. Clair Middle,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair Middle,Representative In Congress,,REP,Dan Meuser,38,15,2,1,56
+Schuylkill,St. Clair Middle,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,St. Clair Middle,State Senate,29,REP,Dave Argall,38,14,3,1,56
+Schuylkill,St. Clair Middle,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair Middle,General Assembly,123,REP,John Leshko,19,10,0,0,29
+Schuylkill,St. Clair Middle,General Assembly,123,REP,Tim Twardzik,17,7,3,1,28
+Schuylkill,St. Clair Middle,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,St. Clair South,Registered Voters,,,,,,,,664
+Schuylkill,St. Clair South,Registered Voters,,DEM,,,,,,335
+Schuylkill,St. Clair South,Registered Voters,,REP,,,,,,252
+Schuylkill,St. Clair South,Registered Voters,,NPA,,,,,,77
+Schuylkill,St. Clair South,Ballots Cast,,,,155,67,20,2,244
+Schuylkill,St. Clair South,Ballots Cast,,DEM,,80,42,15,1,138
+Schuylkill,St. Clair South,Ballots Cast,,REP,,75,25,5,1,106
+Schuylkill,St. Clair South,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,St. Clair South,President,,DEM,Bernie Sanders,11,1,1,1,14
+Schuylkill,St. Clair South,President,,DEM,Joseph R. Biden,47,33,11,0,91
+Schuylkill,St. Clair South,President,,DEM,Tulsi Gabbard,5,4,1,0,10
+Schuylkill,St. Clair South,President,,DEM,Write-in,11,1,1,0,13
+Schuylkill,St. Clair South,Attorney General,,DEM,Josh Shapiro,66,35,14,0,115
+Schuylkill,St. Clair South,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,St. Clair South,Auditor General,,DEM,H. Scott Conklin,5,2,2,0,9
+Schuylkill,St. Clair South,Auditor General,,DEM,Michael Lamb,9,3,1,0,13
+Schuylkill,St. Clair South,Auditor General,,DEM,Tracie Fountain,11,6,1,0,18
+Schuylkill,St. Clair South,Auditor General,,DEM,Rose Rosie Marie Davis,2,7,0,0,9
+Schuylkill,St. Clair South,Auditor General,,DEM,Nina Ahmad,12,5,4,0,21
+Schuylkill,St. Clair South,Auditor General,,DEM,Christina M. Hartman,26,12,7,0,45
+Schuylkill,St. Clair South,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,St. Clair South,State Treasurer,,DEM,Joe Torsella,66,34,13,0,113
+Schuylkill,St. Clair South,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,St. Clair South,Representative In Congress,,DEM,Laura Quick,32,21,7,0,60
+Schuylkill,St. Clair South,Representative In Congress,,DEM,Gary Wegman,37,15,8,0,60
+Schuylkill,St. Clair South,Representative In Congress,,DEM,Write-in,1,2,0,0,3
+Schuylkill,St. Clair South,State Senate,29,DEM,Write-in,7,6,0,0,13
+Schuylkill,St. Clair South,General Assembly,123,DEM,Peter PJ Symons Jr.,73,40,14,1,128
+Schuylkill,St. Clair South,General Assembly,123,DEM,Write-in,3,1,0,0,4
+Schuylkill,St. Clair South,President,,REP,Donald J. Trump,62,14,4,1,81
+Schuylkill,St. Clair South,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,St. Clair South,President,,REP,Bill Weld,5,4,1,0,10
+Schuylkill,St. Clair South,President,,REP,Write-in,2,1,0,0,3
+Schuylkill,St. Clair South,Attorney General,,REP,Heather Heidelbaugh,64,18,2,1,85
+Schuylkill,St. Clair South,Attorney General,,REP,Write-in,0,2,0,0,2
+Schuylkill,St. Clair South,Auditor General,,REP,Timothy Defoor,64,19,2,1,86
+Schuylkill,St. Clair South,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,St. Clair South,State Treasurer,,REP,Stacy L. Garrity,64,20,2,1,87
+Schuylkill,St. Clair South,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair South,Representative In Congress,,REP,Dan Meuser,69,19,2,1,91
+Schuylkill,St. Clair South,Representative In Congress,,REP,Write-in,0,2,2,0,4
+Schuylkill,St. Clair South,State Senate,29,REP,Dave Argall,71,23,4,1,99
+Schuylkill,St. Clair South,State Senate,29,REP,Write-in,0,1,1,0,2
+Schuylkill,St. Clair South,General Assembly,123,REP,John Leshko,35,9,2,1,47
+Schuylkill,St. Clair South,General Assembly,123,REP,Tim Twardzik,33,12,0,0,45
+Schuylkill,St. Clair South,General Assembly,123,REP,Write-in,5,2,2,0,9
+Schuylkill,St. Clair North,Registered Voters,,,,,,,,562
+Schuylkill,St. Clair North,Registered Voters,,DEM,,,,,,281
+Schuylkill,St. Clair North,Registered Voters,,REP,,,,,,208
+Schuylkill,St. Clair North,Registered Voters,,NPA,,,,,,73
+Schuylkill,St. Clair North,Ballots Cast,,,,116,73,14,3,206
+Schuylkill,St. Clair North,Ballots Cast,,DEM,,64,40,10,1,115
+Schuylkill,St. Clair North,Ballots Cast,,REP,,52,33,4,2,91
+Schuylkill,St. Clair North,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,St. Clair North,President,,DEM,Bernie Sanders,9,4,0,0,13
+Schuylkill,St. Clair North,President,,DEM,Joseph R. Biden,32,33,9,0,74
+Schuylkill,St. Clair North,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,St. Clair North,President,,DEM,Write-in,11,2,1,1,15
+Schuylkill,St. Clair North,Attorney General,,DEM,Josh Shapiro,54,38,9,1,102
+Schuylkill,St. Clair North,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,St. Clair North,Auditor General,,DEM,H. Scott Conklin,7,2,2,0,11
+Schuylkill,St. Clair North,Auditor General,,DEM,Michael Lamb,12,11,1,0,24
+Schuylkill,St. Clair North,Auditor General,,DEM,Tracie Fountain,11,8,3,0,22
+Schuylkill,St. Clair North,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,0,0,6
+Schuylkill,St. Clair North,Auditor General,,DEM,Nina Ahmad,7,3,2,0,12
+Schuylkill,St. Clair North,Auditor General,,DEM,Christina M. Hartman,11,14,2,1,28
+Schuylkill,St. Clair North,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,St. Clair North,State Treasurer,,DEM,Joe Torsella,51,39,8,1,99
+Schuylkill,St. Clair North,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,St. Clair North,Representative In Congress,,DEM,Laura Quick,25,17,3,1,46
+Schuylkill,St. Clair North,Representative In Congress,,DEM,Gary Wegman,32,22,7,0,61
+Schuylkill,St. Clair North,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,St. Clair North,State Senate,29,DEM,Write-in,7,2,1,0,10
+Schuylkill,St. Clair North,General Assembly,123,DEM,Peter PJ Symons Jr.,59,40,9,1,109
+Schuylkill,St. Clair North,General Assembly,123,DEM,Write-in,2,0,0,0,2
+Schuylkill,St. Clair North,President,,REP,Donald J. Trump,50,30,4,2,86
+Schuylkill,St. Clair North,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,St. Clair North,President,,REP,Bill Weld,0,2,0,0,2
+Schuylkill,St. Clair North,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,St. Clair North,Attorney General,,REP,Heather Heidelbaugh,45,30,4,0,79
+Schuylkill,St. Clair North,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair North,Auditor General,,REP,Timothy Defoor,43,29,3,0,75
+Schuylkill,St. Clair North,Auditor General,,REP,Write-in,0,0,1,0,1
+Schuylkill,St. Clair North,State Treasurer,,REP,Stacy L. Garrity,45,29,4,0,78
+Schuylkill,St. Clair North,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair North,Representative In Congress,,REP,Dan Meuser,47,32,4,2,85
+Schuylkill,St. Clair North,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair North,State Senate,29,REP,Dave Argall,48,31,4,2,85
+Schuylkill,St. Clair North,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,St. Clair North,General Assembly,123,REP,John Leshko,22,15,3,1,41
+Schuylkill,St. Clair North,General Assembly,123,REP,Tim Twardzik,25,17,1,1,44
+Schuylkill,St. Clair North,General Assembly,123,REP,Write-in,0,1,0,0,1
+Schuylkill,Shenandoah 1st,Registered Voters,,,,,,,,135
+Schuylkill,Shenandoah 1st,Registered Voters,,DEM,,,,,,57
+Schuylkill,Shenandoah 1st,Registered Voters,,REP,,,,,,58
+Schuylkill,Shenandoah 1st,Registered Voters,,NPA,,,,,,20
+Schuylkill,Shenandoah 1st,Ballots Cast,,,,34,13,4,0,51
+Schuylkill,Shenandoah 1st,Ballots Cast,,DEM,,13,8,2,0,23
+Schuylkill,Shenandoah 1st,Ballots Cast,,REP,,21,5,2,0,28
+Schuylkill,Shenandoah 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Shenandoah 1st,President,,DEM,Bernie Sanders,1,1,1,0,3
+Schuylkill,Shenandoah 1st,President,,DEM,Joseph R. Biden,7,7,1,0,15
+Schuylkill,Shenandoah 1st,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Schuylkill,Shenandoah 1st,President,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Shenandoah 1st,Attorney General,,DEM,Josh Shapiro,10,7,2,0,19
+Schuylkill,Shenandoah 1st,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,Auditor General,,DEM,H. Scott Conklin,1,0,0,0,1
+Schuylkill,Shenandoah 1st,Auditor General,,DEM,Michael Lamb,2,1,0,0,3
+Schuylkill,Shenandoah 1st,Auditor General,,DEM,Tracie Fountain,1,1,0,0,2
+Schuylkill,Shenandoah 1st,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,1,0,5
+Schuylkill,Shenandoah 1st,Auditor General,,DEM,Nina Ahmad,0,2,1,0,3
+Schuylkill,Shenandoah 1st,Auditor General,,DEM,Christina M. Hartman,3,2,0,0,5
+Schuylkill,Shenandoah 1st,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,State Treasurer,,DEM,Joe Torsella,8,8,2,0,18
+Schuylkill,Shenandoah 1st,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,Representative In Congress,,DEM,Laura Quick,4,3,0,0,7
+Schuylkill,Shenandoah 1st,Representative In Congress,,DEM,Gary Wegman,4,5,2,0,11
+Schuylkill,Shenandoah 1st,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,State Senate,29,DEM,Write-in,5,2,0,0,7
+Schuylkill,Shenandoah 1st,General Assembly,123,DEM,Peter PJ Symons Jr.,7,8,1,0,16
+Schuylkill,Shenandoah 1st,General Assembly,123,DEM,Write-in,3,0,0,0,3
+Schuylkill,Shenandoah 1st,President,,REP,Donald J. Trump,21,5,0,0,26
+Schuylkill,Shenandoah 1st,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Shenandoah 1st,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Shenandoah 1st,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,Attorney General,,REP,Heather Heidelbaugh,18,5,2,0,25
+Schuylkill,Shenandoah 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,Auditor General,,REP,Timothy Defoor,18,5,2,0,25
+Schuylkill,Shenandoah 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,State Treasurer,,REP,Stacy L. Garrity,17,5,2,0,24
+Schuylkill,Shenandoah 1st,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,Representative In Congress,,REP,Dan Meuser,19,5,2,0,26
+Schuylkill,Shenandoah 1st,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 1st,State Senate,29,REP,Dave Argall,19,5,2,0,26
+Schuylkill,Shenandoah 1st,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 1st,General Assembly,123,REP,John Leshko,3,0,0,0,3
+Schuylkill,Shenandoah 1st,General Assembly,123,REP,Tim Twardzik,18,5,2,0,25
+Schuylkill,Shenandoah 1st,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 2nd,Registered Voters,,,,,,,,362
+Schuylkill,Shenandoah 2nd,Registered Voters,,DEM,,,,,,172
+Schuylkill,Shenandoah 2nd,Registered Voters,,REP,,,,,,130
+Schuylkill,Shenandoah 2nd,Registered Voters,,NPA,,,,,,60
+Schuylkill,Shenandoah 2nd,Ballots Cast,,,,72,27,8,0,107
+Schuylkill,Shenandoah 2nd,Ballots Cast,,DEM,,34,14,6,0,54
+Schuylkill,Shenandoah 2nd,Ballots Cast,,REP,,38,13,2,0,53
+Schuylkill,Shenandoah 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Shenandoah 2nd,President,,DEM,Bernie Sanders,3,1,1,0,5
+Schuylkill,Shenandoah 2nd,President,,DEM,Joseph R. Biden,16,12,5,0,33
+Schuylkill,Shenandoah 2nd,President,,DEM,Tulsi Gabbard,5,1,0,0,6
+Schuylkill,Shenandoah 2nd,President,,DEM,Write-in,7,0,0,0,7
+Schuylkill,Shenandoah 2nd,Attorney General,,DEM,Josh Shapiro,30,11,5,0,46
+Schuylkill,Shenandoah 2nd,Attorney General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Shenandoah 2nd,Auditor General,,DEM,H. Scott Conklin,6,2,0,0,8
+Schuylkill,Shenandoah 2nd,Auditor General,,DEM,Michael Lamb,5,1,0,0,6
+Schuylkill,Shenandoah 2nd,Auditor General,,DEM,Tracie Fountain,5,0,3,0,8
+Schuylkill,Shenandoah 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,0,0,4
+Schuylkill,Shenandoah 2nd,Auditor General,,DEM,Nina Ahmad,7,0,2,0,9
+Schuylkill,Shenandoah 2nd,Auditor General,,DEM,Christina M. Hartman,5,5,0,0,10
+Schuylkill,Shenandoah 2nd,Auditor General,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Shenandoah 2nd,State Treasurer,,DEM,Joe Torsella,26,10,5,0,41
+Schuylkill,Shenandoah 2nd,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 2nd,Representative In Congress,,DEM,Laura Quick,14,10,4,0,28
+Schuylkill,Shenandoah 2nd,Representative In Congress,,DEM,Gary Wegman,13,3,1,0,17
+Schuylkill,Shenandoah 2nd,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Shenandoah 2nd,State Senate,29,DEM,Write-in,1,2,1,0,4
+Schuylkill,Shenandoah 2nd,General Assembly,123,DEM,Peter PJ Symons Jr.,27,11,5,0,43
+Schuylkill,Shenandoah 2nd,General Assembly,123,DEM,Write-in,5,0,0,0,5
+Schuylkill,Shenandoah 2nd,President,,REP,Donald J. Trump,33,13,2,0,48
+Schuylkill,Shenandoah 2nd,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Shenandoah 2nd,President,,REP,Bill Weld,2,0,0,0,2
+Schuylkill,Shenandoah 2nd,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 2nd,Attorney General,,REP,Heather Heidelbaugh,32,12,2,0,46
+Schuylkill,Shenandoah 2nd,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 2nd,Auditor General,,REP,Timothy Defoor,32,12,2,0,46
+Schuylkill,Shenandoah 2nd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 2nd,State Treasurer,,REP,Stacy L. Garrity,34,12,2,0,48
+Schuylkill,Shenandoah 2nd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 2nd,Representative In Congress,,REP,Dan Meuser,34,12,2,0,48
+Schuylkill,Shenandoah 2nd,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 2nd,State Senate,29,REP,Dave Argall,33,11,2,0,46
+Schuylkill,Shenandoah 2nd,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 2nd,General Assembly,123,REP,John Leshko,6,2,0,0,8
+Schuylkill,Shenandoah 2nd,General Assembly,123,REP,Tim Twardzik,32,11,2,0,45
+Schuylkill,Shenandoah 2nd,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 3rd,Registered Voters,,,,,,,,651
+Schuylkill,Shenandoah 3rd,Registered Voters,,DEM,,,,,,302
+Schuylkill,Shenandoah 3rd,Registered Voters,,REP,,,,,,234
+Schuylkill,Shenandoah 3rd,Registered Voters,,NPA,,,,,,115
+Schuylkill,Shenandoah 3rd,Ballots Cast,,,,130,36,7,0,173
+Schuylkill,Shenandoah 3rd,Ballots Cast,,DEM,,51,21,5,0,77
+Schuylkill,Shenandoah 3rd,Ballots Cast,,REP,,79,15,2,0,96
+Schuylkill,Shenandoah 3rd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Shenandoah 3rd,President,,DEM,Bernie Sanders,12,4,1,0,17
+Schuylkill,Shenandoah 3rd,President,,DEM,Joseph R. Biden,22,13,4,0,39
+Schuylkill,Shenandoah 3rd,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Shenandoah 3rd,President,,DEM,Write-in,9,3,0,0,12
+Schuylkill,Shenandoah 3rd,Attorney General,,DEM,Josh Shapiro,43,18,4,0,65
+Schuylkill,Shenandoah 3rd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 3rd,Auditor General,,DEM,H. Scott Conklin,5,3,0,0,8
+Schuylkill,Shenandoah 3rd,Auditor General,,DEM,Michael Lamb,10,5,1,0,16
+Schuylkill,Shenandoah 3rd,Auditor General,,DEM,Tracie Fountain,5,3,0,0,8
+Schuylkill,Shenandoah 3rd,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,1,0,3
+Schuylkill,Shenandoah 3rd,Auditor General,,DEM,Nina Ahmad,11,2,2,0,15
+Schuylkill,Shenandoah 3rd,Auditor General,,DEM,Christina M. Hartman,11,7,1,0,19
+Schuylkill,Shenandoah 3rd,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 3rd,State Treasurer,,DEM,Joe Torsella,38,18,4,0,60
+Schuylkill,Shenandoah 3rd,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Shenandoah 3rd,Representative In Congress,,DEM,Laura Quick,20,10,3,0,33
+Schuylkill,Shenandoah 3rd,Representative In Congress,,DEM,Gary Wegman,23,10,2,0,35
+Schuylkill,Shenandoah 3rd,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 3rd,State Senate,29,DEM,Write-in,6,4,1,0,11
+Schuylkill,Shenandoah 3rd,General Assembly,123,DEM,Peter PJ Symons Jr.,40,16,4,0,60
+Schuylkill,Shenandoah 3rd,General Assembly,123,DEM,Write-in,7,3,0,0,10
+Schuylkill,Shenandoah 3rd,President,,REP,Donald J. Trump,68,9,2,0,79
+Schuylkill,Shenandoah 3rd,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Schuylkill,Shenandoah 3rd,President,,REP,Bill Weld,2,0,0,0,2
+Schuylkill,Shenandoah 3rd,President,,REP,Write-in,2,3,0,0,5
+Schuylkill,Shenandoah 3rd,Attorney General,,REP,Heather Heidelbaugh,69,12,1,0,82
+Schuylkill,Shenandoah 3rd,Attorney General,,REP,Write-in,1,2,0,0,3
+Schuylkill,Shenandoah 3rd,Auditor General,,REP,Timothy Defoor,69,11,1,0,81
+Schuylkill,Shenandoah 3rd,Auditor General,,REP,Write-in,0,2,0,0,2
+Schuylkill,Shenandoah 3rd,State Treasurer,,REP,Stacy L. Garrity,70,10,1,0,81
+Schuylkill,Shenandoah 3rd,State Treasurer,,REP,Write-in,0,2,0,0,2
+Schuylkill,Shenandoah 3rd,Representative In Congress,,REP,Dan Meuser,71,10,2,0,83
+Schuylkill,Shenandoah 3rd,Representative In Congress,,REP,Write-in,1,2,0,0,3
+Schuylkill,Shenandoah 3rd,State Senate,29,REP,Dave Argall,74,14,2,0,90
+Schuylkill,Shenandoah 3rd,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 3rd,General Assembly,123,REP,John Leshko,9,0,0,0,9
+Schuylkill,Shenandoah 3rd,General Assembly,123,REP,Tim Twardzik,69,13,2,0,84
+Schuylkill,Shenandoah 3rd,General Assembly,123,REP,Write-in,0,2,0,0,2
+Schuylkill,Shenandoah 4th,Registered Voters,,,,,,,,385
+Schuylkill,Shenandoah 4th,Registered Voters,,DEM,,,,,,198
+Schuylkill,Shenandoah 4th,Registered Voters,,REP,,,,,,125
+Schuylkill,Shenandoah 4th,Registered Voters,,NPA,,,,,,62
+Schuylkill,Shenandoah 4th,Ballots Cast,,,,82,10,5,1,98
+Schuylkill,Shenandoah 4th,Ballots Cast,,DEM,,44,7,5,0,56
+Schuylkill,Shenandoah 4th,Ballots Cast,,REP,,38,3,0,1,42
+Schuylkill,Shenandoah 4th,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Shenandoah 4th,President,,DEM,Bernie Sanders,6,0,1,0,7
+Schuylkill,Shenandoah 4th,President,,DEM,Joseph R. Biden,28,6,4,0,38
+Schuylkill,Shenandoah 4th,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Schuylkill,Shenandoah 4th,President,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Shenandoah 4th,Attorney General,,DEM,Josh Shapiro,36,7,5,0,48
+Schuylkill,Shenandoah 4th,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 4th,Auditor General,,DEM,H. Scott Conklin,5,0,1,0,6
+Schuylkill,Shenandoah 4th,Auditor General,,DEM,Michael Lamb,7,1,0,0,8
+Schuylkill,Shenandoah 4th,Auditor General,,DEM,Tracie Fountain,9,0,1,0,10
+Schuylkill,Shenandoah 4th,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,0,5
+Schuylkill,Shenandoah 4th,Auditor General,,DEM,Nina Ahmad,8,2,1,0,11
+Schuylkill,Shenandoah 4th,Auditor General,,DEM,Christina M. Hartman,6,0,2,0,8
+Schuylkill,Shenandoah 4th,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 4th,State Treasurer,,DEM,Joe Torsella,39,6,5,0,50
+Schuylkill,Shenandoah 4th,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 4th,Representative In Congress,,DEM,Laura Quick,19,4,2,0,25
+Schuylkill,Shenandoah 4th,Representative In Congress,,DEM,Gary Wegman,21,2,3,0,26
+Schuylkill,Shenandoah 4th,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 4th,State Senate,29,DEM,Write-in,7,1,2,0,10
+Schuylkill,Shenandoah 4th,General Assembly,123,DEM,Peter PJ Symons Jr.,37,7,5,0,49
+Schuylkill,Shenandoah 4th,General Assembly,123,DEM,Write-in,4,0,0,0,4
+Schuylkill,Shenandoah 4th,President,,REP,Donald J. Trump,36,2,0,0,38
+Schuylkill,Shenandoah 4th,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Shenandoah 4th,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,Shenandoah 4th,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Shenandoah 4th,Attorney General,,REP,Heather Heidelbaugh,33,3,0,0,36
+Schuylkill,Shenandoah 4th,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 4th,Auditor General,,REP,Timothy Defoor,34,3,0,0,37
+Schuylkill,Shenandoah 4th,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 4th,State Treasurer,,REP,Stacy L. Garrity,33,3,0,0,36
+Schuylkill,Shenandoah 4th,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 4th,Representative In Congress,,REP,Dan Meuser,33,3,0,0,36
+Schuylkill,Shenandoah 4th,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 4th,State Senate,29,REP,Dave Argall,35,3,0,0,38
+Schuylkill,Shenandoah 4th,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 4th,General Assembly,123,REP,John Leshko,9,0,0,0,9
+Schuylkill,Shenandoah 4th,General Assembly,123,REP,Tim Twardzik,29,3,0,1,33
+Schuylkill,Shenandoah 4th,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 5th,Registered Voters,,,,,,,,370
+Schuylkill,Shenandoah 5th,Registered Voters,,DEM,,,,,,197
+Schuylkill,Shenandoah 5th,Registered Voters,,REP,,,,,,124
+Schuylkill,Shenandoah 5th,Registered Voters,,NPA,,,,,,49
+Schuylkill,Shenandoah 5th,Ballots Cast,,,,58,32,5,0,95
+Schuylkill,Shenandoah 5th,Ballots Cast,,DEM,,25,20,3,0,48
+Schuylkill,Shenandoah 5th,Ballots Cast,,REP,,33,12,2,0,47
+Schuylkill,Shenandoah 5th,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Shenandoah 5th,President,,DEM,Bernie Sanders,4,3,1,0,8
+Schuylkill,Shenandoah 5th,President,,DEM,Joseph R. Biden,13,14,2,0,29
+Schuylkill,Shenandoah 5th,President,,DEM,Tulsi Gabbard,2,2,0,0,4
+Schuylkill,Shenandoah 5th,President,,DEM,Write-in,3,1,0,0,4
+Schuylkill,Shenandoah 5th,Attorney General,,DEM,Josh Shapiro,17,20,3,0,40
+Schuylkill,Shenandoah 5th,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Shenandoah 5th,Auditor General,,DEM,H. Scott Conklin,2,1,1,0,4
+Schuylkill,Shenandoah 5th,Auditor General,,DEM,Michael Lamb,4,6,0,0,10
+Schuylkill,Shenandoah 5th,Auditor General,,DEM,Tracie Fountain,4,4,0,0,8
+Schuylkill,Shenandoah 5th,Auditor General,,DEM,Rose Rosie Marie Davis,2,3,1,0,6
+Schuylkill,Shenandoah 5th,Auditor General,,DEM,Nina Ahmad,3,2,1,0,6
+Schuylkill,Shenandoah 5th,Auditor General,,DEM,Christina M. Hartman,5,4,0,0,9
+Schuylkill,Shenandoah 5th,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Shenandoah 5th,State Treasurer,,DEM,Joe Torsella,18,20,3,0,41
+Schuylkill,Shenandoah 5th,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 5th,Representative In Congress,,DEM,Laura Quick,9,8,0,0,17
+Schuylkill,Shenandoah 5th,Representative In Congress,,DEM,Gary Wegman,11,11,3,0,25
+Schuylkill,Shenandoah 5th,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Shenandoah 5th,State Senate,29,DEM,Write-in,4,2,0,0,6
+Schuylkill,Shenandoah 5th,General Assembly,123,DEM,Peter PJ Symons Jr.,20,18,2,0,40
+Schuylkill,Shenandoah 5th,General Assembly,123,DEM,Write-in,3,1,0,0,4
+Schuylkill,Shenandoah 5th,President,,REP,Donald J. Trump,29,12,2,0,43
+Schuylkill,Shenandoah 5th,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Shenandoah 5th,President,,REP,Bill Weld,3,0,0,0,3
+Schuylkill,Shenandoah 5th,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 5th,Attorney General,,REP,Heather Heidelbaugh,30,10,2,0,42
+Schuylkill,Shenandoah 5th,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 5th,Auditor General,,REP,Timothy Defoor,29,10,2,0,41
+Schuylkill,Shenandoah 5th,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 5th,State Treasurer,,REP,Stacy L. Garrity,31,10,2,0,43
+Schuylkill,Shenandoah 5th,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 5th,Representative In Congress,,REP,Dan Meuser,31,12,2,0,45
+Schuylkill,Shenandoah 5th,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 5th,State Senate,29,REP,Dave Argall,31,10,2,0,43
+Schuylkill,Shenandoah 5th,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 5th,General Assembly,123,REP,John Leshko,5,3,0,0,8
+Schuylkill,Shenandoah 5th,General Assembly,123,REP,Tim Twardzik,27,9,2,0,38
+Schuylkill,Shenandoah 5th,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,Shenandoah 6th,Registered Voters,,,,,,,,123
+Schuylkill,Shenandoah 6th,Registered Voters,,DEM,,,,,,58
+Schuylkill,Shenandoah 6th,Registered Voters,,REP,,,,,,46
+Schuylkill,Shenandoah 6th,Registered Voters,,NPA,,,,,,19
+Schuylkill,Shenandoah 6th,Ballots Cast,,,,25,14,3,2,44
+Schuylkill,Shenandoah 6th,Ballots Cast,,DEM,,9,9,3,0,21
+Schuylkill,Shenandoah 6th,Ballots Cast,,REP,,16,5,0,2,23
+Schuylkill,Shenandoah 6th,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Shenandoah 6th,President,,DEM,Bernie Sanders,3,0,0,0,3
+Schuylkill,Shenandoah 6th,President,,DEM,Joseph R. Biden,4,7,3,0,14
+Schuylkill,Shenandoah 6th,President,,DEM,Tulsi Gabbard,0,2,0,0,2
+Schuylkill,Shenandoah 6th,President,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,Attorney General,,DEM,Josh Shapiro,9,9,3,0,21
+Schuylkill,Shenandoah 6th,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,Auditor General,,DEM,H. Scott Conklin,2,2,0,0,4
+Schuylkill,Shenandoah 6th,Auditor General,,DEM,Michael Lamb,2,0,0,0,2
+Schuylkill,Shenandoah 6th,Auditor General,,DEM,Tracie Fountain,0,3,1,0,4
+Schuylkill,Shenandoah 6th,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,0,1
+Schuylkill,Shenandoah 6th,Auditor General,,DEM,Nina Ahmad,1,0,0,0,1
+Schuylkill,Shenandoah 6th,Auditor General,,DEM,Christina M. Hartman,3,4,2,0,9
+Schuylkill,Shenandoah 6th,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,State Treasurer,,DEM,Joe Torsella,9,9,2,0,20
+Schuylkill,Shenandoah 6th,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,Representative In Congress,,DEM,Laura Quick,7,5,1,0,13
+Schuylkill,Shenandoah 6th,Representative In Congress,,DEM,Gary Wegman,2,4,2,0,8
+Schuylkill,Shenandoah 6th,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,State Senate,29,DEM,Write-in,0,3,0,0,3
+Schuylkill,Shenandoah 6th,General Assembly,123,DEM,Peter PJ Symons Jr.,9,9,3,0,21
+Schuylkill,Shenandoah 6th,General Assembly,123,DEM,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,President,,REP,Donald J. Trump,15,3,0,2,20
+Schuylkill,Shenandoah 6th,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Shenandoah 6th,President,,REP,Bill Weld,1,1,0,0,2
+Schuylkill,Shenandoah 6th,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Shenandoah 6th,Attorney General,,REP,Heather Heidelbaugh,15,5,0,0,20
+Schuylkill,Shenandoah 6th,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,Auditor General,,REP,Timothy Defoor,15,5,0,0,20
+Schuylkill,Shenandoah 6th,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,State Treasurer,,REP,Stacy L. Garrity,15,5,0,0,20
+Schuylkill,Shenandoah 6th,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,Representative In Congress,,REP,Dan Meuser,16,5,0,2,23
+Schuylkill,Shenandoah 6th,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Shenandoah 6th,State Senate,29,REP,Dave Argall,15,4,0,1,20
+Schuylkill,Shenandoah 6th,State Senate,29,REP,Write-in,0,0,0,1,1
+Schuylkill,Shenandoah 6th,General Assembly,123,REP,John Leshko,1,3,0,0,4
+Schuylkill,Shenandoah 6th,General Assembly,123,REP,Tim Twardzik,15,2,0,2,19
+Schuylkill,Shenandoah 6th,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Altamont,Registered Voters,,,,,,,,533
+Schuylkill,West Mahanoy Altamont,Registered Voters,,DEM,,,,,,211
+Schuylkill,West Mahanoy Altamont,Registered Voters,,REP,,,,,,268
+Schuylkill,West Mahanoy Altamont,Registered Voters,,NPA,,,,,,54
+Schuylkill,West Mahanoy Altamont,Ballots Cast,,,,144,44,12,0,200
+Schuylkill,West Mahanoy Altamont,Ballots Cast,,DEM,,40,23,8,0,71
+Schuylkill,West Mahanoy Altamont,Ballots Cast,,REP,,104,21,4,0,129
+Schuylkill,West Mahanoy Altamont,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,West Mahanoy Altamont,President,,DEM,Bernie Sanders,9,0,3,0,12
+Schuylkill,West Mahanoy Altamont,President,,DEM,Joseph R. Biden,17,20,5,0,42
+Schuylkill,West Mahanoy Altamont,President,,DEM,Tulsi Gabbard,0,1,0,0,1
+Schuylkill,West Mahanoy Altamont,President,,DEM,Write-in,9,2,0,0,11
+Schuylkill,West Mahanoy Altamont,Attorney General,,DEM,Josh Shapiro,33,20,8,0,61
+Schuylkill,West Mahanoy Altamont,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,West Mahanoy Altamont,Auditor General,,DEM,H. Scott Conklin,4,3,0,0,7
+Schuylkill,West Mahanoy Altamont,Auditor General,,DEM,Michael Lamb,7,0,1,0,8
+Schuylkill,West Mahanoy Altamont,Auditor General,,DEM,Tracie Fountain,8,4,2,0,14
+Schuylkill,West Mahanoy Altamont,Auditor General,,DEM,Rose Rosie Marie Davis,3,6,0,0,9
+Schuylkill,West Mahanoy Altamont,Auditor General,,DEM,Nina Ahmad,6,2,1,0,9
+Schuylkill,West Mahanoy Altamont,Auditor General,,DEM,Christina M. Hartman,9,7,3,0,19
+Schuylkill,West Mahanoy Altamont,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,West Mahanoy Altamont,State Treasurer,,DEM,Joe Torsella,32,20,8,0,60
+Schuylkill,West Mahanoy Altamont,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,West Mahanoy Altamont,Representative In Congress,,DEM,Laura Quick,18,12,6,0,36
+Schuylkill,West Mahanoy Altamont,Representative In Congress,,DEM,Gary Wegman,15,9,2,0,26
+Schuylkill,West Mahanoy Altamont,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,West Mahanoy Altamont,State Senate,29,DEM,Write-in,6,1,0,0,7
+Schuylkill,West Mahanoy Altamont,General Assembly,123,DEM,Peter PJ Symons Jr.,32,22,8,0,62
+Schuylkill,West Mahanoy Altamont,General Assembly,123,DEM,Write-in,3,0,0,0,3
+Schuylkill,West Mahanoy Altamont,President,,REP,Donald J. Trump,100,16,4,0,120
+Schuylkill,West Mahanoy Altamont,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,West Mahanoy Altamont,President,,REP,Bill Weld,3,1,0,0,4
+Schuylkill,West Mahanoy Altamont,President,,REP,Write-in,0,4,0,0,4
+Schuylkill,West Mahanoy Altamont,Attorney General,,REP,Heather Heidelbaugh,90,17,3,0,110
+Schuylkill,West Mahanoy Altamont,Attorney General,,REP,Write-in,1,2,0,0,3
+Schuylkill,West Mahanoy Altamont,Auditor General,,REP,Timothy Defoor,88,17,3,0,108
+Schuylkill,West Mahanoy Altamont,Auditor General,,REP,Write-in,1,2,0,0,3
+Schuylkill,West Mahanoy Altamont,State Treasurer,,REP,Stacy L. Garrity,91,16,3,0,110
+Schuylkill,West Mahanoy Altamont,State Treasurer,,REP,Write-in,1,2,0,0,3
+Schuylkill,West Mahanoy Altamont,Representative In Congress,,REP,Dan Meuser,98,17,4,0,119
+Schuylkill,West Mahanoy Altamont,Representative In Congress,,REP,Write-in,1,3,0,0,4
+Schuylkill,West Mahanoy Altamont,State Senate,29,REP,Dave Argall,97,19,4,0,120
+Schuylkill,West Mahanoy Altamont,State Senate,29,REP,Write-in,3,1,0,0,4
+Schuylkill,West Mahanoy Altamont,General Assembly,123,REP,John Leshko,20,7,1,0,28
+Schuylkill,West Mahanoy Altamont,General Assembly,123,REP,Tim Twardzik,84,13,3,0,100
+Schuylkill,West Mahanoy Altamont,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 2nd,Registered Voters,,,,,,,,861
+Schuylkill,West Mahanoy Twp 2nd,Registered Voters,,DEM,,,,,,420
+Schuylkill,West Mahanoy Twp 2nd,Registered Voters,,REP,,,,,,349
+Schuylkill,West Mahanoy Twp 2nd,Registered Voters,,NPA,,,,,,92
+Schuylkill,West Mahanoy Twp 2nd,Ballots Cast,,,,198,102,27,4,331
+Schuylkill,West Mahanoy Twp 2nd,Ballots Cast,,DEM,,78,63,17,1,159
+Schuylkill,West Mahanoy Twp 2nd,Ballots Cast,,REP,,120,39,10,3,172
+Schuylkill,West Mahanoy Twp 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 2nd,President,,DEM,Bernie Sanders,11,7,2,0,20
+Schuylkill,West Mahanoy Twp 2nd,President,,DEM,Joseph R. Biden,39,51,13,1,104
+Schuylkill,West Mahanoy Twp 2nd,President,,DEM,Tulsi Gabbard,6,1,1,0,8
+Schuylkill,West Mahanoy Twp 2nd,President,,DEM,Write-in,14,1,1,0,16
+Schuylkill,West Mahanoy Twp 2nd,Attorney General,,DEM,Josh Shapiro,61,55,13,1,130
+Schuylkill,West Mahanoy Twp 2nd,Attorney General,,DEM,Write-in,3,1,1,0,5
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,DEM,H. Scott Conklin,5,8,0,0,13
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,DEM,Michael Lamb,11,4,2,0,17
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,DEM,Tracie Fountain,13,19,0,0,32
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,7,7,2,1,17
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,DEM,Nina Ahmad,12,6,1,0,19
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,DEM,Christina M. Hartman,14,9,8,0,31
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,DEM,Write-in,2,1,0,0,3
+Schuylkill,West Mahanoy Twp 2nd,State Treasurer,,DEM,Joe Torsella,59,53,13,1,126
+Schuylkill,West Mahanoy Twp 2nd,State Treasurer,,DEM,Write-in,2,1,1,0,4
+Schuylkill,West Mahanoy Twp 2nd,Representative In Congress,,DEM,Laura Quick,35,20,5,0,60
+Schuylkill,West Mahanoy Twp 2nd,Representative In Congress,,DEM,Gary Wegman,27,35,8,1,71
+Schuylkill,West Mahanoy Twp 2nd,Representative In Congress,,DEM,Write-in,3,3,1,0,7
+Schuylkill,West Mahanoy Twp 2nd,State Senate,29,DEM,Write-in,10,3,2,0,15
+Schuylkill,West Mahanoy Twp 2nd,General Assembly,123,DEM,Peter PJ Symons Jr.,65,55,12,1,133
+Schuylkill,West Mahanoy Twp 2nd,General Assembly,123,DEM,Write-in,8,2,3,0,13
+Schuylkill,West Mahanoy Twp 2nd,President,,REP,Donald J. Trump,114,32,8,3,157
+Schuylkill,West Mahanoy Twp 2nd,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 2nd,President,,REP,Bill Weld,4,0,0,0,4
+Schuylkill,West Mahanoy Twp 2nd,President,,REP,Write-in,1,2,2,0,5
+Schuylkill,West Mahanoy Twp 2nd,Attorney General,,REP,Heather Heidelbaugh,99,31,9,3,142
+Schuylkill,West Mahanoy Twp 2nd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,REP,Timothy Defoor,99,31,8,3,141
+Schuylkill,West Mahanoy Twp 2nd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 2nd,State Treasurer,,REP,Stacy L. Garrity,99,32,9,3,143
+Schuylkill,West Mahanoy Twp 2nd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 2nd,Representative In Congress,,REP,Dan Meuser,106,35,9,3,153
+Schuylkill,West Mahanoy Twp 2nd,Representative In Congress,,REP,Write-in,2,0,1,0,3
+Schuylkill,West Mahanoy Twp 2nd,State Senate,29,REP,Dave Argall,104,33,9,3,149
+Schuylkill,West Mahanoy Twp 2nd,State Senate,29,REP,Write-in,0,0,1,0,1
+Schuylkill,West Mahanoy Twp 2nd,General Assembly,123,REP,John Leshko,17,5,2,0,24
+Schuylkill,West Mahanoy Twp 2nd,General Assembly,123,REP,Tim Twardzik,97,34,8,3,142
+Schuylkill,West Mahanoy Twp 2nd,General Assembly,123,REP,Write-in,1,0,0,0,1
+Schuylkill,West Mahanoy Twp 1st,Registered Voters,,,,,,,,316
+Schuylkill,West Mahanoy Twp 1st,Registered Voters,,DEM,,,,,,185
+Schuylkill,West Mahanoy Twp 1st,Registered Voters,,REP,,,,,,93
+Schuylkill,West Mahanoy Twp 1st,Registered Voters,,NPA,,,,,,38
+Schuylkill,West Mahanoy Twp 1st,Ballots Cast,,,,67,34,2,3,106
+Schuylkill,West Mahanoy Twp 1st,Ballots Cast,,DEM,,41,24,2,2,69
+Schuylkill,West Mahanoy Twp 1st,Ballots Cast,,REP,,26,10,0,1,37
+Schuylkill,West Mahanoy Twp 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,President,,DEM,Bernie Sanders,8,2,0,1,11
+Schuylkill,West Mahanoy Twp 1st,President,,DEM,Joseph R. Biden,15,16,2,1,34
+Schuylkill,West Mahanoy Twp 1st,President,,DEM,Tulsi Gabbard,1,2,0,0,3
+Schuylkill,West Mahanoy Twp 1st,President,,DEM,Write-in,14,2,0,0,16
+Schuylkill,West Mahanoy Twp 1st,Attorney General,,DEM,Josh Shapiro,36,24,2,1,63
+Schuylkill,West Mahanoy Twp 1st,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,DEM,H. Scott Conklin,1,2,0,0,3
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,DEM,Michael Lamb,2,3,1,0,6
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,DEM,Tracie Fountain,10,11,1,1,23
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,DEM,Rose Rosie Marie Davis,5,1,0,0,6
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,DEM,Nina Ahmad,4,3,0,0,7
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,DEM,Christina M. Hartman,14,4,0,1,19
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,State Treasurer,,DEM,Joe Torsella,33,22,2,2,59
+Schuylkill,West Mahanoy Twp 1st,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Schuylkill,West Mahanoy Twp 1st,Representative In Congress,,DEM,Laura Quick,18,14,1,1,34
+Schuylkill,West Mahanoy Twp 1st,Representative In Congress,,DEM,Gary Wegman,17,10,1,1,29
+Schuylkill,West Mahanoy Twp 1st,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,West Mahanoy Twp 1st,State Senate,29,DEM,Write-in,8,3,0,0,11
+Schuylkill,West Mahanoy Twp 1st,General Assembly,123,DEM,Peter PJ Symons Jr.,34,19,2,2,57
+Schuylkill,West Mahanoy Twp 1st,General Assembly,123,DEM,Write-in,4,2,0,0,6
+Schuylkill,West Mahanoy Twp 1st,President,,REP,Donald J. Trump,23,9,0,1,33
+Schuylkill,West Mahanoy Twp 1st,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,West Mahanoy Twp 1st,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,West Mahanoy Twp 1st,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,Attorney General,,REP,Heather Heidelbaugh,25,10,0,1,36
+Schuylkill,West Mahanoy Twp 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,REP,Timothy Defoor,25,10,0,1,36
+Schuylkill,West Mahanoy Twp 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,State Treasurer,,REP,Stacy L. Garrity,25,10,0,1,36
+Schuylkill,West Mahanoy Twp 1st,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,Representative In Congress,,REP,Dan Meuser,26,10,0,1,37
+Schuylkill,West Mahanoy Twp 1st,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,State Senate,29,REP,Dave Argall,25,10,0,1,36
+Schuylkill,West Mahanoy Twp 1st,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,West Mahanoy Twp 1st,General Assembly,123,REP,John Leshko,9,0,0,0,9
+Schuylkill,West Mahanoy Twp 1st,General Assembly,123,REP,Tim Twardzik,17,10,0,1,28
+Schuylkill,West Mahanoy Twp 1st,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Auburn,Registered Voters,,,,,,,,436
+Schuylkill,Auburn,Registered Voters,,DEM,,,,,,116
+Schuylkill,Auburn,Registered Voters,,REP,,,,,,250
+Schuylkill,Auburn,Registered Voters,,NPA,,,,,,70
+Schuylkill,Auburn,Ballots Cast,,,,109,40,5,3,157
+Schuylkill,Auburn,Ballots Cast,,DEM,,24,23,2,0,49
+Schuylkill,Auburn,Ballots Cast,,REP,,85,17,3,3,108
+Schuylkill,Auburn,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Auburn,President,,DEM,Bernie Sanders,6,8,0,0,14
+Schuylkill,Auburn,President,,DEM,Joseph R. Biden,13,11,2,0,26
+Schuylkill,Auburn,President,,DEM,Tulsi Gabbard,2,2,0,0,4
+Schuylkill,Auburn,President,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Auburn,Attorney General,,DEM,Josh Shapiro,24,22,2,0,48
+Schuylkill,Auburn,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Auburn,Auditor General,,DEM,H. Scott Conklin,2,3,1,0,6
+Schuylkill,Auburn,Auditor General,,DEM,Michael Lamb,2,0,0,0,2
+Schuylkill,Auburn,Auditor General,,DEM,Tracie Fountain,5,3,1,0,9
+Schuylkill,Auburn,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,0,1
+Schuylkill,Auburn,Auditor General,,DEM,Nina Ahmad,3,8,0,0,11
+Schuylkill,Auburn,Auditor General,,DEM,Christina M. Hartman,10,5,0,0,15
+Schuylkill,Auburn,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Auburn,State Treasurer,,DEM,Joe Torsella,24,19,2,0,45
+Schuylkill,Auburn,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Auburn,Representative In Congress,,DEM,Laura Quick,8,10,1,0,19
+Schuylkill,Auburn,Representative In Congress,,DEM,Gary Wegman,15,11,1,0,27
+Schuylkill,Auburn,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Auburn,State Senate,29,DEM,Write-in,2,0,0,0,2
+Schuylkill,Auburn,General Assembly,125,DEM,Write-in,2,0,0,0,2
+Schuylkill,Auburn,President,,REP,Donald J. Trump,79,15,3,3,100
+Schuylkill,Auburn,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,Auburn,President,,REP,Bill Weld,2,2,0,0,4
+Schuylkill,Auburn,President,,REP,Write-in,2,0,0,0,2
+Schuylkill,Auburn,Attorney General,,REP,Heather Heidelbaugh,71,16,3,2,92
+Schuylkill,Auburn,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Auburn,Auditor General,,REP,Timothy Defoor,70,16,3,2,91
+Schuylkill,Auburn,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Auburn,State Treasurer,,REP,Stacy L. Garrity,71,16,3,2,92
+Schuylkill,Auburn,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Auburn,Representative In Congress,,REP,Dan Meuser,72,16,3,2,93
+Schuylkill,Auburn,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Auburn,State Senate,29,REP,Dave Argall,72,17,3,3,95
+Schuylkill,Auburn,State Senate,29,REP,Write-in,6,0,0,0,6
+Schuylkill,Auburn,General Assembly,125,REP,Herv Breault,16,1,0,0,17
+Schuylkill,Auburn,General Assembly,125,REP,Theresa Gaffney,21,4,0,0,25
+Schuylkill,Auburn,General Assembly,125,REP,Christy Joy,33,7,2,3,45
+Schuylkill,Auburn,General Assembly,125,REP,Joe Kerwin,14,5,0,0,19
+Schuylkill,Auburn,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Coaldale East,Registered Voters,,,,,,,,640
+Schuylkill,Coaldale East,Registered Voters,,DEM,,,,,,228
+Schuylkill,Coaldale East,Registered Voters,,REP,,,,,,306
+Schuylkill,Coaldale East,Registered Voters,,NPA,,,,,,106
+Schuylkill,Coaldale East,Ballots Cast,,,,134,57,15,1,207
+Schuylkill,Coaldale East,Ballots Cast,,DEM,,38,31,9,0,78
+Schuylkill,Coaldale East,Ballots Cast,,REP,,96,26,6,1,129
+Schuylkill,Coaldale East,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Coaldale East,President,,DEM,Bernie Sanders,7,3,1,0,11
+Schuylkill,Coaldale East,President,,DEM,Joseph R. Biden,23,27,8,0,58
+Schuylkill,Coaldale East,President,,DEM,Tulsi Gabbard,5,1,0,0,6
+Schuylkill,Coaldale East,President,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Coaldale East,Attorney General,,DEM,Josh Shapiro,37,31,9,0,77
+Schuylkill,Coaldale East,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Coaldale East,Auditor General,,DEM,H. Scott Conklin,1,5,1,0,7
+Schuylkill,Coaldale East,Auditor General,,DEM,Michael Lamb,6,5,3,0,14
+Schuylkill,Coaldale East,Auditor General,,DEM,Tracie Fountain,3,6,0,0,9
+Schuylkill,Coaldale East,Auditor General,,DEM,Rose Rosie Marie Davis,7,6,0,0,13
+Schuylkill,Coaldale East,Auditor General,,DEM,Nina Ahmad,6,3,2,0,11
+Schuylkill,Coaldale East,Auditor General,,DEM,Christina M. Hartman,13,4,3,0,20
+Schuylkill,Coaldale East,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Coaldale East,State Treasurer,,DEM,Joe Torsella,35,29,9,0,73
+Schuylkill,Coaldale East,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Coaldale East,Representative In Congress,,DEM,Laura Quick,17,16,5,0,38
+Schuylkill,Coaldale East,Representative In Congress,,DEM,Gary Wegman,18,15,4,0,37
+Schuylkill,Coaldale East,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Coaldale East,State Senate,29,DEM,Write-in,3,3,0,0,6
+Schuylkill,Coaldale East,General Assembly,124,DEM,Taylor Picone,33,29,9,0,71
+Schuylkill,Coaldale East,General Assembly,124,DEM,Write-in,0,0,0,0,0
+Schuylkill,Coaldale East,President,,REP,Donald J. Trump,90,22,4,1,117
+Schuylkill,Coaldale East,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Coaldale East,President,,REP,Bill Weld,2,0,2,0,4
+Schuylkill,Coaldale East,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale East,Attorney General,,REP,Heather Heidelbaugh,84,22,5,1,112
+Schuylkill,Coaldale East,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale East,Auditor General,,REP,Timothy Defoor,83,23,5,1,112
+Schuylkill,Coaldale East,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale East,State Treasurer,,REP,Stacy L. Garrity,84,22,5,1,112
+Schuylkill,Coaldale East,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale East,Representative In Congress,,REP,Dan Meuser,88,23,5,1,117
+Schuylkill,Coaldale East,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale East,State Senate,29,REP,Dave Argall,93,25,5,1,124
+Schuylkill,Coaldale East,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale East,General Assembly,124,REP,Jerry Knowles,95,25,5,1,126
+Schuylkill,Coaldale East,General Assembly,124,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale West,Registered Voters,,,,,,,,658
+Schuylkill,Coaldale West,Registered Voters,,DEM,,,,,,226
+Schuylkill,Coaldale West,Registered Voters,,REP,,,,,,327
+Schuylkill,Coaldale West,Registered Voters,,NPA,,,,,,105
+Schuylkill,Coaldale West,Ballots Cast,,,,131,62,18,3,214
+Schuylkill,Coaldale West,Ballots Cast,,DEM,,35,36,12,2,85
+Schuylkill,Coaldale West,Ballots Cast,,REP,,96,26,6,1,129
+Schuylkill,Coaldale West,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Coaldale West,President,,DEM,Bernie Sanders,11,5,3,0,19
+Schuylkill,Coaldale West,President,,DEM,Joseph R. Biden,18,29,8,2,57
+Schuylkill,Coaldale West,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Schuylkill,Coaldale West,President,,DEM,Write-in,4,0,1,0,5
+Schuylkill,Coaldale West,Attorney General,,DEM,Josh Shapiro,26,32,11,2,71
+Schuylkill,Coaldale West,Attorney General,,DEM,Write-in,1,0,1,0,2
+Schuylkill,Coaldale West,Auditor General,,DEM,H. Scott Conklin,1,3,2,0,6
+Schuylkill,Coaldale West,Auditor General,,DEM,Michael Lamb,4,6,1,0,11
+Schuylkill,Coaldale West,Auditor General,,DEM,Tracie Fountain,1,3,3,0,7
+Schuylkill,Coaldale West,Auditor General,,DEM,Rose Rosie Marie Davis,6,6,2,0,14
+Schuylkill,Coaldale West,Auditor General,,DEM,Nina Ahmad,6,5,2,1,14
+Schuylkill,Coaldale West,Auditor General,,DEM,Christina M. Hartman,10,9,1,1,21
+Schuylkill,Coaldale West,Auditor General,,DEM,Write-in,0,0,1,0,1
+Schuylkill,Coaldale West,State Treasurer,,DEM,Joe Torsella,22,34,11,2,69
+Schuylkill,Coaldale West,State Treasurer,,DEM,Write-in,1,0,1,0,2
+Schuylkill,Coaldale West,Representative In Congress,,DEM,Laura Quick,13,10,5,1,29
+Schuylkill,Coaldale West,Representative In Congress,,DEM,Gary Wegman,15,22,6,1,44
+Schuylkill,Coaldale West,Representative In Congress,,DEM,Write-in,0,0,1,0,1
+Schuylkill,Coaldale West,State Senate,29,DEM,Write-in,2,3,2,0,7
+Schuylkill,Coaldale West,General Assembly,124,DEM,Taylor Picone,20,33,11,2,66
+Schuylkill,Coaldale West,General Assembly,124,DEM,Write-in,0,0,1,0,1
+Schuylkill,Coaldale West,President,,REP,Donald J. Trump,88,20,3,1,112
+Schuylkill,Coaldale West,President,,REP,Roque Rocky De La Fuente,2,1,0,0,3
+Schuylkill,Coaldale West,President,,REP,Bill Weld,3,3,0,0,6
+Schuylkill,Coaldale West,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale West,Attorney General,,REP,Heather Heidelbaugh,89,24,5,1,119
+Schuylkill,Coaldale West,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale West,Auditor General,,REP,Timothy Defoor,88,24,5,1,118
+Schuylkill,Coaldale West,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale West,State Treasurer,,REP,Stacy L. Garrity,88,24,5,1,118
+Schuylkill,Coaldale West,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Coaldale West,Representative In Congress,,REP,Dan Meuser,91,23,5,0,119
+Schuylkill,Coaldale West,Representative In Congress,,REP,Write-in,1,1,1,0,3
+Schuylkill,Coaldale West,State Senate,29,REP,Dave Argall,90,25,5,1,121
+Schuylkill,Coaldale West,State Senate,29,REP,Write-in,3,1,1,0,5
+Schuylkill,Coaldale West,General Assembly,124,REP,Jerry Knowles,91,25,6,0,122
+Schuylkill,Coaldale West,General Assembly,124,REP,Write-in,3,0,0,0,3
+Schuylkill,Deer Lake,Registered Voters,,,,,,,,473
+Schuylkill,Deer Lake,Registered Voters,,DEM,,,,,,122
+Schuylkill,Deer Lake,Registered Voters,,REP,,,,,,269
+Schuylkill,Deer Lake,Registered Voters,,NPA,,,,,,82
+Schuylkill,Deer Lake,Ballots Cast,,,,136,59,15,1,211
+Schuylkill,Deer Lake,Ballots Cast,,DEM,,19,41,10,0,70
+Schuylkill,Deer Lake,Ballots Cast,,REP,,117,18,5,1,141
+Schuylkill,Deer Lake,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Deer Lake,President,,DEM,Bernie Sanders,2,3,1,0,6
+Schuylkill,Deer Lake,President,,DEM,Joseph R. Biden,14,37,8,0,59
+Schuylkill,Deer Lake,President,,DEM,Tulsi Gabbard,2,0,1,0,3
+Schuylkill,Deer Lake,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Deer Lake,Attorney General,,DEM,Josh Shapiro,16,40,9,0,65
+Schuylkill,Deer Lake,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Deer Lake,Auditor General,,DEM,H. Scott Conklin,3,3,0,0,6
+Schuylkill,Deer Lake,Auditor General,,DEM,Michael Lamb,3,5,0,0,8
+Schuylkill,Deer Lake,Auditor General,,DEM,Tracie Fountain,4,4,3,0,11
+Schuylkill,Deer Lake,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,0,0,3
+Schuylkill,Deer Lake,Auditor General,,DEM,Nina Ahmad,4,6,1,0,11
+Schuylkill,Deer Lake,Auditor General,,DEM,Christina M. Hartman,4,18,4,0,26
+Schuylkill,Deer Lake,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Deer Lake,State Treasurer,,DEM,Joe Torsella,17,39,9,0,65
+Schuylkill,Deer Lake,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Deer Lake,Representative In Congress,,DEM,Laura Quick,6,15,2,0,23
+Schuylkill,Deer Lake,Representative In Congress,,DEM,Gary Wegman,13,25,7,0,45
+Schuylkill,Deer Lake,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Deer Lake,State Senate,29,DEM,Write-in,0,3,1,0,4
+Schuylkill,Deer Lake,General Assembly,124,DEM,Taylor Picone,18,40,9,0,67
+Schuylkill,Deer Lake,General Assembly,124,DEM,Write-in,0,0,0,0,0
+Schuylkill,Deer Lake,President,,REP,Donald J. Trump,108,16,5,1,130
+Schuylkill,Deer Lake,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Deer Lake,President,,REP,Bill Weld,4,1,0,0,5
+Schuylkill,Deer Lake,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Deer Lake,Attorney General,,REP,Heather Heidelbaugh,97,15,3,1,116
+Schuylkill,Deer Lake,Attorney General,,REP,Write-in,1,0,1,0,2
+Schuylkill,Deer Lake,Auditor General,,REP,Timothy Defoor,94,15,4,1,114
+Schuylkill,Deer Lake,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Deer Lake,State Treasurer,,REP,Stacy L. Garrity,95,15,4,1,115
+Schuylkill,Deer Lake,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Deer Lake,Representative In Congress,,REP,Dan Meuser,105,15,3,1,124
+Schuylkill,Deer Lake,Representative In Congress,,REP,Write-in,1,1,1,0,3
+Schuylkill,Deer Lake,State Senate,29,REP,Dave Argall,106,15,3,1,125
+Schuylkill,Deer Lake,State Senate,29,REP,Write-in,0,0,1,0,1
+Schuylkill,Deer Lake,General Assembly,124,REP,Jerry Knowles,102,15,4,1,122
+Schuylkill,Deer Lake,General Assembly,124,REP,Write-in,4,1,0,0,5
+Schuylkill,East Brunswick Twp,Registered Voters,,,,,,,,1258
+Schuylkill,East Brunswick Twp,Registered Voters,,DEM,,,,,,278
+Schuylkill,East Brunswick Twp,Registered Voters,,REP,,,,,,834
+Schuylkill,East Brunswick Twp,Registered Voters,,NPA,,,,,,146
+Schuylkill,East Brunswick Twp,Ballots Cast,,,,340,135,24,4,503
+Schuylkill,East Brunswick Twp,Ballots Cast,,DEM,,54,56,14,1,125
+Schuylkill,East Brunswick Twp,Ballots Cast,,REP,,286,79,10,3,378
+Schuylkill,East Brunswick Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,East Brunswick Twp,President,,DEM,Bernie Sanders,9,5,1,0,15
+Schuylkill,East Brunswick Twp,President,,DEM,Joseph R. Biden,35,47,12,1,95
+Schuylkill,East Brunswick Twp,President,,DEM,Tulsi Gabbard,5,0,1,0,6
+Schuylkill,East Brunswick Twp,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,East Brunswick Twp,Attorney General,,DEM,Josh Shapiro,48,51,11,1,111
+Schuylkill,East Brunswick Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,East Brunswick Twp,Auditor General,,DEM,H. Scott Conklin,7,4,0,0,11
+Schuylkill,East Brunswick Twp,Auditor General,,DEM,Michael Lamb,3,8,3,0,14
+Schuylkill,East Brunswick Twp,Auditor General,,DEM,Tracie Fountain,5,13,2,0,20
+Schuylkill,East Brunswick Twp,Auditor General,,DEM,Rose Rosie Marie Davis,4,2,1,0,7
+Schuylkill,East Brunswick Twp,Auditor General,,DEM,Nina Ahmad,13,15,3,0,31
+Schuylkill,East Brunswick Twp,Auditor General,,DEM,Christina M. Hartman,18,9,3,1,31
+Schuylkill,East Brunswick Twp,Auditor General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,East Brunswick Twp,State Treasurer,,DEM,Joe Torsella,49,51,11,1,112
+Schuylkill,East Brunswick Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,East Brunswick Twp,Representative In Congress,,DEM,Laura Quick,23,13,5,0,41
+Schuylkill,East Brunswick Twp,Representative In Congress,,DEM,Gary Wegman,28,39,9,1,77
+Schuylkill,East Brunswick Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,East Brunswick Twp,State Senate,29,DEM,Write-in,10,10,1,1,22
+Schuylkill,East Brunswick Twp,General Assembly,124,DEM,Taylor Picone,45,51,11,1,108
+Schuylkill,East Brunswick Twp,General Assembly,124,DEM,Write-in,0,0,0,0,0
+Schuylkill,East Brunswick Twp,President,,REP,Donald J. Trump,276,70,7,3,356
+Schuylkill,East Brunswick Twp,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,East Brunswick Twp,President,,REP,Bill Weld,2,5,1,0,8
+Schuylkill,East Brunswick Twp,President,,REP,Write-in,3,1,1,0,5
+Schuylkill,East Brunswick Twp,Attorney General,,REP,Heather Heidelbaugh,261,72,8,3,344
+Schuylkill,East Brunswick Twp,Attorney General,,REP,Write-in,0,0,1,0,1
+Schuylkill,East Brunswick Twp,Auditor General,,REP,Timothy Defoor,257,72,8,3,340
+Schuylkill,East Brunswick Twp,Auditor General,,REP,Write-in,2,0,1,0,3
+Schuylkill,East Brunswick Twp,State Treasurer,,REP,Stacy L. Garrity,257,71,7,3,338
+Schuylkill,East Brunswick Twp,State Treasurer,,REP,Write-in,1,0,1,0,2
+Schuylkill,East Brunswick Twp,Representative In Congress,,REP,Dan Meuser,269,72,8,3,352
+Schuylkill,East Brunswick Twp,Representative In Congress,,REP,Write-in,0,1,2,0,3
+Schuylkill,East Brunswick Twp,State Senate,29,REP,Dave Argall,272,70,8,3,353
+Schuylkill,East Brunswick Twp,State Senate,29,REP,Write-in,4,2,0,0,6
+Schuylkill,East Brunswick Twp,General Assembly,124,REP,Jerry Knowles,266,74,8,3,351
+Schuylkill,East Brunswick Twp,General Assembly,124,REP,Write-in,6,1,1,0,8
+Schuylkill,East Union Twp,Registered Voters,,,,,,,,1245
+Schuylkill,East Union Twp,Registered Voters,,DEM,,,,,,434
+Schuylkill,East Union Twp,Registered Voters,,REP,,,,,,645
+Schuylkill,East Union Twp,Registered Voters,,NPA,,,,,,166
+Schuylkill,East Union Twp,Ballots Cast,,,,243,91,23,9,366
+Schuylkill,East Union Twp,Ballots Cast,,DEM,,57,37,11,3,108
+Schuylkill,East Union Twp,Ballots Cast,,REP,,186,54,12,6,258
+Schuylkill,East Union Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,East Union Twp,President,,DEM,Bernie Sanders,7,9,1,1,18
+Schuylkill,East Union Twp,President,,DEM,Joseph R. Biden,30,26,7,1,64
+Schuylkill,East Union Twp,President,,DEM,Tulsi Gabbard,7,1,1,0,9
+Schuylkill,East Union Twp,President,,DEM,Write-in,7,1,1,1,10
+Schuylkill,East Union Twp,Attorney General,,DEM,Josh Shapiro,39,35,10,2,86
+Schuylkill,East Union Twp,Attorney General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,East Union Twp,Auditor General,,DEM,H. Scott Conklin,8,3,2,0,13
+Schuylkill,East Union Twp,Auditor General,,DEM,Michael Lamb,10,2,0,0,12
+Schuylkill,East Union Twp,Auditor General,,DEM,Tracie Fountain,3,10,2,0,15
+Schuylkill,East Union Twp,Auditor General,,DEM,Rose Rosie Marie Davis,11,5,1,0,17
+Schuylkill,East Union Twp,Auditor General,,DEM,Nina Ahmad,5,7,1,1,14
+Schuylkill,East Union Twp,Auditor General,,DEM,Christina M. Hartman,15,8,4,1,28
+Schuylkill,East Union Twp,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,East Union Twp,State Treasurer,,DEM,Joe Torsella,40,34,9,2,85
+Schuylkill,East Union Twp,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,East Union Twp,Representative In Congress,,DEM,Laura Quick,32,22,3,2,59
+Schuylkill,East Union Twp,Representative In Congress,,DEM,Gary Wegman,16,14,7,0,37
+Schuylkill,East Union Twp,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,East Union Twp,State Senate,29,DEM,Write-in,3,2,0,0,5
+Schuylkill,East Union Twp,General Assembly,124,DEM,Taylor Picone,40,32,9,2,83
+Schuylkill,East Union Twp,General Assembly,124,DEM,Write-in,2,1,0,0,3
+Schuylkill,East Union Twp,President,,REP,Donald J. Trump,181,48,9,5,243
+Schuylkill,East Union Twp,President,,REP,Roque Rocky De La Fuente,0,0,1,0,1
+Schuylkill,East Union Twp,President,,REP,Bill Weld,2,4,1,0,7
+Schuylkill,East Union Twp,President,,REP,Write-in,3,1,1,0,5
+Schuylkill,East Union Twp,Attorney General,,REP,Heather Heidelbaugh,165,51,8,3,227
+Schuylkill,East Union Twp,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,East Union Twp,Auditor General,,REP,Timothy Defoor,162,50,7,3,222
+Schuylkill,East Union Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,East Union Twp,State Treasurer,,REP,Stacy L. Garrity,159,50,6,3,218
+Schuylkill,East Union Twp,State Treasurer,,REP,Write-in,2,0,0,0,2
+Schuylkill,East Union Twp,Representative In Congress,,REP,Dan Meuser,173,50,9,2,234
+Schuylkill,East Union Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,East Union Twp,State Senate,29,REP,Dave Argall,173,50,9,3,235
+Schuylkill,East Union Twp,State Senate,29,REP,Write-in,2,1,0,0,3
+Schuylkill,East Union Twp,General Assembly,124,REP,Jerry Knowles,177,48,9,3,237
+Schuylkill,East Union Twp,General Assembly,124,REP,Write-in,0,1,0,0,1
+Schuylkill,Kline Twp,Registered Voters,,,,,,,,1022
+Schuylkill,Kline Twp,Registered Voters,,DEM,,,,,,323
+Schuylkill,Kline Twp,Registered Voters,,REP,,,,,,605
+Schuylkill,Kline Twp,Registered Voters,,NPA,,,,,,94
+Schuylkill,Kline Twp,Ballots Cast,,,,207,94,25,8,334
+Schuylkill,Kline Twp,Ballots Cast,,DEM,,53,35,7,0,95
+Schuylkill,Kline Twp,Ballots Cast,,REP,,154,59,18,8,239
+Schuylkill,Kline Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Kline Twp,President,,DEM,Bernie Sanders,12,9,3,0,24
+Schuylkill,Kline Twp,President,,DEM,Joseph R. Biden,32,25,2,0,59
+Schuylkill,Kline Twp,President,,DEM,Tulsi Gabbard,3,1,1,0,5
+Schuylkill,Kline Twp,President,,DEM,Write-in,5,0,1,0,6
+Schuylkill,Kline Twp,Attorney General,,DEM,Josh Shapiro,48,35,7,0,90
+Schuylkill,Kline Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,Auditor General,,DEM,H. Scott Conklin,7,4,0,0,11
+Schuylkill,Kline Twp,Auditor General,,DEM,Michael Lamb,12,3,1,0,16
+Schuylkill,Kline Twp,Auditor General,,DEM,Tracie Fountain,4,7,2,0,13
+Schuylkill,Kline Twp,Auditor General,,DEM,Rose Rosie Marie Davis,7,3,2,0,12
+Schuylkill,Kline Twp,Auditor General,,DEM,Nina Ahmad,12,7,0,0,19
+Schuylkill,Kline Twp,Auditor General,,DEM,Christina M. Hartman,8,8,2,0,18
+Schuylkill,Kline Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,State Treasurer,,DEM,Joe Torsella,45,33,7,0,85
+Schuylkill,Kline Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,Representative In Congress,,DEM,Laura Quick,27,24,6,0,57
+Schuylkill,Kline Twp,Representative In Congress,,DEM,Gary Wegman,19,9,1,0,29
+Schuylkill,Kline Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,State Senate,29,DEM,Write-in,5,7,2,0,14
+Schuylkill,Kline Twp,General Assembly,124,DEM,Taylor Picone,44,30,7,0,81
+Schuylkill,Kline Twp,General Assembly,124,DEM,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,President,,REP,Donald J. Trump,149,52,18,8,227
+Schuylkill,Kline Twp,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Kline Twp,President,,REP,Bill Weld,1,1,0,0,2
+Schuylkill,Kline Twp,President,,REP,Write-in,2,3,0,0,5
+Schuylkill,Kline Twp,Attorney General,,REP,Heather Heidelbaugh,129,50,17,7,203
+Schuylkill,Kline Twp,Attorney General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Kline Twp,Auditor General,,REP,Timothy Defoor,130,51,16,7,204
+Schuylkill,Kline Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,State Treasurer,,REP,Stacy L. Garrity,133,52,17,8,210
+Schuylkill,Kline Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,Representative In Congress,,REP,Dan Meuser,142,54,18,8,222
+Schuylkill,Kline Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,State Senate,29,REP,Dave Argall,151,51,18,8,228
+Schuylkill,Kline Twp,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Kline Twp,General Assembly,124,REP,Jerry Knowles,147,52,18,8,225
+Schuylkill,Kline Twp,General Assembly,124,REP,Write-in,0,0,0,0,0
+Schuylkill,Landingville,Registered Voters,,,,,,,,113
+Schuylkill,Landingville,Registered Voters,,DEM,,,,,,24
+Schuylkill,Landingville,Registered Voters,,REP,,,,,,74
+Schuylkill,Landingville,Registered Voters,,NPA,,,,,,15
+Schuylkill,Landingville,Ballots Cast,,,,34,16,0,0,50
+Schuylkill,Landingville,Ballots Cast,,DEM,,5,7,0,0,12
+Schuylkill,Landingville,Ballots Cast,,REP,,29,9,0,0,38
+Schuylkill,Landingville,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Landingville,President,,DEM,Bernie Sanders,0,2,0,0,2
+Schuylkill,Landingville,President,,DEM,Joseph R. Biden,4,5,0,0,9
+Schuylkill,Landingville,President,,DEM,Tulsi Gabbard,0,0,0,0,0
+Schuylkill,Landingville,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Landingville,Attorney General,,DEM,Josh Shapiro,4,4,0,0,8
+Schuylkill,Landingville,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Landingville,Auditor General,,DEM,H. Scott Conklin,0,0,0,0,0
+Schuylkill,Landingville,Auditor General,,DEM,Michael Lamb,0,0,0,0,0
+Schuylkill,Landingville,Auditor General,,DEM,Tracie Fountain,0,2,0,0,2
+Schuylkill,Landingville,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0,0
+Schuylkill,Landingville,Auditor General,,DEM,Nina Ahmad,3,1,0,0,4
+Schuylkill,Landingville,Auditor General,,DEM,Christina M. Hartman,0,0,0,0,0
+Schuylkill,Landingville,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Landingville,State Treasurer,,DEM,Joe Torsella,4,4,0,0,8
+Schuylkill,Landingville,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Landingville,Representative In Congress,,DEM,Laura Quick,0,3,0,0,3
+Schuylkill,Landingville,Representative In Congress,,DEM,Gary Wegman,2,3,0,0,5
+Schuylkill,Landingville,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Landingville,State Senate,29,DEM,Write-in,1,1,0,0,2
+Schuylkill,Landingville,General Assembly,125,DEM,Write-in,1,1,0,0,2
+Schuylkill,Landingville,President,,REP,Donald J. Trump,28,8,0,0,36
+Schuylkill,Landingville,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,Landingville,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,Landingville,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Landingville,Attorney General,,REP,Heather Heidelbaugh,24,8,0,0,32
+Schuylkill,Landingville,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Landingville,Auditor General,,REP,Timothy Defoor,24,8,0,0,32
+Schuylkill,Landingville,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Landingville,State Treasurer,,REP,Stacy L. Garrity,26,8,0,0,34
+Schuylkill,Landingville,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Landingville,Representative In Congress,,REP,Dan Meuser,26,8,0,0,34
+Schuylkill,Landingville,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Landingville,State Senate,29,REP,Dave Argall,28,7,0,0,35
+Schuylkill,Landingville,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Landingville,General Assembly,125,REP,Herv Breault,5,1,0,0,6
+Schuylkill,Landingville,General Assembly,125,REP,Theresa Gaffney,8,2,0,0,10
+Schuylkill,Landingville,General Assembly,125,REP,Christy Joy,10,3,0,0,13
+Schuylkill,Landingville,General Assembly,125,REP,Joe Kerwin,6,2,0,0,8
+Schuylkill,Landingville,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,McAdoo 1st,Registered Voters,,,,,,,,592
+Schuylkill,McAdoo 1st,Registered Voters,,DEM,,,,,,247
+Schuylkill,McAdoo 1st,Registered Voters,,REP,,,,,,271
+Schuylkill,McAdoo 1st,Registered Voters,,NPA,,,,,,74
+Schuylkill,McAdoo 1st,Ballots Cast,,,,113,64,13,1,191
+Schuylkill,McAdoo 1st,Ballots Cast,,DEM,,29,34,5,0,68
+Schuylkill,McAdoo 1st,Ballots Cast,,REP,,84,30,8,1,123
+Schuylkill,McAdoo 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,McAdoo 1st,President,,DEM,Bernie Sanders,5,4,2,0,11
+Schuylkill,McAdoo 1st,President,,DEM,Joseph R. Biden,13,25,3,0,41
+Schuylkill,McAdoo 1st,President,,DEM,Tulsi Gabbard,4,1,0,0,5
+Schuylkill,McAdoo 1st,President,,DEM,Write-in,5,3,0,0,8
+Schuylkill,McAdoo 1st,Attorney General,,DEM,Josh Shapiro,22,30,5,0,57
+Schuylkill,McAdoo 1st,Attorney General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,McAdoo 1st,Auditor General,,DEM,H. Scott Conklin,3,2,0,0,5
+Schuylkill,McAdoo 1st,Auditor General,,DEM,Michael Lamb,4,6,4,0,14
+Schuylkill,McAdoo 1st,Auditor General,,DEM,Tracie Fountain,5,8,0,0,13
+Schuylkill,McAdoo 1st,Auditor General,,DEM,Rose Rosie Marie Davis,1,6,0,0,7
+Schuylkill,McAdoo 1st,Auditor General,,DEM,Nina Ahmad,5,6,0,0,11
+Schuylkill,McAdoo 1st,Auditor General,,DEM,Christina M. Hartman,5,3,1,0,9
+Schuylkill,McAdoo 1st,Auditor General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,McAdoo 1st,State Treasurer,,DEM,Joe Torsella,24,28,5,0,57
+Schuylkill,McAdoo 1st,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,McAdoo 1st,Representative In Congress,,DEM,Laura Quick,12,20,3,0,35
+Schuylkill,McAdoo 1st,Representative In Congress,,DEM,Gary Wegman,12,8,2,0,22
+Schuylkill,McAdoo 1st,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,McAdoo 1st,State Senate,29,DEM,Write-in,3,5,1,0,9
+Schuylkill,McAdoo 1st,General Assembly,124,DEM,Taylor Picone,19,30,5,0,54
+Schuylkill,McAdoo 1st,General Assembly,124,DEM,Write-in,1,1,0,0,2
+Schuylkill,McAdoo 1st,President,,REP,Donald J. Trump,78,29,6,1,114
+Schuylkill,McAdoo 1st,President,,REP,Roque Rocky De La Fuente,2,0,1,0,3
+Schuylkill,McAdoo 1st,President,,REP,Bill Weld,0,0,1,0,1
+Schuylkill,McAdoo 1st,President,,REP,Write-in,3,1,0,0,4
+Schuylkill,McAdoo 1st,Attorney General,,REP,Heather Heidelbaugh,78,28,6,1,113
+Schuylkill,McAdoo 1st,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,McAdoo 1st,Auditor General,,REP,Timothy Defoor,80,28,6,1,115
+Schuylkill,McAdoo 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,McAdoo 1st,State Treasurer,,REP,Stacy L. Garrity,78,27,6,1,112
+Schuylkill,McAdoo 1st,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,McAdoo 1st,Representative In Congress,,REP,Dan Meuser,78,29,6,1,114
+Schuylkill,McAdoo 1st,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,McAdoo 1st,State Senate,29,REP,Dave Argall,77,30,7,1,115
+Schuylkill,McAdoo 1st,State Senate,29,REP,Write-in,2,0,0,0,2
+Schuylkill,McAdoo 1st,General Assembly,124,REP,Jerry Knowles,81,29,8,1,119
+Schuylkill,McAdoo 1st,General Assembly,124,REP,Write-in,2,0,0,0,2
+Schuylkill,McAdoo 2nd,Registered Voters,,,,,,,,736
+Schuylkill,McAdoo 2nd,Registered Voters,,DEM,,,,,,355
+Schuylkill,McAdoo 2nd,Registered Voters,,REP,,,,,,283
+Schuylkill,McAdoo 2nd,Registered Voters,,NPA,,,,,,98
+Schuylkill,McAdoo 2nd,Ballots Cast,,,,113,55,14,2,184
+Schuylkill,McAdoo 2nd,Ballots Cast,,DEM,,48,34,7,1,90
+Schuylkill,McAdoo 2nd,Ballots Cast,,REP,,65,21,7,1,94
+Schuylkill,McAdoo 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,McAdoo 2nd,President,,DEM,Bernie Sanders,9,3,1,0,13
+Schuylkill,McAdoo 2nd,President,,DEM,Joseph R. Biden,23,25,5,0,53
+Schuylkill,McAdoo 2nd,President,,DEM,Tulsi Gabbard,2,0,1,0,3
+Schuylkill,McAdoo 2nd,President,,DEM,Write-in,12,2,0,1,15
+Schuylkill,McAdoo 2nd,Attorney General,,DEM,Josh Shapiro,39,33,7,1,80
+Schuylkill,McAdoo 2nd,Attorney General,,DEM,Write-in,6,0,0,0,6
+Schuylkill,McAdoo 2nd,Auditor General,,DEM,H. Scott Conklin,3,1,1,0,5
+Schuylkill,McAdoo 2nd,Auditor General,,DEM,Michael Lamb,9,6,0,0,15
+Schuylkill,McAdoo 2nd,Auditor General,,DEM,Tracie Fountain,5,7,1,0,13
+Schuylkill,McAdoo 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,10,4,0,1,15
+Schuylkill,McAdoo 2nd,Auditor General,,DEM,Nina Ahmad,7,4,4,0,15
+Schuylkill,McAdoo 2nd,Auditor General,,DEM,Christina M. Hartman,8,7,1,0,16
+Schuylkill,McAdoo 2nd,Auditor General,,DEM,Write-in,6,0,0,0,6
+Schuylkill,McAdoo 2nd,State Treasurer,,DEM,Joe Torsella,40,33,7,1,81
+Schuylkill,McAdoo 2nd,State Treasurer,,DEM,Write-in,6,0,0,0,6
+Schuylkill,McAdoo 2nd,Representative In Congress,,DEM,Laura Quick,27,22,5,1,55
+Schuylkill,McAdoo 2nd,Representative In Congress,,DEM,Gary Wegman,12,10,2,0,24
+Schuylkill,McAdoo 2nd,Representative In Congress,,DEM,Write-in,7,0,0,0,7
+Schuylkill,McAdoo 2nd,State Senate,29,DEM,Write-in,12,1,3,0,16
+Schuylkill,McAdoo 2nd,General Assembly,124,DEM,Taylor Picone,36,30,7,1,74
+Schuylkill,McAdoo 2nd,General Assembly,124,DEM,Write-in,7,0,0,0,7
+Schuylkill,McAdoo 2nd,President,,REP,Donald J. Trump,62,17,6,1,86
+Schuylkill,McAdoo 2nd,President,,REP,Roque Rocky De La Fuente,1,0,1,0,2
+Schuylkill,McAdoo 2nd,President,,REP,Bill Weld,2,3,0,0,5
+Schuylkill,McAdoo 2nd,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,McAdoo 2nd,Attorney General,,REP,Heather Heidelbaugh,59,18,7,1,85
+Schuylkill,McAdoo 2nd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,McAdoo 2nd,Auditor General,,REP,Timothy Defoor,57,18,7,1,83
+Schuylkill,McAdoo 2nd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,McAdoo 2nd,State Treasurer,,REP,Stacy L. Garrity,55,19,7,1,82
+Schuylkill,McAdoo 2nd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,McAdoo 2nd,Representative In Congress,,REP,Dan Meuser,61,18,7,1,87
+Schuylkill,McAdoo 2nd,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,McAdoo 2nd,State Senate,29,REP,Dave Argall,62,18,7,1,88
+Schuylkill,McAdoo 2nd,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,McAdoo 2nd,General Assembly,124,REP,Jerry Knowles,60,20,7,1,88
+Schuylkill,McAdoo 2nd,General Assembly,124,REP,Write-in,0,0,0,0,0
+Schuylkill,New Ringgold,Registered Voters,,,,,,,,158
+Schuylkill,New Ringgold,Registered Voters,,DEM,,,,,,45
+Schuylkill,New Ringgold,Registered Voters,,REP,,,,,,94
+Schuylkill,New Ringgold,Registered Voters,,NPA,,,,,,19
+Schuylkill,New Ringgold,Ballots Cast,,,,54,13,4,0,71
+Schuylkill,New Ringgold,Ballots Cast,,DEM,,18,4,2,0,24
+Schuylkill,New Ringgold,Ballots Cast,,REP,,36,9,2,0,47
+Schuylkill,New Ringgold,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,New Ringgold,President,,DEM,Bernie Sanders,2,1,2,0,5
+Schuylkill,New Ringgold,President,,DEM,Joseph R. Biden,6,3,0,0,9
+Schuylkill,New Ringgold,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Schuylkill,New Ringgold,President,,DEM,Write-in,8,0,0,0,8
+Schuylkill,New Ringgold,Attorney General,,DEM,Josh Shapiro,14,3,2,0,19
+Schuylkill,New Ringgold,Attorney General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,New Ringgold,Auditor General,,DEM,H. Scott Conklin,3,1,0,0,4
+Schuylkill,New Ringgold,Auditor General,,DEM,Michael Lamb,2,1,0,0,3
+Schuylkill,New Ringgold,Auditor General,,DEM,Tracie Fountain,1,0,1,0,2
+Schuylkill,New Ringgold,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,0,0,2
+Schuylkill,New Ringgold,Auditor General,,DEM,Nina Ahmad,1,0,0,0,1
+Schuylkill,New Ringgold,Auditor General,,DEM,Christina M. Hartman,5,2,1,0,8
+Schuylkill,New Ringgold,Auditor General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,New Ringgold,State Treasurer,,DEM,Joe Torsella,12,4,2,0,18
+Schuylkill,New Ringgold,State Treasurer,,DEM,Write-in,4,0,0,0,4
+Schuylkill,New Ringgold,Representative In Congress,,DEM,Laura Quick,6,3,1,0,10
+Schuylkill,New Ringgold,Representative In Congress,,DEM,Gary Wegman,9,0,1,0,10
+Schuylkill,New Ringgold,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,New Ringgold,State Senate,29,DEM,Write-in,6,0,0,0,6
+Schuylkill,New Ringgold,General Assembly,124,DEM,Taylor Picone,14,4,2,0,20
+Schuylkill,New Ringgold,General Assembly,124,DEM,Write-in,3,0,0,0,3
+Schuylkill,New Ringgold,President,,REP,Donald J. Trump,36,4,2,0,42
+Schuylkill,New Ringgold,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,New Ringgold,President,,REP,Bill Weld,0,2,0,0,2
+Schuylkill,New Ringgold,President,,REP,Write-in,0,2,0,0,2
+Schuylkill,New Ringgold,Attorney General,,REP,Heather Heidelbaugh,31,8,2,0,41
+Schuylkill,New Ringgold,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Ringgold,Auditor General,,REP,Timothy Defoor,31,8,2,0,41
+Schuylkill,New Ringgold,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Ringgold,State Treasurer,,REP,Stacy L. Garrity,31,8,2,0,41
+Schuylkill,New Ringgold,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,New Ringgold,Representative In Congress,,REP,Dan Meuser,32,8,2,0,42
+Schuylkill,New Ringgold,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,New Ringgold,State Senate,29,REP,Dave Argall,33,9,2,0,44
+Schuylkill,New Ringgold,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,New Ringgold,General Assembly,124,REP,Jerry Knowles,34,9,2,0,45
+Schuylkill,New Ringgold,General Assembly,124,REP,Write-in,1,0,0,0,1
+Schuylkill,North Union Twp,Registered Voters,,,,,,,,866
+Schuylkill,North Union Twp,Registered Voters,,DEM,,,,,,243
+Schuylkill,North Union Twp,Registered Voters,,REP,,,,,,502
+Schuylkill,North Union Twp,Registered Voters,,NPA,,,,,,121
+Schuylkill,North Union Twp,Ballots Cast,,,,180,79,26,4,289
+Schuylkill,North Union Twp,Ballots Cast,,DEM,,30,40,13,2,85
+Schuylkill,North Union Twp,Ballots Cast,,REP,,150,39,13,2,204
+Schuylkill,North Union Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,North Union Twp,President,,DEM,Bernie Sanders,6,5,3,0,14
+Schuylkill,North Union Twp,President,,DEM,Joseph R. Biden,15,30,9,1,55
+Schuylkill,North Union Twp,President,,DEM,Tulsi Gabbard,4,1,1,1,7
+Schuylkill,North Union Twp,President,,DEM,Write-in,3,2,0,0,5
+Schuylkill,North Union Twp,Attorney General,,DEM,Josh Shapiro,25,36,9,2,72
+Schuylkill,North Union Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Union Twp,Auditor General,,DEM,H. Scott Conklin,6,4,1,0,11
+Schuylkill,North Union Twp,Auditor General,,DEM,Michael Lamb,4,7,0,0,11
+Schuylkill,North Union Twp,Auditor General,,DEM,Tracie Fountain,1,3,0,0,4
+Schuylkill,North Union Twp,Auditor General,,DEM,Rose Rosie Marie Davis,6,7,5,1,19
+Schuylkill,North Union Twp,Auditor General,,DEM,Nina Ahmad,4,4,1,0,9
+Schuylkill,North Union Twp,Auditor General,,DEM,Christina M. Hartman,5,11,1,1,18
+Schuylkill,North Union Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Union Twp,State Treasurer,,DEM,Joe Torsella,24,37,8,2,71
+Schuylkill,North Union Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Union Twp,Representative In Congress,,DEM,Laura Quick,20,20,8,1,49
+Schuylkill,North Union Twp,Representative In Congress,,DEM,Gary Wegman,8,15,2,1,26
+Schuylkill,North Union Twp,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,North Union Twp,State Senate,29,DEM,Write-in,1,2,1,0,4
+Schuylkill,North Union Twp,General Assembly,124,DEM,Taylor Picone,24,36,8,2,70
+Schuylkill,North Union Twp,General Assembly,124,DEM,Write-in,0,0,1,0,1
+Schuylkill,North Union Twp,President,,REP,Donald J. Trump,147,31,11,2,191
+Schuylkill,North Union Twp,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,North Union Twp,President,,REP,Bill Weld,0,7,0,0,7
+Schuylkill,North Union Twp,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,North Union Twp,Attorney General,,REP,Heather Heidelbaugh,133,34,10,2,179
+Schuylkill,North Union Twp,Attorney General,,REP,Write-in,2,0,0,0,2
+Schuylkill,North Union Twp,Auditor General,,REP,Timothy Defoor,130,33,11,2,176
+Schuylkill,North Union Twp,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,North Union Twp,State Treasurer,,REP,Stacy L. Garrity,125,35,11,2,173
+Schuylkill,North Union Twp,State Treasurer,,REP,Write-in,2,0,0,0,2
+Schuylkill,North Union Twp,Representative In Congress,,REP,Dan Meuser,138,36,13,2,189
+Schuylkill,North Union Twp,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,North Union Twp,State Senate,29,REP,Dave Argall,139,38,13,2,192
+Schuylkill,North Union Twp,State Senate,29,REP,Write-in,2,0,0,0,2
+Schuylkill,North Union Twp,General Assembly,124,REP,Jerry Knowles,138,37,11,2,188
+Schuylkill,North Union Twp,General Assembly,124,REP,Write-in,1,1,0,0,2
+Schuylkill,Port Clinton,Registered Voters,,,,,,,,166
+Schuylkill,Port Clinton,Registered Voters,,DEM,,,,,,53
+Schuylkill,Port Clinton,Registered Voters,,REP,,,,,,89
+Schuylkill,Port Clinton,Registered Voters,,NPA,,,,,,24
+Schuylkill,Port Clinton,Ballots Cast,,,,46,18,1,0,65
+Schuylkill,Port Clinton,Ballots Cast,,DEM,,16,7,1,0,24
+Schuylkill,Port Clinton,Ballots Cast,,REP,,30,11,0,0,41
+Schuylkill,Port Clinton,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Port Clinton,President,,DEM,Bernie Sanders,8,1,0,0,9
+Schuylkill,Port Clinton,President,,DEM,Joseph R. Biden,8,6,1,0,15
+Schuylkill,Port Clinton,President,,DEM,Tulsi Gabbard,0,0,0,0,0
+Schuylkill,Port Clinton,President,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,Attorney General,,DEM,Josh Shapiro,15,6,1,0,22
+Schuylkill,Port Clinton,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,Auditor General,,DEM,H. Scott Conklin,0,2,0,0,2
+Schuylkill,Port Clinton,Auditor General,,DEM,Michael Lamb,1,1,0,0,2
+Schuylkill,Port Clinton,Auditor General,,DEM,Tracie Fountain,4,0,0,0,4
+Schuylkill,Port Clinton,Auditor General,,DEM,Rose Rosie Marie Davis,2,0,1,0,3
+Schuylkill,Port Clinton,Auditor General,,DEM,Nina Ahmad,3,1,0,0,4
+Schuylkill,Port Clinton,Auditor General,,DEM,Christina M. Hartman,5,1,0,0,6
+Schuylkill,Port Clinton,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,State Treasurer,,DEM,Joe Torsella,14,5,1,0,20
+Schuylkill,Port Clinton,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,Representative In Congress,,DEM,Laura Quick,3,1,0,0,4
+Schuylkill,Port Clinton,Representative In Congress,,DEM,Gary Wegman,12,5,1,0,18
+Schuylkill,Port Clinton,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,State Senate,29,DEM,Write-in,2,0,0,0,2
+Schuylkill,Port Clinton,General Assembly,124,DEM,Taylor Picone,15,5,1,0,21
+Schuylkill,Port Clinton,General Assembly,124,DEM,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,President,,REP,Donald J. Trump,29,9,0,0,38
+Schuylkill,Port Clinton,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Port Clinton,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Port Clinton,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Port Clinton,Attorney General,,REP,Heather Heidelbaugh,28,9,0,0,37
+Schuylkill,Port Clinton,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,Auditor General,,REP,Timothy Defoor,26,8,0,0,34
+Schuylkill,Port Clinton,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,State Treasurer,,REP,Stacy L. Garrity,29,10,0,0,39
+Schuylkill,Port Clinton,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,Representative In Congress,,REP,Dan Meuser,27,9,0,0,36
+Schuylkill,Port Clinton,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,State Senate,29,REP,Dave Argall,29,9,0,0,38
+Schuylkill,Port Clinton,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Port Clinton,General Assembly,124,REP,Jerry Knowles,28,10,0,0,38
+Schuylkill,Port Clinton,General Assembly,124,REP,Write-in,0,0,0,0,0
+Schuylkill,Ringtown,Registered Voters,,,,,,,,485
+Schuylkill,Ringtown,Registered Voters,,DEM,,,,,,126
+Schuylkill,Ringtown,Registered Voters,,REP,,,,,,290
+Schuylkill,Ringtown,Registered Voters,,NPA,,,,,,69
+Schuylkill,Ringtown,Ballots Cast,,,,132,51,11,1,195
+Schuylkill,Ringtown,Ballots Cast,,DEM,,29,21,6,1,57
+Schuylkill,Ringtown,Ballots Cast,,REP,,103,30,5,0,138
+Schuylkill,Ringtown,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Ringtown,President,,DEM,Bernie Sanders,2,2,1,1,6
+Schuylkill,Ringtown,President,,DEM,Joseph R. Biden,15,19,5,0,39
+Schuylkill,Ringtown,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Schuylkill,Ringtown,President,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Ringtown,Attorney General,,DEM,Josh Shapiro,20,19,6,1,46
+Schuylkill,Ringtown,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Ringtown,Auditor General,,DEM,H. Scott Conklin,3,3,2,0,8
+Schuylkill,Ringtown,Auditor General,,DEM,Michael Lamb,3,5,0,0,8
+Schuylkill,Ringtown,Auditor General,,DEM,Tracie Fountain,5,3,2,0,10
+Schuylkill,Ringtown,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,0,5
+Schuylkill,Ringtown,Auditor General,,DEM,Nina Ahmad,4,1,2,1,8
+Schuylkill,Ringtown,Auditor General,,DEM,Christina M. Hartman,5,5,0,0,10
+Schuylkill,Ringtown,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Ringtown,State Treasurer,,DEM,Joe Torsella,20,20,5,1,46
+Schuylkill,Ringtown,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Ringtown,Representative In Congress,,DEM,Laura Quick,12,5,3,1,21
+Schuylkill,Ringtown,Representative In Congress,,DEM,Gary Wegman,15,15,3,0,33
+Schuylkill,Ringtown,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Ringtown,State Senate,29,DEM,Write-in,2,1,0,0,3
+Schuylkill,Ringtown,General Assembly,124,DEM,Taylor Picone,21,19,6,1,47
+Schuylkill,Ringtown,General Assembly,124,DEM,Write-in,3,0,0,0,3
+Schuylkill,Ringtown,President,,REP,Donald J. Trump,93,23,5,0,121
+Schuylkill,Ringtown,President,,REP,Roque Rocky De La Fuente,4,0,0,0,4
+Schuylkill,Ringtown,President,,REP,Bill Weld,4,5,0,0,9
+Schuylkill,Ringtown,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Ringtown,Attorney General,,REP,Heather Heidelbaugh,89,23,5,0,117
+Schuylkill,Ringtown,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Ringtown,Auditor General,,REP,Timothy Defoor,88,23,5,0,116
+Schuylkill,Ringtown,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Ringtown,State Treasurer,,REP,Stacy L. Garrity,90,21,5,0,116
+Schuylkill,Ringtown,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Ringtown,Representative In Congress,,REP,Dan Meuser,95,24,5,0,124
+Schuylkill,Ringtown,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Ringtown,State Senate,29,REP,Dave Argall,94,22,5,0,121
+Schuylkill,Ringtown,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Ringtown,General Assembly,124,REP,Jerry Knowles,93,23,5,0,121
+Schuylkill,Ringtown,General Assembly,124,REP,Write-in,1,0,0,0,1
+Schuylkill,Rush Twp East,Registered Voters,,,,,,,,1093
+Schuylkill,Rush Twp East,Registered Voters,,DEM,,,,,,305
+Schuylkill,Rush Twp East,Registered Voters,,REP,,,,,,683
+Schuylkill,Rush Twp East,Registered Voters,,NPA,,,,,,105
+Schuylkill,Rush Twp East,Ballots Cast,,,,212,162,40,7,421
+Schuylkill,Rush Twp East,Ballots Cast,,DEM,,33,82,18,2,135
+Schuylkill,Rush Twp East,Ballots Cast,,REP,,179,80,22,5,286
+Schuylkill,Rush Twp East,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Rush Twp East,President,,DEM,Bernie Sanders,10,5,4,1,20
+Schuylkill,Rush Twp East,President,,DEM,Joseph R. Biden,15,75,14,1,105
+Schuylkill,Rush Twp East,President,,DEM,Tulsi Gabbard,2,2,0,0,4
+Schuylkill,Rush Twp East,President,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Rush Twp East,Attorney General,,DEM,Josh Shapiro,26,77,17,1,121
+Schuylkill,Rush Twp East,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp East,Auditor General,,DEM,H. Scott Conklin,4,6,1,0,11
+Schuylkill,Rush Twp East,Auditor General,,DEM,Michael Lamb,4,10,3,0,17
+Schuylkill,Rush Twp East,Auditor General,,DEM,Tracie Fountain,4,11,2,0,17
+Schuylkill,Rush Twp East,Auditor General,,DEM,Rose Rosie Marie Davis,3,14,4,0,21
+Schuylkill,Rush Twp East,Auditor General,,DEM,Nina Ahmad,6,9,3,1,19
+Schuylkill,Rush Twp East,Auditor General,,DEM,Christina M. Hartman,5,24,4,0,33
+Schuylkill,Rush Twp East,Auditor General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Rush Twp East,State Treasurer,,DEM,Joe Torsella,25,74,17,1,117
+Schuylkill,Rush Twp East,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp East,Representative In Congress,,DEM,Laura Quick,20,42,6,1,69
+Schuylkill,Rush Twp East,Representative In Congress,,DEM,Gary Wegman,7,34,11,1,53
+Schuylkill,Rush Twp East,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp East,State Senate,29,DEM,Write-in,4,5,2,0,11
+Schuylkill,Rush Twp East,General Assembly,124,DEM,Taylor Picone,22,70,16,2,110
+Schuylkill,Rush Twp East,General Assembly,124,DEM,Write-in,2,0,0,0,2
+Schuylkill,Rush Twp East,President,,REP,Donald J. Trump,169,59,19,5,252
+Schuylkill,Rush Twp East,President,,REP,Roque Rocky De La Fuente,2,2,1,0,5
+Schuylkill,Rush Twp East,President,,REP,Bill Weld,3,6,1,0,10
+Schuylkill,Rush Twp East,President,,REP,Write-in,2,3,0,0,5
+Schuylkill,Rush Twp East,Attorney General,,REP,Heather Heidelbaugh,153,66,17,3,239
+Schuylkill,Rush Twp East,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp East,Auditor General,,REP,Timothy Defoor,152,65,17,3,237
+Schuylkill,Rush Twp East,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp East,State Treasurer,,REP,Stacy L. Garrity,155,65,17,3,240
+Schuylkill,Rush Twp East,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp East,Representative In Congress,,REP,Dan Meuser,162,69,16,4,251
+Schuylkill,Rush Twp East,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp East,State Senate,29,REP,Dave Argall,159,68,19,4,250
+Schuylkill,Rush Twp East,State Senate,29,REP,Write-in,3,2,0,0,5
+Schuylkill,Rush Twp East,General Assembly,124,REP,Jerry Knowles,157,70,18,4,249
+Schuylkill,Rush Twp East,General Assembly,124,REP,Write-in,4,3,0,0,7
+Schuylkill,Rush Twp West,Registered Voters,,,,,,,,997
+Schuylkill,Rush Twp West,Registered Voters,,DEM,,,,,,281
+Schuylkill,Rush Twp West,Registered Voters,,REP,,,,,,611
+Schuylkill,Rush Twp West,Registered Voters,,NPA,,,,,,105
+Schuylkill,Rush Twp West,Ballots Cast,,,,239,138,25,4,406
+Schuylkill,Rush Twp West,Ballots Cast,,DEM,,51,45,12,2,110
+Schuylkill,Rush Twp West,Ballots Cast,,REP,,188,93,13,2,296
+Schuylkill,Rush Twp West,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Rush Twp West,President,,DEM,Bernie Sanders,7,7,2,0,16
+Schuylkill,Rush Twp West,President,,DEM,Joseph R. Biden,35,36,9,2,82
+Schuylkill,Rush Twp West,President,,DEM,Tulsi Gabbard,3,1,1,0,5
+Schuylkill,Rush Twp West,President,,DEM,Write-in,4,1,0,0,5
+Schuylkill,Rush Twp West,Attorney General,,DEM,Josh Shapiro,48,43,11,2,104
+Schuylkill,Rush Twp West,Attorney General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Rush Twp West,Auditor General,,DEM,H. Scott Conklin,7,2,2,0,11
+Schuylkill,Rush Twp West,Auditor General,,DEM,Michael Lamb,3,8,1,0,12
+Schuylkill,Rush Twp West,Auditor General,,DEM,Tracie Fountain,4,14,1,0,19
+Schuylkill,Rush Twp West,Auditor General,,DEM,Rose Rosie Marie Davis,6,6,2,0,14
+Schuylkill,Rush Twp West,Auditor General,,DEM,Nina Ahmad,14,6,1,1,22
+Schuylkill,Rush Twp West,Auditor General,,DEM,Christina M. Hartman,13,9,4,1,27
+Schuylkill,Rush Twp West,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp West,State Treasurer,,DEM,Joe Torsella,44,41,11,2,98
+Schuylkill,Rush Twp West,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Rush Twp West,Representative In Congress,,DEM,Laura Quick,21,11,2,0,34
+Schuylkill,Rush Twp West,Representative In Congress,,DEM,Gary Wegman,24,33,9,2,68
+Schuylkill,Rush Twp West,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Rush Twp West,State Senate,29,DEM,Write-in,6,6,1,0,13
+Schuylkill,Rush Twp West,General Assembly,124,DEM,Taylor Picone,43,40,10,2,95
+Schuylkill,Rush Twp West,General Assembly,124,DEM,Write-in,1,2,1,0,4
+Schuylkill,Rush Twp West,President,,REP,Donald J. Trump,178,72,12,2,264
+Schuylkill,Rush Twp West,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Rush Twp West,President,,REP,Bill Weld,4,9,0,0,13
+Schuylkill,Rush Twp West,President,,REP,Write-in,3,5,1,0,9
+Schuylkill,Rush Twp West,Attorney General,,REP,Heather Heidelbaugh,170,79,10,2,261
+Schuylkill,Rush Twp West,Attorney General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Rush Twp West,Auditor General,,REP,Timothy Defoor,169,77,10,2,258
+Schuylkill,Rush Twp West,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Rush Twp West,State Treasurer,,REP,Stacy L. Garrity,166,81,10,2,259
+Schuylkill,Rush Twp West,State Treasurer,,REP,Write-in,2,0,0,0,2
+Schuylkill,Rush Twp West,Representative In Congress,,REP,Dan Meuser,177,79,11,1,268
+Schuylkill,Rush Twp West,Representative In Congress,,REP,Write-in,0,2,0,0,2
+Schuylkill,Rush Twp West,State Senate,29,REP,Dave Argall,178,78,12,2,270
+Schuylkill,Rush Twp West,State Senate,29,REP,Write-in,1,1,0,0,2
+Schuylkill,Rush Twp West,General Assembly,124,REP,Jerry Knowles,175,80,12,2,269
+Schuylkill,Rush Twp West,General Assembly,124,REP,Write-in,1,2,0,0,3
+Schuylkill,Rush Twp Elixir,Registered Voters,,,,,,,,298
+Schuylkill,Rush Twp Elixir,Registered Voters,,DEM,,,,,,82
+Schuylkill,Rush Twp Elixir,Registered Voters,,REP,,,,,,188
+Schuylkill,Rush Twp Elixir,Registered Voters,,NPA,,,,,,28
+Schuylkill,Rush Twp Elixir,Ballots Cast,,,,62,35,12,0,109
+Schuylkill,Rush Twp Elixir,Ballots Cast,,DEM,,16,12,8,0,36
+Schuylkill,Rush Twp Elixir,Ballots Cast,,REP,,46,23,4,0,73
+Schuylkill,Rush Twp Elixir,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Rush Twp Elixir,President,,DEM,Bernie Sanders,6,2,1,0,9
+Schuylkill,Rush Twp Elixir,President,,DEM,Joseph R. Biden,4,10,5,0,19
+Schuylkill,Rush Twp Elixir,President,,DEM,Tulsi Gabbard,1,0,1,0,2
+Schuylkill,Rush Twp Elixir,President,,DEM,Write-in,2,0,1,0,3
+Schuylkill,Rush Twp Elixir,Attorney General,,DEM,Josh Shapiro,13,12,6,0,31
+Schuylkill,Rush Twp Elixir,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Rush Twp Elixir,Auditor General,,DEM,H. Scott Conklin,1,0,1,0,2
+Schuylkill,Rush Twp Elixir,Auditor General,,DEM,Michael Lamb,1,0,0,0,1
+Schuylkill,Rush Twp Elixir,Auditor General,,DEM,Tracie Fountain,2,5,2,0,9
+Schuylkill,Rush Twp Elixir,Auditor General,,DEM,Rose Rosie Marie Davis,4,0,1,0,5
+Schuylkill,Rush Twp Elixir,Auditor General,,DEM,Nina Ahmad,1,4,0,0,5
+Schuylkill,Rush Twp Elixir,Auditor General,,DEM,Christina M. Hartman,4,3,3,0,10
+Schuylkill,Rush Twp Elixir,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Rush Twp Elixir,State Treasurer,,DEM,Joe Torsella,11,12,6,0,29
+Schuylkill,Rush Twp Elixir,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Rush Twp Elixir,Representative In Congress,,DEM,Laura Quick,5,5,5,0,15
+Schuylkill,Rush Twp Elixir,Representative In Congress,,DEM,Gary Wegman,8,7,1,0,16
+Schuylkill,Rush Twp Elixir,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Rush Twp Elixir,State Senate,29,DEM,Write-in,1,0,1,0,2
+Schuylkill,Rush Twp Elixir,General Assembly,124,DEM,Taylor Picone,11,12,6,0,29
+Schuylkill,Rush Twp Elixir,General Assembly,124,DEM,Write-in,1,0,1,0,2
+Schuylkill,Rush Twp Elixir,President,,REP,Donald J. Trump,45,19,3,0,67
+Schuylkill,Rush Twp Elixir,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Rush Twp Elixir,President,,REP,Bill Weld,0,2,0,0,2
+Schuylkill,Rush Twp Elixir,President,,REP,Write-in,0,0,1,0,1
+Schuylkill,Rush Twp Elixir,Attorney General,,REP,Heather Heidelbaugh,37,20,3,0,60
+Schuylkill,Rush Twp Elixir,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Rush Twp Elixir,Auditor General,,REP,Timothy Defoor,36,21,3,0,60
+Schuylkill,Rush Twp Elixir,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp Elixir,State Treasurer,,REP,Stacy L. Garrity,36,20,3,0,59
+Schuylkill,Rush Twp Elixir,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Rush Twp Elixir,Representative In Congress,,REP,Dan Meuser,38,20,4,0,62
+Schuylkill,Rush Twp Elixir,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Rush Twp Elixir,State Senate,29,REP,Dave Argall,37,21,4,0,62
+Schuylkill,Rush Twp Elixir,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Rush Twp Elixir,General Assembly,124,REP,Jerry Knowles,38,20,4,0,62
+Schuylkill,Rush Twp Elixir,General Assembly,124,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Twp,Registered Voters,,,,,,,,743
+Schuylkill,Schuylkill Twp,Registered Voters,,DEM,,,,,,253
+Schuylkill,Schuylkill Twp,Registered Voters,,REP,,,,,,417
+Schuylkill,Schuylkill Twp,Registered Voters,,NPA,,,,,,73
+Schuylkill,Schuylkill Twp,Ballots Cast,,,,176,89,28,2,295
+Schuylkill,Schuylkill Twp,Ballots Cast,,DEM,,41,43,14,0,98
+Schuylkill,Schuylkill Twp,Ballots Cast,,REP,,135,46,14,2,197
+Schuylkill,Schuylkill Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Schuylkill Twp,President,,DEM,Bernie Sanders,6,8,1,0,15
+Schuylkill,Schuylkill Twp,President,,DEM,Joseph R. Biden,26,34,12,0,72
+Schuylkill,Schuylkill Twp,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Schuylkill Twp,President,,DEM,Write-in,4,0,1,0,5
+Schuylkill,Schuylkill Twp,Attorney General,,DEM,Josh Shapiro,39,39,12,0,90
+Schuylkill,Schuylkill Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Twp,Auditor General,,DEM,H. Scott Conklin,3,1,1,0,5
+Schuylkill,Schuylkill Twp,Auditor General,,DEM,Michael Lamb,10,9,2,0,21
+Schuylkill,Schuylkill Twp,Auditor General,,DEM,Tracie Fountain,3,4,0,0,7
+Schuylkill,Schuylkill Twp,Auditor General,,DEM,Rose Rosie Marie Davis,4,3,4,0,11
+Schuylkill,Schuylkill Twp,Auditor General,,DEM,Nina Ahmad,8,6,3,0,17
+Schuylkill,Schuylkill Twp,Auditor General,,DEM,Christina M. Hartman,8,15,3,0,26
+Schuylkill,Schuylkill Twp,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Twp,State Treasurer,,DEM,Joe Torsella,37,38,12,0,87
+Schuylkill,Schuylkill Twp,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Twp,Representative In Congress,,DEM,Laura Quick,12,17,5,0,34
+Schuylkill,Schuylkill Twp,Representative In Congress,,DEM,Gary Wegman,26,23,7,0,56
+Schuylkill,Schuylkill Twp,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Twp,State Senate,29,DEM,Write-in,2,3,3,0,8
+Schuylkill,Schuylkill Twp,General Assembly,124,DEM,Taylor Picone,36,38,12,0,86
+Schuylkill,Schuylkill Twp,General Assembly,124,DEM,Write-in,2,1,0,0,3
+Schuylkill,Schuylkill Twp,President,,REP,Donald J. Trump,129,39,12,2,182
+Schuylkill,Schuylkill Twp,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,Schuylkill Twp,President,,REP,Bill Weld,2,3,1,0,6
+Schuylkill,Schuylkill Twp,President,,REP,Write-in,0,0,1,0,1
+Schuylkill,Schuylkill Twp,Attorney General,,REP,Heather Heidelbaugh,123,41,12,2,178
+Schuylkill,Schuylkill Twp,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Schuylkill Twp,Auditor General,,REP,Timothy Defoor,124,40,12,2,178
+Schuylkill,Schuylkill Twp,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Schuylkill Twp,State Treasurer,,REP,Stacy L. Garrity,124,42,12,2,180
+Schuylkill,Schuylkill Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Twp,Representative In Congress,,REP,Dan Meuser,128,42,12,2,184
+Schuylkill,Schuylkill Twp,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Twp,State Senate,29,REP,Dave Argall,130,43,13,2,188
+Schuylkill,Schuylkill Twp,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Twp,General Assembly,124,REP,Jerry Knowles,129,43,13,2,187
+Schuylkill,Schuylkill Twp,General Assembly,124,REP,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 1st,Registered Voters,,,,,,,,955
+Schuylkill,Tamaqua 1st,Registered Voters,,DEM,,,,,,302
+Schuylkill,Tamaqua 1st,Registered Voters,,REP,,,,,,501
+Schuylkill,Tamaqua 1st,Registered Voters,,NPA,,,,,,152
+Schuylkill,Tamaqua 1st,Ballots Cast,,,,186,78,10,0,274
+Schuylkill,Tamaqua 1st,Ballots Cast,,DEM,,41,43,6,0,90
+Schuylkill,Tamaqua 1st,Ballots Cast,,REP,,145,35,4,0,184
+Schuylkill,Tamaqua 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Tamaqua 1st,President,,DEM,Bernie Sanders,11,4,1,0,16
+Schuylkill,Tamaqua 1st,President,,DEM,Joseph R. Biden,17,34,5,0,56
+Schuylkill,Tamaqua 1st,President,,DEM,Tulsi Gabbard,4,3,0,0,7
+Schuylkill,Tamaqua 1st,President,,DEM,Write-in,7,2,0,0,9
+Schuylkill,Tamaqua 1st,Attorney General,,DEM,Josh Shapiro,34,40,6,0,80
+Schuylkill,Tamaqua 1st,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 1st,Auditor General,,DEM,H. Scott Conklin,4,5,2,0,11
+Schuylkill,Tamaqua 1st,Auditor General,,DEM,Michael Lamb,3,4,0,0,7
+Schuylkill,Tamaqua 1st,Auditor General,,DEM,Tracie Fountain,4,5,1,0,10
+Schuylkill,Tamaqua 1st,Auditor General,,DEM,Rose Rosie Marie Davis,4,9,0,0,13
+Schuylkill,Tamaqua 1st,Auditor General,,DEM,Nina Ahmad,5,7,0,0,12
+Schuylkill,Tamaqua 1st,Auditor General,,DEM,Christina M. Hartman,15,9,3,0,27
+Schuylkill,Tamaqua 1st,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 1st,State Treasurer,,DEM,Joe Torsella,34,40,6,0,80
+Schuylkill,Tamaqua 1st,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 1st,Representative In Congress,,DEM,Laura Quick,13,15,3,0,31
+Schuylkill,Tamaqua 1st,Representative In Congress,,DEM,Gary Wegman,20,25,3,0,48
+Schuylkill,Tamaqua 1st,Representative In Congress,,DEM,Write-in,2,1,0,0,3
+Schuylkill,Tamaqua 1st,State Senate,29,DEM,Write-in,5,3,1,0,9
+Schuylkill,Tamaqua 1st,General Assembly,124,DEM,Taylor Picone,32,38,6,0,76
+Schuylkill,Tamaqua 1st,General Assembly,124,DEM,Write-in,2,2,0,0,4
+Schuylkill,Tamaqua 1st,President,,REP,Donald J. Trump,138,26,2,0,166
+Schuylkill,Tamaqua 1st,President,,REP,Roque Rocky De La Fuente,2,2,1,0,5
+Schuylkill,Tamaqua 1st,President,,REP,Bill Weld,2,4,0,0,6
+Schuylkill,Tamaqua 1st,President,,REP,Write-in,1,3,1,0,5
+Schuylkill,Tamaqua 1st,Attorney General,,REP,Heather Heidelbaugh,126,30,2,0,158
+Schuylkill,Tamaqua 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tamaqua 1st,Auditor General,,REP,Timothy Defoor,121,30,2,0,153
+Schuylkill,Tamaqua 1st,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Tamaqua 1st,State Treasurer,,REP,Stacy L. Garrity,121,31,3,0,155
+Schuylkill,Tamaqua 1st,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 1st,Representative In Congress,,REP,Dan Meuser,134,29,3,0,166
+Schuylkill,Tamaqua 1st,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tamaqua 1st,State Senate,29,REP,Dave Argall,132,31,4,0,167
+Schuylkill,Tamaqua 1st,State Senate,29,REP,Write-in,3,0,0,0,3
+Schuylkill,Tamaqua 1st,General Assembly,124,REP,Jerry Knowles,131,32,4,0,167
+Schuylkill,Tamaqua 1st,General Assembly,124,REP,Write-in,4,1,0,0,5
+Schuylkill,Tamaqua 2nd,Registered Voters,,,,,,,,991
+Schuylkill,Tamaqua 2nd,Registered Voters,,DEM,,,,,,306
+Schuylkill,Tamaqua 2nd,Registered Voters,,REP,,,,,,518
+Schuylkill,Tamaqua 2nd,Registered Voters,,NPA,,,,,,167
+Schuylkill,Tamaqua 2nd,Ballots Cast,,,,159,89,12,2,262
+Schuylkill,Tamaqua 2nd,Ballots Cast,,DEM,,43,40,8,0,91
+Schuylkill,Tamaqua 2nd,Ballots Cast,,REP,,116,49,4,2,171
+Schuylkill,Tamaqua 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Tamaqua 2nd,President,,DEM,Bernie Sanders,11,4,1,0,16
+Schuylkill,Tamaqua 2nd,President,,DEM,Joseph R. Biden,23,32,6,0,61
+Schuylkill,Tamaqua 2nd,President,,DEM,Tulsi Gabbard,3,2,1,0,6
+Schuylkill,Tamaqua 2nd,President,,DEM,Write-in,4,1,0,0,5
+Schuylkill,Tamaqua 2nd,Attorney General,,DEM,Josh Shapiro,36,37,8,0,81
+Schuylkill,Tamaqua 2nd,Attorney General,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Tamaqua 2nd,Auditor General,,DEM,H. Scott Conklin,2,9,0,0,11
+Schuylkill,Tamaqua 2nd,Auditor General,,DEM,Michael Lamb,5,2,0,0,7
+Schuylkill,Tamaqua 2nd,Auditor General,,DEM,Tracie Fountain,6,4,1,0,11
+Schuylkill,Tamaqua 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,5,5,1,0,11
+Schuylkill,Tamaqua 2nd,Auditor General,,DEM,Nina Ahmad,11,3,1,0,15
+Schuylkill,Tamaqua 2nd,Auditor General,,DEM,Christina M. Hartman,11,14,4,0,29
+Schuylkill,Tamaqua 2nd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Tamaqua 2nd,State Treasurer,,DEM,Joe Torsella,34,38,8,0,80
+Schuylkill,Tamaqua 2nd,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 2nd,Representative In Congress,,DEM,Laura Quick,22,21,6,0,49
+Schuylkill,Tamaqua 2nd,Representative In Congress,,DEM,Gary Wegman,17,16,2,0,35
+Schuylkill,Tamaqua 2nd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Tamaqua 2nd,State Senate,29,DEM,Write-in,8,3,0,0,11
+Schuylkill,Tamaqua 2nd,General Assembly,124,DEM,Taylor Picone,37,36,8,0,81
+Schuylkill,Tamaqua 2nd,General Assembly,124,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 2nd,President,,REP,Donald J. Trump,109,43,4,2,158
+Schuylkill,Tamaqua 2nd,President,,REP,Roque Rocky De La Fuente,3,1,0,0,4
+Schuylkill,Tamaqua 2nd,President,,REP,Bill Weld,2,3,0,0,5
+Schuylkill,Tamaqua 2nd,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Tamaqua 2nd,Attorney General,,REP,Heather Heidelbaugh,98,42,4,2,146
+Schuylkill,Tamaqua 2nd,Attorney General,,REP,Write-in,0,2,0,0,2
+Schuylkill,Tamaqua 2nd,Auditor General,,REP,Timothy Defoor,96,41,4,2,143
+Schuylkill,Tamaqua 2nd,Auditor General,,REP,Write-in,2,2,0,0,4
+Schuylkill,Tamaqua 2nd,State Treasurer,,REP,Stacy L. Garrity,98,42,4,2,146
+Schuylkill,Tamaqua 2nd,State Treasurer,,REP,Write-in,2,1,0,0,3
+Schuylkill,Tamaqua 2nd,Representative In Congress,,REP,Dan Meuser,104,43,4,2,153
+Schuylkill,Tamaqua 2nd,Representative In Congress,,REP,Write-in,1,2,0,0,3
+Schuylkill,Tamaqua 2nd,State Senate,29,REP,Dave Argall,102,42,4,2,150
+Schuylkill,Tamaqua 2nd,State Senate,29,REP,Write-in,5,2,0,0,7
+Schuylkill,Tamaqua 2nd,General Assembly,124,REP,Jerry Knowles,102,44,4,2,152
+Schuylkill,Tamaqua 2nd,General Assembly,124,REP,Write-in,7,1,0,0,8
+Schuylkill,Tamaqua 3rd,Registered Voters,,,,,,,,974
+Schuylkill,Tamaqua 3rd,Registered Voters,,DEM,,,,,,308
+Schuylkill,Tamaqua 3rd,Registered Voters,,REP,,,,,,527
+Schuylkill,Tamaqua 3rd,Registered Voters,,NPA,,,,,,139
+Schuylkill,Tamaqua 3rd,Ballots Cast,,,,167,106,23,11,307
+Schuylkill,Tamaqua 3rd,Ballots Cast,,DEM,,42,48,12,1,103
+Schuylkill,Tamaqua 3rd,Ballots Cast,,REP,,125,58,11,10,204
+Schuylkill,Tamaqua 3rd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Tamaqua 3rd,President,,DEM,Bernie Sanders,12,11,2,0,25
+Schuylkill,Tamaqua 3rd,President,,DEM,Joseph R. Biden,21,35,10,1,67
+Schuylkill,Tamaqua 3rd,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Tamaqua 3rd,President,,DEM,Write-in,4,2,0,0,6
+Schuylkill,Tamaqua 3rd,Attorney General,,DEM,Josh Shapiro,34,44,12,1,91
+Schuylkill,Tamaqua 3rd,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Tamaqua 3rd,Auditor General,,DEM,H. Scott Conklin,4,5,1,0,10
+Schuylkill,Tamaqua 3rd,Auditor General,,DEM,Michael Lamb,8,7,1,1,17
+Schuylkill,Tamaqua 3rd,Auditor General,,DEM,Tracie Fountain,3,10,1,0,14
+Schuylkill,Tamaqua 3rd,Auditor General,,DEM,Rose Rosie Marie Davis,7,7,2,0,16
+Schuylkill,Tamaqua 3rd,Auditor General,,DEM,Nina Ahmad,13,2,5,0,20
+Schuylkill,Tamaqua 3rd,Auditor General,,DEM,Christina M. Hartman,5,10,1,0,16
+Schuylkill,Tamaqua 3rd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Tamaqua 3rd,State Treasurer,,DEM,Joe Torsella,37,44,12,1,94
+Schuylkill,Tamaqua 3rd,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Tamaqua 3rd,Representative In Congress,,DEM,Laura Quick,18,20,7,1,46
+Schuylkill,Tamaqua 3rd,Representative In Congress,,DEM,Gary Wegman,20,24,5,0,49
+Schuylkill,Tamaqua 3rd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Tamaqua 3rd,State Senate,29,DEM,Write-in,11,5,3,0,19
+Schuylkill,Tamaqua 3rd,General Assembly,124,DEM,Taylor Picone,38,39,11,1,89
+Schuylkill,Tamaqua 3rd,General Assembly,124,DEM,Write-in,3,2,0,0,5
+Schuylkill,Tamaqua 3rd,President,,REP,Donald J. Trump,114,47,7,10,178
+Schuylkill,Tamaqua 3rd,President,,REP,Roque Rocky De La Fuente,3,1,0,0,4
+Schuylkill,Tamaqua 3rd,President,,REP,Bill Weld,5,5,4,0,14
+Schuylkill,Tamaqua 3rd,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 3rd,Attorney General,,REP,Heather Heidelbaugh,109,50,8,8,175
+Schuylkill,Tamaqua 3rd,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 3rd,Auditor General,,REP,Timothy Defoor,107,48,7,8,170
+Schuylkill,Tamaqua 3rd,Auditor General,,REP,Write-in,0,1,1,0,2
+Schuylkill,Tamaqua 3rd,State Treasurer,,REP,Stacy L. Garrity,110,51,8,8,177
+Schuylkill,Tamaqua 3rd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tamaqua 3rd,Representative In Congress,,REP,Dan Meuser,116,51,7,8,182
+Schuylkill,Tamaqua 3rd,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Tamaqua 3rd,State Senate,29,REP,Dave Argall,116,50,9,9,184
+Schuylkill,Tamaqua 3rd,State Senate,29,REP,Write-in,3,1,0,0,4
+Schuylkill,Tamaqua 3rd,General Assembly,124,REP,Jerry Knowles,115,52,10,9,186
+Schuylkill,Tamaqua 3rd,General Assembly,124,REP,Write-in,2,0,0,0,2
+Schuylkill,Tamaqua 4th,Registered Voters,,,,,,,,723
+Schuylkill,Tamaqua 4th,Registered Voters,,DEM,,,,,,246
+Schuylkill,Tamaqua 4th,Registered Voters,,REP,,,,,,361
+Schuylkill,Tamaqua 4th,Registered Voters,,NPA,,,,,,116
+Schuylkill,Tamaqua 4th,Ballots Cast,,,,150,56,13,1,220
+Schuylkill,Tamaqua 4th,Ballots Cast,,DEM,,39,25,4,0,68
+Schuylkill,Tamaqua 4th,Ballots Cast,,REP,,111,31,9,1,152
+Schuylkill,Tamaqua 4th,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Tamaqua 4th,President,,DEM,Bernie Sanders,13,4,1,0,18
+Schuylkill,Tamaqua 4th,President,,DEM,Joseph R. Biden,19,21,3,0,43
+Schuylkill,Tamaqua 4th,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Tamaqua 4th,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 4th,Attorney General,,DEM,Josh Shapiro,37,20,4,0,61
+Schuylkill,Tamaqua 4th,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 4th,Auditor General,,DEM,H. Scott Conklin,2,1,1,0,4
+Schuylkill,Tamaqua 4th,Auditor General,,DEM,Michael Lamb,5,3,1,0,9
+Schuylkill,Tamaqua 4th,Auditor General,,DEM,Tracie Fountain,1,3,0,0,4
+Schuylkill,Tamaqua 4th,Auditor General,,DEM,Rose Rosie Marie Davis,8,3,2,0,13
+Schuylkill,Tamaqua 4th,Auditor General,,DEM,Nina Ahmad,12,5,0,0,17
+Schuylkill,Tamaqua 4th,Auditor General,,DEM,Christina M. Hartman,10,6,0,0,16
+Schuylkill,Tamaqua 4th,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 4th,State Treasurer,,DEM,Joe Torsella,37,19,3,0,59
+Schuylkill,Tamaqua 4th,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 4th,Representative In Congress,,DEM,Laura Quick,23,2,0,0,25
+Schuylkill,Tamaqua 4th,Representative In Congress,,DEM,Gary Wegman,14,15,4,0,33
+Schuylkill,Tamaqua 4th,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 4th,State Senate,29,DEM,Write-in,6,1,2,0,9
+Schuylkill,Tamaqua 4th,General Assembly,124,DEM,Taylor Picone,36,20,4,0,60
+Schuylkill,Tamaqua 4th,General Assembly,124,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 4th,President,,REP,Donald J. Trump,106,24,8,1,139
+Schuylkill,Tamaqua 4th,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Tamaqua 4th,President,,REP,Bill Weld,2,3,0,0,5
+Schuylkill,Tamaqua 4th,President,,REP,Write-in,1,2,1,0,4
+Schuylkill,Tamaqua 4th,Attorney General,,REP,Heather Heidelbaugh,96,26,8,1,131
+Schuylkill,Tamaqua 4th,Attorney General,,REP,Write-in,1,0,1,0,2
+Schuylkill,Tamaqua 4th,Auditor General,,REP,Timothy Defoor,93,27,8,1,129
+Schuylkill,Tamaqua 4th,Auditor General,,REP,Write-in,1,0,1,0,2
+Schuylkill,Tamaqua 4th,State Treasurer,,REP,Stacy L. Garrity,94,26,9,1,130
+Schuylkill,Tamaqua 4th,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tamaqua 4th,Representative In Congress,,REP,Dan Meuser,99,27,9,1,136
+Schuylkill,Tamaqua 4th,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Tamaqua 4th,State Senate,29,REP,Dave Argall,98,25,9,1,133
+Schuylkill,Tamaqua 4th,State Senate,29,REP,Write-in,1,3,0,0,4
+Schuylkill,Tamaqua 4th,General Assembly,124,REP,Jerry Knowles,99,26,8,1,134
+Schuylkill,Tamaqua 4th,General Assembly,124,REP,Write-in,1,3,1,0,5
+Schuylkill,Union Twp,Registered Voters,,,,,,,,852
+Schuylkill,Union Twp,Registered Voters,,DEM,,,,,,243
+Schuylkill,Union Twp,Registered Voters,,REP,,,,,,528
+Schuylkill,Union Twp,Registered Voters,,NPA,,,,,,81
+Schuylkill,Union Twp,Ballots Cast,,,,266,89,20,4,379
+Schuylkill,Union Twp,Ballots Cast,,DEM,,51,39,12,1,103
+Schuylkill,Union Twp,Ballots Cast,,REP,,215,50,8,3,276
+Schuylkill,Union Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Union Twp,President,,DEM,Bernie Sanders,9,5,1,1,16
+Schuylkill,Union Twp,President,,DEM,Joseph R. Biden,24,32,9,0,65
+Schuylkill,Union Twp,President,,DEM,Tulsi Gabbard,9,2,1,0,12
+Schuylkill,Union Twp,President,,DEM,Write-in,7,0,1,0,8
+Schuylkill,Union Twp,Attorney General,,DEM,Josh Shapiro,47,38,10,1,96
+Schuylkill,Union Twp,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Union Twp,Auditor General,,DEM,H. Scott Conklin,2,9,2,1,14
+Schuylkill,Union Twp,Auditor General,,DEM,Michael Lamb,9,11,1,0,21
+Schuylkill,Union Twp,Auditor General,,DEM,Tracie Fountain,7,3,2,0,12
+Schuylkill,Union Twp,Auditor General,,DEM,Rose Rosie Marie Davis,1,4,0,0,5
+Schuylkill,Union Twp,Auditor General,,DEM,Nina Ahmad,10,2,2,0,14
+Schuylkill,Union Twp,Auditor General,,DEM,Christina M. Hartman,20,9,3,0,32
+Schuylkill,Union Twp,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Union Twp,State Treasurer,,DEM,Joe Torsella,45,38,8,1,92
+Schuylkill,Union Twp,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Union Twp,Representative In Congress,,DEM,Laura Quick,24,23,8,1,56
+Schuylkill,Union Twp,Representative In Congress,,DEM,Gary Wegman,23,13,3,0,39
+Schuylkill,Union Twp,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Union Twp,State Senate,29,DEM,Write-in,7,1,1,0,9
+Schuylkill,Union Twp,General Assembly,124,DEM,Taylor Picone,45,35,9,1,90
+Schuylkill,Union Twp,General Assembly,124,DEM,Write-in,1,0,0,0,1
+Schuylkill,Union Twp,President,,REP,Donald J. Trump,197,39,7,3,246
+Schuylkill,Union Twp,President,,REP,Roque Rocky De La Fuente,3,3,0,0,6
+Schuylkill,Union Twp,President,,REP,Bill Weld,7,3,0,0,10
+Schuylkill,Union Twp,President,,REP,Write-in,1,2,0,0,3
+Schuylkill,Union Twp,Attorney General,,REP,Heather Heidelbaugh,199,44,7,3,253
+Schuylkill,Union Twp,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Union Twp,Auditor General,,REP,Timothy Defoor,195,42,7,3,247
+Schuylkill,Union Twp,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Union Twp,State Treasurer,,REP,Stacy L. Garrity,198,44,7,3,252
+Schuylkill,Union Twp,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Union Twp,Representative In Congress,,REP,Dan Meuser,199,44,8,3,254
+Schuylkill,Union Twp,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,Union Twp,State Senate,29,REP,Dave Argall,201,46,8,2,257
+Schuylkill,Union Twp,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Union Twp,General Assembly,124,REP,Jerry Knowles,194,46,8,2,250
+Schuylkill,Union Twp,General Assembly,124,REP,Write-in,1,0,0,0,1
+Schuylkill,Walker Twp,Registered Voters,,,,,,,,646
+Schuylkill,Walker Twp,Registered Voters,,DEM,,,,,,132
+Schuylkill,Walker Twp,Registered Voters,,REP,,,,,,452
+Schuylkill,Walker Twp,Registered Voters,,NPA,,,,,,62
+Schuylkill,Walker Twp,Ballots Cast,,,,193,75,17,7,292
+Schuylkill,Walker Twp,Ballots Cast,,DEM,,25,27,5,0,57
+Schuylkill,Walker Twp,Ballots Cast,,REP,,168,48,12,7,235
+Schuylkill,Walker Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Walker Twp,President,,DEM,Bernie Sanders,4,8,1,0,13
+Schuylkill,Walker Twp,President,,DEM,Joseph R. Biden,16,19,4,0,39
+Schuylkill,Walker Twp,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Schuylkill,Walker Twp,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Walker Twp,Attorney General,,DEM,Josh Shapiro,21,24,4,0,49
+Schuylkill,Walker Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Walker Twp,Auditor General,,DEM,H. Scott Conklin,0,2,0,0,2
+Schuylkill,Walker Twp,Auditor General,,DEM,Michael Lamb,7,3,2,0,12
+Schuylkill,Walker Twp,Auditor General,,DEM,Tracie Fountain,4,4,0,0,8
+Schuylkill,Walker Twp,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,0,0,3
+Schuylkill,Walker Twp,Auditor General,,DEM,Nina Ahmad,1,5,1,0,7
+Schuylkill,Walker Twp,Auditor General,,DEM,Christina M. Hartman,8,8,2,0,18
+Schuylkill,Walker Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Walker Twp,State Treasurer,,DEM,Joe Torsella,21,25,4,0,50
+Schuylkill,Walker Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Walker Twp,Representative In Congress,,DEM,Laura Quick,7,7,2,0,16
+Schuylkill,Walker Twp,Representative In Congress,,DEM,Gary Wegman,15,17,3,0,35
+Schuylkill,Walker Twp,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Walker Twp,State Senate,29,DEM,Write-in,0,4,1,0,5
+Schuylkill,Walker Twp,General Assembly,124,DEM,Taylor Picone,22,25,4,0,51
+Schuylkill,Walker Twp,General Assembly,124,DEM,Write-in,0,0,0,0,0
+Schuylkill,Walker Twp,President,,REP,Donald J. Trump,159,44,12,7,222
+Schuylkill,Walker Twp,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Walker Twp,President,,REP,Bill Weld,3,2,0,0,5
+Schuylkill,Walker Twp,President,,REP,Write-in,3,1,0,0,4
+Schuylkill,Walker Twp,Attorney General,,REP,Heather Heidelbaugh,139,45,11,6,201
+Schuylkill,Walker Twp,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Walker Twp,Auditor General,,REP,Timothy Defoor,141,44,10,6,201
+Schuylkill,Walker Twp,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Walker Twp,State Treasurer,,REP,Stacy L. Garrity,142,45,10,6,203
+Schuylkill,Walker Twp,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Walker Twp,Representative In Congress,,REP,Dan Meuser,158,45,10,6,219
+Schuylkill,Walker Twp,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,Walker Twp,State Senate,29,REP,Dave Argall,150,40,12,7,209
+Schuylkill,Walker Twp,State Senate,29,REP,Write-in,4,2,0,0,6
+Schuylkill,Walker Twp,General Assembly,124,REP,Jerry Knowles,154,44,12,6,216
+Schuylkill,Walker Twp,General Assembly,124,REP,Write-in,2,0,0,0,2
+Schuylkill,West Brunswick Twp North,Registered Voters,,,,,,,,1384
+Schuylkill,West Brunswick Twp North,Registered Voters,,DEM,,,,,,402
+Schuylkill,West Brunswick Twp North,Registered Voters,,REP,,,,,,814
+Schuylkill,West Brunswick Twp North,Registered Voters,,NPA,,,,,,168
+Schuylkill,West Brunswick Twp North,Ballots Cast,,,,291,223,32,0,546
+Schuylkill,West Brunswick Twp North,Ballots Cast,,DEM,,70,103,13,0,186
+Schuylkill,West Brunswick Twp North,Ballots Cast,,REP,,221,120,19,0,360
+Schuylkill,West Brunswick Twp North,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,West Brunswick Twp North,President,,DEM,Bernie Sanders,16,20,6,0,42
+Schuylkill,West Brunswick Twp North,President,,DEM,Joseph R. Biden,43,78,7,0,128
+Schuylkill,West Brunswick Twp North,President,,DEM,Tulsi Gabbard,6,1,0,0,7
+Schuylkill,West Brunswick Twp North,President,,DEM,Write-in,1,3,0,0,4
+Schuylkill,West Brunswick Twp North,Attorney General,,DEM,Josh Shapiro,59,97,12,0,168
+Schuylkill,West Brunswick Twp North,Attorney General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,West Brunswick Twp North,Auditor General,,DEM,H. Scott Conklin,7,15,1,0,23
+Schuylkill,West Brunswick Twp North,Auditor General,,DEM,Michael Lamb,5,12,1,0,18
+Schuylkill,West Brunswick Twp North,Auditor General,,DEM,Tracie Fountain,4,21,3,0,28
+Schuylkill,West Brunswick Twp North,Auditor General,,DEM,Rose Rosie Marie Davis,3,5,1,0,9
+Schuylkill,West Brunswick Twp North,Auditor General,,DEM,Nina Ahmad,12,15,5,0,32
+Schuylkill,West Brunswick Twp North,Auditor General,,DEM,Christina M. Hartman,27,31,1,0,59
+Schuylkill,West Brunswick Twp North,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Brunswick Twp North,State Treasurer,,DEM,Joe Torsella,57,94,12,0,163
+Schuylkill,West Brunswick Twp North,State Treasurer,,DEM,Write-in,0,2,0,0,2
+Schuylkill,West Brunswick Twp North,Representative In Congress,,DEM,Laura Quick,23,26,5,0,54
+Schuylkill,West Brunswick Twp North,Representative In Congress,,DEM,Gary Wegman,35,75,7,0,117
+Schuylkill,West Brunswick Twp North,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,West Brunswick Twp North,State Senate,29,DEM,Write-in,3,12,1,0,16
+Schuylkill,West Brunswick Twp North,General Assembly,124,DEM,Taylor Picone,57,97,12,0,166
+Schuylkill,West Brunswick Twp North,General Assembly,124,DEM,Write-in,0,1,0,0,1
+Schuylkill,West Brunswick Twp North,President,,REP,Donald J. Trump,214,100,13,0,327
+Schuylkill,West Brunswick Twp North,President,,REP,Roque Rocky De La Fuente,0,1,1,0,2
+Schuylkill,West Brunswick Twp North,President,,REP,Bill Weld,3,10,2,0,15
+Schuylkill,West Brunswick Twp North,President,,REP,Write-in,1,3,2,0,6
+Schuylkill,West Brunswick Twp North,Attorney General,,REP,Heather Heidelbaugh,180,107,15,0,302
+Schuylkill,West Brunswick Twp North,Attorney General,,REP,Write-in,1,1,0,0,2
+Schuylkill,West Brunswick Twp North,Auditor General,,REP,Timothy Defoor,179,107,17,0,303
+Schuylkill,West Brunswick Twp North,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,West Brunswick Twp North,State Treasurer,,REP,Stacy L. Garrity,182,105,18,0,305
+Schuylkill,West Brunswick Twp North,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,West Brunswick Twp North,Representative In Congress,,REP,Dan Meuser,192,106,18,0,316
+Schuylkill,West Brunswick Twp North,Representative In Congress,,REP,Write-in,3,4,0,0,7
+Schuylkill,West Brunswick Twp North,State Senate,29,REP,Dave Argall,202,109,17,0,328
+Schuylkill,West Brunswick Twp North,State Senate,29,REP,Write-in,2,2,1,0,5
+Schuylkill,West Brunswick Twp North,General Assembly,124,REP,Jerry Knowles,202,113,18,0,333
+Schuylkill,West Brunswick Twp North,General Assembly,124,REP,Write-in,3,2,0,0,5
+Schuylkill,West Brunswick Twp South,Registered Voters,,,,,,,,947
+Schuylkill,West Brunswick Twp South,Registered Voters,,DEM,,,,,,217
+Schuylkill,West Brunswick Twp South,Registered Voters,,REP,,,,,,609
+Schuylkill,West Brunswick Twp South,Registered Voters,,NPA,,,,,,121
+Schuylkill,West Brunswick Twp South,Ballots Cast,,,,218,117,12,10,357
+Schuylkill,West Brunswick Twp South,Ballots Cast,,DEM,,32,64,8,1,105
+Schuylkill,West Brunswick Twp South,Ballots Cast,,REP,,186,53,4,9,252
+Schuylkill,West Brunswick Twp South,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,West Brunswick Twp South,President,,DEM,Bernie Sanders,8,7,2,0,17
+Schuylkill,West Brunswick Twp South,President,,DEM,Joseph R. Biden,16,53,6,1,76
+Schuylkill,West Brunswick Twp South,President,,DEM,Tulsi Gabbard,3,1,0,0,4
+Schuylkill,West Brunswick Twp South,President,,DEM,Write-in,3,3,0,0,6
+Schuylkill,West Brunswick Twp South,Attorney General,,DEM,Josh Shapiro,26,59,7,1,93
+Schuylkill,West Brunswick Twp South,Attorney General,,DEM,Write-in,0,2,0,0,2
+Schuylkill,West Brunswick Twp South,Auditor General,,DEM,H. Scott Conklin,3,7,0,0,10
+Schuylkill,West Brunswick Twp South,Auditor General,,DEM,Michael Lamb,3,5,1,0,9
+Schuylkill,West Brunswick Twp South,Auditor General,,DEM,Tracie Fountain,3,8,2,1,14
+Schuylkill,West Brunswick Twp South,Auditor General,,DEM,Rose Rosie Marie Davis,0,2,0,0,2
+Schuylkill,West Brunswick Twp South,Auditor General,,DEM,Nina Ahmad,8,16,2,0,26
+Schuylkill,West Brunswick Twp South,Auditor General,,DEM,Christina M. Hartman,11,22,2,0,35
+Schuylkill,West Brunswick Twp South,Auditor General,,DEM,Write-in,0,2,0,0,2
+Schuylkill,West Brunswick Twp South,State Treasurer,,DEM,Joe Torsella,26,58,7,1,92
+Schuylkill,West Brunswick Twp South,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,West Brunswick Twp South,Representative In Congress,,DEM,Laura Quick,7,20,2,0,29
+Schuylkill,West Brunswick Twp South,Representative In Congress,,DEM,Gary Wegman,20,40,5,1,66
+Schuylkill,West Brunswick Twp South,Representative In Congress,,DEM,Write-in,0,2,0,0,2
+Schuylkill,West Brunswick Twp South,State Senate,29,DEM,Write-in,1,11,0,0,12
+Schuylkill,West Brunswick Twp South,General Assembly,124,DEM,Taylor Picone,27,58,7,1,93
+Schuylkill,West Brunswick Twp South,General Assembly,124,DEM,Write-in,0,3,0,0,3
+Schuylkill,West Brunswick Twp South,President,,REP,Donald J. Trump,181,48,4,9,242
+Schuylkill,West Brunswick Twp South,President,,REP,Roque Rocky De La Fuente,2,1,0,0,3
+Schuylkill,West Brunswick Twp South,President,,REP,Bill Weld,1,2,0,0,3
+Schuylkill,West Brunswick Twp South,President,,REP,Write-in,2,2,0,0,4
+Schuylkill,West Brunswick Twp South,Attorney General,,REP,Heather Heidelbaugh,158,45,4,8,215
+Schuylkill,West Brunswick Twp South,Attorney General,,REP,Write-in,1,2,0,0,3
+Schuylkill,West Brunswick Twp South,Auditor General,,REP,Timothy Defoor,159,44,4,7,214
+Schuylkill,West Brunswick Twp South,Auditor General,,REP,Write-in,0,2,0,0,2
+Schuylkill,West Brunswick Twp South,State Treasurer,,REP,Stacy L. Garrity,158,45,4,7,214
+Schuylkill,West Brunswick Twp South,State Treasurer,,REP,Write-in,2,2,0,0,4
+Schuylkill,West Brunswick Twp South,Representative In Congress,,REP,Dan Meuser,164,46,4,8,222
+Schuylkill,West Brunswick Twp South,Representative In Congress,,REP,Write-in,1,2,0,0,3
+Schuylkill,West Brunswick Twp South,State Senate,29,REP,Dave Argall,172,48,4,8,232
+Schuylkill,West Brunswick Twp South,State Senate,29,REP,Write-in,2,1,0,0,3
+Schuylkill,West Brunswick Twp South,General Assembly,124,REP,Jerry Knowles,164,47,4,8,223
+Schuylkill,West Brunswick Twp South,General Assembly,124,REP,Write-in,4,2,0,0,6
+Schuylkill,West Penn Twp 2nd,Registered Voters,,,,,,,,699
+Schuylkill,West Penn Twp 2nd,Registered Voters,,DEM,,,,,,151
+Schuylkill,West Penn Twp 2nd,Registered Voters,,REP,,,,,,467
+Schuylkill,West Penn Twp 2nd,Registered Voters,,NPA,,,,,,81
+Schuylkill,West Penn Twp 2nd,Ballots Cast,,,,206,77,11,7,301
+Schuylkill,West Penn Twp 2nd,Ballots Cast,,DEM,,35,25,6,1,67
+Schuylkill,West Penn Twp 2nd,Ballots Cast,,REP,,171,52,5,6,234
+Schuylkill,West Penn Twp 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,West Penn Twp 2nd,President,,DEM,Bernie Sanders,12,2,0,0,14
+Schuylkill,West Penn Twp 2nd,President,,DEM,Joseph R. Biden,13,20,5,1,39
+Schuylkill,West Penn Twp 2nd,President,,DEM,Tulsi Gabbard,3,3,0,0,6
+Schuylkill,West Penn Twp 2nd,President,,DEM,Write-in,1,0,1,0,2
+Schuylkill,West Penn Twp 2nd,Attorney General,,DEM,Josh Shapiro,29,24,6,1,60
+Schuylkill,West Penn Twp 2nd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 2nd,Auditor General,,DEM,H. Scott Conklin,1,1,0,0,2
+Schuylkill,West Penn Twp 2nd,Auditor General,,DEM,Michael Lamb,5,4,1,0,10
+Schuylkill,West Penn Twp 2nd,Auditor General,,DEM,Tracie Fountain,2,4,1,0,7
+Schuylkill,West Penn Twp 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,6,3,1,0,10
+Schuylkill,West Penn Twp 2nd,Auditor General,,DEM,Nina Ahmad,6,5,2,0,13
+Schuylkill,West Penn Twp 2nd,Auditor General,,DEM,Christina M. Hartman,9,8,1,0,18
+Schuylkill,West Penn Twp 2nd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 2nd,State Treasurer,,DEM,Joe Torsella,28,23,6,1,58
+Schuylkill,West Penn Twp 2nd,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 2nd,Representative In Congress,,DEM,Laura Quick,14,9,4,0,27
+Schuylkill,West Penn Twp 2nd,Representative In Congress,,DEM,Gary Wegman,17,15,2,0,34
+Schuylkill,West Penn Twp 2nd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 2nd,State Senate,29,DEM,Write-in,4,0,1,0,5
+Schuylkill,West Penn Twp 2nd,General Assembly,124,DEM,Taylor Picone,25,24,6,0,55
+Schuylkill,West Penn Twp 2nd,General Assembly,124,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 2nd,President,,REP,Donald J. Trump,159,46,5,6,216
+Schuylkill,West Penn Twp 2nd,President,,REP,Roque Rocky De La Fuente,0,2,0,0,2
+Schuylkill,West Penn Twp 2nd,President,,REP,Bill Weld,5,2,0,0,7
+Schuylkill,West Penn Twp 2nd,President,,REP,Write-in,2,0,0,0,2
+Schuylkill,West Penn Twp 2nd,Attorney General,,REP,Heather Heidelbaugh,137,49,5,5,196
+Schuylkill,West Penn Twp 2nd,Attorney General,,REP,Write-in,3,0,0,0,3
+Schuylkill,West Penn Twp 2nd,Auditor General,,REP,Timothy Defoor,137,47,5,5,194
+Schuylkill,West Penn Twp 2nd,Auditor General,,REP,Write-in,2,0,0,0,2
+Schuylkill,West Penn Twp 2nd,State Treasurer,,REP,Stacy L. Garrity,140,49,5,5,199
+Schuylkill,West Penn Twp 2nd,State Treasurer,,REP,Write-in,2,0,0,0,2
+Schuylkill,West Penn Twp 2nd,Representative In Congress,,REP,Dan Meuser,147,47,5,6,205
+Schuylkill,West Penn Twp 2nd,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,West Penn Twp 2nd,State Senate,29,REP,Dave Argall,161,46,5,6,218
+Schuylkill,West Penn Twp 2nd,State Senate,29,REP,Write-in,4,2,0,0,6
+Schuylkill,West Penn Twp 2nd,General Assembly,124,REP,Jerry Knowles,158,48,5,6,217
+Schuylkill,West Penn Twp 2nd,General Assembly,124,REP,Write-in,2,0,0,0,2
+Schuylkill,West Penn Twp 1st,Registered Voters,,,,,,,,1398
+Schuylkill,West Penn Twp 1st,Registered Voters,,DEM,,,,,,328
+Schuylkill,West Penn Twp 1st,Registered Voters,,REP,,,,,,896
+Schuylkill,West Penn Twp 1st,Registered Voters,,NPA,,,,,,174
+Schuylkill,West Penn Twp 1st,Ballots Cast,,,,329,167,29,3,528
+Schuylkill,West Penn Twp 1st,Ballots Cast,,DEM,,39,74,13,0,126
+Schuylkill,West Penn Twp 1st,Ballots Cast,,REP,,290,93,16,3,402
+Schuylkill,West Penn Twp 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,West Penn Twp 1st,President,,DEM,Bernie Sanders,10,15,0,0,25
+Schuylkill,West Penn Twp 1st,President,,DEM,Joseph R. Biden,23,53,12,0,88
+Schuylkill,West Penn Twp 1st,President,,DEM,Tulsi Gabbard,2,1,1,0,4
+Schuylkill,West Penn Twp 1st,President,,DEM,Write-in,1,1,0,0,2
+Schuylkill,West Penn Twp 1st,Attorney General,,DEM,Josh Shapiro,33,68,12,0,113
+Schuylkill,West Penn Twp 1st,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 1st,Auditor General,,DEM,H. Scott Conklin,2,3,0,0,5
+Schuylkill,West Penn Twp 1st,Auditor General,,DEM,Michael Lamb,7,9,0,0,16
+Schuylkill,West Penn Twp 1st,Auditor General,,DEM,Tracie Fountain,3,10,1,0,14
+Schuylkill,West Penn Twp 1st,Auditor General,,DEM,Rose Rosie Marie Davis,4,13,3,0,20
+Schuylkill,West Penn Twp 1st,Auditor General,,DEM,Nina Ahmad,6,9,4,0,19
+Schuylkill,West Penn Twp 1st,Auditor General,,DEM,Christina M. Hartman,13,20,4,0,37
+Schuylkill,West Penn Twp 1st,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 1st,State Treasurer,,DEM,Joe Torsella,34,65,12,0,111
+Schuylkill,West Penn Twp 1st,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 1st,Representative In Congress,,DEM,Laura Quick,18,33,4,0,55
+Schuylkill,West Penn Twp 1st,Representative In Congress,,DEM,Gary Wegman,17,33,9,0,59
+Schuylkill,West Penn Twp 1st,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,West Penn Twp 1st,State Senate,29,DEM,Write-in,3,6,2,0,11
+Schuylkill,West Penn Twp 1st,General Assembly,124,DEM,Taylor Picone,35,63,11,0,109
+Schuylkill,West Penn Twp 1st,General Assembly,124,DEM,Write-in,0,2,0,0,2
+Schuylkill,West Penn Twp 1st,President,,REP,Donald J. Trump,274,75,11,3,363
+Schuylkill,West Penn Twp 1st,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Schuylkill,West Penn Twp 1st,President,,REP,Bill Weld,8,14,3,0,25
+Schuylkill,West Penn Twp 1st,President,,REP,Write-in,4,0,0,0,4
+Schuylkill,West Penn Twp 1st,Attorney General,,REP,Heather Heidelbaugh,260,80,11,3,354
+Schuylkill,West Penn Twp 1st,Attorney General,,REP,Write-in,7,0,0,0,7
+Schuylkill,West Penn Twp 1st,Auditor General,,REP,Timothy Defoor,258,80,11,3,352
+Schuylkill,West Penn Twp 1st,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,West Penn Twp 1st,State Treasurer,,REP,Stacy L. Garrity,255,79,11,3,348
+Schuylkill,West Penn Twp 1st,State Treasurer,,REP,Write-in,7,0,0,0,7
+Schuylkill,West Penn Twp 1st,Representative In Congress,,REP,Dan Meuser,260,81,11,3,355
+Schuylkill,West Penn Twp 1st,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,West Penn Twp 1st,State Senate,29,REP,Dave Argall,272,83,13,3,371
+Schuylkill,West Penn Twp 1st,State Senate,29,REP,Write-in,3,0,0,0,3
+Schuylkill,West Penn Twp 1st,General Assembly,124,REP,Jerry Knowles,270,84,15,3,372
+Schuylkill,West Penn Twp 1st,General Assembly,124,REP,Write-in,6,0,0,0,6
+Schuylkill,Barry Twp,Registered Voters,,,,,,,,594
+Schuylkill,Barry Twp,Registered Voters,,DEM,,,,,,131
+Schuylkill,Barry Twp,Registered Voters,,REP,,,,,,409
+Schuylkill,Barry Twp,Registered Voters,,NPA,,,,,,54
+Schuylkill,Barry Twp,Ballots Cast,,,,201,61,18,0,280
+Schuylkill,Barry Twp,Ballots Cast,,DEM,,28,25,12,0,65
+Schuylkill,Barry Twp,Ballots Cast,,REP,,173,36,6,0,215
+Schuylkill,Barry Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Barry Twp,President,,DEM,Bernie Sanders,3,5,0,0,8
+Schuylkill,Barry Twp,President,,DEM,Joseph R. Biden,18,18,12,0,48
+Schuylkill,Barry Twp,President,,DEM,Tulsi Gabbard,6,1,0,0,7
+Schuylkill,Barry Twp,President,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Barry Twp,Attorney General,,DEM,Josh Shapiro,25,22,12,0,59
+Schuylkill,Barry Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Barry Twp,Auditor General,,DEM,H. Scott Conklin,1,2,0,0,3
+Schuylkill,Barry Twp,Auditor General,,DEM,Michael Lamb,6,4,0,0,10
+Schuylkill,Barry Twp,Auditor General,,DEM,Tracie Fountain,9,10,5,0,24
+Schuylkill,Barry Twp,Auditor General,,DEM,Rose Rosie Marie Davis,2,2,0,0,4
+Schuylkill,Barry Twp,Auditor General,,DEM,Nina Ahmad,2,1,5,0,8
+Schuylkill,Barry Twp,Auditor General,,DEM,Christina M. Hartman,6,4,2,0,12
+Schuylkill,Barry Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Barry Twp,State Treasurer,,DEM,Joe Torsella,23,23,12,0,58
+Schuylkill,Barry Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Barry Twp,Representative In Congress,,DEM,Laura Quick,11,13,8,0,32
+Schuylkill,Barry Twp,Representative In Congress,,DEM,Gary Wegman,14,11,4,0,29
+Schuylkill,Barry Twp,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Barry Twp,State Senate,29,DEM,Write-in,2,1,1,0,4
+Schuylkill,Barry Twp,General Assembly,125,DEM,Write-in,4,3,0,0,7
+Schuylkill,Barry Twp,President,,REP,Donald J. Trump,165,30,6,0,201
+Schuylkill,Barry Twp,President,,REP,Roque Rocky De La Fuente,3,0,0,0,3
+Schuylkill,Barry Twp,President,,REP,Bill Weld,4,5,0,0,9
+Schuylkill,Barry Twp,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Barry Twp,Attorney General,,REP,Heather Heidelbaugh,160,32,5,0,197
+Schuylkill,Barry Twp,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Barry Twp,Auditor General,,REP,Timothy Defoor,160,32,5,0,197
+Schuylkill,Barry Twp,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Barry Twp,State Treasurer,,REP,Stacy L. Garrity,158,33,6,0,197
+Schuylkill,Barry Twp,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Barry Twp,Representative In Congress,,REP,Dan Meuser,164,33,6,0,203
+Schuylkill,Barry Twp,Representative In Congress,,REP,Write-in,1,1,0,0,2
+Schuylkill,Barry Twp,State Senate,29,REP,Dave Argall,165,35,6,0,206
+Schuylkill,Barry Twp,State Senate,29,REP,Write-in,2,0,0,0,2
+Schuylkill,Barry Twp,General Assembly,125,REP,Herv Breault,7,3,0,0,10
+Schuylkill,Barry Twp,General Assembly,125,REP,Theresa Gaffney,65,9,2,0,76
+Schuylkill,Barry Twp,General Assembly,125,REP,Christy Joy,37,18,2,0,57
+Schuylkill,Barry Twp,General Assembly,125,REP,Joe Kerwin,61,6,2,0,69
+Schuylkill,Barry Twp,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Cressona,Registered Voters,,,,,,,,993
+Schuylkill,Cressona,Registered Voters,,DEM,,,,,,289
+Schuylkill,Cressona,Registered Voters,,REP,,,,,,541
+Schuylkill,Cressona,Registered Voters,,NPA,,,,,,163
+Schuylkill,Cressona,Ballots Cast,,,,248,78,12,0,338
+Schuylkill,Cressona,Ballots Cast,,DEM,,43,34,4,0,81
+Schuylkill,Cressona,Ballots Cast,,REP,,205,44,8,0,257
+Schuylkill,Cressona,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Cressona,President,,DEM,Bernie Sanders,10,6,0,0,16
+Schuylkill,Cressona,President,,DEM,Joseph R. Biden,19,26,3,0,48
+Schuylkill,Cressona,President,,DEM,Tulsi Gabbard,2,1,1,0,4
+Schuylkill,Cressona,President,,DEM,Write-in,12,1,0,0,13
+Schuylkill,Cressona,Attorney General,,DEM,Josh Shapiro,31,32,4,0,67
+Schuylkill,Cressona,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Cressona,Auditor General,,DEM,H. Scott Conklin,3,4,1,0,8
+Schuylkill,Cressona,Auditor General,,DEM,Michael Lamb,5,6,0,0,11
+Schuylkill,Cressona,Auditor General,,DEM,Tracie Fountain,6,7,2,0,15
+Schuylkill,Cressona,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,0,3
+Schuylkill,Cressona,Auditor General,,DEM,Nina Ahmad,9,5,1,0,15
+Schuylkill,Cressona,Auditor General,,DEM,Christina M. Hartman,9,10,0,0,19
+Schuylkill,Cressona,Auditor General,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Cressona,State Treasurer,,DEM,Joe Torsella,33,31,4,0,68
+Schuylkill,Cressona,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Cressona,Representative In Congress,,DEM,Laura Quick,19,19,0,0,38
+Schuylkill,Cressona,Representative In Congress,,DEM,Gary Wegman,12,14,4,0,30
+Schuylkill,Cressona,Representative In Congress,,DEM,Write-in,6,0,0,0,6
+Schuylkill,Cressona,State Senate,29,DEM,Write-in,6,4,1,0,11
+Schuylkill,Cressona,General Assembly,125,DEM,Write-in,8,3,1,0,12
+Schuylkill,Cressona,President,,REP,Donald J. Trump,196,34,8,0,238
+Schuylkill,Cressona,President,,REP,Roque Rocky De La Fuente,2,1,0,0,3
+Schuylkill,Cressona,President,,REP,Bill Weld,3,3,0,0,6
+Schuylkill,Cressona,President,,REP,Write-in,2,3,0,0,5
+Schuylkill,Cressona,Attorney General,,REP,Heather Heidelbaugh,178,37,6,0,221
+Schuylkill,Cressona,Attorney General,,REP,Write-in,2,1,0,0,3
+Schuylkill,Cressona,Auditor General,,REP,Timothy Defoor,174,37,6,0,217
+Schuylkill,Cressona,Auditor General,,REP,Write-in,2,1,0,0,3
+Schuylkill,Cressona,State Treasurer,,REP,Stacy L. Garrity,173,38,6,0,217
+Schuylkill,Cressona,State Treasurer,,REP,Write-in,2,1,0,0,3
+Schuylkill,Cressona,Representative In Congress,,REP,Dan Meuser,182,39,6,0,227
+Schuylkill,Cressona,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,Cressona,State Senate,29,REP,Dave Argall,186,36,7,0,229
+Schuylkill,Cressona,State Senate,29,REP,Write-in,4,1,1,0,6
+Schuylkill,Cressona,General Assembly,125,REP,Herv Breault,12,1,1,0,14
+Schuylkill,Cressona,General Assembly,125,REP,Theresa Gaffney,72,21,3,0,96
+Schuylkill,Cressona,General Assembly,125,REP,Christy Joy,65,10,4,0,79
+Schuylkill,Cressona,General Assembly,125,REP,Joe Kerwin,53,7,0,0,60
+Schuylkill,Cressona,General Assembly,125,REP,Write-in,2,2,0,0,4
+Schuylkill,Eldred Twp,Registered Voters,,,,,,,,391
+Schuylkill,Eldred Twp,Registered Voters,,DEM,,,,,,75
+Schuylkill,Eldred Twp,Registered Voters,,REP,,,,,,290
+Schuylkill,Eldred Twp,Registered Voters,,NPA,,,,,,26
+Schuylkill,Eldred Twp,Ballots Cast,,,,119,61,5,2,187
+Schuylkill,Eldred Twp,Ballots Cast,,DEM,,8,14,3,0,25
+Schuylkill,Eldred Twp,Ballots Cast,,REP,,111,47,2,2,162
+Schuylkill,Eldred Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Eldred Twp,President,,DEM,Bernie Sanders,1,4,0,0,5
+Schuylkill,Eldred Twp,President,,DEM,Joseph R. Biden,2,9,2,0,13
+Schuylkill,Eldred Twp,President,,DEM,Tulsi Gabbard,4,0,1,0,5
+Schuylkill,Eldred Twp,President,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Eldred Twp,Attorney General,,DEM,Josh Shapiro,7,14,3,0,24
+Schuylkill,Eldred Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Eldred Twp,Auditor General,,DEM,H. Scott Conklin,0,4,0,0,4
+Schuylkill,Eldred Twp,Auditor General,,DEM,Michael Lamb,1,2,0,0,3
+Schuylkill,Eldred Twp,Auditor General,,DEM,Tracie Fountain,3,4,1,0,8
+Schuylkill,Eldred Twp,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,1,0,1
+Schuylkill,Eldred Twp,Auditor General,,DEM,Nina Ahmad,2,0,1,0,3
+Schuylkill,Eldred Twp,Auditor General,,DEM,Christina M. Hartman,1,3,0,0,4
+Schuylkill,Eldred Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Eldred Twp,State Treasurer,,DEM,Joe Torsella,7,14,3,0,24
+Schuylkill,Eldred Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Eldred Twp,Representative In Congress,,DEM,Laura Quick,4,7,2,0,13
+Schuylkill,Eldred Twp,Representative In Congress,,DEM,Gary Wegman,3,7,1,0,11
+Schuylkill,Eldred Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Eldred Twp,State Senate,29,DEM,Write-in,0,1,1,0,2
+Schuylkill,Eldred Twp,General Assembly,125,DEM,Write-in,0,2,1,0,3
+Schuylkill,Eldred Twp,President,,REP,Donald J. Trump,106,42,2,2,152
+Schuylkill,Eldred Twp,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Eldred Twp,President,,REP,Bill Weld,4,2,0,0,6
+Schuylkill,Eldred Twp,President,,REP,Write-in,0,2,0,0,2
+Schuylkill,Eldred Twp,Attorney General,,REP,Heather Heidelbaugh,104,42,1,2,149
+Schuylkill,Eldred Twp,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Eldred Twp,Auditor General,,REP,Timothy Defoor,103,42,2,2,149
+Schuylkill,Eldred Twp,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Eldred Twp,State Treasurer,,REP,Stacy L. Garrity,104,41,2,2,149
+Schuylkill,Eldred Twp,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Eldred Twp,Representative In Congress,,REP,Dan Meuser,105,43,1,2,151
+Schuylkill,Eldred Twp,Representative In Congress,,REP,Write-in,1,1,0,0,2
+Schuylkill,Eldred Twp,State Senate,29,REP,Dave Argall,109,45,2,2,158
+Schuylkill,Eldred Twp,State Senate,29,REP,Write-in,0,1,0,0,1
+Schuylkill,Eldred Twp,General Assembly,125,REP,Herv Breault,6,2,0,0,8
+Schuylkill,Eldred Twp,General Assembly,125,REP,Theresa Gaffney,42,17,2,1,62
+Schuylkill,Eldred Twp,General Assembly,125,REP,Christy Joy,10,11,0,0,21
+Schuylkill,Eldred Twp,General Assembly,125,REP,Joe Kerwin,53,17,0,1,71
+Schuylkill,Eldred Twp,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,Registered Voters,,,,,,,,184
+Schuylkill,Foster Twp,Registered Voters,,DEM,,,,,,68
+Schuylkill,Foster Twp,Registered Voters,,REP,,,,,,103
+Schuylkill,Foster Twp,Registered Voters,,NPA,,,,,,13
+Schuylkill,Foster Twp,Ballots Cast,,,,37,27,3,0,67
+Schuylkill,Foster Twp,Ballots Cast,,DEM,,6,15,2,0,23
+Schuylkill,Foster Twp,Ballots Cast,,REP,,31,12,1,0,44
+Schuylkill,Foster Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Foster Twp,President,,DEM,Bernie Sanders,3,6,0,0,9
+Schuylkill,Foster Twp,President,,DEM,Joseph R. Biden,2,6,2,0,10
+Schuylkill,Foster Twp,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Schuylkill,Foster Twp,President,,DEM,Write-in,0,3,0,0,3
+Schuylkill,Foster Twp,Attorney General,,DEM,Josh Shapiro,6,14,2,0,22
+Schuylkill,Foster Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,Auditor General,,DEM,H. Scott Conklin,1,1,2,0,4
+Schuylkill,Foster Twp,Auditor General,,DEM,Michael Lamb,1,0,0,0,1
+Schuylkill,Foster Twp,Auditor General,,DEM,Tracie Fountain,1,3,0,0,4
+Schuylkill,Foster Twp,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,0,1
+Schuylkill,Foster Twp,Auditor General,,DEM,Nina Ahmad,2,1,0,0,3
+Schuylkill,Foster Twp,Auditor General,,DEM,Christina M. Hartman,0,10,0,0,10
+Schuylkill,Foster Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,State Treasurer,,DEM,Joe Torsella,6,14,2,0,22
+Schuylkill,Foster Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,Representative In Congress,,DEM,Laura Quick,4,5,0,0,9
+Schuylkill,Foster Twp,Representative In Congress,,DEM,Gary Wegman,2,10,2,0,14
+Schuylkill,Foster Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,State Senate,29,DEM,Write-in,0,2,0,0,2
+Schuylkill,Foster Twp,General Assembly,123,DEM,Peter PJ Symons Jr.,6,15,2,0,23
+Schuylkill,Foster Twp,General Assembly,123,DEM,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,President,,REP,Donald J. Trump,29,9,1,0,39
+Schuylkill,Foster Twp,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Foster Twp,President,,REP,Bill Weld,0,3,0,0,3
+Schuylkill,Foster Twp,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Foster Twp,Attorney General,,REP,Heather Heidelbaugh,20,7,1,0,28
+Schuylkill,Foster Twp,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,Auditor General,,REP,Timothy Defoor,19,7,1,0,27
+Schuylkill,Foster Twp,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Foster Twp,State Treasurer,,REP,Stacy L. Garrity,20,7,1,0,28
+Schuylkill,Foster Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,Representative In Congress,,REP,Dan Meuser,20,5,1,0,26
+Schuylkill,Foster Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,State Senate,29,REP,Dave Argall,24,7,1,0,32
+Schuylkill,Foster Twp,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Foster Twp,General Assembly,123,REP,John Leshko,12,6,0,0,18
+Schuylkill,Foster Twp,General Assembly,123,REP,Tim Twardzik,15,4,1,0,20
+Schuylkill,Foster Twp,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Frailey Twp,Registered Voters,,,,,,,,203
+Schuylkill,Frailey Twp,Registered Voters,,DEM,,,,,,57
+Schuylkill,Frailey Twp,Registered Voters,,REP,,,,,,115
+Schuylkill,Frailey Twp,Registered Voters,,NPA,,,,,,31
+Schuylkill,Frailey Twp,Ballots Cast,,,,65,8,1,1,75
+Schuylkill,Frailey Twp,Ballots Cast,,DEM,,20,1,1,0,22
+Schuylkill,Frailey Twp,Ballots Cast,,REP,,45,7,0,1,53
+Schuylkill,Frailey Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Frailey Twp,President,,DEM,Bernie Sanders,8,0,1,0,9
+Schuylkill,Frailey Twp,President,,DEM,Joseph R. Biden,8,1,0,0,9
+Schuylkill,Frailey Twp,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Schuylkill,Frailey Twp,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Frailey Twp,Attorney General,,DEM,Josh Shapiro,17,1,1,0,19
+Schuylkill,Frailey Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Frailey Twp,Auditor General,,DEM,H. Scott Conklin,3,1,0,0,4
+Schuylkill,Frailey Twp,Auditor General,,DEM,Michael Lamb,2,0,0,0,2
+Schuylkill,Frailey Twp,Auditor General,,DEM,Tracie Fountain,11,0,0,0,11
+Schuylkill,Frailey Twp,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0,0
+Schuylkill,Frailey Twp,Auditor General,,DEM,Nina Ahmad,0,0,0,0,0
+Schuylkill,Frailey Twp,Auditor General,,DEM,Christina M. Hartman,3,0,1,0,4
+Schuylkill,Frailey Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Frailey Twp,State Treasurer,,DEM,Joe Torsella,17,1,1,0,19
+Schuylkill,Frailey Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Frailey Twp,Representative In Congress,,DEM,Laura Quick,13,0,1,0,14
+Schuylkill,Frailey Twp,Representative In Congress,,DEM,Gary Wegman,7,1,0,0,8
+Schuylkill,Frailey Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Frailey Twp,State Senate,29,DEM,Write-in,2,0,0,0,2
+Schuylkill,Frailey Twp,General Assembly,125,DEM,Write-in,2,0,0,0,2
+Schuylkill,Frailey Twp,President,,REP,Donald J. Trump,43,7,0,1,51
+Schuylkill,Frailey Twp,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Frailey Twp,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,Frailey Twp,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Frailey Twp,Attorney General,,REP,Heather Heidelbaugh,32,5,0,1,38
+Schuylkill,Frailey Twp,Attorney General,,REP,Write-in,4,0,0,0,4
+Schuylkill,Frailey Twp,Auditor General,,REP,Timothy Defoor,34,5,0,1,40
+Schuylkill,Frailey Twp,Auditor General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Frailey Twp,State Treasurer,,REP,Stacy L. Garrity,34,5,0,1,40
+Schuylkill,Frailey Twp,State Treasurer,,REP,Write-in,2,0,0,0,2
+Schuylkill,Frailey Twp,Representative In Congress,,REP,Dan Meuser,35,7,0,1,43
+Schuylkill,Frailey Twp,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,Frailey Twp,State Senate,29,REP,Dave Argall,37,6,0,1,44
+Schuylkill,Frailey Twp,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Frailey Twp,General Assembly,125,REP,Herv Breault,5,1,0,0,6
+Schuylkill,Frailey Twp,General Assembly,125,REP,Theresa Gaffney,16,0,0,1,17
+Schuylkill,Frailey Twp,General Assembly,125,REP,Christy Joy,11,2,0,0,13
+Schuylkill,Frailey Twp,General Assembly,125,REP,Joe Kerwin,12,4,0,0,16
+Schuylkill,Frailey Twp,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Hegins Twp East,Registered Voters,,,,,,,,1032
+Schuylkill,Hegins Twp East,Registered Voters,,DEM,,,,,,197
+Schuylkill,Hegins Twp East,Registered Voters,,REP,,,,,,739
+Schuylkill,Hegins Twp East,Registered Voters,,NPA,,,,,,96
+Schuylkill,Hegins Twp East,Ballots Cast,,,,307,96,23,2,428
+Schuylkill,Hegins Twp East,Ballots Cast,,DEM,,41,23,6,0,70
+Schuylkill,Hegins Twp East,Ballots Cast,,REP,,266,73,17,2,358
+Schuylkill,Hegins Twp East,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Hegins Twp East,President,,DEM,Bernie Sanders,3,8,0,0,11
+Schuylkill,Hegins Twp East,President,,DEM,Joseph R. Biden,20,13,5,0,38
+Schuylkill,Hegins Twp East,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Schuylkill,Hegins Twp East,President,,DEM,Write-in,12,2,0,0,14
+Schuylkill,Hegins Twp East,Attorney General,,DEM,Josh Shapiro,32,23,6,0,61
+Schuylkill,Hegins Twp East,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Hegins Twp East,Auditor General,,DEM,H. Scott Conklin,6,4,0,0,10
+Schuylkill,Hegins Twp East,Auditor General,,DEM,Michael Lamb,2,2,0,0,4
+Schuylkill,Hegins Twp East,Auditor General,,DEM,Tracie Fountain,13,13,3,0,29
+Schuylkill,Hegins Twp East,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,2,0,2
+Schuylkill,Hegins Twp East,Auditor General,,DEM,Nina Ahmad,5,2,0,0,7
+Schuylkill,Hegins Twp East,Auditor General,,DEM,Christina M. Hartman,6,1,1,0,8
+Schuylkill,Hegins Twp East,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Hegins Twp East,State Treasurer,,DEM,Joe Torsella,30,23,6,0,59
+Schuylkill,Hegins Twp East,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Hegins Twp East,Representative In Congress,,DEM,Laura Quick,19,14,4,0,37
+Schuylkill,Hegins Twp East,Representative In Congress,,DEM,Gary Wegman,13,8,2,0,23
+Schuylkill,Hegins Twp East,Representative In Congress,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Hegins Twp East,State Senate,29,DEM,Write-in,5,2,0,0,7
+Schuylkill,Hegins Twp East,General Assembly,125,DEM,Write-in,12,3,0,0,15
+Schuylkill,Hegins Twp East,President,,REP,Donald J. Trump,259,65,14,2,340
+Schuylkill,Hegins Twp East,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Hegins Twp East,President,,REP,Bill Weld,3,3,2,0,8
+Schuylkill,Hegins Twp East,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,Hegins Twp East,Attorney General,,REP,Heather Heidelbaugh,240,65,17,2,324
+Schuylkill,Hegins Twp East,Attorney General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Hegins Twp East,Auditor General,,REP,Timothy Defoor,238,66,17,2,323
+Schuylkill,Hegins Twp East,Auditor General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Hegins Twp East,State Treasurer,,REP,Stacy L. Garrity,241,67,17,2,327
+Schuylkill,Hegins Twp East,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Hegins Twp East,Representative In Congress,,REP,Dan Meuser,243,70,17,2,332
+Schuylkill,Hegins Twp East,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Hegins Twp East,State Senate,29,REP,Dave Argall,250,71,17,1,339
+Schuylkill,Hegins Twp East,State Senate,29,REP,Write-in,2,0,0,0,2
+Schuylkill,Hegins Twp East,General Assembly,125,REP,Herv Breault,10,3,0,0,13
+Schuylkill,Hegins Twp East,General Assembly,125,REP,Theresa Gaffney,99,23,4,0,126
+Schuylkill,Hegins Twp East,General Assembly,125,REP,Christy Joy,21,17,1,0,39
+Schuylkill,Hegins Twp East,General Assembly,125,REP,Joe Kerwin,134,28,12,2,176
+Schuylkill,Hegins Twp East,General Assembly,125,REP,Write-in,1,1,0,0,2
+Schuylkill,Hegins Twp West,Registered Voters,,,,,,,,1051
+Schuylkill,Hegins Twp West,Registered Voters,,DEM,,,,,,203
+Schuylkill,Hegins Twp West,Registered Voters,,REP,,,,,,742
+Schuylkill,Hegins Twp West,Registered Voters,,NPA,,,,,,106
+Schuylkill,Hegins Twp West,Ballots Cast,,,,276,116,18,6,416
+Schuylkill,Hegins Twp West,Ballots Cast,,DEM,,44,37,9,2,92
+Schuylkill,Hegins Twp West,Ballots Cast,,REP,,232,79,9,4,324
+Schuylkill,Hegins Twp West,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Hegins Twp West,President,,DEM,Bernie Sanders,9,4,2,0,15
+Schuylkill,Hegins Twp West,President,,DEM,Joseph R. Biden,22,30,6,1,59
+Schuylkill,Hegins Twp West,President,,DEM,Tulsi Gabbard,2,2,1,0,5
+Schuylkill,Hegins Twp West,President,,DEM,Write-in,9,1,0,1,11
+Schuylkill,Hegins Twp West,Attorney General,,DEM,Josh Shapiro,37,34,8,1,80
+Schuylkill,Hegins Twp West,Attorney General,,DEM,Write-in,3,1,0,0,4
+Schuylkill,Hegins Twp West,Auditor General,,DEM,H. Scott Conklin,5,6,1,0,12
+Schuylkill,Hegins Twp West,Auditor General,,DEM,Michael Lamb,4,1,1,0,6
+Schuylkill,Hegins Twp West,Auditor General,,DEM,Tracie Fountain,15,11,4,0,30
+Schuylkill,Hegins Twp West,Auditor General,,DEM,Rose Rosie Marie Davis,5,2,0,0,7
+Schuylkill,Hegins Twp West,Auditor General,,DEM,Nina Ahmad,4,5,0,1,10
+Schuylkill,Hegins Twp West,Auditor General,,DEM,Christina M. Hartman,4,11,2,0,17
+Schuylkill,Hegins Twp West,Auditor General,,DEM,Write-in,4,1,0,0,5
+Schuylkill,Hegins Twp West,State Treasurer,,DEM,Joe Torsella,36,33,8,1,78
+Schuylkill,Hegins Twp West,State Treasurer,,DEM,Write-in,4,1,0,0,5
+Schuylkill,Hegins Twp West,Representative In Congress,,DEM,Laura Quick,21,22,7,1,51
+Schuylkill,Hegins Twp West,Representative In Congress,,DEM,Gary Wegman,16,14,2,0,32
+Schuylkill,Hegins Twp West,Representative In Congress,,DEM,Write-in,5,1,0,0,6
+Schuylkill,Hegins Twp West,State Senate,29,DEM,Write-in,7,3,2,0,12
+Schuylkill,Hegins Twp West,General Assembly,125,DEM,Write-in,11,4,2,0,17
+Schuylkill,Hegins Twp West,President,,REP,Donald J. Trump,216,69,4,3,292
+Schuylkill,Hegins Twp West,President,,REP,Roque Rocky De La Fuente,4,0,1,0,5
+Schuylkill,Hegins Twp West,President,,REP,Bill Weld,5,4,1,0,10
+Schuylkill,Hegins Twp West,President,,REP,Write-in,2,1,1,0,4
+Schuylkill,Hegins Twp West,Attorney General,,REP,Heather Heidelbaugh,212,71,7,3,293
+Schuylkill,Hegins Twp West,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Hegins Twp West,Auditor General,,REP,Timothy Defoor,212,69,7,2,290
+Schuylkill,Hegins Twp West,Auditor General,,REP,Write-in,1,0,1,0,2
+Schuylkill,Hegins Twp West,State Treasurer,,REP,Stacy L. Garrity,208,70,7,2,287
+Schuylkill,Hegins Twp West,State Treasurer,,REP,Write-in,2,0,0,0,2
+Schuylkill,Hegins Twp West,Representative In Congress,,REP,Dan Meuser,212,69,7,2,290
+Schuylkill,Hegins Twp West,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,Hegins Twp West,State Senate,29,REP,Dave Argall,215,75,7,4,301
+Schuylkill,Hegins Twp West,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Hegins Twp West,General Assembly,125,REP,Herv Breault,8,2,0,0,10
+Schuylkill,Hegins Twp West,General Assembly,125,REP,Theresa Gaffney,81,23,3,1,108
+Schuylkill,Hegins Twp West,General Assembly,125,REP,Christy Joy,29,18,4,0,51
+Schuylkill,Hegins Twp West,General Assembly,125,REP,Joe Kerwin,111,35,2,3,151
+Schuylkill,Hegins Twp West,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Hubley Twp,Registered Voters,,,,,,,,451
+Schuylkill,Hubley Twp,Registered Voters,,DEM,,,,,,90
+Schuylkill,Hubley Twp,Registered Voters,,REP,,,,,,324
+Schuylkill,Hubley Twp,Registered Voters,,NPA,,,,,,37
+Schuylkill,Hubley Twp,Ballots Cast,,,,157,43,5,1,206
+Schuylkill,Hubley Twp,Ballots Cast,,DEM,,16,14,2,0,32
+Schuylkill,Hubley Twp,Ballots Cast,,REP,,141,29,3,1,174
+Schuylkill,Hubley Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Hubley Twp,President,,DEM,Bernie Sanders,3,5,0,0,8
+Schuylkill,Hubley Twp,President,,DEM,Joseph R. Biden,10,9,2,0,21
+Schuylkill,Hubley Twp,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Schuylkill,Hubley Twp,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Hubley Twp,Attorney General,,DEM,Josh Shapiro,14,11,2,0,27
+Schuylkill,Hubley Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Hubley Twp,Auditor General,,DEM,H. Scott Conklin,0,1,0,0,1
+Schuylkill,Hubley Twp,Auditor General,,DEM,Michael Lamb,3,0,0,0,3
+Schuylkill,Hubley Twp,Auditor General,,DEM,Tracie Fountain,8,2,1,0,11
+Schuylkill,Hubley Twp,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,0,0,4
+Schuylkill,Hubley Twp,Auditor General,,DEM,Nina Ahmad,2,3,1,0,6
+Schuylkill,Hubley Twp,Auditor General,,DEM,Christina M. Hartman,0,4,0,0,4
+Schuylkill,Hubley Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Hubley Twp,State Treasurer,,DEM,Joe Torsella,14,10,2,0,26
+Schuylkill,Hubley Twp,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Hubley Twp,Representative In Congress,,DEM,Laura Quick,9,7,2,0,18
+Schuylkill,Hubley Twp,Representative In Congress,,DEM,Gary Wegman,5,5,0,0,10
+Schuylkill,Hubley Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Hubley Twp,State Senate,29,DEM,Write-in,1,1,0,0,2
+Schuylkill,Hubley Twp,General Assembly,125,DEM,Write-in,1,1,0,0,2
+Schuylkill,Hubley Twp,President,,REP,Donald J. Trump,134,20,3,1,158
+Schuylkill,Hubley Twp,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,Hubley Twp,President,,REP,Bill Weld,4,5,0,0,9
+Schuylkill,Hubley Twp,President,,REP,Write-in,0,3,0,0,3
+Schuylkill,Hubley Twp,Attorney General,,REP,Heather Heidelbaugh,132,27,3,1,163
+Schuylkill,Hubley Twp,Attorney General,,REP,Write-in,0,2,0,0,2
+Schuylkill,Hubley Twp,Auditor General,,REP,Timothy Defoor,128,26,3,1,158
+Schuylkill,Hubley Twp,Auditor General,,REP,Write-in,0,3,0,0,3
+Schuylkill,Hubley Twp,State Treasurer,,REP,Stacy L. Garrity,128,26,3,1,158
+Schuylkill,Hubley Twp,State Treasurer,,REP,Write-in,0,3,0,0,3
+Schuylkill,Hubley Twp,Representative In Congress,,REP,Dan Meuser,132,26,3,1,162
+Schuylkill,Hubley Twp,Representative In Congress,,REP,Write-in,1,3,0,0,4
+Schuylkill,Hubley Twp,State Senate,29,REP,Dave Argall,135,25,3,1,164
+Schuylkill,Hubley Twp,State Senate,29,REP,Write-in,2,3,0,0,5
+Schuylkill,Hubley Twp,General Assembly,125,REP,Herv Breault,2,1,0,0,3
+Schuylkill,Hubley Twp,General Assembly,125,REP,Theresa Gaffney,26,10,3,0,39
+Schuylkill,Hubley Twp,General Assembly,125,REP,Christy Joy,13,7,0,0,20
+Schuylkill,Hubley Twp,General Assembly,125,REP,Joe Kerwin,99,11,0,1,111
+Schuylkill,Hubley Twp,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Mechanicsville,Registered Voters,,,,,,,,260
+Schuylkill,Mechanicsville,Registered Voters,,DEM,,,,,,121
+Schuylkill,Mechanicsville,Registered Voters,,REP,,,,,,114
+Schuylkill,Mechanicsville,Registered Voters,,NPA,,,,,,25
+Schuylkill,Mechanicsville,Ballots Cast,,,,61,32,5,3,101
+Schuylkill,Mechanicsville,Ballots Cast,,DEM,,37,18,2,0,57
+Schuylkill,Mechanicsville,Ballots Cast,,REP,,24,14,3,3,44
+Schuylkill,Mechanicsville,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Mechanicsville,President,,DEM,Bernie Sanders,7,1,0,0,8
+Schuylkill,Mechanicsville,President,,DEM,Joseph R. Biden,19,17,2,0,38
+Schuylkill,Mechanicsville,President,,DEM,Tulsi Gabbard,5,0,0,0,5
+Schuylkill,Mechanicsville,President,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Mechanicsville,Attorney General,,DEM,Josh Shapiro,29,16,2,0,47
+Schuylkill,Mechanicsville,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mechanicsville,Auditor General,,DEM,H. Scott Conklin,4,1,0,0,5
+Schuylkill,Mechanicsville,Auditor General,,DEM,Michael Lamb,5,2,0,0,7
+Schuylkill,Mechanicsville,Auditor General,,DEM,Tracie Fountain,6,5,0,0,11
+Schuylkill,Mechanicsville,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,0,5
+Schuylkill,Mechanicsville,Auditor General,,DEM,Nina Ahmad,6,1,2,0,9
+Schuylkill,Mechanicsville,Auditor General,,DEM,Christina M. Hartman,8,5,0,0,13
+Schuylkill,Mechanicsville,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mechanicsville,State Treasurer,,DEM,Joe Torsella,31,14,2,0,47
+Schuylkill,Mechanicsville,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mechanicsville,Representative In Congress,,DEM,Laura Quick,16,5,2,0,23
+Schuylkill,Mechanicsville,Representative In Congress,,DEM,Gary Wegman,18,11,0,0,29
+Schuylkill,Mechanicsville,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mechanicsville,State Senate,29,DEM,Write-in,1,1,0,0,2
+Schuylkill,Mechanicsville,General Assembly,123,DEM,Peter PJ Symons Jr.,32,16,2,0,50
+Schuylkill,Mechanicsville,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,Mechanicsville,President,,REP,Donald J. Trump,23,12,3,3,41
+Schuylkill,Mechanicsville,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Mechanicsville,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,Mechanicsville,President,,REP,Write-in,0,2,0,0,2
+Schuylkill,Mechanicsville,Attorney General,,REP,Heather Heidelbaugh,23,13,2,3,41
+Schuylkill,Mechanicsville,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Mechanicsville,Auditor General,,REP,Timothy Defoor,21,13,2,3,39
+Schuylkill,Mechanicsville,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Mechanicsville,State Treasurer,,REP,Stacy L. Garrity,21,13,2,3,39
+Schuylkill,Mechanicsville,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Mechanicsville,Representative In Congress,,REP,Dan Meuser,24,12,2,3,41
+Schuylkill,Mechanicsville,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Mechanicsville,State Senate,29,REP,Dave Argall,23,13,3,3,42
+Schuylkill,Mechanicsville,State Senate,29,REP,Write-in,1,1,0,0,2
+Schuylkill,Mechanicsville,General Assembly,123,REP,John Leshko,10,9,2,2,23
+Schuylkill,Mechanicsville,General Assembly,123,REP,Tim Twardzik,14,5,1,1,21
+Schuylkill,Mechanicsville,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,Registered Voters,,,,,,,,59
+Schuylkill,Mt. Carbon,Registered Voters,,DEM,,,,,,21
+Schuylkill,Mt. Carbon,Registered Voters,,REP,,,,,,26
+Schuylkill,Mt. Carbon,Registered Voters,,NPA,,,,,,12
+Schuylkill,Mt. Carbon,Ballots Cast,,,,13,8,2,0,23
+Schuylkill,Mt. Carbon,Ballots Cast,,DEM,,5,5,2,0,12
+Schuylkill,Mt. Carbon,Ballots Cast,,REP,,8,3,0,0,11
+Schuylkill,Mt. Carbon,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Mt. Carbon,President,,DEM,Bernie Sanders,1,0,0,0,1
+Schuylkill,Mt. Carbon,President,,DEM,Joseph R. Biden,4,5,2,0,11
+Schuylkill,Mt. Carbon,President,,DEM,Tulsi Gabbard,0,0,0,0,0
+Schuylkill,Mt. Carbon,President,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,Attorney General,,DEM,Josh Shapiro,3,3,2,0,8
+Schuylkill,Mt. Carbon,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,Auditor General,,DEM,H. Scott Conklin,0,0,0,0,0
+Schuylkill,Mt. Carbon,Auditor General,,DEM,Michael Lamb,0,2,1,0,3
+Schuylkill,Mt. Carbon,Auditor General,,DEM,Tracie Fountain,1,0,0,0,1
+Schuylkill,Mt. Carbon,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,0,1
+Schuylkill,Mt. Carbon,Auditor General,,DEM,Nina Ahmad,0,0,0,0,0
+Schuylkill,Mt. Carbon,Auditor General,,DEM,Christina M. Hartman,1,1,1,0,3
+Schuylkill,Mt. Carbon,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,State Treasurer,,DEM,Joe Torsella,3,3,2,0,8
+Schuylkill,Mt. Carbon,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,Representative In Congress,,DEM,Laura Quick,3,0,1,0,4
+Schuylkill,Mt. Carbon,Representative In Congress,,DEM,Gary Wegman,1,3,1,0,5
+Schuylkill,Mt. Carbon,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,State Senate,29,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,General Assembly,123,DEM,Peter PJ Symons Jr.,2,4,2,0,8
+Schuylkill,Mt. Carbon,General Assembly,123,DEM,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,President,,REP,Donald J. Trump,8,2,0,0,10
+Schuylkill,Mt. Carbon,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,Mt. Carbon,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Mt. Carbon,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,Attorney General,,REP,Heather Heidelbaugh,8,2,0,0,10
+Schuylkill,Mt. Carbon,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,Auditor General,,REP,Timothy Defoor,8,2,0,0,10
+Schuylkill,Mt. Carbon,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,State Treasurer,,REP,Stacy L. Garrity,8,2,0,0,10
+Schuylkill,Mt. Carbon,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,Representative In Congress,,REP,Dan Meuser,8,2,0,0,10
+Schuylkill,Mt. Carbon,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,State Senate,29,REP,Dave Argall,8,3,0,0,11
+Schuylkill,Mt. Carbon,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Mt. Carbon,General Assembly,123,REP,John Leshko,5,1,0,0,6
+Schuylkill,Mt. Carbon,General Assembly,123,REP,Tim Twardzik,3,1,0,0,4
+Schuylkill,Mt. Carbon,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,Registered Voters,,,,,,,,581
+Schuylkill,North Manheim Twp 3rd,Registered Voters,,DEM,,,,,,167
+Schuylkill,North Manheim Twp 3rd,Registered Voters,,REP,,,,,,341
+Schuylkill,North Manheim Twp 3rd,Registered Voters,,NPA,,,,,,73
+Schuylkill,North Manheim Twp 3rd,Ballots Cast,,,,129,63,9,5,206
+Schuylkill,North Manheim Twp 3rd,Ballots Cast,,DEM,,27,25,3,0,55
+Schuylkill,North Manheim Twp 3rd,Ballots Cast,,REP,,102,38,6,5,151
+Schuylkill,North Manheim Twp 3rd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,President,,DEM,Bernie Sanders,6,2,0,0,8
+Schuylkill,North Manheim Twp 3rd,President,,DEM,Joseph R. Biden,15,21,2,0,38
+Schuylkill,North Manheim Twp 3rd,President,,DEM,Tulsi Gabbard,3,2,1,0,6
+Schuylkill,North Manheim Twp 3rd,President,,DEM,Write-in,2,0,0,0,2
+Schuylkill,North Manheim Twp 3rd,Attorney General,,DEM,Josh Shapiro,24,23,3,0,50
+Schuylkill,North Manheim Twp 3rd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,Auditor General,,DEM,H. Scott Conklin,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,Auditor General,,DEM,Michael Lamb,7,0,1,0,8
+Schuylkill,North Manheim Twp 3rd,Auditor General,,DEM,Tracie Fountain,4,7,1,0,12
+Schuylkill,North Manheim Twp 3rd,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,0,1
+Schuylkill,North Manheim Twp 3rd,Auditor General,,DEM,Nina Ahmad,3,2,0,0,5
+Schuylkill,North Manheim Twp 3rd,Auditor General,,DEM,Christina M. Hartman,9,12,0,0,21
+Schuylkill,North Manheim Twp 3rd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,State Treasurer,,DEM,Joe Torsella,20,22,3,0,45
+Schuylkill,North Manheim Twp 3rd,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,Representative In Congress,,DEM,Laura Quick,7,10,0,0,17
+Schuylkill,North Manheim Twp 3rd,Representative In Congress,,DEM,Gary Wegman,16,12,3,0,31
+Schuylkill,North Manheim Twp 3rd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,State Senate,29,DEM,Write-in,2,2,0,0,4
+Schuylkill,North Manheim Twp 3rd,General Assembly,125,DEM,Write-in,0,2,0,0,2
+Schuylkill,North Manheim Twp 3rd,President,,REP,Donald J. Trump,101,33,6,5,145
+Schuylkill,North Manheim Twp 3rd,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,North Manheim Twp 3rd,President,,REP,Bill Weld,0,1,0,0,1
+Schuylkill,North Manheim Twp 3rd,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,Attorney General,,REP,Heather Heidelbaugh,90,32,5,5,132
+Schuylkill,North Manheim Twp 3rd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,Auditor General,,REP,Timothy Defoor,92,31,5,5,133
+Schuylkill,North Manheim Twp 3rd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,State Treasurer,,REP,Stacy L. Garrity,91,32,5,5,133
+Schuylkill,North Manheim Twp 3rd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 3rd,Representative In Congress,,REP,Dan Meuser,95,32,5,5,137
+Schuylkill,North Manheim Twp 3rd,Representative In Congress,,REP,Write-in,0,1,1,0,2
+Schuylkill,North Manheim Twp 3rd,State Senate,29,REP,Dave Argall,96,35,6,5,142
+Schuylkill,North Manheim Twp 3rd,State Senate,29,REP,Write-in,1,1,0,0,2
+Schuylkill,North Manheim Twp 3rd,General Assembly,125,REP,Herv Breault,6,1,1,0,8
+Schuylkill,North Manheim Twp 3rd,General Assembly,125,REP,Theresa Gaffney,53,15,2,1,71
+Schuylkill,North Manheim Twp 3rd,General Assembly,125,REP,Christy Joy,29,19,3,2,53
+Schuylkill,North Manheim Twp 3rd,General Assembly,125,REP,Joe Kerwin,12,0,0,2,14
+Schuylkill,North Manheim Twp 3rd,General Assembly,125,REP,Write-in,1,1,0,0,2
+Schuylkill,North Manheim Twp 2nd,Registered Voters,,,,,,,,922
+Schuylkill,North Manheim Twp 2nd,Registered Voters,,DEM,,,,,,342
+Schuylkill,North Manheim Twp 2nd,Registered Voters,,REP,,,,,,479
+Schuylkill,North Manheim Twp 2nd,Registered Voters,,NPA,,,,,,101
+Schuylkill,North Manheim Twp 2nd,Ballots Cast,,,,204,99,20,1,324
+Schuylkill,North Manheim Twp 2nd,Ballots Cast,,DEM,,49,51,10,0,110
+Schuylkill,North Manheim Twp 2nd,Ballots Cast,,REP,,155,48,10,1,214
+Schuylkill,North Manheim Twp 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,North Manheim Twp 2nd,President,,DEM,Bernie Sanders,10,13,3,0,26
+Schuylkill,North Manheim Twp 2nd,President,,DEM,Joseph R. Biden,26,35,7,0,68
+Schuylkill,North Manheim Twp 2nd,President,,DEM,Tulsi Gabbard,4,1,0,0,5
+Schuylkill,North Manheim Twp 2nd,President,,DEM,Write-in,5,1,0,0,6
+Schuylkill,North Manheim Twp 2nd,Attorney General,,DEM,Josh Shapiro,42,45,10,0,97
+Schuylkill,North Manheim Twp 2nd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 2nd,Auditor General,,DEM,H. Scott Conklin,5,4,0,0,9
+Schuylkill,North Manheim Twp 2nd,Auditor General,,DEM,Michael Lamb,7,3,1,0,11
+Schuylkill,North Manheim Twp 2nd,Auditor General,,DEM,Tracie Fountain,8,8,3,0,19
+Schuylkill,North Manheim Twp 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,0,6,2,0,8
+Schuylkill,North Manheim Twp 2nd,Auditor General,,DEM,Nina Ahmad,13,10,1,0,24
+Schuylkill,North Manheim Twp 2nd,Auditor General,,DEM,Christina M. Hartman,10,14,3,0,27
+Schuylkill,North Manheim Twp 2nd,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,North Manheim Twp 2nd,State Treasurer,,DEM,Joe Torsella,43,42,9,0,94
+Schuylkill,North Manheim Twp 2nd,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 2nd,Representative In Congress,,DEM,Laura Quick,10,16,4,0,30
+Schuylkill,North Manheim Twp 2nd,Representative In Congress,,DEM,Gary Wegman,35,28,6,0,69
+Schuylkill,North Manheim Twp 2nd,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,North Manheim Twp 2nd,State Senate,29,DEM,Write-in,3,2,0,0,5
+Schuylkill,North Manheim Twp 2nd,General Assembly,125,DEM,Write-in,6,2,0,0,8
+Schuylkill,North Manheim Twp 2nd,President,,REP,Donald J. Trump,145,37,6,1,189
+Schuylkill,North Manheim Twp 2nd,President,,REP,Roque Rocky De La Fuente,1,2,2,0,5
+Schuylkill,North Manheim Twp 2nd,President,,REP,Bill Weld,6,7,1,0,14
+Schuylkill,North Manheim Twp 2nd,President,,REP,Write-in,1,2,0,0,3
+Schuylkill,North Manheim Twp 2nd,Attorney General,,REP,Heather Heidelbaugh,138,44,8,1,191
+Schuylkill,North Manheim Twp 2nd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 2nd,Auditor General,,REP,Timothy Defoor,137,44,8,0,189
+Schuylkill,North Manheim Twp 2nd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 2nd,State Treasurer,,REP,Stacy L. Garrity,140,44,8,1,193
+Schuylkill,North Manheim Twp 2nd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 2nd,Representative In Congress,,REP,Dan Meuser,141,44,8,1,194
+Schuylkill,North Manheim Twp 2nd,Representative In Congress,,REP,Write-in,0,2,1,0,3
+Schuylkill,North Manheim Twp 2nd,State Senate,29,REP,Dave Argall,143,44,10,0,197
+Schuylkill,North Manheim Twp 2nd,State Senate,29,REP,Write-in,1,2,0,0,3
+Schuylkill,North Manheim Twp 2nd,General Assembly,125,REP,Herv Breault,11,2,0,0,13
+Schuylkill,North Manheim Twp 2nd,General Assembly,125,REP,Theresa Gaffney,40,11,3,1,55
+Schuylkill,North Manheim Twp 2nd,General Assembly,125,REP,Christy Joy,65,28,7,0,100
+Schuylkill,North Manheim Twp 2nd,General Assembly,125,REP,Joe Kerwin,36,5,0,0,41
+Schuylkill,North Manheim Twp 2nd,General Assembly,125,REP,Write-in,1,0,0,0,1
+Schuylkill,Orwigsburg 1st,Registered Voters,,,,,,,,825
+Schuylkill,Orwigsburg 1st,Registered Voters,,DEM,,,,,,265
+Schuylkill,Orwigsburg 1st,Registered Voters,,REP,,,,,,445
+Schuylkill,Orwigsburg 1st,Registered Voters,,NPA,,,,,,115
+Schuylkill,Orwigsburg 1st,Ballots Cast,,,,156,105,30,2,293
+Schuylkill,Orwigsburg 1st,Ballots Cast,,DEM,,42,57,15,0,114
+Schuylkill,Orwigsburg 1st,Ballots Cast,,REP,,114,48,15,2,179
+Schuylkill,Orwigsburg 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Orwigsburg 1st,President,,DEM,Bernie Sanders,13,11,3,0,27
+Schuylkill,Orwigsburg 1st,President,,DEM,Joseph R. Biden,25,43,11,0,79
+Schuylkill,Orwigsburg 1st,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Schuylkill,Orwigsburg 1st,President,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 1st,Attorney General,,DEM,Josh Shapiro,38,52,14,0,104
+Schuylkill,Orwigsburg 1st,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 1st,Auditor General,,DEM,H. Scott Conklin,1,1,4,0,6
+Schuylkill,Orwigsburg 1st,Auditor General,,DEM,Michael Lamb,8,6,4,0,18
+Schuylkill,Orwigsburg 1st,Auditor General,,DEM,Tracie Fountain,7,10,2,0,19
+Schuylkill,Orwigsburg 1st,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,0,1
+Schuylkill,Orwigsburg 1st,Auditor General,,DEM,Nina Ahmad,9,17,2,0,28
+Schuylkill,Orwigsburg 1st,Auditor General,,DEM,Christina M. Hartman,13,21,2,0,36
+Schuylkill,Orwigsburg 1st,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 1st,State Treasurer,,DEM,Joe Torsella,36,48,14,0,98
+Schuylkill,Orwigsburg 1st,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 1st,Representative In Congress,,DEM,Laura Quick,16,11,5,0,32
+Schuylkill,Orwigsburg 1st,Representative In Congress,,DEM,Gary Wegman,23,43,10,0,76
+Schuylkill,Orwigsburg 1st,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 1st,State Senate,29,DEM,Write-in,4,7,1,0,12
+Schuylkill,Orwigsburg 1st,General Assembly,124,DEM,Taylor Picone,35,50,14,0,99
+Schuylkill,Orwigsburg 1st,General Assembly,124,DEM,Write-in,0,2,0,0,2
+Schuylkill,Orwigsburg 1st,President,,REP,Donald J. Trump,109,38,9,2,158
+Schuylkill,Orwigsburg 1st,President,,REP,Roque Rocky De La Fuente,0,3,0,0,3
+Schuylkill,Orwigsburg 1st,President,,REP,Bill Weld,2,3,3,0,8
+Schuylkill,Orwigsburg 1st,President,,REP,Write-in,0,2,0,0,2
+Schuylkill,Orwigsburg 1st,Attorney General,,REP,Heather Heidelbaugh,104,39,11,2,156
+Schuylkill,Orwigsburg 1st,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Orwigsburg 1st,Auditor General,,REP,Timothy Defoor,100,41,11,2,154
+Schuylkill,Orwigsburg 1st,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Orwigsburg 1st,State Treasurer,,REP,Stacy L. Garrity,101,41,11,2,155
+Schuylkill,Orwigsburg 1st,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 1st,Representative In Congress,,REP,Dan Meuser,106,40,13,2,161
+Schuylkill,Orwigsburg 1st,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 1st,State Senate,29,REP,Dave Argall,106,42,14,2,164
+Schuylkill,Orwigsburg 1st,State Senate,29,REP,Write-in,1,0,1,0,2
+Schuylkill,Orwigsburg 1st,General Assembly,124,REP,Jerry Knowles,101,40,11,2,154
+Schuylkill,Orwigsburg 1st,General Assembly,124,REP,Write-in,4,0,1,0,5
+Schuylkill,Orwigsburg 2nd,Registered Voters,,,,,,,,1112
+Schuylkill,Orwigsburg 2nd,Registered Voters,,DEM,,,,,,343
+Schuylkill,Orwigsburg 2nd,Registered Voters,,REP,,,,,,621
+Schuylkill,Orwigsburg 2nd,Registered Voters,,NPA,,,,,,148
+Schuylkill,Orwigsburg 2nd,Ballots Cast,,,,209,131,23,4,367
+Schuylkill,Orwigsburg 2nd,Ballots Cast,,DEM,,48,60,14,1,123
+Schuylkill,Orwigsburg 2nd,Ballots Cast,,REP,,161,71,9,3,244
+Schuylkill,Orwigsburg 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,President,,DEM,Bernie Sanders,17,6,5,0,28
+Schuylkill,Orwigsburg 2nd,President,,DEM,Joseph R. Biden,25,50,9,1,85
+Schuylkill,Orwigsburg 2nd,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Schuylkill,Orwigsburg 2nd,President,,DEM,Write-in,1,3,0,0,4
+Schuylkill,Orwigsburg 2nd,Attorney General,,DEM,Josh Shapiro,39,56,13,1,109
+Schuylkill,Orwigsburg 2nd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,Auditor General,,DEM,H. Scott Conklin,5,6,0,0,11
+Schuylkill,Orwigsburg 2nd,Auditor General,,DEM,Michael Lamb,9,8,4,0,21
+Schuylkill,Orwigsburg 2nd,Auditor General,,DEM,Tracie Fountain,4,14,1,0,19
+Schuylkill,Orwigsburg 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,4,6,0,0,10
+Schuylkill,Orwigsburg 2nd,Auditor General,,DEM,Nina Ahmad,10,5,2,0,17
+Schuylkill,Orwigsburg 2nd,Auditor General,,DEM,Christina M. Hartman,12,18,6,1,37
+Schuylkill,Orwigsburg 2nd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,State Treasurer,,DEM,Joe Torsella,38,56,12,1,107
+Schuylkill,Orwigsburg 2nd,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,Representative In Congress,,DEM,Laura Quick,17,25,5,0,47
+Schuylkill,Orwigsburg 2nd,Representative In Congress,,DEM,Gary Wegman,27,34,8,1,70
+Schuylkill,Orwigsburg 2nd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,State Senate,29,DEM,Write-in,4,3,0,0,7
+Schuylkill,Orwigsburg 2nd,General Assembly,124,DEM,Taylor Picone,37,54,12,1,104
+Schuylkill,Orwigsburg 2nd,General Assembly,124,DEM,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,President,,REP,Donald J. Trump,150,55,9,2,216
+Schuylkill,Orwigsburg 2nd,President,,REP,Roque Rocky De La Fuente,0,2,0,1,3
+Schuylkill,Orwigsburg 2nd,President,,REP,Bill Weld,5,7,0,0,12
+Schuylkill,Orwigsburg 2nd,President,,REP,Write-in,2,1,0,0,3
+Schuylkill,Orwigsburg 2nd,Attorney General,,REP,Heather Heidelbaugh,142,64,8,3,217
+Schuylkill,Orwigsburg 2nd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,Auditor General,,REP,Timothy Defoor,144,63,8,3,218
+Schuylkill,Orwigsburg 2nd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,State Treasurer,,REP,Stacy L. Garrity,143,64,8,3,218
+Schuylkill,Orwigsburg 2nd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Orwigsburg 2nd,Representative In Congress,,REP,Dan Meuser,149,67,9,3,228
+Schuylkill,Orwigsburg 2nd,Representative In Congress,,REP,Write-in,2,0,0,0,2
+Schuylkill,Orwigsburg 2nd,State Senate,29,REP,Dave Argall,155,67,9,3,234
+Schuylkill,Orwigsburg 2nd,State Senate,29,REP,Write-in,0,1,0,0,1
+Schuylkill,Orwigsburg 2nd,General Assembly,124,REP,Jerry Knowles,148,65,9,3,225
+Schuylkill,Orwigsburg 2nd,General Assembly,124,REP,Write-in,2,1,0,0,3
+Schuylkill,Pine Grove North,Registered Voters,,,,,,,,705
+Schuylkill,Pine Grove North,Registered Voters,,DEM,,,,,,197
+Schuylkill,Pine Grove North,Registered Voters,,REP,,,,,,388
+Schuylkill,Pine Grove North,Registered Voters,,NPA,,,,,,120
+Schuylkill,Pine Grove North,Ballots Cast,,,,124,66,18,1,209
+Schuylkill,Pine Grove North,Ballots Cast,,DEM,,27,34,13,0,74
+Schuylkill,Pine Grove North,Ballots Cast,,REP,,97,32,5,1,135
+Schuylkill,Pine Grove North,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pine Grove North,President,,DEM,Bernie Sanders,6,3,2,0,11
+Schuylkill,Pine Grove North,President,,DEM,Joseph R. Biden,14,28,10,0,52
+Schuylkill,Pine Grove North,President,,DEM,Tulsi Gabbard,0,1,0,0,1
+Schuylkill,Pine Grove North,President,,DEM,Write-in,3,2,0,0,5
+Schuylkill,Pine Grove North,Attorney General,,DEM,Josh Shapiro,25,31,12,0,68
+Schuylkill,Pine Grove North,Attorney General,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Pine Grove North,Auditor General,,DEM,H. Scott Conklin,1,2,2,0,5
+Schuylkill,Pine Grove North,Auditor General,,DEM,Michael Lamb,1,6,2,0,9
+Schuylkill,Pine Grove North,Auditor General,,DEM,Tracie Fountain,12,10,4,0,26
+Schuylkill,Pine Grove North,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,1,0,2
+Schuylkill,Pine Grove North,Auditor General,,DEM,Nina Ahmad,1,4,1,0,6
+Schuylkill,Pine Grove North,Auditor General,,DEM,Christina M. Hartman,8,8,2,0,18
+Schuylkill,Pine Grove North,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove North,State Treasurer,,DEM,Joe Torsella,20,30,11,0,61
+Schuylkill,Pine Grove North,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove North,Representative In Congress,,DEM,Laura Quick,15,18,8,0,41
+Schuylkill,Pine Grove North,Representative In Congress,,DEM,Gary Wegman,10,15,4,0,29
+Schuylkill,Pine Grove North,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove North,State Senate,29,DEM,Write-in,3,3,2,0,8
+Schuylkill,Pine Grove North,General Assembly,125,DEM,Write-in,6,4,2,0,12
+Schuylkill,Pine Grove North,President,,REP,Donald J. Trump,86,20,4,1,111
+Schuylkill,Pine Grove North,President,,REP,Roque Rocky De La Fuente,1,3,0,0,4
+Schuylkill,Pine Grove North,President,,REP,Bill Weld,7,5,0,0,12
+Schuylkill,Pine Grove North,President,,REP,Write-in,1,0,1,0,2
+Schuylkill,Pine Grove North,Attorney General,,REP,Heather Heidelbaugh,88,24,5,1,118
+Schuylkill,Pine Grove North,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove North,Auditor General,,REP,Timothy Defoor,89,24,5,1,119
+Schuylkill,Pine Grove North,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove North,State Treasurer,,REP,Stacy L. Garrity,88,24,5,1,118
+Schuylkill,Pine Grove North,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove North,Representative In Congress,,REP,Dan Meuser,92,24,5,1,122
+Schuylkill,Pine Grove North,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove North,State Senate,29,REP,Dave Argall,91,28,5,1,125
+Schuylkill,Pine Grove North,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove North,General Assembly,125,REP,Herv Breault,12,1,2,0,15
+Schuylkill,Pine Grove North,General Assembly,125,REP,Theresa Gaffney,44,19,1,1,65
+Schuylkill,Pine Grove North,General Assembly,125,REP,Christy Joy,12,6,2,0,20
+Schuylkill,Pine Grove North,General Assembly,125,REP,Joe Kerwin,25,5,0,0,30
+Schuylkill,Pine Grove North,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,Registered Voters,,,,,,,,475
+Schuylkill,Pine Grove South,Registered Voters,,DEM,,,,,,154
+Schuylkill,Pine Grove South,Registered Voters,,REP,,,,,,253
+Schuylkill,Pine Grove South,Registered Voters,,NPA,,,,,,68
+Schuylkill,Pine Grove South,Ballots Cast,,,,100,35,4,2,141
+Schuylkill,Pine Grove South,Ballots Cast,,DEM,,15,16,2,0,33
+Schuylkill,Pine Grove South,Ballots Cast,,REP,,85,19,2,2,108
+Schuylkill,Pine Grove South,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pine Grove South,President,,DEM,Bernie Sanders,4,1,0,0,5
+Schuylkill,Pine Grove South,President,,DEM,Joseph R. Biden,5,13,2,0,20
+Schuylkill,Pine Grove South,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Schuylkill,Pine Grove South,President,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Pine Grove South,Attorney General,,DEM,Josh Shapiro,10,16,2,0,28
+Schuylkill,Pine Grove South,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,Auditor General,,DEM,H. Scott Conklin,4,1,0,0,5
+Schuylkill,Pine Grove South,Auditor General,,DEM,Michael Lamb,1,3,0,0,4
+Schuylkill,Pine Grove South,Auditor General,,DEM,Tracie Fountain,4,9,1,0,14
+Schuylkill,Pine Grove South,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0,0
+Schuylkill,Pine Grove South,Auditor General,,DEM,Nina Ahmad,0,2,1,0,3
+Schuylkill,Pine Grove South,Auditor General,,DEM,Christina M. Hartman,4,1,0,0,5
+Schuylkill,Pine Grove South,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,State Treasurer,,DEM,Joe Torsella,10,16,2,0,28
+Schuylkill,Pine Grove South,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,Representative In Congress,,DEM,Laura Quick,5,10,1,0,16
+Schuylkill,Pine Grove South,Representative In Congress,,DEM,Gary Wegman,8,6,1,0,15
+Schuylkill,Pine Grove South,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,State Senate,29,DEM,Write-in,0,3,1,0,4
+Schuylkill,Pine Grove South,General Assembly,125,DEM,Write-in,1,4,1,0,6
+Schuylkill,Pine Grove South,President,,REP,Donald J. Trump,81,13,2,2,98
+Schuylkill,Pine Grove South,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Pine Grove South,President,,REP,Bill Weld,3,4,0,0,7
+Schuylkill,Pine Grove South,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,Attorney General,,REP,Heather Heidelbaugh,82,17,2,2,103
+Schuylkill,Pine Grove South,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,Auditor General,,REP,Timothy Defoor,80,17,2,2,101
+Schuylkill,Pine Grove South,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,State Treasurer,,REP,Stacy L. Garrity,82,16,2,2,102
+Schuylkill,Pine Grove South,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,Representative In Congress,,REP,Dan Meuser,77,14,2,2,95
+Schuylkill,Pine Grove South,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pine Grove South,State Senate,29,REP,Dave Argall,81,17,2,2,102
+Schuylkill,Pine Grove South,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove South,General Assembly,125,REP,Herv Breault,11,2,0,0,13
+Schuylkill,Pine Grove South,General Assembly,125,REP,Theresa Gaffney,27,5,1,1,34
+Schuylkill,Pine Grove South,General Assembly,125,REP,Christy Joy,20,8,1,1,30
+Schuylkill,Pine Grove South,General Assembly,125,REP,Joe Kerwin,27,4,0,0,31
+Schuylkill,Pine Grove South,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove Twp 1st,Registered Voters,,,,,,,,1272
+Schuylkill,Pine Grove Twp 1st,Registered Voters,,DEM,,,,,,330
+Schuylkill,Pine Grove Twp 1st,Registered Voters,,REP,,,,,,801
+Schuylkill,Pine Grove Twp 1st,Registered Voters,,NPA,,,,,,141
+Schuylkill,Pine Grove Twp 1st,Ballots Cast,,,,293,136,27,10,466
+Schuylkill,Pine Grove Twp 1st,Ballots Cast,,DEM,,52,58,10,0,120
+Schuylkill,Pine Grove Twp 1st,Ballots Cast,,REP,,241,78,17,10,346
+Schuylkill,Pine Grove Twp 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pine Grove Twp 1st,President,,DEM,Bernie Sanders,9,14,1,0,24
+Schuylkill,Pine Grove Twp 1st,President,,DEM,Joseph R. Biden,32,39,9,0,80
+Schuylkill,Pine Grove Twp 1st,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Schuylkill,Pine Grove Twp 1st,President,,DEM,Write-in,4,5,0,0,9
+Schuylkill,Pine Grove Twp 1st,Attorney General,,DEM,Josh Shapiro,45,50,10,0,105
+Schuylkill,Pine Grove Twp 1st,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove Twp 1st,Auditor General,,DEM,H. Scott Conklin,3,1,4,0,8
+Schuylkill,Pine Grove Twp 1st,Auditor General,,DEM,Michael Lamb,7,5,0,0,12
+Schuylkill,Pine Grove Twp 1st,Auditor General,,DEM,Tracie Fountain,8,23,2,0,33
+Schuylkill,Pine Grove Twp 1st,Auditor General,,DEM,Rose Rosie Marie Davis,6,0,0,0,6
+Schuylkill,Pine Grove Twp 1st,Auditor General,,DEM,Nina Ahmad,4,9,1,0,14
+Schuylkill,Pine Grove Twp 1st,Auditor General,,DEM,Christina M. Hartman,19,16,3,0,38
+Schuylkill,Pine Grove Twp 1st,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove Twp 1st,State Treasurer,,DEM,Joe Torsella,47,49,10,0,106
+Schuylkill,Pine Grove Twp 1st,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove Twp 1st,Representative In Congress,,DEM,Laura Quick,35,31,6,0,72
+Schuylkill,Pine Grove Twp 1st,Representative In Congress,,DEM,Gary Wegman,14,22,4,0,40
+Schuylkill,Pine Grove Twp 1st,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove Twp 1st,State Senate,29,DEM,Write-in,2,2,0,0,4
+Schuylkill,Pine Grove Twp 1st,General Assembly,125,DEM,Write-in,2,5,0,0,7
+Schuylkill,Pine Grove Twp 1st,President,,REP,Donald J. Trump,230,62,15,10,317
+Schuylkill,Pine Grove Twp 1st,President,,REP,Roque Rocky De La Fuente,2,0,1,0,3
+Schuylkill,Pine Grove Twp 1st,President,,REP,Bill Weld,6,9,1,0,16
+Schuylkill,Pine Grove Twp 1st,President,,REP,Write-in,0,3,0,0,3
+Schuylkill,Pine Grove Twp 1st,Attorney General,,REP,Heather Heidelbaugh,203,67,14,9,293
+Schuylkill,Pine Grove Twp 1st,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pine Grove Twp 1st,Auditor General,,REP,Timothy Defoor,201,66,14,9,290
+Schuylkill,Pine Grove Twp 1st,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pine Grove Twp 1st,State Treasurer,,REP,Stacy L. Garrity,200,67,15,9,291
+Schuylkill,Pine Grove Twp 1st,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove Twp 1st,Representative In Congress,,REP,Dan Meuser,213,67,14,10,304
+Schuylkill,Pine Grove Twp 1st,Representative In Congress,,REP,Write-in,1,3,0,0,4
+Schuylkill,Pine Grove Twp 1st,State Senate,29,REP,Dave Argall,224,71,13,10,318
+Schuylkill,Pine Grove Twp 1st,State Senate,29,REP,Write-in,0,2,1,0,3
+Schuylkill,Pine Grove Twp 1st,General Assembly,125,REP,Herv Breault,14,3,0,0,17
+Schuylkill,Pine Grove Twp 1st,General Assembly,125,REP,Theresa Gaffney,100,31,7,3,141
+Schuylkill,Pine Grove Twp 1st,General Assembly,125,REP,Christy Joy,29,20,4,0,53
+Schuylkill,Pine Grove Twp 1st,General Assembly,125,REP,Joe Kerwin,94,18,5,7,124
+Schuylkill,Pine Grove Twp 1st,General Assembly,125,REP,Write-in,0,2,0,0,2
+Schuylkill,Pine Grove Twp 2nd,Registered Voters,,,,,,,,1256
+Schuylkill,Pine Grove Twp 2nd,Registered Voters,,DEM,,,,,,334
+Schuylkill,Pine Grove Twp 2nd,Registered Voters,,REP,,,,,,766
+Schuylkill,Pine Grove Twp 2nd,Registered Voters,,NPA,,,,,,156
+Schuylkill,Pine Grove Twp 2nd,Ballots Cast,,,,281,136,30,12,459
+Schuylkill,Pine Grove Twp 2nd,Ballots Cast,,DEM,,49,61,12,0,122
+Schuylkill,Pine Grove Twp 2nd,Ballots Cast,,REP,,232,75,18,12,337
+Schuylkill,Pine Grove Twp 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pine Grove Twp 2nd,President,,DEM,Bernie Sanders,11,6,0,0,17
+Schuylkill,Pine Grove Twp 2nd,President,,DEM,Joseph R. Biden,24,52,12,0,88
+Schuylkill,Pine Grove Twp 2nd,President,,DEM,Tulsi Gabbard,6,1,0,0,7
+Schuylkill,Pine Grove Twp 2nd,President,,DEM,Write-in,6,1,0,0,7
+Schuylkill,Pine Grove Twp 2nd,Attorney General,,DEM,Josh Shapiro,38,54,12,0,104
+Schuylkill,Pine Grove Twp 2nd,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,DEM,H. Scott Conklin,8,1,0,0,9
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,DEM,Michael Lamb,10,9,2,0,21
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,DEM,Tracie Fountain,13,21,5,0,39
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,0,0,3
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,DEM,Nina Ahmad,4,8,0,0,12
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,DEM,Christina M. Hartman,9,16,5,0,30
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove Twp 2nd,State Treasurer,,DEM,Joe Torsella,39,54,12,0,105
+Schuylkill,Pine Grove Twp 2nd,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove Twp 2nd,Representative In Congress,,DEM,Laura Quick,21,37,5,0,63
+Schuylkill,Pine Grove Twp 2nd,Representative In Congress,,DEM,Gary Wegman,25,21,7,0,53
+Schuylkill,Pine Grove Twp 2nd,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Pine Grove Twp 2nd,State Senate,29,DEM,Write-in,6,5,0,0,11
+Schuylkill,Pine Grove Twp 2nd,General Assembly,125,DEM,Write-in,5,4,1,0,10
+Schuylkill,Pine Grove Twp 2nd,President,,REP,Donald J. Trump,226,61,15,11,313
+Schuylkill,Pine Grove Twp 2nd,President,,REP,Roque Rocky De La Fuente,1,3,1,0,5
+Schuylkill,Pine Grove Twp 2nd,President,,REP,Bill Weld,3,7,2,0,12
+Schuylkill,Pine Grove Twp 2nd,President,,REP,Write-in,2,3,0,0,5
+Schuylkill,Pine Grove Twp 2nd,Attorney General,,REP,Heather Heidelbaugh,201,70,16,12,299
+Schuylkill,Pine Grove Twp 2nd,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,REP,Timothy Defoor,198,69,16,12,295
+Schuylkill,Pine Grove Twp 2nd,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pine Grove Twp 2nd,State Treasurer,,REP,Stacy L. Garrity,205,69,15,12,301
+Schuylkill,Pine Grove Twp 2nd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pine Grove Twp 2nd,Representative In Congress,,REP,Dan Meuser,209,68,14,11,302
+Schuylkill,Pine Grove Twp 2nd,Representative In Congress,,REP,Write-in,0,1,0,1,2
+Schuylkill,Pine Grove Twp 2nd,State Senate,29,REP,Dave Argall,218,69,16,12,315
+Schuylkill,Pine Grove Twp 2nd,State Senate,29,REP,Write-in,2,1,0,0,3
+Schuylkill,Pine Grove Twp 2nd,General Assembly,125,REP,Herv Breault,11,4,3,0,18
+Schuylkill,Pine Grove Twp 2nd,General Assembly,125,REP,Theresa Gaffney,98,26,4,7,135
+Schuylkill,Pine Grove Twp 2nd,General Assembly,125,REP,Christy Joy,40,34,6,3,83
+Schuylkill,Pine Grove Twp 2nd,General Assembly,125,REP,Joe Kerwin,82,11,3,2,98
+Schuylkill,Pine Grove Twp 2nd,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp East,Registered Voters,,,,,,,,720
+Schuylkill,Porter Twp East,Registered Voters,,DEM,,,,,,141
+Schuylkill,Porter Twp East,Registered Voters,,REP,,,,,,500
+Schuylkill,Porter Twp East,Registered Voters,,NPA,,,,,,79
+Schuylkill,Porter Twp East,Ballots Cast,,,,249,48,20,7,324
+Schuylkill,Porter Twp East,Ballots Cast,,DEM,,29,14,8,0,51
+Schuylkill,Porter Twp East,Ballots Cast,,REP,,220,34,12,7,273
+Schuylkill,Porter Twp East,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Porter Twp East,President,,DEM,Bernie Sanders,5,0,1,0,6
+Schuylkill,Porter Twp East,President,,DEM,Joseph R. Biden,16,13,6,0,35
+Schuylkill,Porter Twp East,President,,DEM,Tulsi Gabbard,1,0,1,0,2
+Schuylkill,Porter Twp East,President,,DEM,Write-in,5,1,0,0,6
+Schuylkill,Porter Twp East,Attorney General,,DEM,Josh Shapiro,22,11,8,0,41
+Schuylkill,Porter Twp East,Attorney General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Porter Twp East,Auditor General,,DEM,H. Scott Conklin,3,0,1,0,4
+Schuylkill,Porter Twp East,Auditor General,,DEM,Michael Lamb,1,2,0,0,3
+Schuylkill,Porter Twp East,Auditor General,,DEM,Tracie Fountain,11,8,2,0,21
+Schuylkill,Porter Twp East,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,1,0,4
+Schuylkill,Porter Twp East,Auditor General,,DEM,Nina Ahmad,3,0,3,0,6
+Schuylkill,Porter Twp East,Auditor General,,DEM,Christina M. Hartman,4,2,1,0,7
+Schuylkill,Porter Twp East,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Porter Twp East,State Treasurer,,DEM,Joe Torsella,21,12,7,0,40
+Schuylkill,Porter Twp East,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Porter Twp East,Representative In Congress,,DEM,Laura Quick,16,6,6,0,28
+Schuylkill,Porter Twp East,Representative In Congress,,DEM,Gary Wegman,7,6,2,0,15
+Schuylkill,Porter Twp East,Representative In Congress,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Porter Twp East,State Senate,29,DEM,Write-in,3,0,0,0,3
+Schuylkill,Porter Twp East,General Assembly,125,DEM,Write-in,4,1,1,0,6
+Schuylkill,Porter Twp East,President,,REP,Donald J. Trump,215,31,11,7,264
+Schuylkill,Porter Twp East,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Porter Twp East,President,,REP,Bill Weld,0,2,1,0,3
+Schuylkill,Porter Twp East,President,,REP,Write-in,2,1,0,0,3
+Schuylkill,Porter Twp East,Attorney General,,REP,Heather Heidelbaugh,203,29,11,7,250
+Schuylkill,Porter Twp East,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp East,Auditor General,,REP,Timothy Defoor,198,29,11,7,245
+Schuylkill,Porter Twp East,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp East,State Treasurer,,REP,Stacy L. Garrity,203,30,11,7,251
+Schuylkill,Porter Twp East,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Porter Twp East,Representative In Congress,,REP,Dan Meuser,201,28,12,7,248
+Schuylkill,Porter Twp East,Representative In Congress,,REP,Write-in,2,1,0,0,3
+Schuylkill,Porter Twp East,State Senate,29,REP,Dave Argall,204,29,11,7,251
+Schuylkill,Porter Twp East,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Porter Twp East,General Assembly,125,REP,Herv Breault,1,0,0,0,1
+Schuylkill,Porter Twp East,General Assembly,125,REP,Theresa Gaffney,19,3,1,1,24
+Schuylkill,Porter Twp East,General Assembly,125,REP,Christy Joy,9,6,0,0,15
+Schuylkill,Porter Twp East,General Assembly,125,REP,Joe Kerwin,190,24,10,6,230
+Schuylkill,Porter Twp East,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp West,Registered Voters,,,,,,,,619
+Schuylkill,Porter Twp West,Registered Voters,,DEM,,,,,,125
+Schuylkill,Porter Twp West,Registered Voters,,REP,,,,,,425
+Schuylkill,Porter Twp West,Registered Voters,,NPA,,,,,,69
+Schuylkill,Porter Twp West,Ballots Cast,,,,171,87,9,9,276
+Schuylkill,Porter Twp West,Ballots Cast,,DEM,,25,27,6,2,60
+Schuylkill,Porter Twp West,Ballots Cast,,REP,,146,60,3,7,216
+Schuylkill,Porter Twp West,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Porter Twp West,President,,DEM,Bernie Sanders,6,2,0,0,8
+Schuylkill,Porter Twp West,President,,DEM,Joseph R. Biden,13,23,5,2,43
+Schuylkill,Porter Twp West,President,,DEM,Tulsi Gabbard,1,0,1,0,2
+Schuylkill,Porter Twp West,President,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Porter Twp West,Attorney General,,DEM,Josh Shapiro,20,25,6,2,53
+Schuylkill,Porter Twp West,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp West,Auditor General,,DEM,H. Scott Conklin,4,0,1,0,5
+Schuylkill,Porter Twp West,Auditor General,,DEM,Michael Lamb,1,4,2,0,7
+Schuylkill,Porter Twp West,Auditor General,,DEM,Tracie Fountain,13,10,0,0,23
+Schuylkill,Porter Twp West,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,0,0,6
+Schuylkill,Porter Twp West,Auditor General,,DEM,Nina Ahmad,1,0,1,2,4
+Schuylkill,Porter Twp West,Auditor General,,DEM,Christina M. Hartman,2,5,2,0,9
+Schuylkill,Porter Twp West,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp West,State Treasurer,,DEM,Joe Torsella,20,22,5,2,49
+Schuylkill,Porter Twp West,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp West,Representative In Congress,,DEM,Laura Quick,18,13,6,1,38
+Schuylkill,Porter Twp West,Representative In Congress,,DEM,Gary Wegman,6,10,0,0,16
+Schuylkill,Porter Twp West,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp West,State Senate,29,DEM,Write-in,2,1,2,0,5
+Schuylkill,Porter Twp West,General Assembly,125,DEM,Write-in,5,3,2,1,11
+Schuylkill,Porter Twp West,President,,REP,Donald J. Trump,141,48,3,7,199
+Schuylkill,Porter Twp West,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Porter Twp West,President,,REP,Bill Weld,3,8,0,0,11
+Schuylkill,Porter Twp West,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp West,Attorney General,,REP,Heather Heidelbaugh,134,53,3,7,197
+Schuylkill,Porter Twp West,Attorney General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Porter Twp West,Auditor General,,REP,Timothy Defoor,133,53,3,7,196
+Schuylkill,Porter Twp West,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Porter Twp West,State Treasurer,,REP,Stacy L. Garrity,135,52,3,7,197
+Schuylkill,Porter Twp West,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp West,Representative In Congress,,REP,Dan Meuser,135,53,3,7,198
+Schuylkill,Porter Twp West,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Porter Twp West,State Senate,29,REP,Dave Argall,138,54,3,7,202
+Schuylkill,Porter Twp West,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Porter Twp West,General Assembly,125,REP,Herv Breault,5,1,0,0,6
+Schuylkill,Porter Twp West,General Assembly,125,REP,Theresa Gaffney,17,7,2,0,26
+Schuylkill,Porter Twp West,General Assembly,125,REP,Christy Joy,9,5,0,0,14
+Schuylkill,Porter Twp West,General Assembly,125,REP,Joe Kerwin,114,46,1,7,168
+Schuylkill,Porter Twp West,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,Registered Voters,,,,,,,,396
+Schuylkill,Pottsville 1st,Registered Voters,,DEM,,,,,,167
+Schuylkill,Pottsville 1st,Registered Voters,,REP,,,,,,146
+Schuylkill,Pottsville 1st,Registered Voters,,NPA,,,,,,83
+Schuylkill,Pottsville 1st,Ballots Cast,,,,55,21,3,2,81
+Schuylkill,Pottsville 1st,Ballots Cast,,DEM,,21,5,1,0,27
+Schuylkill,Pottsville 1st,Ballots Cast,,REP,,34,16,2,2,54
+Schuylkill,Pottsville 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 1st,President,,DEM,Bernie Sanders,5,0,0,0,5
+Schuylkill,Pottsville 1st,President,,DEM,Joseph R. Biden,12,4,1,0,17
+Schuylkill,Pottsville 1st,President,,DEM,Tulsi Gabbard,2,1,0,0,3
+Schuylkill,Pottsville 1st,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 1st,Attorney General,,DEM,Josh Shapiro,18,4,1,0,23
+Schuylkill,Pottsville 1st,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,Auditor General,,DEM,H. Scott Conklin,1,0,0,0,1
+Schuylkill,Pottsville 1st,Auditor General,,DEM,Michael Lamb,2,1,0,0,3
+Schuylkill,Pottsville 1st,Auditor General,,DEM,Tracie Fountain,1,0,0,0,1
+Schuylkill,Pottsville 1st,Auditor General,,DEM,Rose Rosie Marie Davis,1,0,0,0,1
+Schuylkill,Pottsville 1st,Auditor General,,DEM,Nina Ahmad,9,1,1,0,11
+Schuylkill,Pottsville 1st,Auditor General,,DEM,Christina M. Hartman,5,1,0,0,6
+Schuylkill,Pottsville 1st,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,State Treasurer,,DEM,Joe Torsella,19,2,1,0,22
+Schuylkill,Pottsville 1st,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,Representative In Congress,,DEM,Laura Quick,6,2,1,0,9
+Schuylkill,Pottsville 1st,Representative In Congress,,DEM,Gary Wegman,14,3,0,0,17
+Schuylkill,Pottsville 1st,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,State Senate,29,DEM,Write-in,3,0,0,0,3
+Schuylkill,Pottsville 1st,General Assembly,123,DEM,Peter PJ Symons Jr.,21,3,1,0,25
+Schuylkill,Pottsville 1st,General Assembly,123,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,President,,REP,Donald J. Trump,34,15,2,2,53
+Schuylkill,Pottsville 1st,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Pottsville 1st,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Pottsville 1st,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 1st,Attorney General,,REP,Heather Heidelbaugh,30,13,2,1,46
+Schuylkill,Pottsville 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,Auditor General,,REP,Timothy Defoor,30,13,2,2,47
+Schuylkill,Pottsville 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,State Treasurer,,REP,Stacy L. Garrity,31,13,2,2,48
+Schuylkill,Pottsville 1st,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,Representative In Congress,,REP,Dan Meuser,31,16,1,2,50
+Schuylkill,Pottsville 1st,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,State Senate,29,REP,Dave Argall,31,16,1,1,49
+Schuylkill,Pottsville 1st,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 1st,General Assembly,123,REP,John Leshko,15,6,1,1,23
+Schuylkill,Pottsville 1st,General Assembly,123,REP,Tim Twardzik,17,10,1,1,29
+Schuylkill,Pottsville 1st,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 2nd,Registered Voters,,,,,,,,689
+Schuylkill,Pottsville 2nd,Registered Voters,,DEM,,,,,,341
+Schuylkill,Pottsville 2nd,Registered Voters,,REP,,,,,,267
+Schuylkill,Pottsville 2nd,Registered Voters,,NPA,,,,,,81
+Schuylkill,Pottsville 2nd,Ballots Cast,,,,155,53,26,2,236
+Schuylkill,Pottsville 2nd,Ballots Cast,,DEM,,78,42,13,2,135
+Schuylkill,Pottsville 2nd,Ballots Cast,,REP,,77,11,13,0,101
+Schuylkill,Pottsville 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 2nd,President,,DEM,Bernie Sanders,16,5,3,0,24
+Schuylkill,Pottsville 2nd,President,,DEM,Joseph R. Biden,51,33,7,2,93
+Schuylkill,Pottsville 2nd,President,,DEM,Tulsi Gabbard,4,1,0,0,5
+Schuylkill,Pottsville 2nd,President,,DEM,Write-in,5,2,2,0,9
+Schuylkill,Pottsville 2nd,Attorney General,,DEM,Josh Shapiro,75,39,9,2,125
+Schuylkill,Pottsville 2nd,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 2nd,Auditor General,,DEM,H. Scott Conklin,3,5,1,0,9
+Schuylkill,Pottsville 2nd,Auditor General,,DEM,Michael Lamb,16,8,3,0,27
+Schuylkill,Pottsville 2nd,Auditor General,,DEM,Tracie Fountain,17,9,2,0,28
+Schuylkill,Pottsville 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,4,3,1,0,8
+Schuylkill,Pottsville 2nd,Auditor General,,DEM,Nina Ahmad,8,7,0,2,17
+Schuylkill,Pottsville 2nd,Auditor General,,DEM,Christina M. Hartman,25,7,3,0,35
+Schuylkill,Pottsville 2nd,Auditor General,,DEM,Write-in,0,0,1,0,1
+Schuylkill,Pottsville 2nd,State Treasurer,,DEM,Joe Torsella,72,41,8,2,123
+Schuylkill,Pottsville 2nd,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Schuylkill,Pottsville 2nd,Representative In Congress,,DEM,Laura Quick,28,14,6,2,50
+Schuylkill,Pottsville 2nd,Representative In Congress,,DEM,Gary Wegman,45,28,4,0,77
+Schuylkill,Pottsville 2nd,Representative In Congress,,DEM,Write-in,4,0,1,0,5
+Schuylkill,Pottsville 2nd,State Senate,29,DEM,Write-in,11,5,0,1,17
+Schuylkill,Pottsville 2nd,General Assembly,123,DEM,Peter PJ Symons Jr.,73,41,11,2,127
+Schuylkill,Pottsville 2nd,General Assembly,123,DEM,Write-in,2,1,0,0,3
+Schuylkill,Pottsville 2nd,President,,REP,Donald J. Trump,68,6,10,0,84
+Schuylkill,Pottsville 2nd,President,,REP,Roque Rocky De La Fuente,0,1,2,0,3
+Schuylkill,Pottsville 2nd,President,,REP,Bill Weld,0,3,1,0,4
+Schuylkill,Pottsville 2nd,President,,REP,Write-in,3,1,0,0,4
+Schuylkill,Pottsville 2nd,Attorney General,,REP,Heather Heidelbaugh,61,10,11,0,82
+Schuylkill,Pottsville 2nd,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 2nd,Auditor General,,REP,Timothy Defoor,58,10,12,0,80
+Schuylkill,Pottsville 2nd,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 2nd,State Treasurer,,REP,Stacy L. Garrity,59,10,13,0,82
+Schuylkill,Pottsville 2nd,State Treasurer,,REP,Write-in,2,0,0,0,2
+Schuylkill,Pottsville 2nd,Representative In Congress,,REP,Dan Meuser,64,11,10,0,85
+Schuylkill,Pottsville 2nd,Representative In Congress,,REP,Write-in,1,0,1,0,2
+Schuylkill,Pottsville 2nd,State Senate,29,REP,Dave Argall,68,10,12,0,90
+Schuylkill,Pottsville 2nd,State Senate,29,REP,Write-in,2,1,0,0,3
+Schuylkill,Pottsville 2nd,General Assembly,123,REP,John Leshko,35,4,7,0,46
+Schuylkill,Pottsville 2nd,General Assembly,123,REP,Tim Twardzik,31,7,5,0,43
+Schuylkill,Pottsville 2nd,General Assembly,123,REP,Write-in,3,0,0,0,3
+Schuylkill,Pottsville 3-2,Registered Voters,,,,,,,,322
+Schuylkill,Pottsville 3-2,Registered Voters,,DEM,,,,,,160
+Schuylkill,Pottsville 3-2,Registered Voters,,REP,,,,,,101
+Schuylkill,Pottsville 3-2,Registered Voters,,NPA,,,,,,61
+Schuylkill,Pottsville 3-2,Ballots Cast,,,,54,32,6,0,92
+Schuylkill,Pottsville 3-2,Ballots Cast,,DEM,,25,25,6,0,56
+Schuylkill,Pottsville 3-2,Ballots Cast,,REP,,29,7,0,0,36
+Schuylkill,Pottsville 3-2,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 3-2,President,,DEM,Bernie Sanders,5,3,2,0,10
+Schuylkill,Pottsville 3-2,President,,DEM,Joseph R. Biden,18,21,4,0,43
+Schuylkill,Pottsville 3-2,President,,DEM,Tulsi Gabbard,1,1,0,0,2
+Schuylkill,Pottsville 3-2,President,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 3-2,Attorney General,,DEM,Josh Shapiro,23,25,6,0,54
+Schuylkill,Pottsville 3-2,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-2,Auditor General,,DEM,H. Scott Conklin,1,5,1,0,7
+Schuylkill,Pottsville 3-2,Auditor General,,DEM,Michael Lamb,2,5,0,0,7
+Schuylkill,Pottsville 3-2,Auditor General,,DEM,Tracie Fountain,4,4,0,0,8
+Schuylkill,Pottsville 3-2,Auditor General,,DEM,Rose Rosie Marie Davis,3,0,1,0,4
+Schuylkill,Pottsville 3-2,Auditor General,,DEM,Nina Ahmad,5,6,4,0,15
+Schuylkill,Pottsville 3-2,Auditor General,,DEM,Christina M. Hartman,9,3,0,0,12
+Schuylkill,Pottsville 3-2,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-2,State Treasurer,,DEM,Joe Torsella,21,23,6,0,50
+Schuylkill,Pottsville 3-2,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-2,Representative In Congress,,DEM,Laura Quick,12,12,2,0,26
+Schuylkill,Pottsville 3-2,Representative In Congress,,DEM,Gary Wegman,12,13,4,0,29
+Schuylkill,Pottsville 3-2,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-2,State Senate,29,DEM,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 3-2,General Assembly,125,DEM,Write-in,3,8,0,0,11
+Schuylkill,Pottsville 3-2,President,,REP,Donald J. Trump,28,6,0,0,34
+Schuylkill,Pottsville 3-2,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,Pottsville 3-2,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Pottsville 3-2,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-2,Attorney General,,REP,Heather Heidelbaugh,23,6,0,0,29
+Schuylkill,Pottsville 3-2,Attorney General,,REP,Write-in,2,0,0,0,2
+Schuylkill,Pottsville 3-2,Auditor General,,REP,Timothy Defoor,23,6,0,0,29
+Schuylkill,Pottsville 3-2,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-2,State Treasurer,,REP,Stacy L. Garrity,24,6,0,0,30
+Schuylkill,Pottsville 3-2,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-2,Representative In Congress,,REP,Dan Meuser,26,5,0,0,31
+Schuylkill,Pottsville 3-2,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 3-2,State Senate,29,REP,Dave Argall,24,7,0,0,31
+Schuylkill,Pottsville 3-2,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 3-2,General Assembly,125,REP,Herv Breault,1,0,0,0,1
+Schuylkill,Pottsville 3-2,General Assembly,125,REP,Theresa Gaffney,5,1,0,0,6
+Schuylkill,Pottsville 3-2,General Assembly,125,REP,Christy Joy,13,4,0,0,17
+Schuylkill,Pottsville 3-2,General Assembly,125,REP,Joe Kerwin,10,2,0,0,12
+Schuylkill,Pottsville 3-2,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-1,Registered Voters,,,,,,,,655
+Schuylkill,Pottsville 3-1,Registered Voters,,DEM,,,,,,309
+Schuylkill,Pottsville 3-1,Registered Voters,,REP,,,,,,251
+Schuylkill,Pottsville 3-1,Registered Voters,,NPA,,,,,,95
+Schuylkill,Pottsville 3-1,Ballots Cast,,,,122,76,19,3,220
+Schuylkill,Pottsville 3-1,Ballots Cast,,DEM,,55,48,17,2,122
+Schuylkill,Pottsville 3-1,Ballots Cast,,REP,,67,28,2,1,98
+Schuylkill,Pottsville 3-1,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 3-1,President,,DEM,Bernie Sanders,13,3,8,0,24
+Schuylkill,Pottsville 3-1,President,,DEM,Joseph R. Biden,34,42,9,1,86
+Schuylkill,Pottsville 3-1,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Pottsville 3-1,President,,DEM,Write-in,2,2,0,1,5
+Schuylkill,Pottsville 3-1,Attorney General,,DEM,Josh Shapiro,47,44,17,2,110
+Schuylkill,Pottsville 3-1,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 3-1,Auditor General,,DEM,H. Scott Conklin,6,13,0,0,19
+Schuylkill,Pottsville 3-1,Auditor General,,DEM,Michael Lamb,12,2,3,0,17
+Schuylkill,Pottsville 3-1,Auditor General,,DEM,Tracie Fountain,6,9,4,0,19
+Schuylkill,Pottsville 3-1,Auditor General,,DEM,Rose Rosie Marie Davis,2,7,2,0,11
+Schuylkill,Pottsville 3-1,Auditor General,,DEM,Nina Ahmad,10,4,4,1,19
+Schuylkill,Pottsville 3-1,Auditor General,,DEM,Christina M. Hartman,17,7,4,1,29
+Schuylkill,Pottsville 3-1,Auditor General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 3-1,State Treasurer,,DEM,Joe Torsella,50,41,16,2,109
+Schuylkill,Pottsville 3-1,State Treasurer,,DEM,Write-in,1,0,1,0,2
+Schuylkill,Pottsville 3-1,Representative In Congress,,DEM,Laura Quick,27,20,5,2,54
+Schuylkill,Pottsville 3-1,Representative In Congress,,DEM,Gary Wegman,25,23,12,0,60
+Schuylkill,Pottsville 3-1,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 3-1,State Senate,29,DEM,Write-in,9,4,0,0,13
+Schuylkill,Pottsville 3-1,General Assembly,125,DEM,Write-in,11,5,1,0,17
+Schuylkill,Pottsville 3-1,President,,REP,Donald J. Trump,63,23,1,1,88
+Schuylkill,Pottsville 3-1,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Pottsville 3-1,President,,REP,Bill Weld,0,0,1,0,1
+Schuylkill,Pottsville 3-1,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 3-1,Attorney General,,REP,Heather Heidelbaugh,58,25,2,1,86
+Schuylkill,Pottsville 3-1,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-1,Auditor General,,REP,Timothy Defoor,59,24,2,0,85
+Schuylkill,Pottsville 3-1,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-1,State Treasurer,,REP,Stacy L. Garrity,59,25,1,0,85
+Schuylkill,Pottsville 3-1,State Treasurer,,REP,Write-in,0,0,1,0,1
+Schuylkill,Pottsville 3-1,Representative In Congress,,REP,Dan Meuser,62,25,2,1,90
+Schuylkill,Pottsville 3-1,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-1,State Senate,29,REP,Dave Argall,62,23,1,0,86
+Schuylkill,Pottsville 3-1,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-1,General Assembly,125,REP,Herv Breault,3,1,0,0,4
+Schuylkill,Pottsville 3-1,General Assembly,125,REP,Theresa Gaffney,23,8,0,1,32
+Schuylkill,Pottsville 3-1,General Assembly,125,REP,Christy Joy,21,17,2,0,40
+Schuylkill,Pottsville 3-1,General Assembly,125,REP,Joe Kerwin,20,2,0,0,22
+Schuylkill,Pottsville 3-1,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-3,Registered Voters,,,,,,,,356
+Schuylkill,Pottsville 3-3,Registered Voters,,DEM,,,,,,148
+Schuylkill,Pottsville 3-3,Registered Voters,,REP,,,,,,171
+Schuylkill,Pottsville 3-3,Registered Voters,,NPA,,,,,,37
+Schuylkill,Pottsville 3-3,Ballots Cast,,,,80,52,8,3,143
+Schuylkill,Pottsville 3-3,Ballots Cast,,DEM,,29,34,4,2,69
+Schuylkill,Pottsville 3-3,Ballots Cast,,REP,,51,18,4,1,74
+Schuylkill,Pottsville 3-3,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 3-3,President,,DEM,Bernie Sanders,4,4,1,0,9
+Schuylkill,Pottsville 3-3,President,,DEM,Joseph R. Biden,16,28,3,2,49
+Schuylkill,Pottsville 3-3,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Schuylkill,Pottsville 3-3,President,,DEM,Write-in,6,1,0,0,7
+Schuylkill,Pottsville 3-3,Attorney General,,DEM,Josh Shapiro,20,29,3,1,53
+Schuylkill,Pottsville 3-3,Attorney General,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 3-3,Auditor General,,DEM,H. Scott Conklin,2,6,0,0,8
+Schuylkill,Pottsville 3-3,Auditor General,,DEM,Michael Lamb,5,5,0,0,10
+Schuylkill,Pottsville 3-3,Auditor General,,DEM,Tracie Fountain,5,6,1,0,12
+Schuylkill,Pottsville 3-3,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,0,0,3
+Schuylkill,Pottsville 3-3,Auditor General,,DEM,Nina Ahmad,6,2,1,0,9
+Schuylkill,Pottsville 3-3,Auditor General,,DEM,Christina M. Hartman,5,7,1,2,15
+Schuylkill,Pottsville 3-3,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 3-3,State Treasurer,,DEM,Joe Torsella,20,27,2,1,50
+Schuylkill,Pottsville 3-3,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 3-3,Representative In Congress,,DEM,Laura Quick,7,7,2,1,17
+Schuylkill,Pottsville 3-3,Representative In Congress,,DEM,Gary Wegman,17,24,2,1,44
+Schuylkill,Pottsville 3-3,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 3-3,State Senate,29,DEM,Write-in,2,1,0,0,3
+Schuylkill,Pottsville 3-3,General Assembly,125,DEM,Write-in,5,2,0,0,7
+Schuylkill,Pottsville 3-3,President,,REP,Donald J. Trump,43,14,2,1,60
+Schuylkill,Pottsville 3-3,President,,REP,Roque Rocky De La Fuente,1,1,1,0,3
+Schuylkill,Pottsville 3-3,President,,REP,Bill Weld,3,3,0,0,6
+Schuylkill,Pottsville 3-3,President,,REP,Write-in,1,0,1,0,2
+Schuylkill,Pottsville 3-3,Attorney General,,REP,Heather Heidelbaugh,44,16,2,1,63
+Schuylkill,Pottsville 3-3,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-3,Auditor General,,REP,Timothy Defoor,43,14,2,1,60
+Schuylkill,Pottsville 3-3,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 3-3,State Treasurer,,REP,Stacy L. Garrity,45,15,2,1,63
+Schuylkill,Pottsville 3-3,State Treasurer,,REP,Write-in,0,0,1,0,1
+Schuylkill,Pottsville 3-3,Representative In Congress,,REP,Dan Meuser,46,13,2,1,62
+Schuylkill,Pottsville 3-3,Representative In Congress,,REP,Write-in,0,1,1,0,2
+Schuylkill,Pottsville 3-3,State Senate,29,REP,Dave Argall,49,14,1,1,65
+Schuylkill,Pottsville 3-3,State Senate,29,REP,Write-in,0,0,2,0,2
+Schuylkill,Pottsville 3-3,General Assembly,125,REP,Herv Breault,3,0,1,0,4
+Schuylkill,Pottsville 3-3,General Assembly,125,REP,Theresa Gaffney,12,6,0,0,18
+Schuylkill,Pottsville 3-3,General Assembly,125,REP,Christy Joy,24,11,3,1,39
+Schuylkill,Pottsville 3-3,General Assembly,125,REP,Joe Kerwin,12,1,0,0,13
+Schuylkill,Pottsville 3-3,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 4th,Registered Voters,,,,,,,,965
+Schuylkill,Pottsville 4th,Registered Voters,,DEM,,,,,,463
+Schuylkill,Pottsville 4th,Registered Voters,,REP,,,,,,313
+Schuylkill,Pottsville 4th,Registered Voters,,NPA,,,,,,189
+Schuylkill,Pottsville 4th,Ballots Cast,,,,160,73,22,2,257
+Schuylkill,Pottsville 4th,Ballots Cast,,DEM,,74,49,16,1,140
+Schuylkill,Pottsville 4th,Ballots Cast,,REP,,86,24,6,1,117
+Schuylkill,Pottsville 4th,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 4th,President,,DEM,Bernie Sanders,15,7,2,1,25
+Schuylkill,Pottsville 4th,President,,DEM,Joseph R. Biden,47,42,12,0,101
+Schuylkill,Pottsville 4th,President,,DEM,Tulsi Gabbard,4,0,0,0,4
+Schuylkill,Pottsville 4th,President,,DEM,Write-in,5,0,0,0,5
+Schuylkill,Pottsville 4th,Attorney General,,DEM,Josh Shapiro,61,44,16,1,122
+Schuylkill,Pottsville 4th,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Pottsville 4th,Auditor General,,DEM,H. Scott Conklin,12,4,4,0,20
+Schuylkill,Pottsville 4th,Auditor General,,DEM,Michael Lamb,9,10,0,0,19
+Schuylkill,Pottsville 4th,Auditor General,,DEM,Tracie Fountain,5,12,3,0,20
+Schuylkill,Pottsville 4th,Auditor General,,DEM,Rose Rosie Marie Davis,6,1,0,0,7
+Schuylkill,Pottsville 4th,Auditor General,,DEM,Nina Ahmad,16,10,3,0,29
+Schuylkill,Pottsville 4th,Auditor General,,DEM,Christina M. Hartman,18,9,5,1,33
+Schuylkill,Pottsville 4th,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 4th,State Treasurer,,DEM,Joe Torsella,59,43,14,1,117
+Schuylkill,Pottsville 4th,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 4th,Representative In Congress,,DEM,Laura Quick,30,20,8,0,58
+Schuylkill,Pottsville 4th,Representative In Congress,,DEM,Gary Wegman,35,28,8,1,72
+Schuylkill,Pottsville 4th,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 4th,State Senate,29,DEM,Write-in,8,6,2,0,16
+Schuylkill,Pottsville 4th,General Assembly,123,DEM,Peter PJ Symons Jr.,68,46,16,1,131
+Schuylkill,Pottsville 4th,General Assembly,123,DEM,Write-in,3,0,0,0,3
+Schuylkill,Pottsville 4th,President,,REP,Donald J. Trump,78,17,5,1,101
+Schuylkill,Pottsville 4th,President,,REP,Roque Rocky De La Fuente,4,1,0,0,5
+Schuylkill,Pottsville 4th,President,,REP,Bill Weld,1,5,0,0,6
+Schuylkill,Pottsville 4th,President,,REP,Write-in,3,1,1,0,5
+Schuylkill,Pottsville 4th,Attorney General,,REP,Heather Heidelbaugh,74,19,6,1,100
+Schuylkill,Pottsville 4th,Attorney General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 4th,Auditor General,,REP,Timothy Defoor,71,19,6,1,97
+Schuylkill,Pottsville 4th,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 4th,State Treasurer,,REP,Stacy L. Garrity,73,19,6,1,99
+Schuylkill,Pottsville 4th,State Treasurer,,REP,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 4th,Representative In Congress,,REP,Dan Meuser,74,18,6,1,99
+Schuylkill,Pottsville 4th,Representative In Congress,,REP,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 4th,State Senate,29,REP,Dave Argall,80,20,6,1,107
+Schuylkill,Pottsville 4th,State Senate,29,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 4th,General Assembly,123,REP,John Leshko,43,11,2,0,56
+Schuylkill,Pottsville 4th,General Assembly,123,REP,Tim Twardzik,41,9,4,1,55
+Schuylkill,Pottsville 4th,General Assembly,123,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 5-1,Registered Voters,,,,,,,,693
+Schuylkill,Pottsville 5-1,Registered Voters,,DEM,,,,,,345
+Schuylkill,Pottsville 5-1,Registered Voters,,REP,,,,,,218
+Schuylkill,Pottsville 5-1,Registered Voters,,NPA,,,,,,130
+Schuylkill,Pottsville 5-1,Ballots Cast,,,,86,41,9,0,136
+Schuylkill,Pottsville 5-1,Ballots Cast,,DEM,,38,29,9,0,76
+Schuylkill,Pottsville 5-1,Ballots Cast,,REP,,48,12,0,0,60
+Schuylkill,Pottsville 5-1,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 5-1,President,,DEM,Bernie Sanders,6,3,2,0,11
+Schuylkill,Pottsville 5-1,President,,DEM,Joseph R. Biden,25,23,5,0,53
+Schuylkill,Pottsville 5-1,President,,DEM,Tulsi Gabbard,4,1,2,0,7
+Schuylkill,Pottsville 5-1,President,,DEM,Write-in,2,2,0,0,4
+Schuylkill,Pottsville 5-1,Attorney General,,DEM,Josh Shapiro,35,27,9,0,71
+Schuylkill,Pottsville 5-1,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 5-1,Auditor General,,DEM,H. Scott Conklin,5,2,2,0,9
+Schuylkill,Pottsville 5-1,Auditor General,,DEM,Michael Lamb,6,5,0,0,11
+Schuylkill,Pottsville 5-1,Auditor General,,DEM,Tracie Fountain,7,7,0,0,14
+Schuylkill,Pottsville 5-1,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,0,3
+Schuylkill,Pottsville 5-1,Auditor General,,DEM,Nina Ahmad,6,2,3,0,11
+Schuylkill,Pottsville 5-1,Auditor General,,DEM,Christina M. Hartman,9,10,3,0,22
+Schuylkill,Pottsville 5-1,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 5-1,State Treasurer,,DEM,Joe Torsella,32,27,9,0,68
+Schuylkill,Pottsville 5-1,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 5-1,Representative In Congress,,DEM,Laura Quick,14,12,8,0,34
+Schuylkill,Pottsville 5-1,Representative In Congress,,DEM,Gary Wegman,23,15,1,0,39
+Schuylkill,Pottsville 5-1,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 5-1,State Senate,29,DEM,Write-in,10,3,0,0,13
+Schuylkill,Pottsville 5-1,General Assembly,123,DEM,Peter PJ Symons Jr.,35,27,9,0,71
+Schuylkill,Pottsville 5-1,General Assembly,123,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 5-1,President,,REP,Donald J. Trump,44,9,0,0,53
+Schuylkill,Pottsville 5-1,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,Pottsville 5-1,President,,REP,Bill Weld,1,0,0,0,1
+Schuylkill,Pottsville 5-1,President,,REP,Write-in,2,1,0,0,3
+Schuylkill,Pottsville 5-1,Attorney General,,REP,Heather Heidelbaugh,41,10,0,0,51
+Schuylkill,Pottsville 5-1,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 5-1,Auditor General,,REP,Timothy Defoor,41,10,0,0,51
+Schuylkill,Pottsville 5-1,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 5-1,State Treasurer,,REP,Stacy L. Garrity,41,10,0,0,51
+Schuylkill,Pottsville 5-1,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 5-1,Representative In Congress,,REP,Dan Meuser,42,11,0,0,53
+Schuylkill,Pottsville 5-1,Representative In Congress,,REP,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 5-1,State Senate,29,REP,Dave Argall,43,10,0,0,53
+Schuylkill,Pottsville 5-1,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 5-1,General Assembly,123,REP,John Leshko,26,6,0,0,32
+Schuylkill,Pottsville 5-1,General Assembly,123,REP,Tim Twardzik,22,5,0,0,27
+Schuylkill,Pottsville 5-1,General Assembly,123,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 5-2,Registered Voters,,,,,,,,723
+Schuylkill,Pottsville 5-2,Registered Voters,,DEM,,,,,,342
+Schuylkill,Pottsville 5-2,Registered Voters,,REP,,,,,,286
+Schuylkill,Pottsville 5-2,Registered Voters,,NPA,,,,,,95
+Schuylkill,Pottsville 5-2,Ballots Cast,,,,126,82,20,0,228
+Schuylkill,Pottsville 5-2,Ballots Cast,,DEM,,50,56,10,0,116
+Schuylkill,Pottsville 5-2,Ballots Cast,,REP,,76,26,10,0,112
+Schuylkill,Pottsville 5-2,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 5-2,President,,DEM,Bernie Sanders,12,8,3,0,23
+Schuylkill,Pottsville 5-2,President,,DEM,Joseph R. Biden,31,44,7,0,82
+Schuylkill,Pottsville 5-2,President,,DEM,Tulsi Gabbard,0,2,0,0,2
+Schuylkill,Pottsville 5-2,President,,DEM,Write-in,6,0,0,0,6
+Schuylkill,Pottsville 5-2,Attorney General,,DEM,Josh Shapiro,43,51,9,0,103
+Schuylkill,Pottsville 5-2,Attorney General,,DEM,Write-in,3,0,1,0,4
+Schuylkill,Pottsville 5-2,Auditor General,,DEM,H. Scott Conklin,5,4,0,0,9
+Schuylkill,Pottsville 5-2,Auditor General,,DEM,Michael Lamb,4,9,1,0,14
+Schuylkill,Pottsville 5-2,Auditor General,,DEM,Tracie Fountain,7,14,5,0,26
+Schuylkill,Pottsville 5-2,Auditor General,,DEM,Rose Rosie Marie Davis,4,5,2,0,11
+Schuylkill,Pottsville 5-2,Auditor General,,DEM,Nina Ahmad,11,6,0,0,17
+Schuylkill,Pottsville 5-2,Auditor General,,DEM,Christina M. Hartman,12,12,2,0,26
+Schuylkill,Pottsville 5-2,Auditor General,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Pottsville 5-2,State Treasurer,,DEM,Joe Torsella,44,49,8,0,101
+Schuylkill,Pottsville 5-2,State Treasurer,,DEM,Write-in,3,0,1,0,4
+Schuylkill,Pottsville 5-2,Representative In Congress,,DEM,Laura Quick,18,15,4,0,37
+Schuylkill,Pottsville 5-2,Representative In Congress,,DEM,Gary Wegman,26,35,5,0,66
+Schuylkill,Pottsville 5-2,Representative In Congress,,DEM,Write-in,2,0,1,0,3
+Schuylkill,Pottsville 5-2,State Senate,29,DEM,Write-in,13,4,6,0,23
+Schuylkill,Pottsville 5-2,General Assembly,123,DEM,Peter PJ Symons Jr.,45,51,8,0,104
+Schuylkill,Pottsville 5-2,General Assembly,123,DEM,Write-in,2,1,1,0,4
+Schuylkill,Pottsville 5-2,President,,REP,Donald J. Trump,72,18,9,0,99
+Schuylkill,Pottsville 5-2,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Schuylkill,Pottsville 5-2,President,,REP,Bill Weld,1,4,1,0,6
+Schuylkill,Pottsville 5-2,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 5-2,Attorney General,,REP,Heather Heidelbaugh,70,24,8,0,102
+Schuylkill,Pottsville 5-2,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 5-2,Auditor General,,REP,Timothy Defoor,68,23,7,0,98
+Schuylkill,Pottsville 5-2,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 5-2,State Treasurer,,REP,Stacy L. Garrity,71,24,7,0,102
+Schuylkill,Pottsville 5-2,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 5-2,Representative In Congress,,REP,Dan Meuser,71,23,9,0,103
+Schuylkill,Pottsville 5-2,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 5-2,State Senate,29,REP,Dave Argall,74,25,10,0,109
+Schuylkill,Pottsville 5-2,State Senate,29,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 5-2,General Assembly,123,REP,John Leshko,31,13,4,0,48
+Schuylkill,Pottsville 5-2,General Assembly,123,REP,Tim Twardzik,44,12,5,0,61
+Schuylkill,Pottsville 5-2,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 6th,Registered Voters,,,,,,,,703
+Schuylkill,Pottsville 6th,Registered Voters,,DEM,,,,,,332
+Schuylkill,Pottsville 6th,Registered Voters,,REP,,,,,,279
+Schuylkill,Pottsville 6th,Registered Voters,,NPA,,,,,,92
+Schuylkill,Pottsville 6th,Ballots Cast,,,,117,74,8,0,199
+Schuylkill,Pottsville 6th,Ballots Cast,,DEM,,52,41,7,0,100
+Schuylkill,Pottsville 6th,Ballots Cast,,REP,,65,33,1,0,99
+Schuylkill,Pottsville 6th,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 6th,President,,DEM,Bernie Sanders,13,1,3,0,17
+Schuylkill,Pottsville 6th,President,,DEM,Joseph R. Biden,30,39,3,0,72
+Schuylkill,Pottsville 6th,President,,DEM,Tulsi Gabbard,3,0,0,0,3
+Schuylkill,Pottsville 6th,President,,DEM,Write-in,5,1,1,0,7
+Schuylkill,Pottsville 6th,Attorney General,,DEM,Josh Shapiro,46,41,7,0,94
+Schuylkill,Pottsville 6th,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 6th,Auditor General,,DEM,H. Scott Conklin,10,3,1,0,14
+Schuylkill,Pottsville 6th,Auditor General,,DEM,Michael Lamb,6,7,1,0,14
+Schuylkill,Pottsville 6th,Auditor General,,DEM,Tracie Fountain,5,9,0,0,14
+Schuylkill,Pottsville 6th,Auditor General,,DEM,Rose Rosie Marie Davis,3,5,1,0,9
+Schuylkill,Pottsville 6th,Auditor General,,DEM,Nina Ahmad,7,2,2,0,11
+Schuylkill,Pottsville 6th,Auditor General,,DEM,Christina M. Hartman,17,12,2,0,31
+Schuylkill,Pottsville 6th,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 6th,State Treasurer,,DEM,Joe Torsella,41,40,6,0,87
+Schuylkill,Pottsville 6th,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 6th,Representative In Congress,,DEM,Laura Quick,21,18,6,0,45
+Schuylkill,Pottsville 6th,Representative In Congress,,DEM,Gary Wegman,25,23,1,0,49
+Schuylkill,Pottsville 6th,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Pottsville 6th,State Senate,29,DEM,Write-in,6,4,0,0,10
+Schuylkill,Pottsville 6th,General Assembly,123,DEM,Peter PJ Symons Jr.,46,41,5,0,92
+Schuylkill,Pottsville 6th,General Assembly,123,DEM,Write-in,2,0,0,0,2
+Schuylkill,Pottsville 6th,President,,REP,Donald J. Trump,64,25,1,0,90
+Schuylkill,Pottsville 6th,President,,REP,Roque Rocky De La Fuente,1,0,0,0,1
+Schuylkill,Pottsville 6th,President,,REP,Bill Weld,0,2,0,0,2
+Schuylkill,Pottsville 6th,President,,REP,Write-in,0,4,0,0,4
+Schuylkill,Pottsville 6th,Attorney General,,REP,Heather Heidelbaugh,60,29,1,0,90
+Schuylkill,Pottsville 6th,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 6th,Auditor General,,REP,Timothy Defoor,59,30,1,0,90
+Schuylkill,Pottsville 6th,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 6th,State Treasurer,,REP,Stacy L. Garrity,60,29,1,0,90
+Schuylkill,Pottsville 6th,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 6th,Representative In Congress,,REP,Dan Meuser,61,28,1,0,90
+Schuylkill,Pottsville 6th,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 6th,State Senate,29,REP,Dave Argall,63,30,1,0,94
+Schuylkill,Pottsville 6th,State Senate,29,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 6th,General Assembly,123,REP,John Leshko,37,10,1,0,48
+Schuylkill,Pottsville 6th,General Assembly,123,REP,Tim Twardzik,27,21,0,0,48
+Schuylkill,Pottsville 6th,General Assembly,123,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 7-1,Registered Voters,,,,,,,,1086
+Schuylkill,Pottsville 7-1,Registered Voters,,DEM,,,,,,527
+Schuylkill,Pottsville 7-1,Registered Voters,,REP,,,,,,450
+Schuylkill,Pottsville 7-1,Registered Voters,,NPA,,,,,,109
+Schuylkill,Pottsville 7-1,Ballots Cast,,,,224,158,36,6,424
+Schuylkill,Pottsville 7-1,Ballots Cast,,DEM,,102,93,27,3,225
+Schuylkill,Pottsville 7-1,Ballots Cast,,REP,,122,65,9,3,199
+Schuylkill,Pottsville 7-1,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 7-1,President,,DEM,Bernie Sanders,16,11,3,1,31
+Schuylkill,Pottsville 7-1,President,,DEM,Joseph R. Biden,63,78,20,2,163
+Schuylkill,Pottsville 7-1,President,,DEM,Tulsi Gabbard,15,2,4,0,21
+Schuylkill,Pottsville 7-1,President,,DEM,Write-in,4,2,0,0,6
+Schuylkill,Pottsville 7-1,Attorney General,,DEM,Josh Shapiro,92,83,23,3,201
+Schuylkill,Pottsville 7-1,Attorney General,,DEM,Write-in,0,2,0,0,2
+Schuylkill,Pottsville 7-1,Auditor General,,DEM,H. Scott Conklin,19,12,4,0,35
+Schuylkill,Pottsville 7-1,Auditor General,,DEM,Michael Lamb,17,20,8,0,45
+Schuylkill,Pottsville 7-1,Auditor General,,DEM,Tracie Fountain,24,12,6,1,43
+Schuylkill,Pottsville 7-1,Auditor General,,DEM,Rose Rosie Marie Davis,1,3,1,0,5
+Schuylkill,Pottsville 7-1,Auditor General,,DEM,Nina Ahmad,16,15,1,2,34
+Schuylkill,Pottsville 7-1,Auditor General,,DEM,Christina M. Hartman,21,23,5,0,49
+Schuylkill,Pottsville 7-1,Auditor General,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 7-1,State Treasurer,,DEM,Joe Torsella,95,79,22,3,199
+Schuylkill,Pottsville 7-1,State Treasurer,,DEM,Write-in,1,2,0,0,3
+Schuylkill,Pottsville 7-1,Representative In Congress,,DEM,Laura Quick,39,25,6,2,72
+Schuylkill,Pottsville 7-1,Representative In Congress,,DEM,Gary Wegman,61,61,19,1,142
+Schuylkill,Pottsville 7-1,Representative In Congress,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 7-1,State Senate,29,DEM,Write-in,8,10,4,0,22
+Schuylkill,Pottsville 7-1,General Assembly,125,DEM,Write-in,14,9,5,0,28
+Schuylkill,Pottsville 7-1,President,,REP,Donald J. Trump,103,47,8,3,161
+Schuylkill,Pottsville 7-1,President,,REP,Roque Rocky De La Fuente,2,4,0,0,6
+Schuylkill,Pottsville 7-1,President,,REP,Bill Weld,6,4,0,0,10
+Schuylkill,Pottsville 7-1,President,,REP,Write-in,6,3,0,0,9
+Schuylkill,Pottsville 7-1,Attorney General,,REP,Heather Heidelbaugh,110,53,6,3,172
+Schuylkill,Pottsville 7-1,Attorney General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 7-1,Auditor General,,REP,Timothy Defoor,111,52,7,3,173
+Schuylkill,Pottsville 7-1,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 7-1,State Treasurer,,REP,Stacy L. Garrity,113,53,6,3,175
+Schuylkill,Pottsville 7-1,State Treasurer,,REP,Write-in,1,1,0,0,2
+Schuylkill,Pottsville 7-1,Representative In Congress,,REP,Dan Meuser,117,55,6,3,181
+Schuylkill,Pottsville 7-1,Representative In Congress,,REP,Write-in,2,1,0,0,3
+Schuylkill,Pottsville 7-1,State Senate,29,REP,Dave Argall,111,60,6,3,180
+Schuylkill,Pottsville 7-1,State Senate,29,REP,Write-in,2,0,1,0,3
+Schuylkill,Pottsville 7-1,General Assembly,125,REP,Herv Breault,2,3,0,0,5
+Schuylkill,Pottsville 7-1,General Assembly,125,REP,Theresa Gaffney,32,18,1,1,52
+Schuylkill,Pottsville 7-1,General Assembly,125,REP,Christy Joy,70,32,6,1,109
+Schuylkill,Pottsville 7-1,General Assembly,125,REP,Joe Kerwin,18,11,1,1,31
+Schuylkill,Pottsville 7-1,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 7-2,Registered Voters,,,,,,,,1088
+Schuylkill,Pottsville 7-2,Registered Voters,,DEM,,,,,,556
+Schuylkill,Pottsville 7-2,Registered Voters,,REP,,,,,,427
+Schuylkill,Pottsville 7-2,Registered Voters,,NPA,,,,,,105
+Schuylkill,Pottsville 7-2,Ballots Cast,,,,218,190,30,1,439
+Schuylkill,Pottsville 7-2,Ballots Cast,,DEM,,121,107,22,0,250
+Schuylkill,Pottsville 7-2,Ballots Cast,,REP,,97,83,8,1,189
+Schuylkill,Pottsville 7-2,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Pottsville 7-2,President,,DEM,Bernie Sanders,20,10,3,0,33
+Schuylkill,Pottsville 7-2,President,,DEM,Joseph R. Biden,76,88,18,0,182
+Schuylkill,Pottsville 7-2,President,,DEM,Tulsi Gabbard,10,2,0,0,12
+Schuylkill,Pottsville 7-2,President,,DEM,Write-in,11,3,0,0,14
+Schuylkill,Pottsville 7-2,Attorney General,,DEM,Josh Shapiro,104,93,20,0,217
+Schuylkill,Pottsville 7-2,Attorney General,,DEM,Write-in,5,1,0,0,6
+Schuylkill,Pottsville 7-2,Auditor General,,DEM,H. Scott Conklin,6,6,3,0,15
+Schuylkill,Pottsville 7-2,Auditor General,,DEM,Michael Lamb,33,23,10,0,66
+Schuylkill,Pottsville 7-2,Auditor General,,DEM,Tracie Fountain,13,20,6,0,39
+Schuylkill,Pottsville 7-2,Auditor General,,DEM,Rose Rosie Marie Davis,6,4,1,0,11
+Schuylkill,Pottsville 7-2,Auditor General,,DEM,Nina Ahmad,18,13,0,0,31
+Schuylkill,Pottsville 7-2,Auditor General,,DEM,Christina M. Hartman,31,27,0,0,58
+Schuylkill,Pottsville 7-2,Auditor General,,DEM,Write-in,4,1,0,0,5
+Schuylkill,Pottsville 7-2,State Treasurer,,DEM,Joe Torsella,104,85,19,0,208
+Schuylkill,Pottsville 7-2,State Treasurer,,DEM,Write-in,5,1,0,0,6
+Schuylkill,Pottsville 7-2,Representative In Congress,,DEM,Laura Quick,28,29,3,0,60
+Schuylkill,Pottsville 7-2,Representative In Congress,,DEM,Gary Wegman,81,68,17,0,166
+Schuylkill,Pottsville 7-2,Representative In Congress,,DEM,Write-in,5,1,1,0,7
+Schuylkill,Pottsville 7-2,State Senate,29,DEM,Write-in,16,10,4,0,30
+Schuylkill,Pottsville 7-2,General Assembly,125,DEM,Write-in,25,16,6,0,47
+Schuylkill,Pottsville 7-2,President,,REP,Donald J. Trump,92,59,4,1,156
+Schuylkill,Pottsville 7-2,President,,REP,Roque Rocky De La Fuente,2,2,1,0,5
+Schuylkill,Pottsville 7-2,President,,REP,Bill Weld,1,9,2,0,12
+Schuylkill,Pottsville 7-2,President,,REP,Write-in,1,5,1,0,7
+Schuylkill,Pottsville 7-2,Attorney General,,REP,Heather Heidelbaugh,87,64,7,1,159
+Schuylkill,Pottsville 7-2,Attorney General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 7-2,Auditor General,,REP,Timothy Defoor,85,64,7,1,157
+Schuylkill,Pottsville 7-2,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Pottsville 7-2,State Treasurer,,REP,Stacy L. Garrity,88,65,7,1,161
+Schuylkill,Pottsville 7-2,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Pottsville 7-2,Representative In Congress,,REP,Dan Meuser,94,71,7,1,173
+Schuylkill,Pottsville 7-2,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Pottsville 7-2,State Senate,29,REP,Dave Argall,89,73,7,1,170
+Schuylkill,Pottsville 7-2,State Senate,29,REP,Write-in,1,2,0,0,3
+Schuylkill,Pottsville 7-2,General Assembly,125,REP,Herv Breault,4,3,1,0,8
+Schuylkill,Pottsville 7-2,General Assembly,125,REP,Theresa Gaffney,21,13,0,0,34
+Schuylkill,Pottsville 7-2,General Assembly,125,REP,Christy Joy,54,43,4,0,101
+Schuylkill,Pottsville 7-2,General Assembly,125,REP,Joe Kerwin,18,20,3,1,42
+Schuylkill,Pottsville 7-2,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven North,Registered Voters,,,,,,,,717
+Schuylkill,Schuylkill Haven North,Registered Voters,,DEM,,,,,,266
+Schuylkill,Schuylkill Haven North,Registered Voters,,REP,,,,,,345
+Schuylkill,Schuylkill Haven North,Registered Voters,,NPA,,,,,,106
+Schuylkill,Schuylkill Haven North,Ballots Cast,,,,131,67,5,3,206
+Schuylkill,Schuylkill Haven North,Ballots Cast,,DEM,,42,36,2,0,80
+Schuylkill,Schuylkill Haven North,Ballots Cast,,REP,,89,31,3,3,126
+Schuylkill,Schuylkill Haven North,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Schuylkill Haven North,President,,DEM,Bernie Sanders,9,9,0,0,18
+Schuylkill,Schuylkill Haven North,President,,DEM,Joseph R. Biden,24,25,2,0,51
+Schuylkill,Schuylkill Haven North,President,,DEM,Tulsi Gabbard,5,0,0,0,5
+Schuylkill,Schuylkill Haven North,President,,DEM,Write-in,2,1,0,0,3
+Schuylkill,Schuylkill Haven North,Attorney General,,DEM,Josh Shapiro,34,34,2,0,70
+Schuylkill,Schuylkill Haven North,Attorney General,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Schuylkill Haven North,Auditor General,,DEM,H. Scott Conklin,1,1,0,0,2
+Schuylkill,Schuylkill Haven North,Auditor General,,DEM,Michael Lamb,7,4,1,0,12
+Schuylkill,Schuylkill Haven North,Auditor General,,DEM,Tracie Fountain,5,7,0,0,12
+Schuylkill,Schuylkill Haven North,Auditor General,,DEM,Rose Rosie Marie Davis,2,4,0,0,6
+Schuylkill,Schuylkill Haven North,Auditor General,,DEM,Nina Ahmad,8,8,0,0,16
+Schuylkill,Schuylkill Haven North,Auditor General,,DEM,Christina M. Hartman,14,11,1,0,26
+Schuylkill,Schuylkill Haven North,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven North,State Treasurer,,DEM,Joe Torsella,34,34,2,0,70
+Schuylkill,Schuylkill Haven North,State Treasurer,,DEM,Write-in,0,1,0,0,1
+Schuylkill,Schuylkill Haven North,Representative In Congress,,DEM,Laura Quick,20,17,0,0,37
+Schuylkill,Schuylkill Haven North,Representative In Congress,,DEM,Gary Wegman,20,18,2,0,40
+Schuylkill,Schuylkill Haven North,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven North,State Senate,29,DEM,Write-in,3,3,1,0,7
+Schuylkill,Schuylkill Haven North,General Assembly,125,DEM,Write-in,3,4,0,0,7
+Schuylkill,Schuylkill Haven North,President,,REP,Donald J. Trump,82,22,2,3,109
+Schuylkill,Schuylkill Haven North,President,,REP,Roque Rocky De La Fuente,2,1,0,0,3
+Schuylkill,Schuylkill Haven North,President,,REP,Bill Weld,4,3,0,0,7
+Schuylkill,Schuylkill Haven North,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,Schuylkill Haven North,Attorney General,,REP,Heather Heidelbaugh,79,30,3,3,115
+Schuylkill,Schuylkill Haven North,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven North,Auditor General,,REP,Timothy Defoor,78,27,3,3,111
+Schuylkill,Schuylkill Haven North,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Schuylkill Haven North,State Treasurer,,REP,Stacy L. Garrity,79,28,3,3,113
+Schuylkill,Schuylkill Haven North,State Treasurer,,REP,Write-in,1,1,0,0,2
+Schuylkill,Schuylkill Haven North,Representative In Congress,,REP,Dan Meuser,81,28,3,3,115
+Schuylkill,Schuylkill Haven North,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven North,State Senate,29,REP,Dave Argall,83,30,3,3,119
+Schuylkill,Schuylkill Haven North,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven North,General Assembly,125,REP,Herv Breault,9,0,1,0,10
+Schuylkill,Schuylkill Haven North,General Assembly,125,REP,Theresa Gaffney,31,11,0,0,42
+Schuylkill,Schuylkill Haven North,General Assembly,125,REP,Christy Joy,35,19,2,1,57
+Schuylkill,Schuylkill Haven North,General Assembly,125,REP,Joe Kerwin,14,1,0,2,17
+Schuylkill,Schuylkill Haven North,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven East,Registered Voters,,,,,,,,931
+Schuylkill,Schuylkill Haven East,Registered Voters,,DEM,,,,,,283
+Schuylkill,Schuylkill Haven East,Registered Voters,,REP,,,,,,503
+Schuylkill,Schuylkill Haven East,Registered Voters,,NPA,,,,,,145
+Schuylkill,Schuylkill Haven East,Ballots Cast,,,,237,70,16,0,323
+Schuylkill,Schuylkill Haven East,Ballots Cast,,DEM,,62,32,12,0,106
+Schuylkill,Schuylkill Haven East,Ballots Cast,,REP,,175,38,4,0,217
+Schuylkill,Schuylkill Haven East,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Schuylkill Haven East,President,,DEM,Bernie Sanders,14,5,4,0,23
+Schuylkill,Schuylkill Haven East,President,,DEM,Joseph R. Biden,37,24,7,0,68
+Schuylkill,Schuylkill Haven East,President,,DEM,Tulsi Gabbard,2,0,0,0,2
+Schuylkill,Schuylkill Haven East,President,,DEM,Write-in,6,3,1,0,10
+Schuylkill,Schuylkill Haven East,Attorney General,,DEM,Josh Shapiro,53,32,10,0,95
+Schuylkill,Schuylkill Haven East,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Schuylkill Haven East,Auditor General,,DEM,H. Scott Conklin,5,1,1,0,7
+Schuylkill,Schuylkill Haven East,Auditor General,,DEM,Michael Lamb,10,3,0,0,13
+Schuylkill,Schuylkill Haven East,Auditor General,,DEM,Tracie Fountain,9,3,3,0,15
+Schuylkill,Schuylkill Haven East,Auditor General,,DEM,Rose Rosie Marie Davis,1,2,0,0,3
+Schuylkill,Schuylkill Haven East,Auditor General,,DEM,Nina Ahmad,12,6,6,0,24
+Schuylkill,Schuylkill Haven East,Auditor General,,DEM,Christina M. Hartman,17,15,2,0,34
+Schuylkill,Schuylkill Haven East,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Schuylkill Haven East,State Treasurer,,DEM,Joe Torsella,50,29,10,0,89
+Schuylkill,Schuylkill Haven East,State Treasurer,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Schuylkill Haven East,Representative In Congress,,DEM,Laura Quick,24,14,9,0,47
+Schuylkill,Schuylkill Haven East,Representative In Congress,,DEM,Gary Wegman,32,18,3,0,53
+Schuylkill,Schuylkill Haven East,Representative In Congress,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Schuylkill Haven East,State Senate,29,DEM,Write-in,2,6,0,0,8
+Schuylkill,Schuylkill Haven East,General Assembly,125,DEM,Write-in,5,6,0,0,11
+Schuylkill,Schuylkill Haven East,President,,REP,Donald J. Trump,164,32,3,0,199
+Schuylkill,Schuylkill Haven East,President,,REP,Roque Rocky De La Fuente,4,0,0,0,4
+Schuylkill,Schuylkill Haven East,President,,REP,Bill Weld,1,2,0,0,3
+Schuylkill,Schuylkill Haven East,President,,REP,Write-in,2,2,1,0,5
+Schuylkill,Schuylkill Haven East,Attorney General,,REP,Heather Heidelbaugh,156,35,4,0,195
+Schuylkill,Schuylkill Haven East,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Haven East,Auditor General,,REP,Timothy Defoor,160,35,4,0,199
+Schuylkill,Schuylkill Haven East,Auditor General,,REP,Write-in,0,1,0,0,1
+Schuylkill,Schuylkill Haven East,State Treasurer,,REP,Stacy L. Garrity,161,36,4,0,201
+Schuylkill,Schuylkill Haven East,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven East,Representative In Congress,,REP,Dan Meuser,162,37,3,0,202
+Schuylkill,Schuylkill Haven East,Representative In Congress,,REP,Write-in,0,0,1,0,1
+Schuylkill,Schuylkill Haven East,State Senate,29,REP,Dave Argall,165,37,3,0,205
+Schuylkill,Schuylkill Haven East,State Senate,29,REP,Write-in,3,0,0,0,3
+Schuylkill,Schuylkill Haven East,General Assembly,125,REP,Herv Breault,5,3,0,0,8
+Schuylkill,Schuylkill Haven East,General Assembly,125,REP,Theresa Gaffney,72,11,1,0,84
+Schuylkill,Schuylkill Haven East,General Assembly,125,REP,Christy Joy,53,18,1,0,72
+Schuylkill,Schuylkill Haven East,General Assembly,125,REP,Joe Kerwin,42,6,2,0,50
+Schuylkill,Schuylkill Haven East,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven South,Registered Voters,,,,,,,,874
+Schuylkill,Schuylkill Haven South,Registered Voters,,DEM,,,,,,294
+Schuylkill,Schuylkill Haven South,Registered Voters,,REP,,,,,,439
+Schuylkill,Schuylkill Haven South,Registered Voters,,NPA,,,,,,141
+Schuylkill,Schuylkill Haven South,Ballots Cast,,,,174,76,11,6,267
+Schuylkill,Schuylkill Haven South,Ballots Cast,,DEM,,47,39,4,2,92
+Schuylkill,Schuylkill Haven South,Ballots Cast,,REP,,127,37,7,4,175
+Schuylkill,Schuylkill Haven South,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Schuylkill Haven South,President,,DEM,Bernie Sanders,11,6,1,0,18
+Schuylkill,Schuylkill Haven South,President,,DEM,Joseph R. Biden,21,29,3,1,54
+Schuylkill,Schuylkill Haven South,President,,DEM,Tulsi Gabbard,5,0,0,0,5
+Schuylkill,Schuylkill Haven South,President,,DEM,Write-in,7,2,0,0,9
+Schuylkill,Schuylkill Haven South,Attorney General,,DEM,Josh Shapiro,38,34,4,2,78
+Schuylkill,Schuylkill Haven South,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Schuylkill Haven South,Auditor General,,DEM,H. Scott Conklin,2,4,0,0,6
+Schuylkill,Schuylkill Haven South,Auditor General,,DEM,Michael Lamb,4,7,0,0,11
+Schuylkill,Schuylkill Haven South,Auditor General,,DEM,Tracie Fountain,8,7,0,0,15
+Schuylkill,Schuylkill Haven South,Auditor General,,DEM,Rose Rosie Marie Davis,3,2,0,0,5
+Schuylkill,Schuylkill Haven South,Auditor General,,DEM,Nina Ahmad,9,4,2,0,15
+Schuylkill,Schuylkill Haven South,Auditor General,,DEM,Christina M. Hartman,14,10,2,1,27
+Schuylkill,Schuylkill Haven South,Auditor General,,DEM,Write-in,2,2,0,0,4
+Schuylkill,Schuylkill Haven South,State Treasurer,,DEM,Joe Torsella,36,31,4,1,72
+Schuylkill,Schuylkill Haven South,State Treasurer,,DEM,Write-in,2,1,0,0,3
+Schuylkill,Schuylkill Haven South,Representative In Congress,,DEM,Laura Quick,19,18,2,1,40
+Schuylkill,Schuylkill Haven South,Representative In Congress,,DEM,Gary Wegman,20,19,2,1,42
+Schuylkill,Schuylkill Haven South,Representative In Congress,,DEM,Write-in,4,1,0,0,5
+Schuylkill,Schuylkill Haven South,State Senate,29,DEM,Write-in,6,4,0,0,10
+Schuylkill,Schuylkill Haven South,General Assembly,125,DEM,Write-in,8,3,0,1,12
+Schuylkill,Schuylkill Haven South,President,,REP,Donald J. Trump,121,25,7,4,157
+Schuylkill,Schuylkill Haven South,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Schuylkill,Schuylkill Haven South,President,,REP,Bill Weld,3,4,0,0,7
+Schuylkill,Schuylkill Haven South,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,Schuylkill Haven South,Attorney General,,REP,Heather Heidelbaugh,114,32,6,3,155
+Schuylkill,Schuylkill Haven South,Attorney General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Haven South,Auditor General,,REP,Timothy Defoor,113,32,5,4,154
+Schuylkill,Schuylkill Haven South,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Haven South,State Treasurer,,REP,Stacy L. Garrity,113,33,5,4,155
+Schuylkill,Schuylkill Haven South,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Haven South,Representative In Congress,,REP,Dan Meuser,116,31,6,4,157
+Schuylkill,Schuylkill Haven South,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven South,State Senate,29,REP,Dave Argall,121,33,6,3,163
+Schuylkill,Schuylkill Haven South,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven South,General Assembly,125,REP,Herv Breault,4,3,1,0,8
+Schuylkill,Schuylkill Haven South,General Assembly,125,REP,Theresa Gaffney,49,11,1,1,62
+Schuylkill,Schuylkill Haven South,General Assembly,125,REP,Christy Joy,48,16,4,2,70
+Schuylkill,Schuylkill Haven South,General Assembly,125,REP,Joe Kerwin,19,7,1,1,28
+Schuylkill,Schuylkill Haven South,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,Registered Voters,,,,,,,,757
+Schuylkill,Schuylkill Haven West,Registered Voters,,DEM,,,,,,236
+Schuylkill,Schuylkill Haven West,Registered Voters,,REP,,,,,,439
+Schuylkill,Schuylkill Haven West,Registered Voters,,NPA,,,,,,82
+Schuylkill,Schuylkill Haven West,Ballots Cast,,,,245,79,8,2,334
+Schuylkill,Schuylkill Haven West,Ballots Cast,,DEM,,61,36,5,0,102
+Schuylkill,Schuylkill Haven West,Ballots Cast,,REP,,184,43,3,2,232
+Schuylkill,Schuylkill Haven West,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,President,,DEM,Bernie Sanders,5,7,1,0,13
+Schuylkill,Schuylkill Haven West,President,,DEM,Joseph R. Biden,37,28,4,0,69
+Schuylkill,Schuylkill Haven West,President,,DEM,Tulsi Gabbard,9,1,0,0,10
+Schuylkill,Schuylkill Haven West,President,,DEM,Write-in,6,0,0,0,6
+Schuylkill,Schuylkill Haven West,Attorney General,,DEM,Josh Shapiro,52,31,5,0,88
+Schuylkill,Schuylkill Haven West,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,Auditor General,,DEM,H. Scott Conklin,8,0,0,0,8
+Schuylkill,Schuylkill Haven West,Auditor General,,DEM,Michael Lamb,4,7,2,0,13
+Schuylkill,Schuylkill Haven West,Auditor General,,DEM,Tracie Fountain,6,5,0,0,11
+Schuylkill,Schuylkill Haven West,Auditor General,,DEM,Rose Rosie Marie Davis,4,1,0,0,5
+Schuylkill,Schuylkill Haven West,Auditor General,,DEM,Nina Ahmad,12,4,2,0,18
+Schuylkill,Schuylkill Haven West,Auditor General,,DEM,Christina M. Hartman,15,13,1,0,29
+Schuylkill,Schuylkill Haven West,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,State Treasurer,,DEM,Joe Torsella,43,27,4,0,74
+Schuylkill,Schuylkill Haven West,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,Representative In Congress,,DEM,Laura Quick,24,15,2,0,41
+Schuylkill,Schuylkill Haven West,Representative In Congress,,DEM,Gary Wegman,30,17,3,0,50
+Schuylkill,Schuylkill Haven West,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Schuylkill Haven West,State Senate,29,DEM,Write-in,7,5,0,0,12
+Schuylkill,Schuylkill Haven West,General Assembly,125,DEM,Write-in,14,6,0,0,20
+Schuylkill,Schuylkill Haven West,President,,REP,Donald J. Trump,175,36,3,2,216
+Schuylkill,Schuylkill Haven West,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Schuylkill Haven West,President,,REP,Bill Weld,6,4,0,0,10
+Schuylkill,Schuylkill Haven West,President,,REP,Write-in,0,1,0,0,1
+Schuylkill,Schuylkill Haven West,Attorney General,,REP,Heather Heidelbaugh,163,38,3,2,206
+Schuylkill,Schuylkill Haven West,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,Auditor General,,REP,Timothy Defoor,167,38,3,2,210
+Schuylkill,Schuylkill Haven West,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,State Treasurer,,REP,Stacy L. Garrity,171,37,3,2,213
+Schuylkill,Schuylkill Haven West,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,Representative In Congress,,REP,Dan Meuser,168,41,3,2,214
+Schuylkill,Schuylkill Haven West,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,State Senate,29,REP,Dave Argall,174,41,3,2,220
+Schuylkill,Schuylkill Haven West,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Schuylkill Haven West,General Assembly,125,REP,Herv Breault,10,3,0,0,13
+Schuylkill,Schuylkill Haven West,General Assembly,125,REP,Theresa Gaffney,55,17,0,0,72
+Schuylkill,Schuylkill Haven West,General Assembly,125,REP,Christy Joy,56,16,2,1,75
+Schuylkill,Schuylkill Haven West,General Assembly,125,REP,Joe Kerwin,62,5,1,1,69
+Schuylkill,Schuylkill Haven West,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,South Manheim Twp,Registered Voters,,,,,,,,1884
+Schuylkill,South Manheim Twp,Registered Voters,,DEM,,,,,,453
+Schuylkill,South Manheim Twp,Registered Voters,,REP,,,,,,1173
+Schuylkill,South Manheim Twp,Registered Voters,,NPA,,,,,,258
+Schuylkill,South Manheim Twp,Ballots Cast,,,,420,215,64,6,705
+Schuylkill,South Manheim Twp,Ballots Cast,,DEM,,51,98,28,2,179
+Schuylkill,South Manheim Twp,Ballots Cast,,REP,,369,117,36,4,526
+Schuylkill,South Manheim Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,South Manheim Twp,President,,DEM,Bernie Sanders,5,11,2,0,18
+Schuylkill,South Manheim Twp,President,,DEM,Joseph R. Biden,29,79,26,1,135
+Schuylkill,South Manheim Twp,President,,DEM,Tulsi Gabbard,6,3,0,1,10
+Schuylkill,South Manheim Twp,President,,DEM,Write-in,6,5,0,0,11
+Schuylkill,South Manheim Twp,Attorney General,,DEM,Josh Shapiro,40,92,23,2,157
+Schuylkill,South Manheim Twp,Attorney General,,DEM,Write-in,2,1,0,0,3
+Schuylkill,South Manheim Twp,Auditor General,,DEM,H. Scott Conklin,5,8,1,0,14
+Schuylkill,South Manheim Twp,Auditor General,,DEM,Michael Lamb,7,10,3,1,21
+Schuylkill,South Manheim Twp,Auditor General,,DEM,Tracie Fountain,7,25,7,0,39
+Schuylkill,South Manheim Twp,Auditor General,,DEM,Rose Rosie Marie Davis,6,3,0,0,9
+Schuylkill,South Manheim Twp,Auditor General,,DEM,Nina Ahmad,8,15,4,0,27
+Schuylkill,South Manheim Twp,Auditor General,,DEM,Christina M. Hartman,10,30,8,1,49
+Schuylkill,South Manheim Twp,Auditor General,,DEM,Write-in,2,1,0,0,3
+Schuylkill,South Manheim Twp,State Treasurer,,DEM,Joe Torsella,36,92,25,2,155
+Schuylkill,South Manheim Twp,State Treasurer,,DEM,Write-in,2,1,0,0,3
+Schuylkill,South Manheim Twp,Representative In Congress,,DEM,Laura Quick,14,46,4,2,66
+Schuylkill,South Manheim Twp,Representative In Congress,,DEM,Gary Wegman,28,46,20,0,94
+Schuylkill,South Manheim Twp,Representative In Congress,,DEM,Write-in,4,1,0,0,5
+Schuylkill,South Manheim Twp,State Senate,29,DEM,Write-in,5,4,0,0,9
+Schuylkill,South Manheim Twp,General Assembly,125,DEM,Write-in,7,11,0,0,18
+Schuylkill,South Manheim Twp,President,,REP,Donald J. Trump,353,91,33,4,481
+Schuylkill,South Manheim Twp,President,,REP,Roque Rocky De La Fuente,0,3,1,0,4
+Schuylkill,South Manheim Twp,President,,REP,Bill Weld,8,13,1,0,22
+Schuylkill,South Manheim Twp,President,,REP,Write-in,4,5,1,0,10
+Schuylkill,South Manheim Twp,Attorney General,,REP,Heather Heidelbaugh,327,98,31,4,460
+Schuylkill,South Manheim Twp,Attorney General,,REP,Write-in,1,1,0,0,2
+Schuylkill,South Manheim Twp,Auditor General,,REP,Timothy Defoor,322,95,31,4,452
+Schuylkill,South Manheim Twp,Auditor General,,REP,Write-in,1,1,0,0,2
+Schuylkill,South Manheim Twp,State Treasurer,,REP,Stacy L. Garrity,328,97,31,4,460
+Schuylkill,South Manheim Twp,State Treasurer,,REP,Write-in,2,2,0,0,4
+Schuylkill,South Manheim Twp,Representative In Congress,,REP,Dan Meuser,341,101,32,3,477
+Schuylkill,South Manheim Twp,Representative In Congress,,REP,Write-in,1,1,0,0,2
+Schuylkill,South Manheim Twp,State Senate,29,REP,Dave Argall,352,104,33,3,492
+Schuylkill,South Manheim Twp,State Senate,29,REP,Write-in,1,1,0,0,2
+Schuylkill,South Manheim Twp,General Assembly,125,REP,Herv Breault,43,16,4,0,63
+Schuylkill,South Manheim Twp,General Assembly,125,REP,Theresa Gaffney,81,28,3,0,112
+Schuylkill,South Manheim Twp,General Assembly,125,REP,Christy Joy,135,53,27,1,216
+Schuylkill,South Manheim Twp,General Assembly,125,REP,Joe Kerwin,107,17,1,2,127
+Schuylkill,South Manheim Twp,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Tower City,Registered Voters,,,,,,,,717
+Schuylkill,Tower City,Registered Voters,,DEM,,,,,,157
+Schuylkill,Tower City,Registered Voters,,REP,,,,,,473
+Schuylkill,Tower City,Registered Voters,,NPA,,,,,,87
+Schuylkill,Tower City,Ballots Cast,,,,195,68,7,0,270
+Schuylkill,Tower City,Ballots Cast,,DEM,,21,26,4,0,51
+Schuylkill,Tower City,Ballots Cast,,REP,,174,42,3,0,219
+Schuylkill,Tower City,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Tower City,President,,DEM,Bernie Sanders,2,3,1,0,6
+Schuylkill,Tower City,President,,DEM,Joseph R. Biden,8,23,3,0,34
+Schuylkill,Tower City,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Schuylkill,Tower City,President,,DEM,Write-in,8,0,0,0,8
+Schuylkill,Tower City,Attorney General,,DEM,Josh Shapiro,18,23,4,0,45
+Schuylkill,Tower City,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tower City,Auditor General,,DEM,H. Scott Conklin,2,1,0,0,3
+Schuylkill,Tower City,Auditor General,,DEM,Michael Lamb,0,2,0,0,2
+Schuylkill,Tower City,Auditor General,,DEM,Tracie Fountain,10,15,2,0,27
+Schuylkill,Tower City,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,0,1
+Schuylkill,Tower City,Auditor General,,DEM,Nina Ahmad,4,2,1,0,7
+Schuylkill,Tower City,Auditor General,,DEM,Christina M. Hartman,3,3,1,0,7
+Schuylkill,Tower City,Auditor General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Tower City,State Treasurer,,DEM,Joe Torsella,17,23,4,0,44
+Schuylkill,Tower City,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tower City,Representative In Congress,,DEM,Laura Quick,14,21,2,0,37
+Schuylkill,Tower City,Representative In Congress,,DEM,Gary Wegman,2,3,2,0,7
+Schuylkill,Tower City,Representative In Congress,,DEM,Write-in,4,0,0,0,4
+Schuylkill,Tower City,State Senate,29,DEM,Write-in,5,2,1,0,8
+Schuylkill,Tower City,General Assembly,125,DEM,Write-in,6,2,1,0,9
+Schuylkill,Tower City,President,,REP,Donald J. Trump,170,34,2,0,206
+Schuylkill,Tower City,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Tower City,President,,REP,Bill Weld,3,4,0,0,7
+Schuylkill,Tower City,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tower City,Attorney General,,REP,Heather Heidelbaugh,158,34,2,0,194
+Schuylkill,Tower City,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tower City,Auditor General,,REP,Timothy Defoor,154,36,2,0,192
+Schuylkill,Tower City,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tower City,State Treasurer,,REP,Stacy L. Garrity,153,35,2,0,190
+Schuylkill,Tower City,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Tower City,Representative In Congress,,REP,Dan Meuser,160,35,2,0,197
+Schuylkill,Tower City,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tower City,State Senate,29,REP,Dave Argall,164,39,3,0,206
+Schuylkill,Tower City,State Senate,29,REP,Write-in,1,0,0,0,1
+Schuylkill,Tower City,General Assembly,125,REP,Herv Breault,2,3,0,0,5
+Schuylkill,Tower City,General Assembly,125,REP,Theresa Gaffney,16,3,0,0,19
+Schuylkill,Tower City,General Assembly,125,REP,Christy Joy,8,5,0,0,13
+Schuylkill,Tower City,General Assembly,125,REP,Joe Kerwin,146,30,2,0,178
+Schuylkill,Tower City,General Assembly,125,REP,Write-in,1,0,0,0,1
+Schuylkill,Tremont,Registered Voters,,,,,,,,829
+Schuylkill,Tremont,Registered Voters,,DEM,,,,,,247
+Schuylkill,Tremont,Registered Voters,,REP,,,,,,459
+Schuylkill,Tremont,Registered Voters,,NPA,,,,,,123
+Schuylkill,Tremont,Ballots Cast,,,,186,76,12,0,274
+Schuylkill,Tremont,Ballots Cast,,DEM,,51,34,7,0,92
+Schuylkill,Tremont,Ballots Cast,,REP,,135,42,5,0,182
+Schuylkill,Tremont,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Tremont,President,,DEM,Bernie Sanders,14,5,0,0,19
+Schuylkill,Tremont,President,,DEM,Joseph R. Biden,20,27,6,0,53
+Schuylkill,Tremont,President,,DEM,Tulsi Gabbard,8,1,0,0,9
+Schuylkill,Tremont,President,,DEM,Write-in,7,1,0,0,8
+Schuylkill,Tremont,Attorney General,,DEM,Josh Shapiro,35,27,7,0,69
+Schuylkill,Tremont,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tremont,Auditor General,,DEM,H. Scott Conklin,4,3,2,0,9
+Schuylkill,Tremont,Auditor General,,DEM,Michael Lamb,9,6,1,0,16
+Schuylkill,Tremont,Auditor General,,DEM,Tracie Fountain,12,16,2,0,30
+Schuylkill,Tremont,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0,0
+Schuylkill,Tremont,Auditor General,,DEM,Nina Ahmad,3,1,0,0,4
+Schuylkill,Tremont,Auditor General,,DEM,Christina M. Hartman,15,4,1,0,20
+Schuylkill,Tremont,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tremont,State Treasurer,,DEM,Joe Torsella,34,27,7,0,68
+Schuylkill,Tremont,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tremont,Representative In Congress,,DEM,Laura Quick,23,12,4,0,39
+Schuylkill,Tremont,Representative In Congress,,DEM,Gary Wegman,20,18,3,0,41
+Schuylkill,Tremont,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Tremont,State Senate,29,DEM,Write-in,5,4,0,0,9
+Schuylkill,Tremont,General Assembly,125,DEM,Write-in,6,13,0,0,19
+Schuylkill,Tremont,President,,REP,Donald J. Trump,123,40,3,0,166
+Schuylkill,Tremont,President,,REP,Roque Rocky De La Fuente,2,0,1,0,3
+Schuylkill,Tremont,President,,REP,Bill Weld,2,1,1,0,4
+Schuylkill,Tremont,President,,REP,Write-in,4,1,0,0,5
+Schuylkill,Tremont,Attorney General,,REP,Heather Heidelbaugh,122,37,5,0,164
+Schuylkill,Tremont,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont,Auditor General,,REP,Timothy Defoor,118,37,5,0,160
+Schuylkill,Tremont,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont,State Treasurer,,REP,Stacy L. Garrity,121,37,5,0,163
+Schuylkill,Tremont,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,Tremont,Representative In Congress,,REP,Dan Meuser,120,38,5,0,163
+Schuylkill,Tremont,Representative In Congress,,REP,Write-in,1,1,0,0,2
+Schuylkill,Tremont,State Senate,29,REP,Dave Argall,123,38,5,0,166
+Schuylkill,Tremont,State Senate,29,REP,Write-in,1,3,0,0,4
+Schuylkill,Tremont,General Assembly,125,REP,Herv Breault,19,1,0,0,20
+Schuylkill,Tremont,General Assembly,125,REP,Theresa Gaffney,48,14,2,0,64
+Schuylkill,Tremont,General Assembly,125,REP,Christy Joy,32,14,2,0,48
+Schuylkill,Tremont,General Assembly,125,REP,Joe Kerwin,33,12,1,0,46
+Schuylkill,Tremont,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,Registered Voters,,,,,,,,161
+Schuylkill,Tremont Twp,Registered Voters,,DEM,,,,,,39
+Schuylkill,Tremont Twp,Registered Voters,,REP,,,,,,101
+Schuylkill,Tremont Twp,Registered Voters,,NPA,,,,,,21
+Schuylkill,Tremont Twp,Ballots Cast,,,,36,11,2,0,49
+Schuylkill,Tremont Twp,Ballots Cast,,DEM,,8,2,2,0,12
+Schuylkill,Tremont Twp,Ballots Cast,,REP,,28,9,0,0,37
+Schuylkill,Tremont Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Tremont Twp,President,,DEM,Bernie Sanders,1,1,0,0,2
+Schuylkill,Tremont Twp,President,,DEM,Joseph R. Biden,3,1,2,0,6
+Schuylkill,Tremont Twp,President,,DEM,Tulsi Gabbard,1,0,0,0,1
+Schuylkill,Tremont Twp,President,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Tremont Twp,Attorney General,,DEM,Josh Shapiro,7,2,2,0,11
+Schuylkill,Tremont Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,Auditor General,,DEM,H. Scott Conklin,0,0,0,0,0
+Schuylkill,Tremont Twp,Auditor General,,DEM,Michael Lamb,2,0,1,0,3
+Schuylkill,Tremont Twp,Auditor General,,DEM,Tracie Fountain,4,1,0,0,5
+Schuylkill,Tremont Twp,Auditor General,,DEM,Rose Rosie Marie Davis,0,0,0,0,0
+Schuylkill,Tremont Twp,Auditor General,,DEM,Nina Ahmad,0,1,0,0,1
+Schuylkill,Tremont Twp,Auditor General,,DEM,Christina M. Hartman,1,0,0,0,1
+Schuylkill,Tremont Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,State Treasurer,,DEM,Joe Torsella,6,2,2,0,10
+Schuylkill,Tremont Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,Representative In Congress,,DEM,Laura Quick,6,1,1,0,8
+Schuylkill,Tremont Twp,Representative In Congress,,DEM,Gary Wegman,1,1,1,0,3
+Schuylkill,Tremont Twp,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tremont Twp,State Senate,29,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tremont Twp,General Assembly,125,DEM,Write-in,1,0,0,0,1
+Schuylkill,Tremont Twp,President,,REP,Donald J. Trump,28,9,0,0,37
+Schuylkill,Tremont Twp,President,,REP,Roque Rocky De La Fuente,0,0,0,0,0
+Schuylkill,Tremont Twp,President,,REP,Bill Weld,0,0,0,0,0
+Schuylkill,Tremont Twp,President,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,Attorney General,,REP,Heather Heidelbaugh,28,8,0,0,36
+Schuylkill,Tremont Twp,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,Auditor General,,REP,Timothy Defoor,26,8,0,0,34
+Schuylkill,Tremont Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,State Treasurer,,REP,Stacy L. Garrity,27,8,0,0,35
+Schuylkill,Tremont Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,Representative In Congress,,REP,Dan Meuser,26,8,0,0,34
+Schuylkill,Tremont Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,State Senate,29,REP,Dave Argall,28,9,0,0,37
+Schuylkill,Tremont Twp,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Tremont Twp,General Assembly,125,REP,Herv Breault,3,0,0,0,3
+Schuylkill,Tremont Twp,General Assembly,125,REP,Theresa Gaffney,10,6,0,0,16
+Schuylkill,Tremont Twp,General Assembly,125,REP,Christy Joy,4,0,0,0,4
+Schuylkill,Tremont Twp,General Assembly,125,REP,Joe Kerwin,11,3,0,0,14
+Schuylkill,Tremont Twp,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,Registered Voters,,,,,,,,382
+Schuylkill,Upper Mahantongo Twp,Registered Voters,,DEM,,,,,,88
+Schuylkill,Upper Mahantongo Twp,Registered Voters,,REP,,,,,,260
+Schuylkill,Upper Mahantongo Twp,Registered Voters,,NPA,,,,,,34
+Schuylkill,Upper Mahantongo Twp,Ballots Cast,,,,112,53,6,0,171
+Schuylkill,Upper Mahantongo Twp,Ballots Cast,,DEM,,19,19,1,0,39
+Schuylkill,Upper Mahantongo Twp,Ballots Cast,,REP,,93,34,5,0,132
+Schuylkill,Upper Mahantongo Twp,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,President,,DEM,Bernie Sanders,1,2,0,0,3
+Schuylkill,Upper Mahantongo Twp,President,,DEM,Joseph R. Biden,9,15,1,0,25
+Schuylkill,Upper Mahantongo Twp,President,,DEM,Tulsi Gabbard,5,0,0,0,5
+Schuylkill,Upper Mahantongo Twp,President,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Upper Mahantongo Twp,Attorney General,,DEM,Josh Shapiro,17,17,1,0,35
+Schuylkill,Upper Mahantongo Twp,Attorney General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,Auditor General,,DEM,H. Scott Conklin,6,5,0,0,11
+Schuylkill,Upper Mahantongo Twp,Auditor General,,DEM,Michael Lamb,1,3,1,0,5
+Schuylkill,Upper Mahantongo Twp,Auditor General,,DEM,Tracie Fountain,6,4,0,0,10
+Schuylkill,Upper Mahantongo Twp,Auditor General,,DEM,Rose Rosie Marie Davis,0,1,0,0,1
+Schuylkill,Upper Mahantongo Twp,Auditor General,,DEM,Nina Ahmad,3,0,0,0,3
+Schuylkill,Upper Mahantongo Twp,Auditor General,,DEM,Christina M. Hartman,2,3,0,0,5
+Schuylkill,Upper Mahantongo Twp,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,State Treasurer,,DEM,Joe Torsella,16,17,1,0,34
+Schuylkill,Upper Mahantongo Twp,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,Representative In Congress,,DEM,Laura Quick,11,11,0,0,22
+Schuylkill,Upper Mahantongo Twp,Representative In Congress,,DEM,Gary Wegman,7,5,1,0,13
+Schuylkill,Upper Mahantongo Twp,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,State Senate,29,DEM,Write-in,1,3,0,0,4
+Schuylkill,Upper Mahantongo Twp,General Assembly,125,DEM,Write-in,0,2,0,0,2
+Schuylkill,Upper Mahantongo Twp,President,,REP,Donald J. Trump,89,30,5,0,124
+Schuylkill,Upper Mahantongo Twp,President,,REP,Roque Rocky De La Fuente,1,1,0,0,2
+Schuylkill,Upper Mahantongo Twp,President,,REP,Bill Weld,1,2,0,0,3
+Schuylkill,Upper Mahantongo Twp,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,Upper Mahantongo Twp,Attorney General,,REP,Heather Heidelbaugh,82,34,5,0,121
+Schuylkill,Upper Mahantongo Twp,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,Auditor General,,REP,Timothy Defoor,82,34,5,0,121
+Schuylkill,Upper Mahantongo Twp,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,State Treasurer,,REP,Stacy L. Garrity,83,34,5,0,122
+Schuylkill,Upper Mahantongo Twp,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,Representative In Congress,,REP,Dan Meuser,81,33,5,0,119
+Schuylkill,Upper Mahantongo Twp,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Upper Mahantongo Twp,State Senate,29,REP,Dave Argall,83,33,4,0,120
+Schuylkill,Upper Mahantongo Twp,State Senate,29,REP,Write-in,0,1,0,0,1
+Schuylkill,Upper Mahantongo Twp,General Assembly,125,REP,Herv Breault,2,0,0,0,2
+Schuylkill,Upper Mahantongo Twp,General Assembly,125,REP,Theresa Gaffney,29,8,2,0,39
+Schuylkill,Upper Mahantongo Twp,General Assembly,125,REP,Christy Joy,7,5,0,0,12
+Schuylkill,Upper Mahantongo Twp,General Assembly,125,REP,Joe Kerwin,53,21,3,0,77
+Schuylkill,Upper Mahantongo Twp,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Washington Twp North,Registered Voters,,,,,,,,947
+Schuylkill,Washington Twp North,Registered Voters,,DEM,,,,,,229
+Schuylkill,Washington Twp North,Registered Voters,,REP,,,,,,594
+Schuylkill,Washington Twp North,Registered Voters,,NPA,,,,,,124
+Schuylkill,Washington Twp North,Ballots Cast,,,,212,108,21,4,345
+Schuylkill,Washington Twp North,Ballots Cast,,DEM,,34,59,8,0,101
+Schuylkill,Washington Twp North,Ballots Cast,,REP,,178,49,13,4,244
+Schuylkill,Washington Twp North,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Washington Twp North,President,,DEM,Bernie Sanders,6,4,1,0,11
+Schuylkill,Washington Twp North,President,,DEM,Joseph R. Biden,18,47,6,0,71
+Schuylkill,Washington Twp North,President,,DEM,Tulsi Gabbard,1,4,0,0,5
+Schuylkill,Washington Twp North,President,,DEM,Write-in,5,3,0,0,8
+Schuylkill,Washington Twp North,Attorney General,,DEM,Josh Shapiro,22,54,7,0,83
+Schuylkill,Washington Twp North,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp North,Auditor General,,DEM,H. Scott Conklin,3,1,0,0,4
+Schuylkill,Washington Twp North,Auditor General,,DEM,Michael Lamb,2,5,0,0,7
+Schuylkill,Washington Twp North,Auditor General,,DEM,Tracie Fountain,8,23,4,0,35
+Schuylkill,Washington Twp North,Auditor General,,DEM,Rose Rosie Marie Davis,0,3,0,0,3
+Schuylkill,Washington Twp North,Auditor General,,DEM,Nina Ahmad,8,8,1,0,17
+Schuylkill,Washington Twp North,Auditor General,,DEM,Christina M. Hartman,5,19,3,0,27
+Schuylkill,Washington Twp North,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp North,State Treasurer,,DEM,Joe Torsella,22,51,7,0,80
+Schuylkill,Washington Twp North,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Washington Twp North,Representative In Congress,,DEM,Laura Quick,17,34,3,0,54
+Schuylkill,Washington Twp North,Representative In Congress,,DEM,Gary Wegman,10,25,4,0,39
+Schuylkill,Washington Twp North,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp North,State Senate,29,DEM,Write-in,6,8,0,0,14
+Schuylkill,Washington Twp North,General Assembly,125,DEM,Write-in,6,10,0,0,16
+Schuylkill,Washington Twp North,President,,REP,Donald J. Trump,172,35,13,2,222
+Schuylkill,Washington Twp North,President,,REP,Roque Rocky De La Fuente,2,2,0,1,5
+Schuylkill,Washington Twp North,President,,REP,Bill Weld,2,6,0,1,9
+Schuylkill,Washington Twp North,President,,REP,Write-in,1,4,0,0,5
+Schuylkill,Washington Twp North,Attorney General,,REP,Heather Heidelbaugh,152,38,11,4,205
+Schuylkill,Washington Twp North,Attorney General,,REP,Write-in,1,1,0,0,2
+Schuylkill,Washington Twp North,Auditor General,,REP,Timothy Defoor,152,42,11,4,209
+Schuylkill,Washington Twp North,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp North,State Treasurer,,REP,Stacy L. Garrity,152,41,11,4,208
+Schuylkill,Washington Twp North,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp North,Representative In Congress,,REP,Dan Meuser,163,41,12,4,220
+Schuylkill,Washington Twp North,Representative In Congress,,REP,Write-in,0,4,0,0,4
+Schuylkill,Washington Twp North,State Senate,29,REP,Dave Argall,164,42,12,4,222
+Schuylkill,Washington Twp North,State Senate,29,REP,Write-in,1,2,0,0,3
+Schuylkill,Washington Twp North,General Assembly,125,REP,Herv Breault,8,2,0,1,11
+Schuylkill,Washington Twp North,General Assembly,125,REP,Theresa Gaffney,70,18,5,0,93
+Schuylkill,Washington Twp North,General Assembly,125,REP,Christy Joy,55,17,6,1,79
+Schuylkill,Washington Twp North,General Assembly,125,REP,Joe Kerwin,42,11,2,2,57
+Schuylkill,Washington Twp North,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Washington Twp South,Registered Voters,,,,,,,,860
+Schuylkill,Washington Twp South,Registered Voters,,DEM,,,,,,220
+Schuylkill,Washington Twp South,Registered Voters,,REP,,,,,,526
+Schuylkill,Washington Twp South,Registered Voters,,NPA,,,,,,114
+Schuylkill,Washington Twp South,Ballots Cast,,,,226,93,9,0,328
+Schuylkill,Washington Twp South,Ballots Cast,,DEM,,39,38,6,0,83
+Schuylkill,Washington Twp South,Ballots Cast,,REP,,187,55,3,0,245
+Schuylkill,Washington Twp South,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Washington Twp South,President,,DEM,Bernie Sanders,6,8,2,0,16
+Schuylkill,Washington Twp South,President,,DEM,Joseph R. Biden,19,26,4,0,49
+Schuylkill,Washington Twp South,President,,DEM,Tulsi Gabbard,3,2,0,0,5
+Schuylkill,Washington Twp South,President,,DEM,Write-in,6,2,0,0,8
+Schuylkill,Washington Twp South,Attorney General,,DEM,Josh Shapiro,30,31,4,0,65
+Schuylkill,Washington Twp South,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Washington Twp South,Auditor General,,DEM,H. Scott Conklin,4,6,0,0,10
+Schuylkill,Washington Twp South,Auditor General,,DEM,Michael Lamb,2,2,1,0,5
+Schuylkill,Washington Twp South,Auditor General,,DEM,Tracie Fountain,10,8,0,0,18
+Schuylkill,Washington Twp South,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,0,3
+Schuylkill,Washington Twp South,Auditor General,,DEM,Nina Ahmad,6,3,0,0,9
+Schuylkill,Washington Twp South,Auditor General,,DEM,Christina M. Hartman,9,15,4,0,28
+Schuylkill,Washington Twp South,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp South,State Treasurer,,DEM,Joe Torsella,29,30,4,0,63
+Schuylkill,Washington Twp South,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp South,Representative In Congress,,DEM,Laura Quick,19,19,3,0,41
+Schuylkill,Washington Twp South,Representative In Congress,,DEM,Gary Wegman,16,16,3,0,35
+Schuylkill,Washington Twp South,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp South,State Senate,29,DEM,Write-in,4,0,1,0,5
+Schuylkill,Washington Twp South,General Assembly,125,DEM,Write-in,5,1,1,0,7
+Schuylkill,Washington Twp South,President,,REP,Donald J. Trump,182,48,2,0,232
+Schuylkill,Washington Twp South,President,,REP,Roque Rocky De La Fuente,0,1,0,0,1
+Schuylkill,Washington Twp South,President,,REP,Bill Weld,4,4,1,0,9
+Schuylkill,Washington Twp South,President,,REP,Write-in,1,1,0,0,2
+Schuylkill,Washington Twp South,Attorney General,,REP,Heather Heidelbaugh,161,48,3,0,212
+Schuylkill,Washington Twp South,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Washington Twp South,Auditor General,,REP,Timothy Defoor,156,49,3,0,208
+Schuylkill,Washington Twp South,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp South,State Treasurer,,REP,Stacy L. Garrity,157,48,3,0,208
+Schuylkill,Washington Twp South,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,Washington Twp South,Representative In Congress,,REP,Dan Meuser,163,53,3,0,219
+Schuylkill,Washington Twp South,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,Washington Twp South,State Senate,29,REP,Dave Argall,171,53,3,0,227
+Schuylkill,Washington Twp South,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Washington Twp South,General Assembly,125,REP,Herv Breault,9,4,0,0,13
+Schuylkill,Washington Twp South,General Assembly,125,REP,Theresa Gaffney,65,22,0,0,87
+Schuylkill,Washington Twp South,General Assembly,125,REP,Christy Joy,54,20,2,0,76
+Schuylkill,Washington Twp South,General Assembly,125,REP,Joe Kerwin,55,9,1,0,65
+Schuylkill,Washington Twp South,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 1st,Registered Voters,,,,,,,,1203
+Schuylkill,Wayne Twp 1st,Registered Voters,,DEM,,,,,,319
+Schuylkill,Wayne Twp 1st,Registered Voters,,REP,,,,,,746
+Schuylkill,Wayne Twp 1st,Registered Voters,,NPA,,,,,,138
+Schuylkill,Wayne Twp 1st,Ballots Cast,,,,308,162,24,7,501
+Schuylkill,Wayne Twp 1st,Ballots Cast,,DEM,,53,70,11,0,134
+Schuylkill,Wayne Twp 1st,Ballots Cast,,REP,,255,92,13,7,367
+Schuylkill,Wayne Twp 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Wayne Twp 1st,President,,DEM,Bernie Sanders,12,11,2,0,25
+Schuylkill,Wayne Twp 1st,President,,DEM,Joseph R. Biden,33,47,8,0,88
+Schuylkill,Wayne Twp 1st,President,,DEM,Tulsi Gabbard,3,6,0,0,9
+Schuylkill,Wayne Twp 1st,President,,DEM,Write-in,4,1,1,0,6
+Schuylkill,Wayne Twp 1st,Attorney General,,DEM,Josh Shapiro,46,63,8,0,117
+Schuylkill,Wayne Twp 1st,Attorney General,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Wayne Twp 1st,Auditor General,,DEM,H. Scott Conklin,3,7,1,0,11
+Schuylkill,Wayne Twp 1st,Auditor General,,DEM,Michael Lamb,11,7,1,0,19
+Schuylkill,Wayne Twp 1st,Auditor General,,DEM,Tracie Fountain,8,21,2,0,31
+Schuylkill,Wayne Twp 1st,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,0,0,3
+Schuylkill,Wayne Twp 1st,Auditor General,,DEM,Nina Ahmad,13,4,0,0,17
+Schuylkill,Wayne Twp 1st,Auditor General,,DEM,Christina M. Hartman,13,24,5,0,42
+Schuylkill,Wayne Twp 1st,Auditor General,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Wayne Twp 1st,State Treasurer,,DEM,Joe Torsella,39,63,8,0,110
+Schuylkill,Wayne Twp 1st,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Wayne Twp 1st,Representative In Congress,,DEM,Laura Quick,23,31,4,0,58
+Schuylkill,Wayne Twp 1st,Representative In Congress,,DEM,Gary Wegman,24,33,6,0,63
+Schuylkill,Wayne Twp 1st,Representative In Congress,,DEM,Write-in,3,0,0,0,3
+Schuylkill,Wayne Twp 1st,State Senate,29,DEM,Write-in,3,4,1,0,8
+Schuylkill,Wayne Twp 1st,General Assembly,125,DEM,Write-in,8,6,0,0,14
+Schuylkill,Wayne Twp 1st,President,,REP,Donald J. Trump,242,69,12,6,329
+Schuylkill,Wayne Twp 1st,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Schuylkill,Wayne Twp 1st,President,,REP,Bill Weld,3,14,0,1,18
+Schuylkill,Wayne Twp 1st,President,,REP,Write-in,3,3,0,0,6
+Schuylkill,Wayne Twp 1st,Attorney General,,REP,Heather Heidelbaugh,229,86,10,7,332
+Schuylkill,Wayne Twp 1st,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 1st,Auditor General,,REP,Timothy Defoor,227,88,10,7,332
+Schuylkill,Wayne Twp 1st,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 1st,State Treasurer,,REP,Stacy L. Garrity,226,86,10,7,329
+Schuylkill,Wayne Twp 1st,State Treasurer,,REP,Write-in,1,1,0,0,2
+Schuylkill,Wayne Twp 1st,Representative In Congress,,REP,Dan Meuser,237,85,11,7,340
+Schuylkill,Wayne Twp 1st,Representative In Congress,,REP,Write-in,0,4,0,0,4
+Schuylkill,Wayne Twp 1st,State Senate,29,REP,Dave Argall,237,77,10,7,331
+Schuylkill,Wayne Twp 1st,State Senate,29,REP,Write-in,2,3,0,0,5
+Schuylkill,Wayne Twp 1st,General Assembly,125,REP,Herv Breault,5,7,0,0,12
+Schuylkill,Wayne Twp 1st,General Assembly,125,REP,Theresa Gaffney,119,30,7,6,162
+Schuylkill,Wayne Twp 1st,General Assembly,125,REP,Christy Joy,87,46,3,1,137
+Schuylkill,Wayne Twp 1st,General Assembly,125,REP,Joe Kerwin,41,7,3,0,51
+Schuylkill,Wayne Twp 1st,General Assembly,125,REP,Write-in,0,2,0,0,2
+Schuylkill,Wayne Twp 2nd,Registered Voters,,,,,,,,1138
+Schuylkill,Wayne Twp 2nd,Registered Voters,,DEM,,,,,,286
+Schuylkill,Wayne Twp 2nd,Registered Voters,,REP,,,,,,702
+Schuylkill,Wayne Twp 2nd,Registered Voters,,NPA,,,,,,150
+Schuylkill,Wayne Twp 2nd,Ballots Cast,,,,309,118,19,5,451
+Schuylkill,Wayne Twp 2nd,Ballots Cast,,DEM,,50,52,9,2,113
+Schuylkill,Wayne Twp 2nd,Ballots Cast,,REP,,259,66,10,3,338
+Schuylkill,Wayne Twp 2nd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Wayne Twp 2nd,President,,DEM,Bernie Sanders,12,10,0,0,22
+Schuylkill,Wayne Twp 2nd,President,,DEM,Joseph R. Biden,23,40,8,2,73
+Schuylkill,Wayne Twp 2nd,President,,DEM,Tulsi Gabbard,6,0,1,0,7
+Schuylkill,Wayne Twp 2nd,President,,DEM,Write-in,8,0,0,0,8
+Schuylkill,Wayne Twp 2nd,Attorney General,,DEM,Josh Shapiro,44,47,9,2,102
+Schuylkill,Wayne Twp 2nd,Attorney General,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Wayne Twp 2nd,Auditor General,,DEM,H. Scott Conklin,4,6,2,0,12
+Schuylkill,Wayne Twp 2nd,Auditor General,,DEM,Michael Lamb,6,3,0,0,9
+Schuylkill,Wayne Twp 2nd,Auditor General,,DEM,Tracie Fountain,5,13,1,0,19
+Schuylkill,Wayne Twp 2nd,Auditor General,,DEM,Rose Rosie Marie Davis,2,1,1,0,4
+Schuylkill,Wayne Twp 2nd,Auditor General,,DEM,Nina Ahmad,5,3,1,2,11
+Schuylkill,Wayne Twp 2nd,Auditor General,,DEM,Christina M. Hartman,22,22,4,0,48
+Schuylkill,Wayne Twp 2nd,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Wayne Twp 2nd,State Treasurer,,DEM,Joe Torsella,42,46,9,2,99
+Schuylkill,Wayne Twp 2nd,State Treasurer,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Wayne Twp 2nd,Representative In Congress,,DEM,Laura Quick,19,19,2,0,40
+Schuylkill,Wayne Twp 2nd,Representative In Congress,,DEM,Gary Wegman,27,32,7,2,68
+Schuylkill,Wayne Twp 2nd,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,Wayne Twp 2nd,State Senate,29,DEM,Write-in,4,3,0,0,7
+Schuylkill,Wayne Twp 2nd,General Assembly,125,DEM,Write-in,7,5,0,0,12
+Schuylkill,Wayne Twp 2nd,President,,REP,Donald J. Trump,247,58,9,3,317
+Schuylkill,Wayne Twp 2nd,President,,REP,Roque Rocky De La Fuente,2,0,0,0,2
+Schuylkill,Wayne Twp 2nd,President,,REP,Bill Weld,5,5,1,0,11
+Schuylkill,Wayne Twp 2nd,President,,REP,Write-in,1,0,0,0,1
+Schuylkill,Wayne Twp 2nd,Attorney General,,REP,Heather Heidelbaugh,230,58,10,3,301
+Schuylkill,Wayne Twp 2nd,Attorney General,,REP,Write-in,2,1,0,0,3
+Schuylkill,Wayne Twp 2nd,Auditor General,,REP,Timothy Defoor,230,58,9,3,300
+Schuylkill,Wayne Twp 2nd,Auditor General,,REP,Write-in,1,0,0,0,1
+Schuylkill,Wayne Twp 2nd,State Treasurer,,REP,Stacy L. Garrity,230,57,10,3,300
+Schuylkill,Wayne Twp 2nd,State Treasurer,,REP,Write-in,1,1,0,0,2
+Schuylkill,Wayne Twp 2nd,Representative In Congress,,REP,Dan Meuser,237,59,9,3,308
+Schuylkill,Wayne Twp 2nd,Representative In Congress,,REP,Write-in,1,0,0,0,1
+Schuylkill,Wayne Twp 2nd,State Senate,29,REP,Dave Argall,246,58,8,3,315
+Schuylkill,Wayne Twp 2nd,State Senate,29,REP,Write-in,4,2,0,0,6
+Schuylkill,Wayne Twp 2nd,General Assembly,125,REP,Herv Breault,18,3,1,0,22
+Schuylkill,Wayne Twp 2nd,General Assembly,125,REP,Theresa Gaffney,110,21,4,3,138
+Schuylkill,Wayne Twp 2nd,General Assembly,125,REP,Christy Joy,59,26,2,0,87
+Schuylkill,Wayne Twp 2nd,General Assembly,125,REP,Joe Kerwin,70,14,3,0,87
+Schuylkill,Wayne Twp 2nd,General Assembly,125,REP,Write-in,0,0,0,0,0
+Schuylkill,North Manheim Twp 1st,Registered Voters,,,,,,,,1046
+Schuylkill,North Manheim Twp 1st,Registered Voters,,DEM,,,,,,309
+Schuylkill,North Manheim Twp 1st,Registered Voters,,REP,,,,,,601
+Schuylkill,North Manheim Twp 1st,Registered Voters,,NPA,,,,,,136
+Schuylkill,North Manheim Twp 1st,Ballots Cast,,,,220,149,38,3,410
+Schuylkill,North Manheim Twp 1st,Ballots Cast,,DEM,,53,67,15,0,135
+Schuylkill,North Manheim Twp 1st,Ballots Cast,,REP,,167,82,23,3,275
+Schuylkill,North Manheim Twp 1st,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,North Manheim Twp 1st,President,,DEM,Bernie Sanders,10,10,2,0,22
+Schuylkill,North Manheim Twp 1st,President,,DEM,Joseph R. Biden,29,49,13,0,91
+Schuylkill,North Manheim Twp 1st,President,,DEM,Tulsi Gabbard,2,6,0,0,8
+Schuylkill,North Manheim Twp 1st,President,,DEM,Write-in,11,1,0,0,12
+Schuylkill,North Manheim Twp 1st,Attorney General,,DEM,Josh Shapiro,43,57,13,0,113
+Schuylkill,North Manheim Twp 1st,Attorney General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,North Manheim Twp 1st,Auditor General,,DEM,H. Scott Conklin,6,5,1,0,12
+Schuylkill,North Manheim Twp 1st,Auditor General,,DEM,Michael Lamb,10,14,1,0,25
+Schuylkill,North Manheim Twp 1st,Auditor General,,DEM,Tracie Fountain,4,15,3,0,22
+Schuylkill,North Manheim Twp 1st,Auditor General,,DEM,Rose Rosie Marie Davis,3,9,1,0,13
+Schuylkill,North Manheim Twp 1st,Auditor General,,DEM,Nina Ahmad,8,8,1,0,17
+Schuylkill,North Manheim Twp 1st,Auditor General,,DEM,Christina M. Hartman,13,12,6,0,31
+Schuylkill,North Manheim Twp 1st,Auditor General,,DEM,Write-in,1,0,0,0,1
+Schuylkill,North Manheim Twp 1st,State Treasurer,,DEM,Joe Torsella,44,52,13,0,109
+Schuylkill,North Manheim Twp 1st,State Treasurer,,DEM,Write-in,1,0,0,0,1
+Schuylkill,North Manheim Twp 1st,Representative In Congress,,DEM,Laura Quick,25,28,6,0,59
+Schuylkill,North Manheim Twp 1st,Representative In Congress,,DEM,Gary Wegman,23,35,7,0,65
+Schuylkill,North Manheim Twp 1st,Representative In Congress,,DEM,Write-in,1,0,0,0,1
+Schuylkill,North Manheim Twp 1st,State Senate,29,DEM,Write-in,1,4,1,0,6
+Schuylkill,North Manheim Twp 1st,General Assembly,125,DEM,Write-in,6,4,1,0,11
+Schuylkill,North Manheim Twp 1st,President,,REP,Donald J. Trump,161,69,19,3,252
+Schuylkill,North Manheim Twp 1st,President,,REP,Roque Rocky De La Fuente,1,2,0,0,3
+Schuylkill,North Manheim Twp 1st,President,,REP,Bill Weld,4,5,0,0,9
+Schuylkill,North Manheim Twp 1st,President,,REP,Write-in,0,4,2,0,6
+Schuylkill,North Manheim Twp 1st,Attorney General,,REP,Heather Heidelbaugh,146,62,19,2,229
+Schuylkill,North Manheim Twp 1st,Attorney General,,REP,Write-in,1,3,1,0,5
+Schuylkill,North Manheim Twp 1st,Auditor General,,REP,Timothy Defoor,144,63,20,2,229
+Schuylkill,North Manheim Twp 1st,Auditor General,,REP,Write-in,1,1,1,0,3
+Schuylkill,North Manheim Twp 1st,State Treasurer,,REP,Stacy L. Garrity,142,65,21,2,230
+Schuylkill,North Manheim Twp 1st,State Treasurer,,REP,Write-in,1,0,0,0,1
+Schuylkill,North Manheim Twp 1st,Representative In Congress,,REP,Dan Meuser,149,70,19,3,241
+Schuylkill,North Manheim Twp 1st,Representative In Congress,,REP,Write-in,2,4,1,0,7
+Schuylkill,North Manheim Twp 1st,State Senate,29,REP,Dave Argall,162,69,20,3,254
+Schuylkill,North Manheim Twp 1st,State Senate,29,REP,Write-in,2,3,0,0,5
+Schuylkill,North Manheim Twp 1st,General Assembly,125,REP,Herv Breault,4,0,2,0,6
+Schuylkill,North Manheim Twp 1st,General Assembly,125,REP,Theresa Gaffney,44,28,7,0,79
+Schuylkill,North Manheim Twp 1st,General Assembly,125,REP,Christy Joy,67,33,9,2,111
+Schuylkill,North Manheim Twp 1st,General Assembly,125,REP,Joe Kerwin,49,16,4,1,70
+Schuylkill,North Manheim Twp 1st,General Assembly,125,REP,Write-in,0,1,0,0,1
+Schuylkill,West Penn Twp 3rd,Registered Voters,,,,,,,,942
+Schuylkill,West Penn Twp 3rd,Registered Voters,,DEM,,,,,,191
+Schuylkill,West Penn Twp 3rd,Registered Voters,,REP,,,,,,638
+Schuylkill,West Penn Twp 3rd,Registered Voters,,NPA,,,,,,113
+Schuylkill,West Penn Twp 3rd,Ballots Cast,,,,179,110,20,0,309
+Schuylkill,West Penn Twp 3rd,Ballots Cast,,DEM,,29,38,8,0,75
+Schuylkill,West Penn Twp 3rd,Ballots Cast,,REP,,150,72,12,0,234
+Schuylkill,West Penn Twp 3rd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,West Penn Twp 3rd,President,,DEM,Bernie Sanders,4,5,1,0,10
+Schuylkill,West Penn Twp 3rd,President,,DEM,Joseph R. Biden,20,29,6,0,55
+Schuylkill,West Penn Twp 3rd,President,,DEM,Tulsi Gabbard,5,2,0,0,7
+Schuylkill,West Penn Twp 3rd,President,,DEM,Write-in,0,2,1,0,3
+Schuylkill,West Penn Twp 3rd,Attorney General,,DEM,Josh Shapiro,27,32,6,0,65
+Schuylkill,West Penn Twp 3rd,Attorney General,,DEM,Write-in,0,0,1,0,1
+Schuylkill,West Penn Twp 3rd,Auditor General,,DEM,H. Scott Conklin,5,4,1,0,10
+Schuylkill,West Penn Twp 3rd,Auditor General,,DEM,Michael Lamb,3,5,1,0,9
+Schuylkill,West Penn Twp 3rd,Auditor General,,DEM,Tracie Fountain,2,7,2,0,11
+Schuylkill,West Penn Twp 3rd,Auditor General,,DEM,Rose Rosie Marie Davis,2,6,2,0,10
+Schuylkill,West Penn Twp 3rd,Auditor General,,DEM,Nina Ahmad,8,4,1,0,13
+Schuylkill,West Penn Twp 3rd,Auditor General,,DEM,Christina M. Hartman,7,5,0,0,12
+Schuylkill,West Penn Twp 3rd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 3rd,State Treasurer,,DEM,Joe Torsella,27,29,6,0,62
+Schuylkill,West Penn Twp 3rd,State Treasurer,,DEM,Write-in,0,0,1,0,1
+Schuylkill,West Penn Twp 3rd,Representative In Congress,,DEM,Laura Quick,13,15,4,0,32
+Schuylkill,West Penn Twp 3rd,Representative In Congress,,DEM,Gary Wegman,14,20,3,0,37
+Schuylkill,West Penn Twp 3rd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,West Penn Twp 3rd,State Senate,29,DEM,Write-in,0,3,0,0,3
+Schuylkill,West Penn Twp 3rd,General Assembly,124,DEM,Taylor Picone,26,31,7,0,64
+Schuylkill,West Penn Twp 3rd,General Assembly,124,DEM,Write-in,0,1,0,0,1
+Schuylkill,West Penn Twp 3rd,President,,REP,Donald J. Trump,145,50,10,0,205
+Schuylkill,West Penn Twp 3rd,President,,REP,Roque Rocky De La Fuente,2,2,0,0,4
+Schuylkill,West Penn Twp 3rd,President,,REP,Bill Weld,2,11,0,0,13
+Schuylkill,West Penn Twp 3rd,President,,REP,Write-in,1,1,2,0,4
+Schuylkill,West Penn Twp 3rd,Attorney General,,REP,Heather Heidelbaugh,135,63,12,0,210
+Schuylkill,West Penn Twp 3rd,Attorney General,,REP,Write-in,0,2,0,0,2
+Schuylkill,West Penn Twp 3rd,Auditor General,,REP,Timothy Defoor,137,62,12,0,211
+Schuylkill,West Penn Twp 3rd,Auditor General,,REP,Write-in,0,2,0,0,2
+Schuylkill,West Penn Twp 3rd,State Treasurer,,REP,Stacy L. Garrity,136,64,11,0,211
+Schuylkill,West Penn Twp 3rd,State Treasurer,,REP,Write-in,0,1,0,0,1
+Schuylkill,West Penn Twp 3rd,Representative In Congress,,REP,Dan Meuser,135,64,12,0,211
+Schuylkill,West Penn Twp 3rd,Representative In Congress,,REP,Write-in,0,1,0,0,1
+Schuylkill,West Penn Twp 3rd,State Senate,29,REP,Dave Argall,146,64,12,0,222
+Schuylkill,West Penn Twp 3rd,State Senate,29,REP,Write-in,1,2,0,0,3
+Schuylkill,West Penn Twp 3rd,General Assembly,124,REP,Jerry Knowles,145,63,11,0,219
+Schuylkill,West Penn Twp 3rd,General Assembly,124,REP,Write-in,3,1,0,0,4
+Schuylkill,Wayne Twp 3rd,Registered Voters,,,,,,,,1180
+Schuylkill,Wayne Twp 3rd,Registered Voters,,DEM,,,,,,351
+Schuylkill,Wayne Twp 3rd,Registered Voters,,REP,,,,,,664
+Schuylkill,Wayne Twp 3rd,Registered Voters,,NPA,,,,,,165
+Schuylkill,Wayne Twp 3rd,Ballots Cast,,,,286,123,31,3,443
+Schuylkill,Wayne Twp 3rd,Ballots Cast,,DEM,,41,86,17,1,145
+Schuylkill,Wayne Twp 3rd,Ballots Cast,,REP,,245,37,14,2,298
+Schuylkill,Wayne Twp 3rd,Ballots Cast,,NPA,,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,President,,DEM,Bernie Sanders,13,7,2,0,22
+Schuylkill,Wayne Twp 3rd,President,,DEM,Joseph R. Biden,22,76,15,0,113
+Schuylkill,Wayne Twp 3rd,President,,DEM,Tulsi Gabbard,2,2,0,0,4
+Schuylkill,Wayne Twp 3rd,President,,DEM,Write-in,1,1,0,0,2
+Schuylkill,Wayne Twp 3rd,Attorney General,,DEM,Josh Shapiro,34,83,17,1,135
+Schuylkill,Wayne Twp 3rd,Attorney General,,DEM,Write-in,2,0,0,0,2
+Schuylkill,Wayne Twp 3rd,Auditor General,,DEM,H. Scott Conklin,4,4,2,1,11
+Schuylkill,Wayne Twp 3rd,Auditor General,,DEM,Michael Lamb,8,8,3,0,19
+Schuylkill,Wayne Twp 3rd,Auditor General,,DEM,Tracie Fountain,2,20,4,0,26
+Schuylkill,Wayne Twp 3rd,Auditor General,,DEM,Rose Rosie Marie Davis,1,8,1,0,10
+Schuylkill,Wayne Twp 3rd,Auditor General,,DEM,Nina Ahmad,6,16,4,0,26
+Schuylkill,Wayne Twp 3rd,Auditor General,,DEM,Christina M. Hartman,15,26,3,0,44
+Schuylkill,Wayne Twp 3rd,Auditor General,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,State Treasurer,,DEM,Joe Torsella,35,79,17,1,132
+Schuylkill,Wayne Twp 3rd,State Treasurer,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,Representative In Congress,,DEM,Laura Quick,19,40,9,0,68
+Schuylkill,Wayne Twp 3rd,Representative In Congress,,DEM,Gary Wegman,18,45,8,1,72
+Schuylkill,Wayne Twp 3rd,Representative In Congress,,DEM,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,State Senate,29,DEM,Write-in,3,3,0,0,6
+Schuylkill,Wayne Twp 3rd,General Assembly,125,DEM,Write-in,5,7,0,0,12
+Schuylkill,Wayne Twp 3rd,President,,REP,Donald J. Trump,235,29,11,2,277
+Schuylkill,Wayne Twp 3rd,President,,REP,Roque Rocky De La Fuente,2,0,1,0,3
+Schuylkill,Wayne Twp 3rd,President,,REP,Bill Weld,2,2,1,0,5
+Schuylkill,Wayne Twp 3rd,President,,REP,Write-in,2,2,0,0,4
+Schuylkill,Wayne Twp 3rd,Attorney General,,REP,Heather Heidelbaugh,212,30,14,1,257
+Schuylkill,Wayne Twp 3rd,Attorney General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,Auditor General,,REP,Timothy Defoor,210,29,14,1,254
+Schuylkill,Wayne Twp 3rd,Auditor General,,REP,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,State Treasurer,,REP,Stacy L. Garrity,210,30,14,1,255
+Schuylkill,Wayne Twp 3rd,State Treasurer,,REP,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,Representative In Congress,,REP,Dan Meuser,216,32,14,1,263
+Schuylkill,Wayne Twp 3rd,Representative In Congress,,REP,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,State Senate,29,REP,Dave Argall,227,34,14,2,277
+Schuylkill,Wayne Twp 3rd,State Senate,29,REP,Write-in,0,0,0,0,0
+Schuylkill,Wayne Twp 3rd,General Assembly,125,REP,Herv Breault,16,2,0,0,18
+Schuylkill,Wayne Twp 3rd,General Assembly,125,REP,Theresa Gaffney,92,8,5,2,107
+Schuylkill,Wayne Twp 3rd,General Assembly,125,REP,Christy Joy,87,18,7,0,112
+Schuylkill,Wayne Twp 3rd,General Assembly,125,REP,Joe Kerwin,48,7,2,0,57
+Schuylkill,Wayne Twp 3rd,General Assembly,125,REP,Write-in,0,0,0,0,0

--- a/parsers/electionware_parser.py
+++ b/parsers/electionware_parser.py
@@ -1,0 +1,155 @@
+from parsers.pa_pdf_parser import PDFStringIterator
+
+
+INSTRUCTION_ROW_PREFIX = 'Vote For'
+BALLOTS_CAST_PREFIX = 'Ballots Cast'
+
+PARTIES = {
+    'DEM',
+    'REP',
+}
+PARTY_ABBREVIATIONS = {
+    'Total': '',
+    'Blank': 'Blank',
+    'Democratic Party': 'DEM',
+    'Republican Party': 'REP',
+    'DEMOCRATIC': 'DEM',
+    'REPUBLICAN': 'REP',
+    'NONPARTISAN': 'NPA',
+}
+
+
+class ElectionwarePDFStringIterator(PDFStringIterator):
+    _first_footer_substring = None
+    _second_footer_substring = None
+
+    def page_is_done(self):
+        s = self.peek()
+        return s.startswith(self._first_footer_substring) or s.startswith(self._second_footer_substring)
+
+    def table_is_done(self):
+        return self.peek().startswith(INSTRUCTION_ROW_PREFIX)
+
+    def swap_any_bad_ballots_cast_fields(self):
+        s = self._strings[self._strings_offset + 1]
+        if s.startswith(BALLOTS_CAST_PREFIX):
+            self._strings[self._strings_offset + 1] = self._strings[self._strings_offset]
+            self._strings[self._strings_offset] = s
+
+
+class ElectionwarePDFTableParser:
+    _county = None
+    _expected_table_headers = None
+    _openelections_mapped_header = None
+    _raw_office_to_office_and_district = None
+
+    def __init__(self, precinct, string_iterator):
+        self._string_iterator = string_iterator
+        self._precinct = precinct
+        self._skip_instruction_row()
+        self._parse_header()
+        self._verify_table_header()
+
+    def __iter__(self):
+        while True:
+            row = self._parse_row()
+            if self._should_be_recorded(row):
+                yield row
+
+    def _parse_header(self):
+        self._office = next(self._string_iterator)
+        self._party = ''
+        for party in PARTIES:
+            if self._office.upper().startswith(party + ' '):
+                self._party, self._office = self._office.split(' ', 1)
+                self._party = self._party.upper()
+                break
+
+    def _verify_table_header(self):
+        actual_header = ''
+        while len(actual_header) < len(self._expected_table_headers[0]):
+            actual_header += next(self._string_iterator) + ' '
+        assert actual_header.strip() in self._expected_table_headers
+
+    def _parse_row(self):
+        if self._string_iterator.page_is_done() or self._string_iterator.table_is_done():
+            raise StopIteration
+        self._string_iterator.swap_any_bad_ballots_cast_fields()
+        candidate = next(self._string_iterator)
+        row = {'county': self._county,
+               'precinct': self._precinct,
+               'office': self._office,
+               'party': self._party,
+               'district': '',
+               'candidate': candidate.strip()}
+        self._clean_row(row)
+        self._populate_votes(row)
+        return row
+
+    def _populate_votes(self, row):
+        for header in self._openelections_mapped_header:
+            votes_string = next(self._string_iterator)
+            if '%' not in votes_string:
+                row[header] = int(votes_string.replace(',', ''))
+            if row['office'] in ('Registered Voters', 'Voter Turnout'):
+                # only one column for each of these
+                break
+
+    def _skip_instruction_row(self):
+        if self._string_iterator.peek().startswith(INSTRUCTION_ROW_PREFIX):
+            next(self._string_iterator)
+
+    @classmethod
+    def _clean_row(cls, row):
+        if row['office'] == 'STATISTICS':
+            row['office'], party = row['candidate'].split(' - ', 1)
+            row['party'] = PARTY_ABBREVIATIONS[party]
+            row['candidate'] = ''
+        if row['office'] in cls._raw_office_to_office_and_district:
+            row['office'], row['district'] = cls._raw_office_to_office_and_district[row['office']]
+        if row['candidate'] == 'Write-In Totals':
+            row['candidate'] = 'Write-in'
+
+    @classmethod
+    def _should_be_recorded(cls, row):
+        if row['candidate'] in ('Total Votes Cast', 'Contest Totals', 'Not Assigned'):
+            return False
+        if 'Delegate' in row['office']:
+            return False
+        if row['office'] == 'Voter Turnout':
+            return False
+        if row['party'] == 'Blank':
+            return False
+        return True
+
+
+class ElectionwarePDFPageParser:
+    _pdf_string_iterator_clazz = None
+    _pdf_table_parser_clazz = None
+    _header = None
+
+    def __init__(self, page):
+        self._string_iterator = self._pdf_string_iterator_clazz(page.get_strings())
+        self._verify_header()
+        self._init_precinct()
+
+    def __iter__(self):
+        while not self._string_iterator.page_is_done():
+            table_parser = self._pdf_table_parser_clazz(self._precinct, self._string_iterator)
+            yield from iter(table_parser)
+
+    def _verify_header(self):
+        header = [next(self._string_iterator) for _ in range(len(self._header))]
+        assert header == self._header
+
+    def _init_precinct(self):
+        self._precinct = next(self._string_iterator)
+
+
+def pdf_to_csv(pdf, csv_writer, pdf_page_parser_clazz):
+    csv_writer.writeheader()
+    for page in pdf:
+        print(f'processing page {page.get_page_number()}')
+        pdf_page_parser = pdf_page_parser_clazz(page)
+        for row in pdf_page_parser:
+            csv_writer.writerow(row)

--- a/parsers/pa_adams_primary_2020_results_parser.py
+++ b/parsers/pa_adams_primary_2020_results_parser.py
@@ -1,0 +1,83 @@
+import csv
+import os
+from parsers.pa_pdf_parser import PDFPageIterator
+from parsers.electionware_parser import pdf_to_csv, ElectionwarePDFStringIterator, \
+    ElectionwarePDFTableParser, ElectionwarePDFPageParser
+
+COUNTY = 'Adams'
+
+OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__adams__precinct.csv')
+OUTPUT_HEADER = ['county', 'precinct', 'office', 'district', 'party', 'candidate',
+                 'election_day', 'absentee', 'votes']
+
+ADAMS_FILE = os.path.join('..', '..', 'openelections-sources-pa', '2020',
+                          'Adams PA 2020 Primary PrecinctSummary.pdf')
+ADAMS_HEADER = [
+    '',
+    'Summary Results Report',
+    'PRIMARY ELECTION',
+    'June 2, 2020',
+    'OFFICIAL RESULTS',
+    'ADAMS COUNTY, PENNSYLVANIA',
+]
+
+TABLE_HEADER = [
+    'TOTAL',
+    'Election Day',
+    'Absentee',
+]
+EXPECTED_TABLE_HEADERS = (' '.join(TABLE_HEADER),)
+
+OPENELECTIONS_MAPPED_HEADER = [
+    'votes',
+    'election_day',
+    'absentee',
+]
+
+FIRST_FOOTER_SUBSTRING = 'Precinct Summary - 06/19/2020'
+SECOND_FOOTER_SUBSTRING = 'Report generated with Electionware'
+
+RAW_OFFICE_TO_OFFICE_AND_DISTRICT = {
+    'President of the United States': ('President', ''),
+    'Rep in Congress - 13th Dist': ('U.S. House', 13),
+    'Senator in the General Assembly': ('State Senate', 33),
+    'Rep in Gen Assembly - 91st Dist': ('General Assembly', 91),
+    'Rep in Gen Assembly - 193rd Dist': ('General Assembly', 193),
+}
+
+
+class AdamsPDFStringIterator(ElectionwarePDFStringIterator):
+    _first_footer_substring = FIRST_FOOTER_SUBSTRING
+    _second_footer_substring = SECOND_FOOTER_SUBSTRING
+
+
+class AdamsPDFTableParser(ElectionwarePDFTableParser):
+    _county = COUNTY
+    _expected_table_headers = EXPECTED_TABLE_HEADERS
+    _openelections_mapped_header = OPENELECTIONS_MAPPED_HEADER
+    _raw_office_to_office_and_district = RAW_OFFICE_TO_OFFICE_AND_DISTRICT
+
+    def _verify_table_header(self):
+        if self._office != 'STATISTICS':
+            vote_percent_header = next(self._string_iterator)
+            assert vote_percent_header == 'VOTE %'
+        super()._verify_table_header()
+
+    def _populate_votes(self, row):
+        super()._populate_votes(row)
+        if self._office != 'STATISTICS' and row['candidate'] != 'Contest Totals':
+            vote_percent_string = next(self._string_iterator)
+            assert '%' in vote_percent_string
+
+
+class AdamsPDFPageParser(ElectionwarePDFPageParser):
+    _pdf_string_iterator_clazz = AdamsPDFStringIterator
+    _pdf_table_parser_clazz = AdamsPDFTableParser
+    _header = ADAMS_HEADER
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', newline='') as f:
+        pdf_to_csv(PDFPageIterator(ADAMS_FILE),
+                   csv.DictWriter(f, OUTPUT_HEADER),
+                   AdamsPDFPageParser)

--- a/parsers/pa_cambria_primary_2020_results_parser.py
+++ b/parsers/pa_cambria_primary_2020_results_parser.py
@@ -1,0 +1,90 @@
+import csv
+import os
+from parsers.pa_pdf_parser import PDFPageIterator
+from parsers.electionware_parser import pdf_to_csv, ElectionwarePDFStringIterator, \
+    ElectionwarePDFTableParser, ElectionwarePDFPageParser
+
+COUNTY = 'Cambria'
+
+OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__cambria__precinct.csv')
+OUTPUT_HEADER = ['county', 'precinct', 'office', 'district', 'party', 'candidate',
+                 'election_day', 'mail_in', 'provisional', 'votes']
+
+CAMBRIA_FILE = os.path.join('..', '..', 'openelections-sources-pa', '2020',
+                            'Cambria PA General+Primary+Precinct+2020.pdf')
+CAMBRIA_HEADER = [
+    '',
+    'Summary Results Report',
+    'GENERAL PRIMARY BALLOT',
+    'June 2, 2020',
+    'OFFICIAL RESULTS',
+    'CAMBRIA COUNTY',
+]
+
+TABLE_HEADER = [
+    'TOTAL',
+    'Election Day',
+    'Absentee/M',
+    'ail-In',
+    'Provisional',
+]
+# column ordering is the same but the header text strings order can be different
+TABLE_HEADER_VARIANT = [
+    'TOTAL',
+    'Election Day',
+    'Provisional',
+    'Absentee/',
+    'Mail-In',
+]
+EXPECTED_TABLE_HEADERS = (' '.join(TABLE_HEADER), ' '.join(TABLE_HEADER_VARIANT))
+
+OPENELECTIONS_MAPPED_HEADER = [
+    'votes',
+    'election_day',
+    'mail_in',
+    'provisional',
+]
+
+FIRST_FOOTER_SUBSTRING = 'Precinct Summary - 06/22/2020'
+SECOND_FOOTER_SUBSTRING = 'Report generated with Electionware'
+
+RAW_OFFICE_TO_OFFICE_AND_DISTRICT = {
+    'PRESIDENT OF THE UNITED STATES': ('President', ''),
+    'REPRESENTATIVE IN CONGRESS 13TH DISTRICT': ('U.S. House', 13),
+    'REPRESENTATIVE IN CONGRESS 15TH DISTRICT': ('U.S. House', 15),
+    'SENATOR IN THE GENERAL ASSEMBLY 35TH DIST': ('State Senator', 35),
+    'GENERAL ASSEMBLY 71ST DISTRICT': ('General Assembly', 71),
+    'GENERAL ASSEMBLY 72ND DISTRICT': ('General Assembly', 72),
+    'GENERAL ASSEMBLY 73RD DISTRICT': ('General Assembly', 73),
+}
+
+
+class CambriaPDFStringIterator(ElectionwarePDFStringIterator):
+    _first_footer_substring = FIRST_FOOTER_SUBSTRING
+    _second_footer_substring = SECOND_FOOTER_SUBSTRING
+
+
+class CambriaPDFTableParser(ElectionwarePDFTableParser):
+    _county = COUNTY
+    _expected_table_headers = EXPECTED_TABLE_HEADERS
+    _openelections_mapped_header = OPENELECTIONS_MAPPED_HEADER
+    _raw_office_to_office_and_district = RAW_OFFICE_TO_OFFICE_AND_DISTRICT
+
+    @classmethod
+    def _clean_row(cls, row):
+        super()._clean_row(row)
+        row['office'] = row['office'].title()
+        row['candidate'] = row['candidate'].title()
+
+
+class CambriaPDFPageParser(ElectionwarePDFPageParser):
+    _pdf_string_iterator_clazz = CambriaPDFStringIterator
+    _pdf_table_parser_clazz = CambriaPDFTableParser
+    _header = CAMBRIA_HEADER
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', newline='') as f:
+        pdf_to_csv(PDFPageIterator(CAMBRIA_FILE),
+                   csv.DictWriter(f, OUTPUT_HEADER),
+                   CambriaPDFPageParser)

--- a/parsers/pa_lackawanna_primary_2020_results_parser.py
+++ b/parsers/pa_lackawanna_primary_2020_results_parser.py
@@ -1,0 +1,89 @@
+import csv
+import os
+from parsers.pa_pdf_parser import PDFPageIterator
+from parsers.electionware_parser import pdf_to_csv, ElectionwarePDFStringIterator, \
+    ElectionwarePDFTableParser, ElectionwarePDFPageParser
+
+COUNTY = 'Lackawanna'
+
+OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__lackawanna__precinct.csv')
+OUTPUT_HEADER = ['county', 'precinct', 'office', 'district', 'party', 'candidate',
+                 'election_day', 'mail_in', 'absentee', 'provisional', 'votes']
+
+LACKAWANNA_FILE = os.path.join('..', '..', 'openelections-sources-pa', '2020',
+                               'Lackawanna PA 20PrimaryPrecinctCertified.pdf')
+LACKAWANNA_HEADER = [
+    '',
+    'Precinct Results Report',
+    'PRIMARY ELECTION',
+    'June 2, 2020',
+    'CERTIFIED RESULTS',
+    'Lackawanna',
+]
+
+TABLE_HEADER = [
+    'TOTAL',
+    'Election Day',
+    'Mail-In',
+    'Absentee',
+    'Provisional',
+]
+# column ordering is the same but the header text strings order can be different
+TABLE_HEADER_VARIANT = [
+    'TOTAL',
+    'Election Day',
+    'Provisional',
+    'Absentee',
+    'Mail-In',
+]
+EXPECTED_TABLE_HEADERS = (' '.join(TABLE_HEADER), ' '.join(TABLE_HEADER_VARIANT))
+
+OPENELECTIONS_MAPPED_HEADER = [
+    'votes',
+    'election_day',
+    'mail_in',
+    'absentee',
+    'provisional',
+]
+
+FIRST_FOOTER_SUBSTRING = 'precinct_lackawanna - 06/17/2020'
+SECOND_FOOTER_SUBSTRING = 'Report generated with Electionware'
+
+RAW_OFFICE_TO_OFFICE_AND_DISTRICT = {
+    'CONGRESS 8TH DISTRICT': ('U.S. House', 8),
+    'REPRESENTATIVE 112TH': ('General Assembly', 112),
+    'REPRESENTATIVE 113TH': ('General Assembly', 113),
+    'REPRESENTATIVE 114TH': ('General Assembly', 114),
+    'REPRESENTATIVE 117TH': ('General Assembly', 117),
+    'REPRESENTATIVE 118TH': ('General Assembly', 118),
+}
+
+
+class LackawannaPDFStringIterator(ElectionwarePDFStringIterator):
+    _first_footer_substring = FIRST_FOOTER_SUBSTRING
+    _second_footer_substring = SECOND_FOOTER_SUBSTRING
+
+
+class LackawannaPDFTableParser(ElectionwarePDFTableParser):
+    _county = COUNTY
+    _expected_table_headers = EXPECTED_TABLE_HEADERS
+    _openelections_mapped_header = OPENELECTIONS_MAPPED_HEADER
+    _raw_office_to_office_and_district = RAW_OFFICE_TO_OFFICE_AND_DISTRICT
+
+    @classmethod
+    def _clean_row(cls, row):
+        super()._clean_row(row)
+        row['office'] = row['office'].title()
+
+
+class LackawannaPDFPageParser(ElectionwarePDFPageParser):
+    _pdf_string_iterator_clazz = LackawannaPDFStringIterator
+    _pdf_table_parser_clazz = LackawannaPDFTableParser
+    _header = LACKAWANNA_HEADER
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', newline='') as f:
+        pdf_to_csv(PDFPageIterator(LACKAWANNA_FILE),
+                   csv.DictWriter(f, OUTPUT_HEADER),
+                   LackawannaPDFPageParser)

--- a/parsers/pa_mercer_primary_2020_results_parser.py
+++ b/parsers/pa_mercer_primary_2020_results_parser.py
@@ -1,0 +1,86 @@
+import csv
+import os
+from parsers.pa_pdf_parser import PDFPageIterator
+from parsers.electionware_parser import pdf_to_csv, ElectionwarePDFStringIterator, \
+    ElectionwarePDFTableParser, ElectionwarePDFPageParser
+
+COUNTY = 'Mercer'
+
+OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__mercer__precinct.csv')
+OUTPUT_HEADER = ['county', 'precinct', 'office', 'district', 'party', 'candidate',
+                 'election_day', 'mail_in', 'votes']
+
+MERCER_FILE = os.path.join('..', '..', 'openelections-sources-pa', '2020',
+                           'Mercer PA 2020 Primary PRECINCT.pdf')
+MERCER_HEADER = [
+    '',
+    'Precinct Summary Results Report',
+    'PRIMARY ELECTION',
+    'JUNE 2, 2020',
+    'OFFICIAL RESULTS',
+    'Mercer County',
+]
+
+TABLE_HEADER = [
+    'TOTAL',
+    'Election Day',
+    'Mail /',
+    'Provisional',
+]
+EXPECTED_TABLE_HEADERS = (' '.join(TABLE_HEADER),)
+
+OPENELECTIONS_MAPPED_HEADER = [
+    'votes',
+    'election_day',
+    'mail_in',
+]
+
+FIRST_FOOTER_SUBSTRING = 'Precinct Summary - 06/15/2020'
+SECOND_FOOTER_SUBSTRING = 'Report generated with Electionware'
+
+RAW_OFFICE_TO_OFFICE_AND_DISTRICT = {
+    'PRESIDENT OF THE UNITED STATES': ('President', ''),
+    'U.S. REP, 16TH DISTRICT': ('U.S. House', 16),
+    'STATE REP., 7TH DISTRICT': ('General Assembly', 7),
+    'STATE REP., 8TH DISTRICT': ('General Assembly', 8),
+    'STATE REP., 17TH DISTRICT': ('General Assembly', 17),
+}
+
+
+class MercerPDFStringIterator(ElectionwarePDFStringIterator):
+    _first_footer_substring = FIRST_FOOTER_SUBSTRING
+    _second_footer_substring = SECOND_FOOTER_SUBSTRING
+
+
+class MercerPDFTableParser(ElectionwarePDFTableParser):
+    _county = COUNTY
+    _expected_table_headers = EXPECTED_TABLE_HEADERS
+    _openelections_mapped_header = OPENELECTIONS_MAPPED_HEADER
+    _raw_office_to_office_and_district = RAW_OFFICE_TO_OFFICE_AND_DISTRICT
+
+    @classmethod
+    def _clean_row(cls, row):
+        super()._clean_row(row)
+        row['office'] = row['office'].title()
+        row['candidate'] = row['candidate'].replace('Write-In: ', '').title()
+
+    @classmethod
+    def _should_be_recorded(cls, row):
+        if not super()._should_be_recorded(row):
+            return False
+        if row['office'] == 'Wheatland Home Rule':
+            return False
+        return True
+
+
+class MercerPDFPageParser(ElectionwarePDFPageParser):
+    _pdf_string_iterator_clazz = MercerPDFStringIterator
+    _pdf_table_parser_clazz = MercerPDFTableParser
+    _header = MERCER_HEADER
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', newline='') as f:
+        pdf_to_csv(PDFPageIterator(MERCER_FILE),
+                   csv.DictWriter(f, OUTPUT_HEADER),
+                   MercerPDFPageParser)

--- a/parsers/pa_northampton_primary_2020_results_parser.py
+++ b/parsers/pa_northampton_primary_2020_results_parser.py
@@ -1,9 +1,9 @@
 import csv
 import os
-from parsers.pa_pdf_parser import PDFPageIterator, PDFStringIterator
+from parsers.pa_pdf_parser import PDFPageIterator
+from parsers.electionware_parser import pdf_to_csv, ElectionwarePDFStringIterator, \
+    ElectionwarePDFTableParser, ElectionwarePDFPageParser
 
-
-# Uses Electionware Summary Precinct Results Report PDF format
 COUNTY = 'Northampton'
 
 OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__northampton__precinct.csv')
@@ -38,18 +38,17 @@ TABLE_HEADER_VARIANT = [
 ]
 EXPECTED_TABLE_HEADERS = (' '.join(TABLE_HEADER), ' '.join(TABLE_HEADER_VARIANT))
 
-TABLE_HEADER_TO_DICT = {
-    'TOTAL': 'votes',
-    'Election Day': 'election_day',
-    'Absentee': 'absentee',
-    'Mail-in': 'provisional',
-}
+OPENELECTIONS_MAPPED_HEADER = [
+    'votes',
+    'election_day',
+    'absentee',
+    'provisional',
+]
 
-INSTRUCTION_ROW_SUBSTRING = 'Vote For'
 FIRST_FOOTER_SUBSTRING = 'Precinct Summary - 06/22/2020'
 SECOND_FOOTER_SUBSTRING = 'Report generated with Electionware'
 
-RAW_OFFICE_TO_OFFICE_AND_DISTRICT  = {
+RAW_OFFICE_TO_OFFICE_AND_DISTRICT = {
     'President of the United States': ('President', ''),
     'Representative in Congress': ('U.S. House', 7),
     'Representative in the General Assembly 131st Legislative District': ('General Assembly', 131),
@@ -60,137 +59,37 @@ RAW_OFFICE_TO_OFFICE_AND_DISTRICT  = {
     'Representative in the General Assembly 183rd Legislative District': ('General Assembly', 183),
 }
 
-PARTIES = {
-    'DEM',
-    'REP',
-}
-PARTY_ABBREVIATIONS = {
-    'Total': '',
-    'Blank': 'Blank',
-    'DEMOCRATIC': 'DEM',
-    'REPUBLICAN': 'REP',
-    'NONPARTISAN': 'NPA',    
-}
+
+class NorthamptonPDFStringIterator(ElectionwarePDFStringIterator):
+    _first_footer_substring = FIRST_FOOTER_SUBSTRING
+    _second_footer_substring = SECOND_FOOTER_SUBSTRING
 
 
-class NorthamptonPDFStringIterator(PDFStringIterator):
-    def page_is_done(self):
-        s = self.peek()
-        return s.startswith(FIRST_FOOTER_SUBSTRING) or s.startswith(SECOND_FOOTER_SUBSTRING)
+class NorthamptonPDFTableParser(ElectionwarePDFTableParser):
+    _county = COUNTY
+    _expected_table_headers = EXPECTED_TABLE_HEADERS
+    _openelections_mapped_header = OPENELECTIONS_MAPPED_HEADER
+    _raw_office_to_office_and_district = RAW_OFFICE_TO_OFFICE_AND_DISTRICT
 
-    def table_is_done(self):
-        return self.peek().startswith(INSTRUCTION_ROW_SUBSTRING)
-
-    def swap_any_bad_ballots_cast_fields(self):
-        s = self._strings[self._strings_offset + 1]
-        if s.startswith('Ballots Cast'):
-            self._strings[self._strings_offset + 1] = self._strings[self._strings_offset]
-            self._strings[self._strings_offset] = s
-
-
-class NorthamptonPDFTableParser():
-    def __init__(self, precinct, string_iterator):
-        self._string_iterator = string_iterator
-        self._precinct = precinct
-        self._skip_instruction_row()
-        self._parse_header()
-        self._verify_table_header()
-
-    def __iter__(self):
-        while True:
-            row = self._parse_row()
-            if self._should_be_recorded(row):
-                yield row
-
-    def _parse_header(self):
-        self._office = next(self._string_iterator)
-        self._party = ''
-        for party in PARTIES:
-            if self._office.startswith(party):
-                self._party, self._office = self._office.split(' ', 1)
-
-    def _verify_table_header(self):
-        actual_header = ''
-        while len(actual_header) < len(EXPECTED_TABLE_HEADERS[0]):
-            actual_header += next(self._string_iterator) + ' '
-        assert(actual_header.strip() in EXPECTED_TABLE_HEADERS)
-
-    def _parse_row(self):
-        if self._string_iterator.page_is_done() or self._string_iterator.table_is_done():
-            raise StopIteration
-        self._string_iterator.swap_any_bad_ballots_cast_fields()
-        candidate = next(self._string_iterator)
-        row = {'county': COUNTY, 'precinct': self._precinct,'office': self._office, 'party': self._party,
-               'district': '', 'candidate': candidate.strip()}
-        self._clean_row(row)
-        self._populate_votes(row)
-        return row
-
-    def _populate_votes(self, row):
-        for header in TABLE_HEADER[:-1]:
-            votes_string = next(self._string_iterator)
-            if '%' not in votes_string:
-                row[TABLE_HEADER_TO_DICT[header]] = int(votes_string.replace(',', ''))
-            if row['office'] in ('Registered Voters', 'Voter Turnout'):
-                # only one column for each of these
-                break
-
-    def _skip_instruction_row(self):
-        if self._string_iterator.peek().startswith(INSTRUCTION_ROW_SUBSTRING):
-            next(self._string_iterator)
-
-    @staticmethod
-    def _clean_row(row):
-        if row['office'] == 'STATISTICS':
-            row['office'], party = row['candidate'].split(' - ', 1)
-            row['party'] = PARTY_ABBREVIATIONS[party]
-            row['candidate'] = ''
-        if row['office'] in RAW_OFFICE_TO_OFFICE_AND_DISTRICT:
-            row['office'], row['district'] = RAW_OFFICE_TO_OFFICE_AND_DISTRICT[row['office']]
-        if row['candidate'] == 'Write-In Totals':
-            row['candidate'] = 'Write-in'
-
-    @staticmethod
-    def _should_be_recorded(row):
-        if row['candidate'] == 'Not Assigned':
+    @classmethod
+    def _should_be_recorded(cls, row):
+        if not super()._should_be_recorded(row):
             return False
-        if 'Delegate' in row['office'] or 'County Committee' in row['office']:
+        if 'County Committee' in row['office']:
             return False
-        if row['office'] in ('Voter Turnout', 'Library Tax Question'):
-            return False
-        if row['party'] == 'Blank':
+        if row['office'] == 'Library Tax Question':
             return False
         return True
 
 
-class NorthamptonPDFPageParser:
-    def __init__(self, page):
-        self._string_iterator = NorthamptonPDFStringIterator(page.get_strings())
-        self._verify_header()
-        self._init_precinct()
-
-    def __iter__(self):
-        while not self._string_iterator.page_is_done():
-            table_parser = NorthamptonPDFTableParser(self._precinct, self._string_iterator)
-            yield from iter(table_parser)
-
-    def _verify_header(self):
-        header = [next(self._string_iterator) for _ in range(len(NORTHAMPTON_HEADER))]
-        assert (header == NORTHAMPTON_HEADER)
-
-    def _init_precinct(self):
-        self._precinct = next(self._string_iterator)
-
-
-def pdf_to_csv(pdf, csv_writer):
-    csv_writer.writeheader()
-    for page in pdf:
-        print(f'processing page {page.get_page_number()}')
-        pdf_page_parser = NorthamptonPDFPageParser(page)
-        for row in pdf_page_parser:
-            csv_writer.writerow(row)
+class NorthamptonPDFPageParser(ElectionwarePDFPageParser):
+    _pdf_string_iterator_clazz = NorthamptonPDFStringIterator
+    _pdf_table_parser_clazz = NorthamptonPDFTableParser
+    _header = NORTHAMPTON_HEADER
 
 
 if __name__ == "__main__":
     with open(OUTPUT_FILE, 'w', newline='') as f:
-        pdf_to_csv(PDFPageIterator(NORTHAMPTON_FILE), csv.DictWriter(f, OUTPUT_HEADER))
+        pdf_to_csv(PDFPageIterator(NORTHAMPTON_FILE),
+                   csv.DictWriter(f, OUTPUT_HEADER),
+                   NorthamptonPDFPageParser)

--- a/parsers/pa_schuylkill_primary_2020_results_parser.py
+++ b/parsers/pa_schuylkill_primary_2020_results_parser.py
@@ -1,0 +1,115 @@
+import csv
+import os
+from parsers.pa_pdf_parser import PDFPageIterator
+from parsers.electionware_parser import pdf_to_csv, ElectionwarePDFStringIterator, \
+    ElectionwarePDFTableParser, ElectionwarePDFPageParser
+
+COUNTY = 'Schuylkill'
+
+OUTPUT_FILE = os.path.join('..', '2020', '20200602__pa__primary__schuylkill__precinct.csv')
+OUTPUT_HEADER = ['county', 'precinct', 'office', 'district', 'party', 'candidate',
+                 'election_day', 'mail_in', 'absentee', 'provisional', 'votes']
+
+SCHUYLKILL_FILE = os.path.join('..', '..', 'openelections-sources-pa', '2020',
+                               'Schuylkill PA Official June 2, 2020 Precinct Report.pdf')
+SCHUYLKILL_HEADER = [
+    '',
+    'Summary Results Report',
+    'Schuylkill Primary 2020',
+    'June 2, 2020',
+    'OFFICIAL RESULTS',
+    'Schuylkill County',
+]
+
+TABLE_HEADER = [
+    'TOTAL',
+    'Election Day',
+    'Mail-in',
+    'Absentee',
+    'Provisional',
+]
+TABLE_HEADER_VARIANT = [
+    'TOTAL',
+    'Election Day',
+    'Provisional',
+    'Absentee',
+    'Mail-in',
+]
+EXPECTED_TABLE_HEADERS = (' '.join(TABLE_HEADER), ' '.join(TABLE_HEADER_VARIANT))
+
+OPENELECTIONS_MAPPED_HEADER = [
+    'votes',
+    'election_day',
+    'mail_in',
+    'absentee',
+    'provisional',
+]
+
+FIRST_FOOTER_SUBSTRING = 'Precinct Summary - 06/19/2020'
+SECOND_FOOTER_SUBSTRING = 'Report generated with Electionware'
+
+RAW_OFFICE_TO_OFFICE_AND_DISTRICT = {
+    'PRESIDENT OF THE UNITED STATES': ('President', ''),
+    'CONGRESS 8TH DISTRICT': ('U.S. House', 9),
+    'REPRESENTATIVE IN THE GENERAL ASSEMBLY 123rd': ('General Assembly', 123),
+    'REPRESENTATIVE IN THE GENERAL ASSEMBLY 124th': ('General Assembly', 124),
+    'REPRESENTATIVE IN THE GENERAL ASSEMBLY 125th': ('General Assembly', 125),
+    'SENATOR IN THE GENERAL ASSEMBLY': ('State Senate', 29),
+}
+
+BUGGY_ROWS = [
+    {'county': 'Schuylkill', 'precinct': 'Mt. Carbon', 'office': 'State Senate', 'party': 'DEM', 'district': 29,
+     'candidate': 'Write-in', 'votes': 0, 'election_day': 0, 'mail_in': 0, 'absentee': 0, 'provisional': 0},
+    {'county': 'Schuylkill', 'precinct': 'Mt. Carbon', 'office': 'State Senate', 'party': 'DEM', 'district': 29,
+     'candidate': 'Total Votes Cast', 'votes': 0, 'election_day': 0, 'mail_in': 0, 'absentee': 0, 'provisional': 0}
+]
+
+
+class SchuylkillPDFStringIterator(ElectionwarePDFStringIterator):
+    _first_footer_substring = FIRST_FOOTER_SUBSTRING
+    _second_footer_substring = SECOND_FOOTER_SUBSTRING
+
+
+class SchuylkillPDFTableParser(ElectionwarePDFTableParser):
+    _county = COUNTY
+    _expected_table_headers = EXPECTED_TABLE_HEADERS
+    _openelections_mapped_header = OPENELECTIONS_MAPPED_HEADER
+    _raw_office_to_office_and_district = RAW_OFFICE_TO_OFFICE_AND_DISTRICT
+
+    def _verify_table_header(self):
+        if self._office != 'STATISTICS':
+            vote_percent_header = next(self._string_iterator)
+            assert vote_percent_header == 'VOTE %'
+        super()._verify_table_header()
+
+    def _populate_votes(self, row):
+        super()._populate_votes(row)
+        if self._office != 'STATISTICS' and row not in BUGGY_ROWS:
+            vote_percent_string = next(self._string_iterator)
+            assert '%' in vote_percent_string
+
+    @classmethod
+    def _clean_row(cls, row):
+        super()._clean_row(row)
+        row['office'] = row['office'].title()
+
+    @classmethod
+    def _should_be_recorded(cls, row):
+        if not super()._should_be_recorded(row):
+            return False
+        if row['office'] == 'Borough Of Mahanoy City Mahanoy City':
+            return False
+        return True
+
+
+class SchuylkillPDFPageParser(ElectionwarePDFPageParser):
+    _pdf_string_iterator_clazz = SchuylkillPDFStringIterator
+    _pdf_table_parser_clazz = SchuylkillPDFTableParser
+    _header = SCHUYLKILL_HEADER
+
+
+if __name__ == "__main__":
+    with open(OUTPUT_FILE, 'w', newline='') as f:
+        pdf_to_csv(PDFPageIterator(SCHUYLKILL_FILE),
+                   csv.DictWriter(f, OUTPUT_HEADER),
+                   SchuylkillPDFPageParser)


### PR DESCRIPTION
Data and logic for Adams, Cambria, Lackawann, Mercer, and Schuylkill
counties. All use `electionware_parser.py` as the core parsing system.
Northampton has been refactored to use this system as well.