### PR TITLE
Remove non-alphanumeric entries

### DIFF
--- a/2018/counties/20181106__pa__general__armstrong__precinct.csv
+++ b/2018/counties/20181106__pa__general__armstrong__precinct.csv
@@ -42,7 +42,7 @@ Armstrong,Applewold Borough,State House,60,,Write-ins,9,9,0
 Armstrong,Atwood Borough,Registered Voters,,,,62,,
 Armstrong,Atwood Borough,Ballots Cast,,,,46,46,0
 Armstrong,Atwood Borough,STRAIGHT PARTY,,DEM,DEMOCRATIC,6,6,0
-Armstrong,Atwood Borough,STRAIGHT PARTY,,REP,REPUBLICAN,18,18,-
+Armstrong,Atwood Borough,STRAIGHT PARTY,,REP,REPUBLICAN,18,18,
 Armstrong,Atwood Borough,STRAIGHT PARTY,,GRN,GREEN,0,0,0
 Armstrong,Atwood Borough,STRAIGHT PARTY,,LIB,LIBERTARIAN,0,0,0
 Armstrong,Atwood Borough,U.S. Senate,,DEM,"Bob Casey, Jr.",15,15,0
@@ -144,7 +144,7 @@ Armstrong,Burrell Township,State House,60,,Write-ins,8,7,1
 Armstrong,Cadogan Township,Registered Voters,,,,222,,
 Armstrong,Cadogan Township,Ballots Cast,,,,111,110,1
 Armstrong,Cadogan Township,STRAIGHT PARTY,,DEM,DEMOCRATIC,17,17,0
-Armstrong,Cadogan Township,STRAIGHT PARTY,,REP,REPUBLICAN,36,36,-
+Armstrong,Cadogan Township,STRAIGHT PARTY,,REP,REPUBLICAN,36,36,
 Armstrong,Cadogan Township,STRAIGHT PARTY,,GRN,GREEN,1,1,0
 Armstrong,Cadogan Township,STRAIGHT PARTY,,LIB,LIBERTARIAN,0,0,0
 Armstrong,Cadogan Township,U.S. Senate,,DEM,"Bob Casey, Jr.",39,39,0
@@ -308,7 +308,7 @@ Armstrong,East Franklin Township - West,State House,60,,Write-ins,9,9,0
 Armstrong,Elderton Borough,Registered Voters,,,,203,,
 Armstrong,Elderton Borough,Ballots Cast,,,,138,138,0
 Armstrong,Elderton Borough,STRAIGHT PARTY,,DEM,DEMOCRATIC,12,12,0
-Armstrong,Elderton Borough,STRAIGHT PARTY,,REP,REPUBLICAN,56,56,-
+Armstrong,Elderton Borough,STRAIGHT PARTY,,REP,REPUBLICAN,56,56,
 Armstrong,Elderton Borough,STRAIGHT PARTY,,GRN,GREEN,0,0,0
 Armstrong,Elderton Borough,STRAIGHT PARTY,,LIB,LIBERTARIAN,1,1,0
 Armstrong,Elderton Borough,U.S. Senate,,DEM,"Bob Casey, Jr.",41,41,0
@@ -329,7 +329,7 @@ Armstrong,Elderton Borough,State House,63,,Write-ins,0,0,0
 Armstrong,Ford City Borough - 1st Ward Nort,Registered Voters,,,,409,,
 Armstrong,Ford City Borough - 1st Ward Nort,Ballots Cast,,,,197,192,5
 Armstrong,Ford City Borough - 1st Ward North,STRAIGHT PARTY,,DEM,DEMOCRATIC,43,43,0
-Armstrong,Ford City Borough - 1st Ward North,STRAIGHT PARTY,,REP,REPUBLICAN,44,44,-
+Armstrong,Ford City Borough - 1st Ward North,STRAIGHT PARTY,,REP,REPUBLICAN,44,44,
 Armstrong,Ford City Borough - 1st Ward North,STRAIGHT PARTY,,GRN,GREEN,0,0,0
 Armstrong,Ford City Borough - 1st Ward North,STRAIGHT PARTY,,LIB,LIBERTARIAN,0,0,0
 Armstrong,Ford City Borough - 1st Ward North,U.S. Senate,,DEM,"Bob Casey, Jr.",110,109,1
@@ -509,7 +509,7 @@ Armstrong,Gilpin Township - #2,State House,60,,Write-ins,2,2,0
 Armstrong,Hovey Township,Registered Voters,,,,40,,
 Armstrong,Hovey Township,Ballots Cast,,,,39,39,0
 Armstrong,Hovey Township,STRAIGHT PARTY,,DEM,DEMOCRATIC,5,5,0
-Armstrong,Hovey Township,STRAIGHT PARTY,,REP,REPUBLICAN,14,14,-
+Armstrong,Hovey Township,STRAIGHT PARTY,,REP,REPUBLICAN,14,14,
 Armstrong,Hovey Township,STRAIGHT PARTY,,GRN,GREEN,0,0,0
 Armstrong,Hovey Township,STRAIGHT PARTY,,LIB,LIBERTARIAN,0,0,0
 Armstrong,Hovey Township,U.S. Senate,,DEM,"Bob Casey, Jr.",15,15,0
@@ -932,7 +932,7 @@ Armstrong,North Buffalo Township - West,State House,60,,Write-ins,1,1,0
 Armstrong,Parker City - 1st Ward,Registered Voters,,,,174,,
 Armstrong,Parker City - 1st Ward,Ballots Cast,,,,101,99,2
 Armstrong,Parker City - 1st Ward,STRAIGHT PARTY,,DEM,DEMOCRATIC,8,8,0
-Armstrong,Parker City - 1st Ward,STRAIGHT PARTY,,REP,REPUBLICAN,28,28,-
+Armstrong,Parker City - 1st Ward,STRAIGHT PARTY,,REP,REPUBLICAN,28,28,
 Armstrong,Parker City - 1st Ward,STRAIGHT PARTY,,GRN,GREEN,0,0,0
 Armstrong,Parker City - 1st Ward,STRAIGHT PARTY,,LIB,LIBERTARIAN,0,0,0
 Armstrong,Parker City - 1st Ward,U.S. Senate,,DEM,"Bob Casey, Jr.",32,32,0
@@ -953,7 +953,7 @@ Armstrong,Parker City - 1st Ward,State House,63,,Write-ins,0,0,0
 Armstrong,Parker City - 2nd Ward,Registered Voters,,,,222,,
 Armstrong,Parker City - 2nd Ward,Ballots Cast,,,,115,114,1
 Armstrong,Parker City - 2nd Ward,STRAIGHT PARTY,,DEM,DEMOCRATIC,18,18,0
-Armstrong,Parker City - 2nd Ward,STRAIGHT PARTY,,REP,REPUBLICAN,50,50,-
+Armstrong,Parker City - 2nd Ward,STRAIGHT PARTY,,REP,REPUBLICAN,50,50,
 Armstrong,Parker City - 2nd Ward,STRAIGHT PARTY,,GRN,GREEN,2,2,0
 Armstrong,Parker City - 2nd Ward,STRAIGHT PARTY,,LIB,LIBERTARIAN,2,2,0
 Armstrong,Parker City - 2nd Ward,U.S. Senate,,DEM,"Bob Casey, Jr.",36,35,1


### PR DESCRIPTION
This removes entries that consisted only of non-alphanumeric characters.

According to the [source file](https://github.com/openelections/openelections-sources-pa/blob/d9ae5e2b46e89294f787c6c10f1a0222d50f77c1/2018/Armstrong%20PA%202018%20general.pdf), these do not appear to represent redactions for privacy reasons.