### PR TITLE
readme: update year range from 2000-2012 to 2000 onward

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 OpenElections Data Pennsylvania
 ================================
 
-Precinct-level election results for Pennsylvania elections from 2000-2012 from the Bureau of Commissions, Elections and Legislation. Format for general and primary election files is described below; special elections have a simpler, different format and county-level results only.
+Precinct-level election results for Pennsylvania elections from 2000 onward. Files for 2000-2016 use the fixed-width format the Bureau of Commissions, Elections and Legislation published at the time; 2018 and after pull from each county's Clarity / EL30 / custom-format reports via per-county parsers in `parsers/`. Format for general and primary election files is described below; special elections have a simpler, different format and county-level results only.
 
 | Field Description    |  Length | Data Type |
 |---|---|---|


### PR DESCRIPTION
The intro says \"2000-2012\" but the repo's been collecting precinct results through 2025. Also called out that the data source changes in 2018 — 2000-2016 is the Bureau's fixed-width format, 2018+ pulls from each county's Clarity / EL30 / custom reports via parsers in \`parsers/\`. That distinction matters to anyone trying to write a new parser, because the older year directories don't look anything like the newer ones.